### PR TITLE
Expose new dotted-pattern matching capabilities from the Pattern matcher.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
         internal static async Task<IEnumerable<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>> FindNavigableDeclaredSymbolInfos(Project project, string pattern, CancellationToken cancellationToken)
         {
             var patternMatcher = new PatternMatcher();
-            var dotSeparatedPatternComponents = pattern.Contains(".") ? pattern.Split(DotArray, StringSplitOptions.RemoveEmptyEntries) : null;
 
             var result = new List<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>();
             foreach (var document in project.Documents)
@@ -29,7 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 foreach (var declaredSymbolInfo in declaredSymbolInfos)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var patternMatches = TryMatch(pattern, dotSeparatedPatternComponents, patternMatcher, declaredSymbolInfo);
+                    var patternMatches = patternMatcher.MatchPattern(
+                        GetSearchName(declaredSymbolInfo),
+                        declaredSymbolInfo.FullyQualifiedContainerName,
+                        pattern);
+
                     if (patternMatches != null)
                     {
                         result.Add(ValueTuple.Create(declaredSymbolInfo, document, patternMatches));
@@ -38,85 +41,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             }
 
             return result;
-        }
-
-        private static IEnumerable<PatternMatch> TryMatch(
-            string pattern,
-            string[] dotSeparatedPatternComponents,
-            PatternMatcher patternMatcher,
-            DeclaredSymbolInfo declaredSymbolInfo)
-        {
-            var matches1 = TryGetDotSeparatedPatternMatches(patternMatcher, dotSeparatedPatternComponents, declaredSymbolInfo);
-            var matches2 = patternMatcher.MatchPattern(GetSearchName(declaredSymbolInfo), pattern);
-
-            if (matches1 == null)
-            {
-                return matches2;
-            }
-
-            if (matches2 == null)
-            {
-                return matches1;
-            }
-
-            return matches1.Concat(matches2);
-        }
-
-        private static IEnumerable<PatternMatch> TryGetDotSeparatedPatternMatches(
-            PatternMatcher patternMatcher,
-            string[] dotSeparatedPatternComponents,
-            DeclaredSymbolInfo declaredSymbolInfo)
-        {
-            if (dotSeparatedPatternComponents == null || declaredSymbolInfo.FullyQualifiedContainerName == null || declaredSymbolInfo.Name == null)
-            {
-                return null;
-            }
-
-            // First, check that the last part of the dot separated pattern matches the name of the
-            // declared symbol.  If not, then there's no point in proceeding and doing the more
-            // expensive work.
-            var symbolNameMatch = patternMatcher.MatchPattern(GetSearchName(declaredSymbolInfo), dotSeparatedPatternComponents.Last());
-            if (symbolNameMatch == null)
-            {
-                return null;
-            }
-
-            // So far so good.  Now break up the container for the symbol and check if all
-            // the dotted parts match up correctly.
-            var totalMatch = symbolNameMatch.ToList();
-
-            var containerParts = declaredSymbolInfo.FullyQualifiedContainerName
-                .Split(DotArray, StringSplitOptions.RemoveEmptyEntries)
-                .ToList();
-
-            // -1 because the last part was checked against hte name, and only the rest
-            // of the parts are checked against the container.
-            if (dotSeparatedPatternComponents.Length - 1 > containerParts.Count)
-            {
-                // There weren't enough container parts to match against the pattern parts.
-                // So this definitely doesn't match.
-                return null;
-            }
-
-            for (int i = dotSeparatedPatternComponents.Length - 2, j = containerParts.Count - 1;
-                    i >= 0;
-                    i--, j--)
-            {
-                var dotPattern = dotSeparatedPatternComponents[i];
-                var containerName = containerParts[j];
-                var containerMatch = patternMatcher.MatchPattern(containerName, dotPattern);
-                if (containerMatch == null)
-                {
-                    // This container didn't match the pattern piece.  So there's no match at all.
-                    return null;
-                }
-
-                totalMatch.AddRange(containerMatch);
-            }
-
-            // Success, this symbol's full name matched against the dotted name the user was asking
-            // about.
-            return totalMatch;
         }
 
         private static string GetSearchName(DeclaredSymbolInfo declaredSymbolInfo)

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -17,14 +19,19 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     /// </summary>
     internal sealed class PatternMatcher
     {
-        private readonly object _gate = new object();
-        private readonly Dictionary<string, List<TextSpan>> _stringToWordParts = new Dictionary<string, List<TextSpan>>();
-        private readonly Dictionary<string, List<TextSpan>> _stringToCharacterParts = new Dictionary<string, List<TextSpan>>();
-        private readonly Func<string, List<TextSpan>> _breakIntoWordParts = StringBreaker.BreakIntoWordParts;
-        private readonly Func<string, List<TextSpan>> _breakIntoCharacterParts = StringBreaker.BreakIntoCharacterParts;
+        private static readonly char[] DotCharacterArray = new[] { '.' };
 
-        private readonly Dictionary<string, string[]> _patternToParts = new Dictionary<string, string[]>();
-        private readonly Func<string, string[]> _breakPatternIntoParts;
+        private readonly object _gate = new object();
+        private readonly Dictionary<string, List<TextSpan>> _stringToWordSpans = new Dictionary<string, List<TextSpan>>();
+        private readonly Dictionary<string, List<TextSpan>> _stringToCharacterSpans = new Dictionary<string, List<TextSpan>>();
+        private readonly Func<string, List<TextSpan>> _breakIntoWordSpans = StringBreaker.BreakIntoWordParts;
+        private readonly Func<string, List<TextSpan>> _breakIntoCharacterSpans = StringBreaker.BreakIntoCharacterParts;
+
+        private readonly Dictionary<string, string[]> _patternToWordParts = new Dictionary<string, string[]>();
+        private readonly Dictionary<string, string[]> _patternToDotSeparatedParts = new Dictionary<string, string[]>();
+
+        private readonly Func<string, string[]> _breakPatternIntoWordParts;
+        private readonly Func<string, string[]> _breakPatternIntoDotSeparatedParts;
 
         // PERF: Cache the culture's compareInfo to avoid the overhead of asking for them repeatedly in inner loops
         private readonly CompareInfo _compareInfo;
@@ -44,30 +51,51 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public PatternMatcher(CultureInfo culture, bool verbatimIdentifierPrefixIsWordCharacter)
         {
             _compareInfo = culture.CompareInfo;
-            _breakPatternIntoParts = (pattern) => BreakPatternIntoParts(pattern, verbatimIdentifierPrefixIsWordCharacter);
+            _breakPatternIntoWordParts = pattern => BreakPatternIntoParts(pattern, verbatimIdentifierPrefixIsWordCharacter);
+            _breakPatternIntoDotSeparatedParts = BreakIntoDotSeparatedParts;
         }
 
-        private List<TextSpan> GetCharacterParts(string pattern)
+        private static string[] BreakIntoDotSeparatedParts(string value)
+        {
+            return value.Contains(".")
+                ? value.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
+                : null;
+        }
+
+        private List<TextSpan> GetCharacterSpans(string pattern)
         {
             lock (_gate)
             {
-                return _stringToCharacterParts.GetOrAdd(pattern, _breakIntoCharacterParts);
+                return _stringToCharacterSpans.GetOrAdd(pattern, _breakIntoCharacterSpans);
             }
         }
 
-        private List<TextSpan> GetWordParts(string word)
+        private List<TextSpan> GetWordSpans(string word)
         {
             lock (_gate)
             {
-                return _stringToWordParts.GetOrAdd(word, _breakIntoWordParts);
+                return _stringToWordSpans.GetOrAdd(word, _breakIntoWordSpans);
             }
         }
 
-        private string[] GetPatternParts(string pattern)
+        private string[] GetWordParts(string pattern)
         {
             lock (_gate)
             {
-                return _patternToParts.GetOrAdd(pattern, _breakPatternIntoParts);
+                return _patternToWordParts.GetOrAdd(pattern, _breakPatternIntoWordParts);
+            }
+        }
+
+        private string[] GetDotSeparatedParts(string pattern)
+        {
+            if (pattern == null)
+            {
+                return null;
+            }
+
+            lock (_gate)
+            {
+                return _patternToDotSeparatedParts.GetOrAdd(pattern, _breakPatternIntoDotSeparatedParts);
             }
         }
 
@@ -172,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     //    Note: We only have a substring match if the lowercase part is prefix match of some
                     //    word part. That way we don't match something like 'Class' when the user types 'a'.
                     //    But we would match 'FooAttribute' (since 'Attribute' starts with 'a').
-                    var candidateParts = GetWordParts(candidate);
+                    var candidateParts = GetWordSpans(candidate);
                     foreach (var part in candidateParts)
                     {
                         if (PartStartsWith(candidate, part, pattern, CompareOptions.IgnoreCase))
@@ -196,10 +224,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (!isLowercase)
             {
                 // e) If the part was not entirely lowercase, then attempt a camel cased match as well.
-                var patternParts = GetCharacterParts(pattern);
+                var patternParts = GetCharacterSpans(pattern);
                 if (patternParts.Count > 0)
                 {
-                    var candidateParts = GetWordParts(candidate);
+                    var candidateParts = GetWordSpans(candidate);
                     var camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, patternParts, CompareOptions.None);
                     if (camelCaseWeight.HasValue)
                     {
@@ -260,8 +288,82 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// patterns. If it was not a match, it returns null.</returns>
         public IEnumerable<PatternMatch> MatchPattern(string candidate, string pattern)
         {
+            return MatchNonDottedPattern(candidate, pattern);
+        }
+
+        /// <summary>
+        /// Matches a pattern against a candidate, and an optional dotted container for the 
+        /// candidate. If the container is provided, and the pattern itself contains dots, then
+        /// the pattern will be tested against the candidate and container.  Specifically,
+        /// the part of the pattern after the last dot will be tested against the candidate. If
+        /// a match occurs there, then the remaining dot-separated portoins of the pattern will
+        /// be tested against every successive portion of the container from right to left.
+        /// 
+        /// i.e. if you have a pattern of "Con.WL" and the candidate is "WriteLine" with a 
+        /// dotted container of "System.Console", then "WL" will be tested against "WriteLine".
+        /// With a match found there, "Con" will then be tested against "Console".
+        /// </summary>
+        public IEnumerable<PatternMatch> MatchPattern(string candidate, string dottedContainer, string pattern)
+        {
+            var dotParts = GetDotSeparatedParts(pattern);
+            return dotParts == null
+                ? MatchNonDottedPattern(candidate, pattern)
+                : MatchDottedPattern(candidate, dottedContainer, pattern, dotParts);
+        }
+
+        private IEnumerable<PatternMatch> MatchDottedPattern(string candidate, string dottedContainer, string pattern, string[] patternParts)
+        {
+            Debug.Assert(patternParts.Length > 0);
+
+            // First, check that the last part of the dot separated pattern matches the name of the
+            // candidate.  If not, then there's no point in proceeding and doing the more
+            // expensive work.
+            var candidateMatch = MatchNonDottedPattern(candidate, patternParts.Last());
+            if (candidateMatch == null)
+            {
+                return null;
+            }
+
+            // So far so good.  Now break up the container for the candidate and check if all
+            // the dotted parts match up correctly.
+            var totalMatch = candidateMatch.ToList();
+
+            var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
+
+            // -1 because the last part was checked against hte name, and only the rest
+            // of the parts are checked against the container.
+            if (patternParts.Length - 1 > containerParts.Length)
+            {
+                // There weren't enough container parts to match against the pattern parts.
+                // So this definitely doesn't match.
+                return null;
+            }
+
+            for (int i = patternParts.Length - 2, j = containerParts.Length - 1;
+                    i >= 0;
+                    i--, j--)
+            {
+                var patternPart = patternParts[i];
+                var containerName = containerParts[j];
+                var containerMatch = MatchNonDottedPattern(containerName, patternPart);
+                if (containerMatch == null)
+                {
+                    // This container didn't match the pattern piece.  So there's no match at all.
+                    return null;
+                }
+
+                totalMatch.AddRange(containerMatch);
+            }
+
+            // Success, this symbol's full name matched against the dotted name the user was asking
+            // about.
+            return totalMatch;
+        }
+
+        private IEnumerable<PatternMatch> MatchNonDottedPattern(string candidate, string pattern)
+        {
             PatternMatch[] matches;
-            var singleMatch = MatchPatternInternal(candidate, pattern, wantAllMatches: true, allMatches: out matches);
+            var singleMatch = MatchNonDottedPattern(candidate, pattern, wantAllMatches: true, allMatches: out matches);
             if (singleMatch.HasValue)
             {
                 return SpecializedCollections.SingletonEnumerable(singleMatch.Value);
@@ -285,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public PatternMatch? MatchPatternFirstOrNullable(string candidate, string pattern)
         {
             PatternMatch[] ignored;
-            return MatchPatternInternal(candidate, pattern, wantAllMatches: false, allMatches: out ignored);
+            return MatchNonDottedPattern(candidate, pattern, wantAllMatches: false, allMatches: out ignored);
         }
 
         /// <summary>
@@ -302,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <param name="wantAllMatches">Does the caller want all matches or just the first?</param>
         /// <param name="allMatches">If <paramref name="wantAllMatches"/> is true, and there's more than one match, then the list of all matches.</param>
         /// <returns>If there's only one match, then the return value is that match. Otherwise it is null.</returns>
-        private PatternMatch? MatchPatternInternal(string candidate, string pattern, bool wantAllMatches, out PatternMatch[] allMatches)
+        private PatternMatch? MatchNonDottedPattern(string candidate, string pattern, bool wantAllMatches, out PatternMatch[] allMatches)
         {
             allMatches = null;
 
@@ -328,7 +430,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 }
             }
 
-            var patternParts = GetPatternParts(pattern);
+            var patternParts = GetWordParts(pattern);
             PatternMatch[] matches = null;
 
             for (int i = 0; i < patternParts.Length; i++)

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -57,9 +57,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
         private static string[] BreakIntoDotSeparatedParts(string value)
         {
-            return value.IndexOf('.') >= 0
-                ? value.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
-                : null;
+            if (value.IndexOf('.') >= 0) {
+                var split = value.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
+                if (split.Length > 0) {
+                    return split;
+                }
+            }
+
+            return null;
         }
 
         private List<TextSpan> GetCharacterSpans(string pattern)

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// candidate. If the container is provided, and the pattern itself contains dots, then
         /// the pattern will be tested against the candidate and container.  Specifically,
         /// the part of the pattern after the last dot will be tested against the candidate. If
-        /// a match occurs there, then the remaining dot-separated portoins of the pattern will
+        /// a match occurs there, then the remaining dot-separated portions of the pattern will
         /// be tested against every successive portion of the container from right to left.
         /// 
         /// i.e. if you have a pattern of "Con.WL" and the candidate is "WriteLine" with a 
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
 
-            // -1 because the last part was checked against hte name, and only the rest
+            // -1 because the last part was checked against the name, and only the rest
             // of the parts are checked against the container.
             if (patternParts.Length - 1 > containerParts.Length)
             {

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -205,12 +205,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     //    Note: We only have a substring match if the lowercase part is prefix match of some
                     //    word part. That way we don't match something like 'Class' when the user types 'a'.
                     //    But we would match 'FooAttribute' (since 'Attribute' starts with 'a').
-                    var candidateParts = GetWordSpans(candidate);
-                    foreach (var part in candidateParts)
+                    var wordSpans = GetWordSpans(candidate);
+                    foreach (var span in wordSpans)
                     {
-                        if (PartStartsWith(candidate, part, pattern, CompareOptions.IgnoreCase))
+                        if (PartStartsWith(candidate, span, pattern, CompareOptions.IgnoreCase))
                         {
-                            return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: PartStartsWith(candidate, part, pattern, CompareOptions.None));
+                            return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: PartStartsWith(candidate, span, pattern, CompareOptions.None));
                         }
                     }
                 }
@@ -229,17 +229,17 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (!isLowercase)
             {
                 // e) If the part was not entirely lowercase, then attempt a camel cased match as well.
-                var patternParts = GetCharacterSpans(pattern);
-                if (patternParts.Count > 0)
+                var characterSpans = GetCharacterSpans(pattern);
+                if (characterSpans.Count > 0)
                 {
                     var candidateParts = GetWordSpans(candidate);
-                    var camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, patternParts, CompareOptions.None);
+                    var camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, characterSpans, CompareOptions.None);
                     if (camelCaseWeight.HasValue)
                     {
                         return new PatternMatch(PatternMatchKind.CamelCase, punctuationStripped, isCaseSensitive: true, camelCaseWeight: camelCaseWeight);
                     }
 
-                    camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, patternParts, CompareOptions.IgnoreCase);
+                    camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, characterSpans, CompareOptions.IgnoreCase);
                     if (camelCaseWeight.HasValue)
                     {
                         return new PatternMatch(PatternMatchKind.CamelCase, punctuationStripped, isCaseSensitive: false, camelCaseWeight: camelCaseWeight);

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
         private static string[] BreakIntoDotSeparatedParts(string value)
         {
-            return value.Contains(".")
+            return value.IndexOf('.') >= 0
                 ? value.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
                 : null;
         }

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -329,11 +329,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 return null;
             }
 
-            // So far so good.  Now break up the container for the candidate and check if all
-            // the dotted parts match up correctly.
-            var totalMatch = candidateMatch.ToList();
-
-            var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
+             var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
 
             // -1 because the last part was checked against the name, and only the rest
             // of the parts are checked against the container.
@@ -343,6 +339,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // So this definitely doesn't match.
                 return null;
             }
