### PR TITLE
Delete our copy of IsBuiltInRuleSet

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -13,6 +13,7 @@ using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.VisualStudio.CodeAnalysis;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.SolutionExplorer;
@@ -266,7 +267,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     EnvDTE.Project envDteProject;
                     project.Hierarchy.TryGetProject(out envDteProject);
 
-                    if (IsBuiltInRuleSet(pathToRuleSet))
+                    if (SdkUiUtilities.IsBuiltInRuleSet(pathToRuleSet, _serviceProvider))
                     {
                         pathToRuleSet = CreateCopyOfRuleSetForProject(pathToRuleSet, envDteProject);
                         if (pathToRuleSet == null)
@@ -488,45 +489,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             return _workspace;
-        }
-
-        private bool IsBuiltInRuleSet(string pathToRuleSet)
-        {
-            if (string.IsNullOrEmpty(pathToRuleSet))
-            {
-                return false;
-            }
-
-            // Canonicalize and compare
-            string ruleSetInBuiltInDirectory = Path.Combine(GetBuiltInRuleSetDirectory(_serviceProvider), Path.GetFileName(pathToRuleSet));
-            if (ruleSetInBuiltInDirectory.Equals(Path.GetFullPath(pathToRuleSet), StringComparison.OrdinalIgnoreCase))
-            {
-                FileInfo ruleSetFile = new FileInfo(pathToRuleSet);
-                if ((ruleSetFile.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private string GetBuiltInRuleSetDirectory(IServiceProvider serviceProvider)
-        {
-            return Path.Combine(GetStaticAnalysisToolsDirectory(serviceProvider), "Rule Sets");
-        }
-
-        private string GetStaticAnalysisToolsDirectory(IServiceProvider serviceProvider)
-        {
-            string installDirectory = null;
-
-            // Get the VS install directory
-            IVsShell shell = (IVsShell)serviceProvider.GetService(typeof(IVsShell));
-            object value;
-            Marshal.ThrowExceptionForHR(shell.GetProperty((int)__VSSPROPID2.VSSPROPID_InstallRootDir, out value));
-            installDirectory = (string)value;
-
-            return Path.Combine(installDirectory, "Team Tools", "Static Analysis Tools");
         }
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -25,6 +25,9 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="Microsoft.VisualStudio.CodeAnalysis.Sdk.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll</HintPath>
+    </Reference> 
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">


### PR DESCRIPTION
This change deletes code we use to determine if a rule set file is one
that shipped with VS, and thus cannot be modified or deleted. It was
largely copied from code in
Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll, and we should just use
the original instead.