### PR TITLE
Add a small cache of AbstractSyntaxContext

### DIFF
--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     internal abstract partial class AbstractSymbolCompletionProvider : AbstractCompletionProvider
     {
-        // PERF: Many CompletionProviders dervice AbstractSymbolCompletionProvider and therefore
+        // PERF: Many CompletionProviders derive AbstractSymbolCompletionProvider and therefore
         // compute identical contexts. This actually shows up on the 2-core typing test.
         // Cache the most recent document/position/computed SyntaxContext to reduce repeat computation.
         private static Document cachedDocument;


### PR DESCRIPTION
AbstractSymbolCompletionProvider computes a SyntaxContext and passes
it around while computing CompletionItems. Many CompletionProviders
derive AbstractSymbolCompletionProvider in order to share the logic for
linked files completion. This means that we'll repeatedly compute the
same SyntaxContext for a given Document and position. This shows up in
the 2-core typing tests. To avoid this, we'll simply cache the most
recent Document/position/SyntaxContext and use it if it matches the
current request.

I'm not sure how to best address the linked files case--currently, each provider iterates over all of the files, which means the one-element cache will never contain the right Document for the next provider. I suppose to the cache could contain more elements, but how many?