+
+            // So far so good.  Now break up the container for the candidate and check if all
+            // the dotted parts match up correctly.
+            var totalMatch = candidateMatch.ToList();
 
             for (int i = patternParts.Length - 2, j = containerParts.Length - 1;
                     i >= 0;

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
@@ -23,22 +23,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         public SearchGraphQuery(string searchPattern)
         {
-            _entireSearchPattern = searchPattern;
-
             // If the pattern has a dot in it, then when we search the compilations, we actually
             // want to only filter by the last name portion of hte pattern (as the compilers 
             // only support returning the basic name of a symbol when searching and filtering 
             // them).  Then, once we have all the results the compiler returned, we check and
             // verify they match against the full dotted pattern.
-            if (searchPattern.Contains("."))
+            if (searchPattern.IndexOf('.') >= 0)
             {
                 var patternParts = searchPattern.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
-                _lastPatternPart = patternParts.Last();
+                _lastPatternPart = patternParts.LastOrDefault();
             }
-            else
-            {
-                _lastPatternPart = searchPattern;
-            }
+
+            _entireSearchPattern = searchPattern;
+            _lastPatternPart = _lastPatternPart ?? searchPattern;
         }
 
         public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,11 +16,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 {
     internal sealed class SearchGraphQuery : IGraphQuery
     {
-        private readonly string _searchPattern;
+        private static readonly char[] DotCharacterArray = new[] { '.' };
+
+        private readonly string _lastPatternPart;
+        private readonly string _entireSearchPattern;
 
         public SearchGraphQuery(string searchPattern)
         {
-            _searchPattern = searchPattern;
+            _entireSearchPattern = searchPattern;
+
+            // If the pattern has a dot in it, then when we search the compilations, we actually
+            // want to only filter by the last name portion of hte pattern (as the compilers 
+            // only support returning the basic name of a symbol when searching and filtering 
+            // them).  Then, once we have all the results the compiler returned, we check and
+            // verify they match against the full dotted pattern.
+            if (searchPattern.Contains("."))
+            {
+                var patternParts = searchPattern.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
+                _lastPatternPart = patternParts.Last();
+            }
+            else
+            {
+                _lastPatternPart = searchPattern;
+            }
         }
 
         public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
@@ -39,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             {
                 using (cacheService.EnableCaching(project.Id))
                 {
-                    var results = await FindNavigableSourceSymbolsAsync(project, _searchPattern, cancellationToken).ConfigureAwait(false);
+                    var results = await FindNavigableSourceSymbolsAsync(project, cancellationToken).ConfigureAwait(false);
 
                     foreach (var result in results)
                     {
@@ -102,14 +121,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             return memberNode;
         }
 
-        internal static async Task<IEnumerable<ValueTuple<ISymbol, IEnumerable<PatternMatch>>>> FindNavigableSourceSymbolsAsync(
-            Project project, string pattern, CancellationToken cancellationToken)
+        internal async Task<IEnumerable<ValueTuple<ISymbol, IEnumerable<PatternMatch>>>> FindNavigableSourceSymbolsAsync(
+            Project project, CancellationToken cancellationToken)
         {
             var results = new List<ValueTuple<ISymbol, IEnumerable<PatternMatch>>>();
 
             var patternMatcher = new PatternMatcher();
             var symbols = await SymbolFinder.FindSourceDeclarationsAsync(
-                project, k => patternMatcher.MatchPattern(k, pattern) != null, SymbolFilter.TypeAndMember, cancellationToken).ConfigureAwait(false);
+                project, k => patternMatcher.MatchPattern(k, _lastPatternPart) != null, SymbolFilter.TypeAndMember, cancellationToken).ConfigureAwait(false);
 
             symbols = symbols.Where(s =>
                 !s.IsConstructor()
@@ -121,7 +140,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var matches = patternMatcher.MatchPattern(GetSearchName(symbol), pattern);
+                // If the search query included a dotted pattern, then verify that this symbol, and 
+                // it's container, matches the dotted pattern.
+                var matches = _lastPatternPart == null
+                    ? patternMatcher.MatchPattern(GetSearchName(symbol), _entireSearchPattern)
+                    : patternMatcher.MatchPattern(GetSearchName(symbol), GetContainer(symbol), _entireSearchPattern);
+
+                if (matches == null)
+                {
+                    continue;
+                }
+
                 results.Add(ValueTuple.Create(symbol, matches));
 
                 // also report matching constructors (using same match result as type)
@@ -147,6 +176,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
 
             return results;
+        }
+
+        public static readonly SymbolDisplayFormat DottedNameFormat =
+            new SymbolDisplayFormat(
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                delegateStyle: SymbolDisplayDelegateStyle.NameOnly,
+                extensionMethodStyle: SymbolDisplayExtensionMethodStyle.StaticMethod,
+                propertyStyle: SymbolDisplayPropertyStyle.NameOnly);
+
+        private static string GetContainer(ISymbol symbol)
+        {
+            var container = symbol.ContainingSymbol;
+            if (container == null)
+            {
+                return null;
+            }
+
+            return container.ToDisplayString(DottedNameFormat);
         }
 
         private static string GetSearchName(ISymbol symbol)

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
@@ -252,5 +252,129 @@ End Namespace
                     </DirectedGraph>)
             End Using
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Sub SearchForDottedName1()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
+                            <Document FilePath="Z:\Project.cs">
+                                class Dog { void Bark() { } }
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim outputContext = testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="D.B"), GraphContextDirection.Custom)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes>
+                            <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
+                            <Node Id="(@3 Type=Dog Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
+                            <Node Id="(@3 Type=Dog)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog"/>
+                        </Nodes>
+                        <Links>
+                            <Link Source="(@1 @2)" Target="(@3 Type=Dog)" Category="Contains"/>
+                            <Link Source="(@3 Type=Dog)" Target="(@3 Type=Dog Member=Bark)" Category="Contains"/>
+                        </Links>
+                        <IdentifierAliases>
+                            <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
+                            <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
+                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
+                        </IdentifierAliases>
+                    </DirectedGraph>)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Sub SearchForDottedName2()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
+                            <Document FilePath="Z:\Project.cs">
+                                class Dog { void Bark() { } }
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim outputContext = testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="C.B"), GraphContextDirection.Custom)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes/>
+                        <Links/>
+                    </DirectedGraph>)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Sub SearchForDottedName3()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
+                            <Document FilePath="Z:\Project.cs">
+                                namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim outputContext = testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="D.B"), GraphContextDirection.Custom)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes>
+                            <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
+                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
+                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
+                        </Nodes>
+                        <Links>
+                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
+                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                        </Links>
+                        <IdentifierAliases>
+                            <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
+                            <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
+                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
+                        </IdentifierAliases>
+                    </DirectedGraph>)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Sub SearchForDottedName4()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
+                            <Document FilePath="Z:\Project.cs">
+                                namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim outputContext = testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="A.D.B"), GraphContextDirection.Custom)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes>
+                            <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
+                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
+                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
+                        </Nodes>
+                        <Links>
+                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
+                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                        </Links>
+                        <IdentifierAliases>
+                            <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
+                            <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
+                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
+                        </IdentifierAliases>
+                    </DirectedGraph>)
+            End Using
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Expose new dotted-pattern matching capabilities from the Pattern matcher.

This will allow other features (like searching in Solution Explorer) to use the same searching facilities that we've just added to NavigateTo.

Also added support to Progression to search for dotted names.