### PR TITLE
Display "ref" and "out" modifiers on parameter types as in the old Call Stack Window implementation.

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpFrameDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpFrameDecoder.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     [DkmReportNonFatalWatsonException(ExcludeExceptionType = typeof(NotImplementedException)), DkmContinueCorruptingException]
-    internal sealed class CSharpFrameDecoder : FrameDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
+    internal sealed class CSharpFrameDecoder : FrameDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol>
     {
         public CSharpFrameDecoder()
             : base(CSharpInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal sealed class CSharpInstructionDecoder : InstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
+    internal sealed class CSharpInstructionDecoder : InstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol>
     {
         // This string was not localized in the old EE.  We'll keep it that way
         // so as not to break consumers who may have been parsing frame names...
@@ -86,6 +86,23 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         break;
                 }
             }
+        }
+
+        internal override void AppendParameterTypeName(StringBuilder builder, IParameterSymbol parameter)
+        {
+            // The old EE only displayed "ref" and "out" modifiers in C# and only when displaying parameter
+            // types.  We will do the same here for compatibility with the old behavior.
+            switch (parameter.RefKind)
+            {
+                case RefKind.Out:
+                    builder.Append("out ");
+                    break;
+                case RefKind.Ref:
+                    builder.Append("ref ");
+                    break;
+            }
+
+            base.AppendParameterTypeName(builder, parameter);
         }
 
         internal override MethodSymbol ConstructMethod(MethodSymbol method, ImmutableArray<TypeParameterSymbol> typeParameters, ImmutableArray<TypeSymbol> typeArguments)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLanguageInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLanguageInstructionDecoder.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     [DkmReportNonFatalWatsonException(ExcludeExceptionType = typeof(NotImplementedException)), DkmContinueCorruptingException]
-    internal sealed class CSharpLanguageInstructionDecoder : LanguageInstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol>
+    internal sealed class CSharpLanguageInstructionDecoder : LanguageInstructionDecoder<CSharpCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol>
     {
         public CSharpLanguageInstructionDecoder()
             : base(CSharpInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -233,6 +233,55 @@ static class C
                 GetName(source, "C.M2", DkmVariableInfoFlags.None));
         }
 
