### PR TITLE
Fix RunTests

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -129,8 +129,8 @@ namespace RunTests
                 var all = File.ReadAllText(resultsPath).Trim();
                 if (all.Length == 0)
                 {
-                    var output = processOutput.OutputLines.Concat(processOutput.ErrorLines).Aggregate((x, y) => x + Environment.NewLine + y);
-                    File.WriteAllText(resultsPath, output);
+                    var output = processOutput.OutputLines.Concat(processOutput.ErrorLines).ToArray();
+                    File.WriteAllLines(resultsPath, output);
                 }
 
                 errorOutput = processOutput.ErrorLines.Aggregate((x, y) => x + Environment.NewLine + y);


### PR DESCRIPTION
It is apparently possible for a test to exit with an error code, produce
no HTML file and no output.  In that case the call to Aggregate was
failing with an exception.  Change it to use ToArray +
File.WriteAllLines.

This won't fix the underlying problem but will at least identify the
test that is failing.
