### PR TITLE
Improve project load/unload performance around linked file mapping

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -615,7 +615,7 @@ namespace Microsoft.CodeAnalysis
             return CreateLinkedFilesMapWithAddedDocuments(projectState, projectState.DocumentIds);
         }
 
-        private ImmutableDictionary<string, ImmutableArray<DocumentId>> CreateLinkedFilesMapWithAddedDocuments(ProjectState projectState, IReadOnlyList<DocumentId> documentIds)
+        private ImmutableDictionary<string, ImmutableArray<DocumentId>> CreateLinkedFilesMapWithAddedDocuments(ProjectState projectState, IEnumerable<DocumentId> documentIds)
         {
             var builder = _linkedFilesMap.ToBuilder();
 
@@ -671,7 +671,7 @@ namespace Microsoft.CodeAnalysis
 
         private ImmutableDictionary<string, ImmutableArray<DocumentId>> CreateLinkedFilesMapWithRemovedDocuments(
             ProjectState projectState,
-            IReadOnlyList<DocumentId> documentIds)
+            IEnumerable<DocumentId> documentIds)
         {
             var builder = _linkedFilesMap.ToBuilder();
 
@@ -1129,7 +1129,10 @@ namespace Microsoft.CodeAnalysis
             var oldProject = this.GetProjectState(state.Id.ProjectId);
             var newProject = oldProject.AddDocument(state);
 
-            return this.ForkProject(newProject, CompilationTranslationAction.AddDocument(state), withDocumentListChange: true);
+            return this.ForkProject(
+                newProject, 
+                CompilationTranslationAction.AddDocument(state), 
+                newLinkedFilesMap: CreateLinkedFilesMapWithAddedDocuments(newProject, SpecializedCollections.SingletonEnumerable(state.Id)));
         }
 
         /// <summary>
@@ -1370,7 +1373,10 @@ namespace Microsoft.CodeAnalysis
             var oldDocument = oldProject.GetDocumentState(documentId);
             var newProject = oldProject.RemoveDocument(documentId);
 
-            return this.ForkProject(newProject, CompilationTranslationAction.RemoveDocument(oldDocument), withDocumentListChange: true);
+            return this.ForkProject(
+                newProject, 
+                CompilationTranslationAction.RemoveDocument(oldDocument),
+                newLinkedFilesMap: CreateLinkedFilesMapWithRemovedDocuments(oldProject, SpecializedCollections.SingletonEnumerable(documentId)));
         }
 
         /// <summary>
@@ -1732,7 +1738,7 @@ namespace Microsoft.CodeAnalysis
             ProjectState newProjectState,
             CompilationTranslationAction translate = null,
             bool withProjectReferenceChange = false,
-            bool withDocumentListChange = false)
+            ImmutableDictionary<string, ImmutableArray<DocumentId>> newLinkedFilesMap = null)
         {
             // make sure we are getting only known translate actions
             CompilationTranslationAction.CheckKnownActions(translate);
@@ -1742,9 +1748,6 @@ namespace Microsoft.CodeAnalysis
             var newStateMap = _projectIdToProjectStateMap.SetItem(projectId, newProjectState);
             var newDependencyGraph = withProjectReferenceChange ? CreateDependencyGraph(_projectIds, newStateMap) : _dependencyGraph;
             var newTrackerMap = CreateCompilationTrackerMap(projectId, newDependencyGraph);
-            var newLinkedFilesMap = withDocumentListChange
-                ? CreateLinkedFilesMapWithChangedProject(_projectIdToProjectStateMap[projectId], newProjectState)
-                : _linkedFilesMap;
 
             // If we have a tracker for this project, then fork it as well (along with the
             // translation action and store it in the tracker map.
@@ -1761,23 +1764,8 @@ namespace Microsoft.CodeAnalysis
                 idToProjectStateMap: newStateMap,
                 projectIdToTrackerMap: newTrackerMap,
                 dependencyGraph: newDependencyGraph,
-                linkedFilesMap: newLinkedFilesMap,
+                linkedFilesMap: newLinkedFilesMap ?? _linkedFilesMap,
                 lazyLatestProjectVersion: newLatestProjectVersion);
-        }
-
-        private ImmutableDictionary<string, ImmutableArray<DocumentId>> CreateLinkedFilesMapWithChangedProject(ProjectState oldProjectState, ProjectState newProjectState)
-        {
-            var oldDocumentIds = oldProjectState.DocumentIds;
-            var newDocumentIds = newProjectState.DocumentIds;
-            var addedDocumentIds = newDocumentIds.ToImmutableArray().RemoveRange(oldDocumentIds);
-            var removedDocumentIds = oldDocumentIds.ToImmutableArray().RemoveRange(newDocumentIds);
-
-            Debug.Assert(addedDocumentIds.Any() || removedDocumentIds.Any(), "The solution's linkedFilesMap should only be recalculated if its files changed.");
-
-            var linkedFilesMap = _linkedFilesMap;
-            linkedFilesMap = addedDocumentIds.Any() ? CreateLinkedFilesMapWithAddedDocuments(newProjectState, addedDocumentIds) : linkedFilesMap;
-            linkedFilesMap = removedDocumentIds.Any() ? CreateLinkedFilesMapWithRemovedDocuments(oldProjectState, removedDocumentIds) : linkedFilesMap;
-            return linkedFilesMap;
         }
 
         /// <summary>


### PR DESCRIPTION
When a project with N files is loaded or unloaded, the project will be
forked N times, each time adding or removing one of the N files. For
each of those forks, we need to update the Solution's map of linked
files. The process of updating the linked files map was previously
O(N^2), resulting in an overall O(N^3) project load/unload process. This
change makes makes the linked file map calculation O(1) and therefore
the project load/unload process O(N).

Updating the linked files map was previously O(N^2) because it tried to
account for arbitrary project edits that might have added any number of
files and removed any number of files. However, all project-related
forking actually happens at either the level of the entire project
(which was already special-cased) or at the level of an individual file.
We now handle the case of individual file adds/removes efficiently.

This fixes internal issue 1112399