+        [Fact, WorkItem(1107978)]
+        void GetNameRefAndOutParameters()
+        {
+            var source = @"
+class C
+{
+    static void M(ref int x, out int y)
+    {
+        y = x;
+    }
+}";
+
+            Assert.Equal(
+                "C.M",
+                GetName(source, "C.M", DkmVariableInfoFlags.None));
+
+            Assert.Equal(
+                "C.M(1, 2)",
+                GetName(source, "C.M", DkmVariableInfoFlags.None, argumentValues: new[] { "1", "2" }));
+
+            Assert.Equal(
+                "C.M(ref int, out int)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types));
+
+            Assert.Equal(
+                "C.M(x, y)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Names));
+
+            Assert.Equal(
+                "C.M(ref int x, out int y)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names));
+        }
+
+        [Fact]
+        void GetNameParamsParameters()
+        {
+            var source = @"
+class C
+{
+    static void M(params int[] x)
+    {
+    }
+}";
+
+            Assert.Equal(
+                "C.M(int[] x)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names));
+        }
+
         [Fact]
         void GetReturnTypeNamePrimitive()
         {

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
@@ -20,16 +20,17 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     /// always used C# syntax (but with language-specific "special names").  Since these names are exposed through public
     /// APIs, we will remain consistent with the old behavior (for consumers who may be parsing the frame names).
     /// </remarks>
-    internal abstract class FrameDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> : IDkmLanguageFrameDecoder
+    internal abstract class FrameDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> : IDkmLanguageFrameDecoder
         where TCompilation : Compilation
         where TMethodSymbol : class, IMethodSymbol
         where TModuleSymbol : class, IModuleSymbol
         where TTypeSymbol : class, ITypeSymbol
         where TTypeParameterSymbol : class, ITypeParameterSymbol
+        where TParameterSymbol : class, IParameterSymbol
     {
-        private readonly InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> _instructionDecoder;
+        private readonly InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> _instructionDecoder;
 
-        internal FrameDecoder(InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> instructionDecoder)
+        internal FrameDecoder(InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> instructionDecoder)
         {
             _instructionDecoder = instructionDecoder;
         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -8,12 +8,13 @@ using Microsoft.VisualStudio.Debugger.Clr;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal abstract class InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol>
+    internal abstract class InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol>
         where TCompilation : Compilation
         where TMethodSymbol : class, IMethodSymbol
         where TModuleSymbol : class, IModuleSymbol
         where TTypeSymbol : class, ITypeSymbol
         where TTypeParameterSymbol : class, ITypeParameterSymbol
+        where TParameterSymbol : class, IParameterSymbol
     {
         internal static readonly SymbolDisplayFormat DisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
@@ -22,6 +23,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
         internal abstract void AppendFullName(StringBuilder builder, TMethodSymbol method);
+
+        internal virtual void AppendParameterTypeName(StringBuilder builder, IParameterSymbol parameter)
+        {
+            builder.Append(parameter.Type.ToDisplayString(DisplayFormat));
+        }
 
         /// <summary>
         /// Constructs a method and any of its generic containing types using the specified <paramref name="typeArguments"/>.
@@ -61,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                     if (includeParameterTypes)
                     {
-                        builder.Append(parameter.Type.ToDisplayString(DisplayFormat));
+                        AppendParameterTypeName(builder, parameter);
                     }
 
                     if (includeParameterNames)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
@@ -17,16 +17,17 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     /// <summary>
     /// This class provides function name information for the Breakpoints window.
     /// </summary>
-    internal abstract class LanguageInstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> : IDkmLanguageInstructionDecoder
+    internal abstract class LanguageInstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> : IDkmLanguageInstructionDecoder
         where TCompilation : Compilation
         where TMethodSymbol : class, IMethodSymbol
         where TModuleSymbol : class, IModuleSymbol
         where TTypeSymbol : class, ITypeSymbol
         where TTypeParameterSymbol : class, ITypeParameterSymbol
+        where TParameterSymbol : class, IParameterSymbol
     {
-        private readonly InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> _instructionDecoder;
+        private readonly InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> _instructionDecoder;
 
-        internal LanguageInstructionDecoder(InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol> instructionDecoder)
+        internal LanguageInstructionDecoder(InstructionDecoder<TCompilation, TMethodSymbol, TModuleSymbol, TTypeSymbol, TTypeParameterSymbol, TParameterSymbol> instructionDecoder)
         {
             _instructionDecoder = instructionDecoder;
         }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicFrameDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicFrameDecoder.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     <DkmReportNonFatalWatsonException(ExcludeExceptionType:=GetType(NotImplementedException)), DkmContinueCorruptingException>
-    Friend NotInheritable Class VisualBasicFrameDecoder : Inherits FrameDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol)
+    Friend NotInheritable Class VisualBasicFrameDecoder : Inherits FrameDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol)
 
         Public Sub New()
             MyBase.New(VisualBasicInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -10,7 +10,7 @@ Imports System.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-    Friend NotInheritable Class VisualBasicInstructionDecoder : Inherits InstructionDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol)
+    Friend NotInheritable Class VisualBasicInstructionDecoder : Inherits InstructionDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol)
 
         ' These strings were not localized in the old EE.  We'll keep them that way
         ' so as not to break consumers who may have been parsing frame names...

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLanguageInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLanguageInstructionDecoder.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     <DkmReportNonFatalWatsonException(ExcludeExceptionType:=GetType(NotImplementedException)), DkmContinueCorruptingException>
-    Friend NotInheritable Class VisualBasicLanguageInstructionDecoder : Inherits LanguageInstructionDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol)
+    Friend NotInheritable Class VisualBasicLanguageInstructionDecoder : Inherits LanguageInstructionDecoder(Of VisualBasicCompilation, MethodSymbol, PEModuleSymbol, TypeSymbol, TypeParameterSymbol, ParameterSymbol)
 
         Public Sub New()
             MyBase.New(VisualBasicInstructionDecoder.Instance)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
@@ -11,7 +11,6 @@ Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-    '// TODO: ref/out
     '// TODO: constructors
     '// TODO: keyword identifiers
     '// TODO: containing type and parameter types that are nested types
@@ -22,7 +21,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     '// TODO: string argument values
     '// TODO: string argument values requiring quotes
     '// TODO: argument flags == names only, types only, values only
-    '// TODO: params Argument values
     '// TODO: generic class/method with 2 or more type parameters
     '// TODO: generic argument type that is not from a referenced assembly
     Public Class InstructionDecoderTests : Inherits ExpressionCompilerTestBase
@@ -327,6 +325,50 @@ End Module"
             Assert.Equal(
                 "Module1.M2",
                 GetName(source, "Module1.M2", DkmVariableInfoFlags.None))
+        End Sub
+
+        <Fact, WorkItem(1107978)>
+        Sub GetNameRefAndOutParameters()
+            Dim source = "
+Imports System.Runtime.InteropServices
+Class C
+    Shared Sub M(ByRef x As Integer, <Out> ByRef y As Integer)
+        y = x
+    End Sub
+End Class"
+
+            Assert.Equal(
+                "C.M",
+                GetName(source, "C.M", DkmVariableInfoFlags.None))
+
+            Assert.Equal(
+                "C.M(1, 2)",
+                GetName(source, "C.M", DkmVariableInfoFlags.None, argumentValues:={"1", "2"}))
+
+            Assert.Equal(
+                "C.M(Integer, Integer)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types))
+
+            Assert.Equal(
+                "C.M(x, y)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Names))
+
+            Assert.Equal(
+                "C.M(Integer x, Integer y)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names))
+        End Sub
+
+        <Fact>
+        Sub GetNameParamsParameters()
+            Dim source = "
+Class C
+    Shared Sub M(ParamArray x() As Integer)
+    End Sub
+End Class"
+
+            Assert.Equal(
+                "C.M(Integer() x)",
+                GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names))
         End Sub
 
         <Fact>


### PR DESCRIPTION
Also add a simple tests for params/array parameters...