### PR TITLE
Fix 353

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorTextFactoryService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorTextFactoryService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             var accessor = stream as ISupportDirectMemoryAccess;
             if (accessor != null)
             {
-                return CreateTextFromTemporaryStorage(accessor, (int)stream.Length, cancellationToken);
+                return CreateTextFromTemporaryStorage(accessor, (int)stream.Length, encoding, cancellationToken);
             }
 
             using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             }
         }
 
-        private unsafe SourceText CreateTextFromTemporaryStorage(ISupportDirectMemoryAccess accessor, int streamLength, CancellationToken cancellationToken)
+        private unsafe SourceText CreateTextFromTemporaryStorage(ISupportDirectMemoryAccess accessor, int streamLength, Encoding encoding, CancellationToken cancellationToken)
         {
             char* src = (char*)accessor.GetPointer();
             Debug.Assert(*src == 0xFEFF); // BOM: Unicode, little endian
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             using (var reader = new DirectMemoryAccessStreamReader(src + 1, streamLength / sizeof(char) - 1))
             {
                 var buffer = CreateTextBuffer(reader, cancellationToken);
-                return buffer.CurrentSnapshot.AsRoslynText(Encoding.Unicode);
+                return buffer.CurrentSnapshot.AsRoslynText(encoding ?? Encoding.Unicode);
             }
         }
 

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -53,13 +53,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 expectedEncoding: Encoding.UTF8);
         }
 
-        [Fact]
+        [Fact, WorkItem(353, "https://github.com/dotnet/roslyn/issues/353")]
         public void TestCreateFromTemporaryStorage()
         {
             var textFactory = CreateMockTextFactoryService();
             var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
 
-            var text = Text.SourceText.From("Hello, World!");
+            var originalEncoding = Encoding.ASCII;
+            var text = Text.SourceText.From("Hello, World!", originalEncoding);
 
             // Create a temporary storage location
             using (var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage(System.Threading.CancellationToken.None))
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
                 Assert.NotSame(text, text2);
                 Assert.Equal(text.ToString(), text2.ToString());
-                Assert.Equal(text2.Encoding, Encoding.Unicode);
+                Assert.Equal(originalEncoding, text2.Encoding);
             }
         }
 

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -79,7 +79,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.NotSame(text, text2);
             Assert.Equal(text.ToString(), text2.ToString());
-            Assert.Equal(text.Encoding, text2.Encoding);
+            if (text.Encoding != null)
+            {
+                Assert.Equal(text.Encoding, text2.Encoding);
+            }
 
             temporaryStorage.Dispose();
         }
@@ -324,25 +327,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     }
                 }
             }
-        }
-
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/353"), Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void TestTemporaryStorageTextEncoding()
-        {
-            var textFactory = new TextFactoryService();
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
-
-            // test normal string
-            var text = SourceText.From(new string(' ', 4096) + "public class A {}", Encoding.ASCII);
-            TestTemporaryStorage(service, text);
-
-            // test empty string
-            text = SourceText.From(string.Empty);
-            TestTemporaryStorage(service, text);
-
-            // test large string
-            text = SourceText.From(new string(' ', 1024 * 1024) + "public class A {}");
-            TestTemporaryStorage(service, text);
         }
     }
 }


### PR DESCRIPTION
When decoding text from temporary storage, we should preserve the original encoding.