### PR TITLE
Throw an ObjectDisposedException instead of an AccessViolationException ...

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -146,6 +146,10 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
+                if (isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PEModule));
+                }
                 if (lazyMetadataReader == null)
                 {
                     MetadataReader newReader;


### PR DESCRIPTION
In the following code, Roslyn throws an AccessViolationException on the last line. 
```c#
var md = AssemblyMetadata.CreateFromFile(typeof(object).Assembly.Location);
var compilation = CSharpCompilation.Create("test", references: new[] { md.GetReference() });

// Use the Compilation once to force lazy initialization of the underlying MetadataReader
compilation.GetTypeByMetadataName("System.Version").GetMembers();

md.Dispose();

compilation.GetTypeByMetadataName("System.Exception").GetMembers(); // <-- AccessViolationException is thrown here
```
This code shows an improper use of the Compilation API where the consumer attempts to (indirectly) use an AssemblyMetadata instance after it has already been disposed. Therefore, an exception should indeed be thrown, but it should be an ObjectDisposedException and not an AccessViolationException. 

It should not be permissible for Roslyn to throw an AccessViolationException, because AVE's cannot be caught by user code and usually cause the process to terminate immediately (unless legacyCorruptedStateExceptionsPolicy or HandleProcessCorruptedStateExceptionAttribute is used - see http://msdn.microsoft.com/en-us/magazine/dd419661.aspx#id0070035 for reference). 

<!---
@huboard:{"order":8.5}
-->
