### PR TITLE
Substitute generic type arguments for generic frames in the Call Stack Window.

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Rewriters\LocalDeclarationRewriter.cs" />
     <Compile Include="Rewriters\MayHaveSideEffectsVisitor.cs" />
     <Compile Include="Rewriters\PlaceholderLocalRewriter.cs" />
+    <Compile Include="SymbolExtensions.cs" />
     <Compile Include="Symbols\DisplayClassInstance.cs" />
     <Compile Include="Symbols\DisplayClassVariable.cs" />
     <Compile Include="Symbols\EEDisplayClassFieldLocalSymbol.cs" />

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpFrameDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpFrameDecoder.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     [DkmReportNonFatalWatsonException(ExcludeExceptionType = typeof(NotImplementedException)), DkmContinueCorruptingException]
-    internal sealed class CSharpFrameDecoder : FrameDecoder
+    internal sealed class CSharpFrameDecoder : FrameDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
     {
         public CSharpFrameDecoder()
             : base(CSharpInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
+using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -9,7 +11,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal sealed class CSharpInstructionDecoder : InstructionDecoder<PEMethodSymbol>
+    internal sealed class CSharpInstructionDecoder : InstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
     {
         // This string was not localized in the old EE.  We'll keep it that way
         // so as not to break consumers who may have been parsing frame names...
@@ -28,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             AddMemberOptions(SymbolDisplayMemberOptions.IncludeParameters).
             WithParameterOptions(SymbolDisplayParameterOptions.IncludeType);
 
-        internal override void AppendFullName(StringBuilder builder, PEMethodSymbol method)
+        internal override void AppendFullName(StringBuilder builder, MethodSymbol method)
         {
             var displayFormat =
                 ((method.MethodKind == MethodKind.PropertyGet) || (method.MethodKind == MethodKind.PropertySet)) ?
@@ -86,7 +88,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
         }
 
-        internal override PEMethodSymbol GetMethod(DkmClrInstructionAddress instructionAddress)
+        internal override MethodSymbol ConstructMethod(MethodSymbol method, ImmutableArray<TypeParameterSymbol> typeParameters, ImmutableArray<TypeSymbol> typeArguments)
+        {
+            var methodArity = method.Arity;
+            var methodArgumentStartIndex = typeParameters.Length - methodArity;
+            var typeMap = new TypeMap(
+                ImmutableArray.Create(typeParameters, 0, methodArgumentStartIndex),
+                ImmutableArray.Create(typeArguments, 0, methodArgumentStartIndex));
+            var substitutedType = typeMap.SubstituteNamedType(method.ContainingType);
+            method = method.AsMember(substitutedType);
+            if (methodArity > 0)
+            {
+                method = method.Construct(ImmutableArray.Create(typeArguments, methodArgumentStartIndex, methodArity));
+            }
+            return method;
+        }
+
+        internal override ImmutableArray<TypeParameterSymbol> GetAllTypeParameters(MethodSymbol method)
+        {
+            return method.GetAllTypeParameters();
+        }
+
+        internal override CSharpCompilation GetCompilation(DkmClrInstructionAddress instructionAddress)
         {
             var moduleInstance = instructionAddress.ModuleInstance;
             var appDomain = moduleInstance.AppDomain;
@@ -105,7 +128,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 compilation = dataItem.Compilation;
             }
 
-            return compilation.GetSourceMethod(moduleInstance.Mvid, instructionAddress.MethodId.Token);
+            return compilation;
+        }
+
+        internal override MethodSymbol GetMethod(CSharpCompilation compilation, DkmClrInstructionAddress instructionAddress)
+        {
+            return compilation.GetSourceMethod(instructionAddress.ModuleInstance.Mvid, instructionAddress.MethodId.Token);
+        }
+
+        internal override TypeNameDecoder<PEModuleSymbol, TypeSymbol> GetTypeNameDecoder(CSharpCompilation compilation, MethodSymbol method)
+        {
+            Debug.Assert(method is PEMethodSymbol);
+            return new EETypeNameDecoder(compilation, (PEModuleSymbol)method.ContainingModule);
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLanguageInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLanguageInstructionDecoder.cs
@@ -2,12 +2,13 @@
 
 using System;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     [DkmReportNonFatalWatsonException(ExcludeExceptionType = typeof(NotImplementedException)), DkmContinueCorruptingException]
-    internal sealed class CSharpLanguageInstructionDecoder : LanguageInstructionDecoder<PEMethodSymbol>
+    internal sealed class CSharpLanguageInstructionDecoder : LanguageInstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
     {
         public CSharpLanguageInstructionDecoder()
             : base(CSharpInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -245,14 +245,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return module;
         }
 
-        private static ImmutableArray<TypeParameterSymbol> GetAllTypeParameters(MethodSymbol method)
-        {
-            var builder = ArrayBuilder<TypeParameterSymbol>.GetInstance();
-            method.ContainingType.GetAllTypeParameters(builder);
-            builder.AddRange(method.TypeParameters);
-            return builder.ToImmutableAndFree();
-        }
-
         private static string GetNextMethodName(ArrayBuilder<MethodSymbol> builder)
         {
             return string.Format("<>m{0}", builder.Count);
@@ -270,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             DiagnosticBag diagnostics)
         {
             var objectType = this.Compilation.GetSpecialType(SpecialType.System_Object);
-            var allTypeParameters = GetAllTypeParameters(_currentFrame);
+            var allTypeParameters = _currentFrame.GetAllTypeParameters();
             var additionalTypes = ArrayBuilder<NamedTypeSymbol>.GetInstance();
 
             EENamedTypeSymbol typeVariablesType = null;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+{
+    internal static class SymbolExtensions
+    {
+        internal static ImmutableArray<TypeParameterSymbol> GetAllTypeParameters(this MethodSymbol method)
+        {
+            var builder = ArrayBuilder<TypeParameterSymbol>.GetInstance();
+            method.ContainingType.GetAllTypeParameters(builder);
+            builder.AddRange(method.TypeParameters);
+            return builder.ToImmutableAndFree();
+        }
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection.Metadata.Ecma335;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -14,8 +17,90 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     public class InstructionDecoderTests : ExpressionCompilerTestBase
     {
+        [Fact]
+        void GetNameGenerics()
+        {
+            var source = @"
+using System;
+class Class1<T>
+{
+    void M1<U>(Action<Int32> a)
+    {
+    }
+    void M2<U>(Action<T> a)
+    {
+    }
+    void M3<U>(Action<U> a)
+    {
+    }
+}";
+
+            Assert.Equal(
+                "Class1<T>.M1<U>(System.Action<int> a)",
+                GetName(source, "Class1.M1", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types));
+
+            Assert.Equal(
+                "Class1<T>.M2<U>(System.Action<T> a)",
+                GetName(source, "Class1.M2", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types));
+
+            Assert.Equal(
+                "Class1<T>.M3<U>(System.Action<U> a)",
+                GetName(source, "Class1.M3", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types));
+
+            Assert.Equal(
+                "Class1<string>.M1<decimal>(System.Action<int> a)",
+                GetName(source, "Class1.M1", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, new[] { typeof(string), typeof(decimal) }));
+
+            Assert.Equal(
+                "Class1<string>.M2<decimal>(System.Action<string> a)",
+                GetName(source, "Class1.M2", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, new[] { typeof(string), typeof(decimal) }));
+
+            Assert.Equal(
+                "Class1<string>.M3<decimal>(System.Action<decimal> a)",
+                GetName(source, "Class1.M3", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, new[] { typeof(string), typeof(decimal) }));
+        }
+
+        [Fact]
+        void GetNameNullTypeArguments()
+        {
+            var source = @"
+using System;
+class Class1<T>
+{
+    void M<U>(Action<U> a)
+    {
+    }
+}";
+
+            Assert.Equal(
+                "Class1<T>.M<U>(System.Action<U> a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, typeArguments: new Type[] { null, null }));
+
+            Assert.Equal(
+                "Class1<T>.M<U>(System.Action<U> a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, typeArguments: new[] { typeof(string), null }));
+
+            Assert.Equal(
+                "Class1<T>.M<U>(System.Action<U> a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, typeArguments: new[] { null, typeof(decimal) }));
+        }
+
+        [Fact]
+        void GetNameGenericArgumentTypeNotInReferences()
+        {
+            var source = @"
+class Class1
+{
+}";
+
+            var serializedTypeArgumentName = "Class1, " + nameof(InstructionDecoderTests) + ", Culture=neutral, PublicKeyToken=null";
+            Assert.Equal(
+                "System.Collections.Generic.Comparer<Class1>.Create(System.Comparison<Class1> comparison)",
+                GetName(source, "System.Collections.Generic.Comparer.Create", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, typeArguments: new[] { serializedTypeArgumentName }));
+        }
+
         [Fact, WorkItem(1107977)]
-        public void GetNameGenericAsync()
+        void GetNameGenericAsync()
         {
             var source = @"
 using System.Threading.Tasks;
@@ -29,12 +114,12 @@ class C
 }";
 
             Assert.Equal(
-                    "C.M<T>(T x)",
-                    GetName(source, "C.<M>d__0.MoveNext", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types));
+                    "C.M<System.Exception>(System.Exception x)",
+                    GetName(source, "C.<M>d__0.MoveNext", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, new[] { typeof(Exception) }));
         }
 
         [Fact]
-        public void GetNameLambda()
+        void GetNameLambda()
         {
             var source = @"
 using System;
@@ -52,7 +137,7 @@ class C
         }
 
         [Fact]
-        public void GetNameGenericLambda()
+        void GetNameGenericLambda()
         {
             var source = @"
 using System;
@@ -65,12 +150,12 @@ class C<T>
 }";
 
             Assert.Equal(
-                "C<T>.M.AnonymousMethod__0_0(U u)",
-                GetName(source, "C.<>c__0.<M>b__0_0", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types));
+                "C<System.Exception>.M.AnonymousMethod__0_0(System.ArgumentException u)",
+                GetName(source, "C.<>c__0.<M>b__0_0", DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types, new[] { typeof(Exception), typeof(ArgumentException) }));
         }
 
         [Fact]
-        public void GetNameProperties()
+        void GetNameProperties()
         {
             var source = @"
 class C
@@ -101,7 +186,7 @@ class C
         }
 
         [Fact]
-        public void GetNameExplicitInterfaceImplementation()
+        void GetNameExplicitInterfaceImplementation()
         {
             var source = @"
 using System;
@@ -116,7 +201,7 @@ class C : IDisposable
         }
 
         [Fact]
-        public void GetNameExtensionMethod()
+        void GetNameExtensionMethod()
         {
             var source = @"
 static class Extensions
@@ -130,7 +215,7 @@ static class Extensions
         }
 
         [Fact]
-        public void GetNameArgumentFlagsNone()
+        void GetNameArgumentFlagsNone()
         {
             var source = @"
 static class C
@@ -148,12 +233,126 @@ static class C
                 GetName(source, "C.M2", DkmVariableInfoFlags.None));
         }
 
-        private string GetName(string source, string methodName, DkmVariableInfoFlags argumentFlags, params string[] argumentValues)
+        [Fact]
+        void GetReturnTypeNamePrimitive()
+        {
+            var source = @"
+static class C
+{
+    static uint M1() { return 42; }
+}";
+
+            Assert.Equal("uint", GetReturnTypeName(source, "C.M1"));
+        }
+
+        [Fact]
+        void GetReturnTypeNameNested()
+        {
+            var source = @"
+static class C
+{
+    static N.D.E M1() { return default(N.D.E); }
+}
+namespace N
+{
+    class D
+    {
+        internal struct E
+        {
+        }
+    }
+}";
+
+            Assert.Equal("N.D.E", GetReturnTypeName(source, "C.M1"));
+        }
+
+        [Fact]
+        void GetReturnTypeNameGenericOfPrimitive()
+        {
+            var source = @"
+using System;
+class C
+{
+    Action<Int32> M1() { return null; }
+}";
+
+            Assert.Equal("System.Action<int>", GetReturnTypeName(source, "C.M1"));
+        }
+
+        [Fact]
+        void GetReturnTypeNameGenericOfNested()
+        {
+            var source = @"
+using System;
+class C
+{
+    Action<D> M1() { return null; }
+    class D
+    {
+    }
+}";
+
+            Assert.Equal("System.Action<C.D>", GetReturnTypeName(source, "C.M1"));
+        }
+
+        [Fact]
+        void GetReturnTypeNameGenericOfGeneric()
+        {
+            var source = @"
+using System;
+class C
+{
+    Action<Func<T>> M1<T>() { return null; }
+}";
+
+            Assert.Equal("System.Action<System.Func<object>>", GetReturnTypeName(source, "C.M1", new[] { typeof(object) }));
+        }
+
+        private string GetName(string source, string methodName, DkmVariableInfoFlags argumentFlags, Type[] typeArguments = null, string[] argumentValues = null)
+        {
+            var serializedTypeArgumentNames = typeArguments?.Select(t => t?.AssemblyQualifiedName).ToArray();
+            return GetName(source, methodName, argumentFlags, serializedTypeArgumentNames, argumentValues);
+        }
+
+        private string GetName(string source, string methodName, DkmVariableInfoFlags argumentFlags, string[] typeArguments, string[] argumentValues = null)
         {
             Debug.Assert((argumentFlags & (DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types)) == argumentFlags,
                 "Unexpected argumentFlags", "argumentFlags = {0}", argumentFlags);
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            var instructionDecoder = CSharpInstructionDecoder.Instance;
+            var method = GetConstructedMethod(source, methodName, typeArguments, instructionDecoder);
+
+            var includeParameterTypes = argumentFlags.Includes(DkmVariableInfoFlags.Types);
+            var includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names);
+            ArrayBuilder<string> builder = null;
+            if (argumentValues != null)
+            {
+                Assert.InRange(argumentValues.Length, 1, int.MaxValue);
+                builder = ArrayBuilder<string>.GetInstance();
+                builder.AddRange(argumentValues);
+            }
+
+            var name = instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, builder);
+            if (builder != null)
+            {
+                builder.Free();
+            }
+
+            return name;
+        }
+
+        private string GetReturnTypeName(string source, string methodName, Type[] typeArguments = null)
+        {
+            var instructionDecoder = CSharpInstructionDecoder.Instance;
+            var serializedTypeArgumentNames = typeArguments?.Select(t => (t != null) ? t.AssemblyQualifiedName : null).ToArray();
+            var method = GetConstructedMethod(source, methodName, serializedTypeArgumentNames, instructionDecoder);
+
+            return instructionDecoder.GetReturnTypeName(method);
+        }
+
+        private MethodSymbol GetConstructedMethod(string source, string methodName, string[] serializedTypeArgumentNames, CSharpInstructionDecoder instructionDecoder)
+        {
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: nameof(InstructionDecoderTests));
             var runtime = CreateRuntimeInstance(compilation);
             var moduleInstances = runtime.Modules;
             var blocks = moduleInstances.SelectAsArray(m => m.MetadataBlock);
@@ -163,26 +362,25 @@ static class C
             // Once we have the method token, we want to look up the method (again)
             // using the same helper as the product code.  This helper will also map
             // async/iterator "MoveNext" methods to the original source method.
-            var method = compilation.GetSourceMethod(
+            MethodSymbol method = compilation.GetSourceMethod(
                 ((PEModuleSymbol)frame.ContainingModule).Module.GetModuleVersionIdOrThrow(),
                 MetadataTokens.GetToken(frame.Handle));
-            var includeParameterTypes = argumentFlags.Includes(DkmVariableInfoFlags.Types);
-            var includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names);
-            ArrayBuilder<string> builder = null;
-            if (argumentValues.Length > 0)
+            if (serializedTypeArgumentNames != null)
             {
-                builder = ArrayBuilder<string>.GetInstance();
-                builder.AddRange(argumentValues);
+                Assert.NotEmpty(serializedTypeArgumentNames);
+                var typeParameters = instructionDecoder.GetAllTypeParameters(method);
+                Assert.NotEmpty(typeParameters);
+                var typeNameDecoder = new EETypeNameDecoder(compilation, (PEModuleSymbol)method.ContainingModule);
+                // Use the same helper method as the FrameDecoder to get the TypeSymbols for the
+                // generic type arguments (rather than using EETypeNameDecoder directly).
+                var typeArguments = instructionDecoder.GetTypeSymbols(compilation, method, serializedTypeArgumentNames);
+                if (!typeArguments.IsEmpty)
+                {
+                    method = instructionDecoder.ConstructMethod(method, typeParameters, typeArguments);
+                }
             }
 
-            var frameDecoder = CSharpInstructionDecoder.Instance;
-            var frameName = frameDecoder.GetName(method, includeParameterTypes, includeParameterNames, builder);
-            if (builder != null)
-            {
-                builder.Free();
-            }
-
-            return frameName;
+            return method;
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
@@ -7,13 +8,12 @@ using Microsoft.VisualStudio.Debugger.Clr;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal abstract class InstructionDecoder
-    {
-        internal abstract string GetName(DkmClrInstructionAddress instructionAddress, bool includeParameterTypes, bool includeParameterNames, ArrayBuilder<string> argumentValues);
-        internal abstract string GetReturnType(DkmClrInstructionAddress instructionAddress);
-    }
-
-    internal abstract class InstructionDecoder<TMethodSymbol> : InstructionDecoder where TMethodSymbol : class, IMethodSymbol
+    internal abstract class InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol>
+        where TCompilation : Compilation
+        where TMethodSymbol : class, IMethodSymbol
+        where TModuleSymbol : class, IModuleSymbol
+        where TTypeSymbol : class, ITypeSymbol
+        where TTypeParameterSymbol : class, ITypeParameterSymbol
     {
         internal static readonly SymbolDisplayFormat DisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
@@ -21,21 +21,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeExplicitInterface,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        internal override string GetName(DkmClrInstructionAddress instructionAddress, bool includeParameterTypes, bool includeParameterNames, ArrayBuilder<string> argumentValues)
-        {
-            var method = this.GetMethod(instructionAddress);
-            return this.GetName(method, includeParameterTypes, includeParameterNames, argumentValues);
-        }
-
-        internal override string GetReturnType(DkmClrInstructionAddress instructionAddress)
-        {
-            var method = this.GetMethod(instructionAddress);
-            return method.ReturnType.ToDisplayString(DisplayFormat);
-        }
-
         internal abstract void AppendFullName(StringBuilder builder, TMethodSymbol method);
 
-        internal abstract TMethodSymbol GetMethod(DkmClrInstructionAddress instructionAddress);
+        /// <summary>
+        /// Constructs a method and any of its generic containing types using the specified <paramref name="typeArguments"/>.
+        /// </summary>
+        internal abstract TMethodSymbol ConstructMethod(TMethodSymbol method, ImmutableArray<TTypeParameterSymbol> typeParameters, ImmutableArray<TTypeSymbol> typeArguments);
+
+        internal abstract ImmutableArray<TTypeParameterSymbol> GetAllTypeParameters(TMethodSymbol method);
+
+        internal abstract TCompilation GetCompilation(DkmClrInstructionAddress instructionAddress);
+
+        internal abstract TMethodSymbol GetMethod(TCompilation compilation, DkmClrInstructionAddress instructionAddress);
 
         internal string GetName(TMethodSymbol method, bool includeParameterTypes, bool includeParameterNames, ArrayBuilder<string> argumentValues = null)
         {
@@ -95,6 +92,34 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
 
             return pooled.ToStringAndFree();
+        }
+
+        internal string GetReturnTypeName(TMethodSymbol method)
+        {
+            return method.ReturnType.ToDisplayString(DisplayFormat);
+        }
+
+        internal abstract TypeNameDecoder<TModuleSymbol, TTypeSymbol> GetTypeNameDecoder(TCompilation compilation, TMethodSymbol method);
+
+        internal ImmutableArray<TTypeSymbol> GetTypeSymbols(TCompilation compilation, TMethodSymbol method, string[] serializedTypeNames)
+        {
+            var builder = ArrayBuilder<TTypeSymbol>.GetInstance();
+            foreach (var name in serializedTypeNames)
+            {
+                // The list of type names will include null values if type arguments are not available.
+                // It seems unlikely that only some type arguments will be missing (and it also seems
+                // like very little incremental value to include only some of the arguments), so we'll
+                // keep things simple and omit all type arguments if any are missing.
+                if (name == null)
+                {
+                    builder.Free();
+                    return ImmutableArray<TTypeSymbol>.Empty;
+                }
+
+                var typeNameDecoder = GetTypeNameDecoder(compilation, method);
+                builder.Add(typeNameDecoder.GetTypeSymbolForSerializedType(name));
+            }
+            return builder.ToImmutableAndFree();
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
@@ -17,11 +17,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     /// <summary>
     /// This class provides function name information for the Breakpoints window.
     /// </summary>
-    internal abstract class LanguageInstructionDecoder<TMethodSymbol> : IDkmLanguageInstructionDecoder where TMethodSymbol : class, IMethodSymbol
+    internal abstract class LanguageInstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> : IDkmLanguageInstructionDecoder
+        where TCompilation : Compilation
+        where TMethodSymbol : class, IMethodSymbol
+        where TModuleSymbol : class, IModuleSymbol
+        where TTypeSymbol : class, ITypeSymbol
+        where TTypeParameterSymbol : class, ITypeParameterSymbol
     {
-        private readonly InstructionDecoder<TMethodSymbol> _instructionDecoder;
+        private readonly InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> _instructionDecoder;
 
-        internal LanguageInstructionDecoder(InstructionDecoder<TMethodSymbol> instructionDecoder)
+        internal LanguageInstructionDecoder(InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> instructionDecoder)
         {
             _instructionDecoder = instructionDecoder;
         }
@@ -37,7 +42,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 Debug.Assert((argumentFlags & (DkmVariableInfoFlags.FullNames | DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types)) == argumentFlags,
                     "Unexpected argumentFlags", "argumentFlags = {0}", argumentFlags);
 
-                var method = _instructionDecoder.GetMethod((DkmClrInstructionAddress)languageInstructionAddress.Address);
+                var instructionAddress = (DkmClrInstructionAddress)languageInstructionAddress.Address;
+                var compilation = _instructionDecoder.GetCompilation(instructionAddress);
+                var method = _instructionDecoder.GetMethod(compilation, instructionAddress);
                 var includeParameterTypes = argumentFlags.Includes(DkmVariableInfoFlags.Types);
                 var includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names);
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -1,4 +1,6 @@
-﻿Imports System
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System
 Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
@@ -171,13 +173,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             resultProperties = properties
             Return moduleBuilder
-        End Function
-
-        Private Shared Function GetAllTypeParameters(method As MethodSymbol) As ImmutableArray(Of TypeParameterSymbol)
-            Dim builder = ArrayBuilder(Of TypeParameterSymbol).GetInstance()
-            method.ContainingType.GetAllTypeParameters(builder)
-            builder.AddRange(method.TypeParameters)
-            Return builder.ToImmutableAndFree()
         End Function
 
         Private Shared Function GetNextMethodName(builder As ArrayBuilder(Of MethodSymbol)) As String

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
@@ -1,4 +1,7 @@
-﻿Imports System.Runtime.CompilerServices
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Runtime.CompilerServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
@@ -58,6 +61,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         <Extension>
         Friend Function IsStateMachineType(type As TypeSymbol) As Boolean
             Return type.Name.StartsWith(StringConstants.StateMachineTypeNamePrefix, StringComparison.Ordinal)
+        End Function
+
+        <Extension>
+        Friend Function GetAllTypeParameters(method As MethodSymbol) As ImmutableArray(Of TypeParameterSymbol)
+            Dim builder = ArrayBuilder(Of TypeParameterSymbol).GetInstance()
+            method.ContainingType.GetAllTypeParameters(builder)
+            builder.AddRange(method.TypeParameters)
+            Return builder.ToImmutableAndFree()
         End Function
     End Module
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicFrameDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicFrameDecoder.vb
@@ -1,9 +1,13 @@
-﻿Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     <DkmReportNonFatalWatsonException(ExcludeExceptionType:=GetType(NotImplementedException)), DkmContinueCorruptingException>
-    Friend NotInheritable Class VisualBasicFrameDecoder : Inherits FrameDecoder
+    Friend NotInheritable Class VisualBasicFrameDecoder : Inherits FrameDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol)
 
         Public Sub New()
             MyBase.New(VisualBasicInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLanguageInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLanguageInstructionDecoder.vb
@@ -1,10 +1,13 @@
-﻿Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     <DkmReportNonFatalWatsonException(ExcludeExceptionType:=GetType(NotImplementedException)), DkmContinueCorruptingException>
-    Friend NotInheritable Class VisualBasicLanguageInstructionDecoder : Inherits LanguageInstructionDecoder(Of PEMethodSymbol)
+    Friend NotInheritable Class VisualBasicLanguageInstructionDecoder : Inherits LanguageInstructionDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol)
 
         Public Sub New()
             MyBase.New(VisualBasicInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -1,4 +1,6 @@
-﻿Imports System.Collections.Immutable
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
 Imports System.Globalization
 Imports System.Reflection.Metadata
 Imports System.Threading

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
@@ -1,4 +1,7 @@
-﻿Imports System.Reflection.Metadata.Ecma335
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Reflection.Metadata.Ecma335
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -20,11 +23,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     '// TODO: string argument values requiring quotes
     '// TODO: argument flags == names only, types only, values only
     '// TODO: params Argument values
-    '// TODO: GetFrameReturnType primitive types
-    '// TODO: GetFrameReturnType non-primitive types (nested namespace/class)
-    '// TODO: GetFrameReturnType generic(Of non-primitive, nested)
-    '// TODO: GetFrameReturnType generic(Of generic)
-    '// TODO: GetFrameReturnType generic(Of primitive)
+    '// TODO: generic class/method with 2 or more type parameters
+    '// TODO: generic argument type that is not from a referenced assembly
     Public Class InstructionDecoderTests : Inherits ExpressionCompilerTestBase
 
         <Fact>
@@ -85,7 +85,6 @@ Class Class1(Of T)
     Sub M3(Of U)(a As Action(Of U))
     End Sub
 End Class"
-            ' TODO: Type parameters should be substituted with type arguments once we have an API to retrieve them.
 
             Assert.Equal(
                 "Class1(Of T).M1(Of U)(System.Action(Of Integer) a)",
@@ -98,6 +97,52 @@ End Class"
             Assert.Equal(
                 "Class1(Of T).M3(Of U)(System.Action(Of U) a)",
                 GetName(source, "Class1.M3", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types))
+
+            Assert.Equal(
+                "Class1(Of String).M1(Of Decimal)(System.Action(Of Integer) a)",
+                GetName(source, "Class1.M1", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(String), GetType(Decimal)}))
+
+            Assert.Equal(
+                "Class1(Of String).M2(Of Decimal)(System.Action(Of String) a)",
+                GetName(source, "Class1.M2", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(String), GetType(Decimal)}))
+
+            Assert.Equal(
+                "Class1(Of String).M3(Of Decimal)(System.Action(Of Decimal) a)",
+                GetName(source, "Class1.M3", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(String), GetType(Decimal)}))
+        End Sub
+
+        <Fact>
+        Sub GetNameNullTypeArguments()
+            Dim source = "
+Imports System
+Class Class1(Of T)
+    Sub M(Of U)(a As Action(Of U))
+    End Sub
+End Class"
+
+            Assert.Equal(
+                "Class1(Of T).M(Of U)(System.Action(Of U) a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:=New Type() {Nothing, Nothing}))
+
+            Assert.Equal(
+                "Class1(Of T).M(Of U)(System.Action(Of U) a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(String), Nothing}))
+
+            Assert.Equal(
+                "Class1(Of T).M(Of U)(System.Action(Of U) a)",
+                GetName(source, "Class1.M", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={Nothing, GetType(Decimal)}))
+        End Sub
+
+        <Fact>
+        Sub GetNameGenericArgumentTypeNotInReferences()
+            Dim source = "
+Class Class1
+End Class"
+
+            Dim serializedTypeArgumentName = "Class1, " & NameOf(InstructionDecoderTests) & ", Culture=neutral, PublicKeyToken=null"
+            Assert.Equal(
+                "System.Collections.Generic.Comparer(Of Class1).Create(System.Comparison(Of Class1) comparison)",
+                GetName(source, "System.Collections.Generic.Comparer.Create", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={serializedTypeArgumentName}))
         End Sub
 
         <Fact>
@@ -130,8 +175,8 @@ Class C
 End Class"
 
             Assert.Equal(
-                "C.M(Of T)(T x)",
-                GetName(source, "C.VB$StateMachine_1_M.MoveNext", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types))
+                "C.M(Of Long)(Long x)",
+                GetName(source, "C.VB$StateMachine_1_M.MoveNext", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(Long)}))
         End Sub
 
         <Fact>
@@ -175,10 +220,10 @@ Class Class1(Of T)
         Dim f As Func(Of U, T) = Function(u2 As U) u2
     End Sub
 End Class"
-            ' TODO: Type parameter $CLS0 should be substituted with a type argument once we have an API to retrieve it.
+
             Assert.Equal(
-                "Class1(Of T).<closure>.<lambda1-1>($CLS0 u2)",
-                GetName(source, "Class1._Closure$__1._Lambda$__1-1", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types))
+                "Class1(Of System.Exception).<closure>.<lambda1-1>(System.ArgumentException u2)",
+                GetName(source, "Class1._Closure$__1._Lambda$__1-1", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, typeArguments:={GetType(Exception), GetType(ArgumentException)}))
         End Sub
 
         <Fact>
@@ -196,7 +241,7 @@ End Module"
 
             Assert.Equal(
                 "Module1.M(Date d = #6/23/1912#)",
-                GetName(source, "Module1.M", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, "#6/23/1912#"))
+                GetName(source, "Module1.M", DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types, argumentValues:={"#6/23/1912#"}))
         End Sub
 
         <Fact>
@@ -284,14 +329,120 @@ End Module"
                 GetName(source, "Module1.M2", DkmVariableInfoFlags.None))
         End Sub
 
-        Private Function GetName(source As String, methodName As String, argumentFlags As DkmVariableInfoFlags, ParamArray argumentValues() As String) As String
+        <Fact>
+        Sub GetReturnTypeNamePrimitive()
+            Dim source = "
+Class C
+    Function M1() As UInteger
+        Return 42
+    End Function
+End Class"
+
+            Assert.Equal("UInteger", GetReturnTypeName(source, "C.M1"))
+        End Sub
+
+        <Fact>
+        Sub GetReturnTypeNameNested()
+            Dim source = "
+Class C
+    Function M1() As N.D.E
+        Return Nothing
+    End Function
+End Class
+Namespace N
+    Class D
+        Friend Structure E
+        End Structure
+    End Class
+End Namespace"
+
+            Assert.Equal("N.D.E", GetReturnTypeName(source, "C.M1"))
+        End Sub
+
+        <Fact>
+        Sub GetReturnTypeNameGenericOfPrimitive()
+            Dim source = "
+Imports System
+Class C
+    Function M1() As Action(Of Int32)
+        Return Nothing
+    End Function
+End Class"
+
+            Assert.Equal("System.Action(Of Integer)", GetReturnTypeName(source, "C.M1"))
+        End Sub
+
+        <Fact>
+        Sub GetReturnTypeNameGenericOfNested()
+            Dim source = "
+Imports System
+Class C
+    Function M1() As Action(Of D)
+        Return Nothing
+    End Function
+    Class D
+    End Class
+End Class"
+
+            Assert.Equal("System.Action(Of C.D)", GetReturnTypeName(source, "C.M1"))
+        End Sub
+
+        <Fact>
+        Sub GetReturnTypeNameGenericOfGeneric()
+            Dim source = "
+Imports System
+Class C
+    Function M1(Of T)() As Action(Of Func(Of T))
+        Return Nothing
+    End Function
+End Class"
+
+            Assert.Equal("System.Action(Of System.Func(Of Object))", GetReturnTypeName(source, "C.M1", typeArguments:={GetType(Object)}))
+        End Sub
+
+        Private Function GetName(source As String, methodName As String, argumentFlags As DkmVariableInfoFlags, Optional typeArguments() As Type = Nothing, Optional argumentValues() As String = Nothing) As String
+            Dim serializedTypeArgumentNames = typeArguments?.Select(Function(t) t?.AssemblyQualifiedName).ToArray()
+            Return GetName(source, methodName, argumentFlags, serializedTypeArgumentNames, argumentValues)
+        End Function
+
+        Private Function GetName(source As String, methodName As String, argumentFlags As DkmVariableInfoFlags, typeArguments() As String, Optional argumentValues() As String = Nothing) As String
             Debug.Assert((argumentFlags And (DkmVariableInfoFlags.Names Or DkmVariableInfoFlags.Types)) = argumentFlags,
                 "Unexpected argumentFlags", "argumentFlags = {0}", argumentFlags)
 
+            Dim instructionDecoder = VisualBasicInstructionDecoder.Instance
+            Dim method = GetConstructedMethod(source, methodName, typeArguments, instructionDecoder)
+
+            Dim includeParameterTypes = argumentFlags.Includes(DkmVariableInfoFlags.Types)
+            Dim includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names)
+            Dim builder As ArrayBuilder(Of String) = Nothing
+            If argumentValues IsNot Nothing Then
+                Assert.InRange(argumentValues.Length, 1, Integer.MaxValue)
+                builder = ArrayBuilder(Of String).GetInstance()
+                builder.AddRange(argumentValues)
+            End If
+
+            Dim name = instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, builder)
+            If builder IsNot Nothing Then
+                builder.Free()
+            End If
+
+            Return name
+        End Function
+
+        Private Function GetReturnTypeName(source As String, methodName As String, Optional typeArguments() As Type = Nothing) As String
+            Dim instructionDecoder = VisualBasicInstructionDecoder.Instance
+            Dim serializedTypeArgumentNames = typeArguments?.Select(Function(t) t?.AssemblyQualifiedName).ToArray()
+            Dim method = GetConstructedMethod(source, methodName, serializedTypeArgumentNames, instructionDecoder)
+
+            Return instructionDecoder.GetReturnTypeName(method)
+        End Function
+
+        Private Function GetConstructedMethod(source As String, methodName As String, serializedTypeArgumentNames() As String, instructionDecoder As VisualBasicInstructionDecoder) As MethodSymbol
             Dim compilation = CreateCompilationWithReferences(
                 {VisualBasicSyntaxTree.ParseText(source)},
                 references:={MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929},
-                options:=TestOptions.DebugDll)
+                options:=TestOptions.DebugDll,
+                assemblyName:=NameOf(InstructionDecoderTests))
             Dim runtime = CreateRuntimeInstance(compilation)
             Dim moduleInstances = runtime.Modules
             Dim blocks = moduleInstances.SelectAsArray(Function(m) m.MetadataBlock)
