### PR TITLE
Allow 'is' for static classes for compatibility

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2537,12 +2537,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundIsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);
             }
 
-            // BREAKING CHANGE: The native compiler allows "x is C" where C is a static class. This
-            // BREAKING CHANGE: is strictly illegal according to the specification (see the section
-            // BREAKING CHANGE: called "Referencing Static Class Types".) We break with the native
-            // BREAKING CHANGE: compiler here and turn this into an error, as it should be.
-
-            if (targetType.IsStatic)
+            // The native compiler allows "x is C" where C is a static class. This
+            // is strictly illegal according to the specification (see the section
+            // called "Referencing Static Class Types".) To retain compatibility we
+            // allow it, but when /feature:strict is enabled we break with the native
+            // compiler and turn this into an error, as it should be.
+            if (targetType.IsStatic && Compilation.FeatureStrictEnabled)
             {
                 Error(diagnostics, ErrorCode.ERR_StaticInAsOrIs, node, targetType);
                 return new BoundIsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);
@@ -2924,15 +2924,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundAsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);
             }
 
-            // BREAKING CHANGE: The C# specification states in the section called 
-            // BREAKING CHANGE: "Referencing Static Class Types" that it is always
-            // BREAKING CHANGE: illegal to use "as" with a static type. The
-            // BREAKING CHANGE: native compiler actually allows "null as C" for
-            // BREAKING CHANGE: a static type C to be an expression of type C.
-            // BREAKING CHANGE: It also allows "someObject as C" if "someObject"
-            // BREAKING CHANGE: is of type object.
-
-            if (targetType.IsStatic)
+            // The C# specification states in the section called 
+            // "Referencing Static Class Types" that it is always
+            // illegal to use "as" with a static type. The
+            // native compiler actually allows "null as C" for
+            // a static type C to be an expression of type C.
+            // It also allows "someObject as C" if "someObject"
+            // is of type object. To retain compatibility we
+            // allow it, but when /feature:strict is enabled we break with the native
+            // compiler and turn this into an error, as it should be.
+            if (targetType.IsStatic && Compilation.FeatureStrictEnabled)
             {
                 Error(diagnostics, ErrorCode.ERR_StaticInAsOrIs, node, targetType);
                 return new BoundAsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 if (_strict.HasValue) return _strict.Value;
-                bool value = _binder.Compilation.Feature("strict") != null;
+                bool value = _binder.Compilation.FeatureStrictEnabled;
                 _strict = value;
                 return value;
             }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -156,6 +156,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// True when the compiler is run in "strict" mode, in which it enforces the language specification
+        /// in some cases even at the expense of full compatibility. Such differences typically arise when
+        /// earlier versions of the compiler failed to enforce the full language specification.
+        /// </summary>
+        internal bool FeatureStrictEnabled => Feature("strict") != null;
+
+        /// <summary>
         /// The language version that was used to parse the syntax trees of this compilation.
         /// </summary>
         public LanguageVersion LanguageVersion

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _sourceAssembly = ((object)member == null) ? null : (SourceAssemblySymbol)member.ContainingAssembly;
             this.currentMethodOrLambda = member as MethodSymbol;
             _unassignedVariableAddressOfSyntaxes = unassignedVariableAddressOfSyntaxes;
-            bool strict = compilation.Feature("strict") != null; // Compiler flag /features:strict removes the relaxed DA checking we have for backward compatibility
+            bool strict = compilation.FeatureStrictEnabled; // Compiler flag /features:strict removes the relaxed DA checking we have for backward compatibility
             _emptyStructTypeCache = new EmptyStructTypeCache(compilation, !strict);
             _requireOutParamsAssigned = requireOutParamsAssigned;
             this.topLevelMethod = member as MethodSymbol;
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _sourceAssembly = ((object)member == null) ? null : (SourceAssemblySymbol)member.ContainingAssembly;
             this.currentMethodOrLambda = member as MethodSymbol;
             _unassignedVariableAddressOfSyntaxes = null;
-            bool strict = compilation.Feature("strict") != null; // Compiler flag /features:strict removes the relaxed DA checking we have for backward compatibility
+            bool strict = compilation.FeatureStrictEnabled; // Compiler flag /features:strict removes the relaxed DA checking we have for backward compatibility
             _emptyStructTypeCache = emptyStructs ?? new EmptyStructTypeCache(compilation, !strict);
             _requireOutParamsAssigned = true;
             this.topLevelMethod = member as MethodSymbol;


### PR DESCRIPTION
but continue to report the diagnostic if "strict" mode is requested.
Fixes #324

<!---
@huboard:{"order":324.25,"milestone_order":331,"custom_state":""}
-->
