### PR TITLE
Added failing test cases for void scripts with a dynamic receiver.

### DIFF
--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -72,6 +72,40 @@ namespace Roslyn.Scripting.CSharp.Test
             var result = CSharpScript.Run("Console.WriteLine(0);");
         }
 
+        [Fact]
+        public void TestRunDynamicVoidScriptWithTerminatingSemicolon()
+        {
+
+            var result = CSharpScript.Run(@"
+class SomeClass
+{
+    public void Do()
+    {
+    }
+}
+dynamic d = new SomeClass();
+d.Do();"
+, ScriptOptions.Default.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
+
+        }
+
+        [Fact]
+        public void TestRunDynamicVoidScriptWithoutTerminatingSemicolon()
+        {
+
+            var result = CSharpScript.Run(@"
+class SomeClass
+{
+    public void Do()
+    {
+    }
+}
+dynamic d = new SomeClass();
+d.Do()"
+, ScriptOptions.Default.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
+
+        }
+
         public class Globals
         {
             public int X;

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -72,7 +72,7 @@ namespace Roslyn.Scripting.CSharp.Test
             var result = CSharpScript.Run("Console.WriteLine(0);");
         }
 
-        [Fact]
+        [Fact(Skip = "Bug 170")]
         public void TestRunDynamicVoidScriptWithTerminatingSemicolon()
         {
 
@@ -89,7 +89,7 @@ d.Do();"
 
         }
 
-        [Fact]
+        [Fact(Skip = "Bug 170")]
         public void TestRunDynamicVoidScriptWithoutTerminatingSemicolon()
         {
 


### PR DESCRIPTION
Scripts with a void return value throw exception when the receiver is dynamic.

Running the added test cases will fail with a "Cannot implicitly convert type 'void' to 'object'" exception.