### PR TITLE
Updating readme links for CTP5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ which installs on top of Visual Studio 2013. *(Note: The VS 2013 preview is quit
 
 Get started building diagnostics, code fixes, refactorings, and other code-aware tools!
 
+To get started on **Visual Studio 2015 Preview**:
+
 1. Set up a box with Visual Studio 2015 Preview. Either 
 [install  Visual Studio 2015 Preview](http://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs), 
 or grab a [prebuilt Azure VM image](http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx).
@@ -31,6 +33,19 @@ You'll need to do this even if you're using the Azure VM image.
 3. Install the [SDK Templates VSIX package](http://visualstudiogallery.msdn.microsoft.com/849f3ab1-05cf-4682-b4af-ef995e2aa1a5) 
 to get the Visual Studio project templates. 
 4. Install the [Syntax Visualizer VSIX package](http://visualstudiogallery.msdn.microsoft.com/70e184da-9b3a-402f-b210-d62a898e2887) 
+to get a [Syntax Visualizer tool window](https://github.com/dotnet/roslyn/wiki/Syntax%20Visualizer) 
+to help explore the syntax trees you'll be analyzing.
+
+To get started on **Visual Studio 2015 CTP5**:
+
+1. Set up a box with Visual Studio 2015 CPT5. Either 
+[install  Visual Studio 2015 Preview](http://go.microsoft.com/fwlink/?LinkId=400496), 
+or grab a [prebuilt Azure VM image](http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx).
+2. Install the [Visual Studio 2015 CTP5 SDK](http://go.microsoft.com/fwlink/?LinkId=400496). 
+You'll need to do this even if you're using the Azure VM image. 
+3. Install the [SDK Templates VSIX package](https://visualstudiogallery.msdn.microsoft.com/ae1cf421-54bf-4406-b48c-76a182819fb7) 
+to get the Visual Studio project templates. 
+4. Install the [Syntax Visualizer VSIX package](https://visualstudiogallery.msdn.microsoft.com/b5104545-29ed-46b2-beb0-351af9ca2d21) 
 to get a [Syntax Visualizer tool window](https://github.com/dotnet/roslyn/wiki/Syntax%20Visualizer) 
 to help explore the syntax trees you'll be analyzing.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ to get the Visual Studio project templates.
 to get a [Syntax Visualizer tool window](https://github.com/dotnet/roslyn/wiki/Syntax%20Visualizer) 
 to help explore the syntax trees you'll be analyzing.
 
-To get started on **Visual Studio 2015 CTP5**:
+To get started on **Visual Studio 2015 CTP 5**:
 
-1. Set up a box with Visual Studio 2015 CPT5. Either 
-[install  Visual Studio 2015 Preview](http://go.microsoft.com/fwlink/?LinkId=400496), 
+1. Set up a box with Visual Studio 2015 CPT 5. Either 
+[install  Visual Studio 2015 CTP 5](http://go.microsoft.com/fwlink/?LinkId=400496), 
 or grab a [prebuilt Azure VM image](http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx).
-2. Install the [Visual Studio 2015 CTP5 SDK](http://go.microsoft.com/fwlink/?LinkId=400496). 
+2. Install the [Visual Studio 2015 CTP 5 SDK](http://go.microsoft.com/fwlink/?LinkId=400496). 
 You'll need to do this even if you're using the Azure VM image. 
 3. Install the [SDK Templates VSIX package](https://visualstudiogallery.msdn.microsoft.com/ae1cf421-54bf-4406-b48c-76a182819fb7) 
 to get the Visual Studio project templates. 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ to help explore the syntax trees you'll be analyzing.
 
 To get started on **Visual Studio 2015 CTP 5**:
 
-1. Set up a box with Visual Studio 2015 CPT 5. Either 
+1. Set up a box with Visual Studio 2015 CTP 5. Either 
 [install  Visual Studio 2015 CTP 5](http://go.microsoft.com/fwlink/?LinkId=400496), 
 or grab a [prebuilt Azure VM image](http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx).
 2. Install the [Visual Studio 2015 CTP 5 SDK](http://go.microsoft.com/fwlink/?LinkId=400496). 


### PR DESCRIPTION
This adds additional info for contributors who want to write analyzers on top of Visual Studio 2015 CTP5.  Just added a new section with the updated links.