### PR TITLE
Update the DeclarePublicAPI analyzer to consider return types

### DIFF
--- a/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIFix.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIFix.cs
@@ -47,7 +47,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
                 if (symbol != null)
                 {
                     var minimalSymbolName = symbol.ToMinimalDisplayString(semanticModel, location.SourceSpan.Start, DeclarePublicAPIAnalyzer.ShortSymbolNameFormat);
-                    var publicSurfaceAreaSymbolName = symbol.ToDisplayString(DeclarePublicAPIAnalyzer.PublicApiFormat);
+                    var publicSurfaceAreaSymbolName = DeclarePublicAPIAnalyzer.GetPublicApiName(symbol);
 
                     context.RegisterCodeFix(
                             new AdditionalDocumentChangeAction(
@@ -196,7 +196,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
 
                             if (symbol != null)
                             {
-                                var publicSurfaceAreaSymbolName = symbol.ToDisplayString(DeclarePublicAPIAnalyzer.PublicApiFormat);
+                                var publicSurfaceAreaSymbolName = DeclarePublicAPIAnalyzer.GetPublicApiName(symbol);
 
                                 if (symbol != null)
                                 {


### PR DESCRIPTION
Fixes #289.

The DeclarePublicAPI draws attention to changes to the public API
surface area in order to prevent breaking changes and to encourage
careful design when adding new APIs. It requires that every project with
a public API capture the public types and members in a file called
PublicAPI.txt, and creates errors when this file does not match the
actual symbols in the project. This makes changes very obvious in code
reviews and source control history.

Currently PublicAPI.txt does not capture the return types of members
(field, properties, methods, and events) so these can changes without it
being caught by the tool. This changes updates the analyzer to include
the return type.

A nice feature of the associated code fix is that it sorts PublicAPI.txt
alphabetically, and since type names are fully qualified this naturally
groups together types in the same namespace, members in the same type,
overloads, etc. To preserve this property we put the return type at the
end of the line, after the type and member name.