### PR TITLE
Update link to `up-for-grabs` issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Some of the best ways to contribute are to try things out, file bugs, and join i
 
 * [Questions, Comments, and Feedback](https://roslyn.codeplex.com/wikipage?title=Questions%2c%20Comments%2c%20and%20Feedback&referringTitle=Home)
 
-Looking for something to work on? The list of [up-for-grabs issues](https://roslyn.codeplex.com/workitem/list/advanced?keyword=grabs&status=Open%2b%28not%2bclosed%29&type=All&priority=All&release=All&assignedTo=All&component=All&reasonClosed=All&sortField=LastUpdatedDate&sortDirection=Descending&page=0) is a great place to start.
+Looking for something to work on? The list of [up-for-grabs issues](https://github.com/dotnet/roslyn/labels/Up%20for%20Grabs) is a great place to start.
 
 * [How to Contribute](https://roslyn.codeplex.com/wikipage?title=How%20to%20Contribute&referringTitle=Home) 
 * [Pull requests](https://github.com/dotnet/roslyn/pulls): [Open](https://github.com/dotnet/roslyn/pulls?q=is%3Aopen+is%3Apr)/[Closed](https://github.com/dotnet/roslyn/pulls?q=is%3Apr+is%3Aclosed)


### PR DESCRIPTION
It points now to the issues on the GitHub repository