### PR TITLE
Removed analysis extension methods.

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Extensions.cs
+++ b/src/Compilers/Core/Portable/Compilation/Extensions.cs
@@ -145,37 +145,5 @@ namespace Microsoft.CodeAnalysis
         {
             return semanticModel.GetMemberGroup(node, cancellationToken);
         }
-
-        /// <summary>
-        /// Analyze control-flow within a part of a method body. 
-        /// </summary>
-        public static ControlFlowAnalysis AnalyzeControlFlow(this SemanticModel semanticModel, SyntaxNode firstStatement, SyntaxNode lastStatement)
-        {
-            return semanticModel.AnalyzeControlFlow(firstStatement, lastStatement);
-        }
-
-        /// <summary>
-        /// Analyze control-flow within a part of a method body. 
-        /// </summary>
-        public static ControlFlowAnalysis AnalyzeControlFlow(this SemanticModel semanticModel, SyntaxNode statement)
-        {
-            return semanticModel.AnalyzeControlFlow(statement);
-        }
-
-        /// <summary>
-        /// Analyze data-flow within a part of a method body. 
-        /// </summary>
-        public static DataFlowAnalysis AnalyzeDataFlow(this SemanticModel semanticModel, SyntaxNode firstStatement, SyntaxNode lastStatement)
-        {
-            return semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
-        }
-
-        /// <summary>
-        /// Analyze data-flow within a part of a method body. 
-        /// </summary>
-        public static DataFlowAnalysis AnalyzeDataFlow(this SemanticModel semanticModel, SyntaxNode statementOrExpression)
-        {
-            return semanticModel.AnalyzeDataFlow(statementOrExpression);
-        }
     }
 }

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The first and last nodes must be fully inside the same method body.
         /// </remarks>
-        internal ControlFlowAnalysis AnalyzeControlFlow(SyntaxNode firstStatement, SyntaxNode lastStatement)
+        public ControlFlowAnalysis AnalyzeControlFlow(SyntaxNode firstStatement, SyntaxNode lastStatement)
         {
             return AnalyzeControlFlowCore(firstStatement, lastStatement);
         }
@@ -615,7 +615,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The statement must be fully inside the same method body.
         /// </remarks>
-        internal ControlFlowAnalysis AnalyzeControlFlow(SyntaxNode statement)
+        public ControlFlowAnalysis AnalyzeControlFlow(SyntaxNode statement)
         {
             return AnalyzeControlFlowCore(statement);
         }
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The first and last nodes must be fully inside the same method body.
         /// </remarks>
-        internal DataFlowAnalysis AnalyzeDataFlow(SyntaxNode firstStatement, SyntaxNode lastStatement)
+        public DataFlowAnalysis AnalyzeDataFlow(SyntaxNode firstStatement, SyntaxNode lastStatement)
         {
             return AnalyzeDataFlowCore(firstStatement, lastStatement);
         }
@@ -671,7 +671,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The statement or expression must be fully inside a method body.
         /// </remarks>
-        internal DataFlowAnalysis AnalyzeDataFlow(SyntaxNode statementOrExpression)
+        public DataFlowAnalysis AnalyzeDataFlow(SyntaxNode statementOrExpression)
         {
             return AnalyzeDataFlowCore(statementOrExpression);
         }


### PR DESCRIPTION
As per #187 I've removed the extension methods from ModelExtensions, and instead made the SemanticModel expose the same functionality as public instead of internal.