### PR TITLE
Exclude mscorlib from Emit test conflict checking

### DIFF
--- a/src/Test/Utilities/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/HostedRuntimeEnvironment.cs
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         // Determines if any of the given dependencies has the same name as already loaded assembly with different content.
         private static string DetectNameCollision(IEnumerable<ModuleData> modules)
         {
+            modules = modules.Where(m => !m.FullName.Contains("mscorlib"));
             lock (allModuleNames)
             {
                 foreach (var module in modules)


### PR DESCRIPTION
In the emit tests we currently check every module to see if we're
emitting an assembly with a name we've already seen. PeVerify
requires that we create a new AppDomain for every conflict we find.
However, mscorlib will always produce a conflict, so this ignores
mscorlib when checking for a conflict and doesn't create a new
AppDomain if it is found during emit.