### PR TITLE
Don't preselect enums on backspace

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -613,6 +613,27 @@ End Module]]></Document>)
             End Using
         End Sub
 
+        <WorkItem(287, "https://github.com/dotnet/roslyn/issues/287")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NotEnumPreselectionAfterBackspace()
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Enum E
+    Bat
+End Enum
+ 
+Class C
+    Sub Test(param As E)
+        Dim b As E
+        Test(b.$$)
+    End Sub
+End Class]]></Document>)
+
+                state.SendBackspace()
+                state.AssertSelectedCompletionItem(displayText:="b", isHardSelected:=True)
+            End Using
+        End Sub
+
         <WorkItem(543496)>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Sub TestNumericLiteralWithNoMatch()

--- a/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
                 Dim prefixLength1 = GetPrefixLength(item1.FilterText, filterText)
                 Dim prefixLength2 = GetPrefixLength(item2.FilterText, filterText)
 
-                Return prefixLength1 > prefixLength2 OrElse (item1.Preselect AndAlso Not item2.Preselect)
+                Return prefixLength1 > prefixLength2 OrElse ((item1.Preselect AndAlso Not item2.Preselect) AndAlso TypeOf item1.CompletionProvider IsNot EnumCompletionProvider)
             End If
 
             If TypeOf item2.CompletionProvider Is EnumCompletionProvider Then


### PR DESCRIPTION
When backspacing in VB, we used to prefer preselected items over text
matches. Dev12 does this for object creation preseletion, but not enum
preselection. We should match that behavior.

Fixes #287.