### PR TITLE
Replace nonbreaking space (0xA0) with a regular space.

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
@@ -10,7 +10,7 @@ namespace Roslyn.Utilities
     {
         // TODO (DevDiv 1117307): Replace with CultureInfo.CurrentUICulture.set when available.
         private const string currentUICultureName = "CurrentUICulture";
-        private readonly static Action<CultureInfo> _setCurrentUICulture;
+        private readonly static Action<CultureInfo> _setCurrentUICulture;
 
         private static bool TryGetCurrentUICultureSetter(out Action<CultureInfo> setter)
         {


### PR DESCRIPTION
It is likely the character was inserted by accident. There is no reason
to use it in the code. It is a valid Unicode whitespace, but not a valid
ASCII. Since the containing file has no encoding bytemarks, the behavior
of this char is dependent on default encoding. Indeed, the file compiles
on Windows and fails on Linux.
As far as I could find, this is the only case where this character is
used in actual code (not in tests) in Roslyn codebase.