### PR TITLE
Remove cancellation token from NavigateTo

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 Document = document;
                 _declaredSymbolInfo = declaredSymbolInfo;
 
+                // Cancellation isn't supported when computing the various properties that depend on the symbol, hence
+                // CancellationToken.None.
                 _lazySymbol = new Lazy<ISymbol>(() => declaredSymbolInfo.GetSymbolAsync(document, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult());
                 _lazyDisplayName = new Lazy<string>(() =>
                 {

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             private readonly Lazy<string> _lazyDisplayName;
             private readonly Lazy<ISymbol> _lazySymbol;
 
-            public DeclaredSymbolNavigableItem(Document document, DeclaredSymbolInfo declaredSymbolInfo, CancellationToken cancellationToken)
+            public DeclaredSymbolNavigableItem(Document document, DeclaredSymbolInfo declaredSymbolInfo)
             {
                 Document = document;
                 _declaredSymbolInfo = declaredSymbolInfo;
 
-                _lazySymbol = new Lazy<ISymbol>(() => declaredSymbolInfo.GetSymbolAsync(document, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult());
+                _lazySymbol = new Lazy<ISymbol>(() => declaredSymbolInfo.GetSymbolAsync(document, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult());
                 _lazyDisplayName = new Lazy<string>(() =>
                 {
                     if (Symbol == null)

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -17,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             return new SymbolLocationNavigableItem(solution, symbol, location);
         }
 
-        public static INavigableItem GetItemFromDeclaredSymbolInfo(DeclaredSymbolInfo declaredSymbolInfo, Document document, CancellationToken cancellationToken)
+        public static INavigableItem GetItemFromDeclaredSymbolInfo(DeclaredSymbolInfo declaredSymbolInfo, Document document)
         {
-            return new DeclaredSymbolNavigableItem(document, declaredSymbolInfo, cancellationToken);
+            return new DeclaredSymbolNavigableItem(document, declaredSymbolInfo);
         }
 
         public static IEnumerable<INavigableItem> GetItemsfromPreferredSourceLocations(Solution solution, ISymbol symbol)

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 var declaredNavigableItem = navigableItem as NavigableItemFactory.DeclaredSymbolNavigableItem;
                 Debug.Assert(declaredNavigableItem != null);
 
-                _lazySummary = new Lazy<string>(() => declaredNavigableItem.Symbol.GetDocumentationComment()?.SummaryText);
+                _lazySummary = new Lazy<string>(() => declaredNavigableItem.Symbol?.GetDocumentationComment()?.SummaryText);
                 _lazyAdditionalInfo = new Lazy<string>(() =>
                 {
                     switch (declaredSymbolInfo.Kind)

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.cs
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
         public async Task<IEnumerable<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, CancellationToken cancellationToken)
         {
             var results = await NavigateToSymbolFinder.FindNavigableDeclaredSymbolInfos(project, searchPattern, cancellationToken).ConfigureAwait(false);
-            return results.Select(r => ConvertResult(r, cancellationToken));
+            return results.Select(r => ConvertResult(r));
         }
 
-        private INavigateToSearchResult ConvertResult(ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>> result, CancellationToken cancellationToken)
+        private INavigateToSearchResult ConvertResult(ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>> result)
         {
             var declaredSymbolInfo = result.Item1;
             var document = result.Item2;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             // case sensitive. 
             var isCaseSensitive = matches.All(m => m.IsCaseSensitive);
             var kind = GetItemKind(declaredSymbolInfo);
-            var navigableItem = NavigableItemFactory.GetItemFromDeclaredSymbolInfo(declaredSymbolInfo, document, cancellationToken);
+            var navigableItem = NavigableItemFactory.GetItemFromDeclaredSymbolInfo(declaredSymbolInfo, document);
 
             return new SearchResult(document, declaredSymbolInfo, kind, matchKind, isCaseSensitive, navigableItem);
         }


### PR DESCRIPTION
NavigateTo doesn't support cancellation when computing the display properties so the cancellation token is getting removed rather than having to manually handle an OperationCanceledException.