@@ -301,26 +452,24 @@ End Module"
             ' Once we have the method token, we want to look up the method (again)
             ' using the same helper as the product code.  This helper will also map
             ' async/ iterator "MoveNext" methods to the original source method.
-            Dim method = compilation.GetSourceMethod(
+            Dim method As MethodSymbol = compilation.GetSourceMethod(
                 DirectCast(frame.ContainingModule, PEModuleSymbol).Module.GetModuleVersionIdOrThrow(),
                 MetadataTokens.GetToken(frame.Handle))
-            Dim includeParameterTypes = argumentFlags.Includes(DkmVariableInfoFlags.Types)
-            Dim includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names)
-            Dim builder As ArrayBuilder(Of String) = Nothing
-            If argumentValues.Length > 0 Then
-                builder = ArrayBuilder(Of String).GetInstance()
-                builder.AddRange(argumentValues)
+            If serializedTypeArgumentNames IsNot Nothing Then
+                Assert.NotEmpty(serializedTypeArgumentNames)
+                Dim typeParameters = instructionDecoder.GetAllTypeParameters(method)
+                Assert.NotEmpty(typeParameters)
+                Dim typeNameDecoder = New EETypeNameDecoder(compilation, DirectCast(method.ContainingModule, PEModuleSymbol))
+                ' Use the same helper method as the FrameDecoder to get the TypeSymbols for the
+                ' generic type arguments (rather than using EETypeNameDecoder directly).
+                Dim typeArgumentSymbols = instructionDecoder.GetTypeSymbols(compilation, method, serializedTypeArgumentNames)
+                If Not typeArgumentSymbols.IsEmpty Then
+                    method = instructionDecoder.ConstructMethod(method, typeParameters, typeArgumentSymbols)
+                End If
             End If
 
-            Dim frameDecoder = VisualBasicInstructionDecoder.Instance
-            Dim frameName = frameDecoder.GetName(method, includeParameterTypes, includeParameterNames, builder)
-            If builder IsNot Nothing Then
-                builder.Free()
-            End If
-
-            Return frameName
+            Return method
         End Function
-
     End Class
 
 End Namespace


### PR DESCRIPTION
This change also ensures that we get non-fatal Watson reports when we're in the continuation of a call to get generic type arguments or argument values from the debugee process.