### PR TITLE
Progression should properly descend into types for IntelliTrace MVC queries

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
@@ -47,10 +47,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _initialized = true;
         }
 
-        public void BeginGetGraphData(IGraphContext context)
+        internal static List<IGraphQuery> GetGraphQueries(IGraphContext context)
         {
-            EnsureInitialized();
-
             var graphQueries = new List<IGraphQuery>();
 
             if (context.Direction == GraphContextDirection.Self && context.RequestedProperties.Contains(DgmlNodeProperties.ContainsChildren))
@@ -58,7 +56,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 graphQueries.Add(new ContainsChildrenGraphQuery());
             }
 
-            if (context.Direction == GraphContextDirection.Contains)
+            if (context.Direction == GraphContextDirection.Contains ||
+                (context.Direction == GraphContextDirection.Target && context.LinkCategories.Contains(CodeLinkCategories.Contains)))
             {
                 graphQueries.Add(new ContainsGraphQuery());
             }
@@ -128,6 +127,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     graphQueries.Add(new SearchGraphQuery(searchParameters.SearchQuery.SearchString));
                 }
             }
+
+            return graphQueries;
+        }
+
+        public void BeginGetGraphData(IGraphContext context)
+        {
+            EnsureInitialized();
+
+            var graphQueries = GetGraphQueries(context);
 
             if (graphQueries.Count > 0)
             {

--- a/src/VisualStudio/Core/Test/Progression/GraphProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/GraphProviderTests.vb
@@ -1,0 +1,36 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.VisualStudio.GraphModel
+Imports Microsoft.VisualStudio.GraphModel.Schemas
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Progression
+Imports Moq
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
+
+    Public Class GraphProviderTests
+        <WorkItem(1078048)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Sub GetContainsGraphQueries()
+            Dim context = CreateGraphContext(GraphContextDirection.Contains, {})
+            Dim queries = AbstractGraphProvider.GetGraphQueries(context)
+            Assert.Equal(queries.Single().GetType(), GetType(ContainsGraphQuery))
+        End Sub
+
+        <WorkItem(1078048)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Sub GetContainsGraphQueriesWithTarget()
+            Dim context = CreateGraphContext(GraphContextDirection.Target, {CodeLinkCategories.Contains})
+            Dim queries = AbstractGraphProvider.GetGraphQueries(context)
+            Assert.Equal(queries.Single().GetType(), GetType(ContainsGraphQuery))
+        End Sub
+
+        Private Shared Function CreateGraphContext(direction As GraphContextDirection, linkCategories As IEnumerable(Of GraphCategory)) As IGraphContext
+            Dim context = New Mock(Of IGraphContext)()
+            context.Setup(Function(x) x.Direction).Returns(direction)
+            context.Setup(Function(x) x.LinkCategories).Returns(linkCategories)
+            Return context.Object
+        End Function
+    End Class
+
+End Namespace

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -331,6 +331,7 @@
     <Compile Include="MockVisualStudioWorkspace.vb" />
     <Compile Include="ObjectBrowser\NavInfoNodeDescriptor.vb" />
     <Compile Include="ObjectBrowser\VisualBasic\ObjectBrowerTests.vb" />
+    <Compile Include="Progression\GraphProviderTests.vb" />
     <Compile Include="ProjectSystemShim\DeferredProjectLoadingTests.vb" />
     <Compile Include="ProjectSystemShim\Framework\MockHierarchy.vb" />
     <Compile Include="ProjectSystemShim\VisualBasicProjectTests.vb" />


### PR DESCRIPTION
When BeginGetGraphData() (in GraphProvider.cs) was migrated from the old code, a query type of the format {Direction=Target, LinkCategories=[Contains]} was missed that IntelliTrace produced when it wanted us to descend into types.