### PR TITLE
Apply spacing options to Using and Catch

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -71,7 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // For Spacing b/n control flow keyword and paren. Parent check not needed.
             if (currentKind == SyntaxKind.OpenParenToken &&
                 (previousKind == SyntaxKind.IfKeyword || previousKind == SyntaxKind.WhileKeyword || previousKind == SyntaxKind.SwitchKeyword ||
-                previousKind == SyntaxKind.ForKeyword || previousKind == SyntaxKind.ForEachKeyword))
+                previousKind == SyntaxKind.ForKeyword || previousKind == SyntaxKind.ForEachKeyword || previousKind == SyntaxKind.CatchKeyword ||
+                previousKind == SyntaxKind.UsingKeyword))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword);
             }
@@ -94,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (previousKind == SyntaxKind.OpenParenToken &&
                 (previousParentKind == SyntaxKind.IfStatement || previousParentKind == SyntaxKind.WhileStatement || previousParentKind == SyntaxKind.SwitchStatement ||
                 previousParentKind == SyntaxKind.ForStatement || previousParentKind == SyntaxKind.ForEachStatement || previousParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration))
+                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -102,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.CloseParenToken &&
                 (currentParentKind == SyntaxKind.IfStatement || currentParentKind == SyntaxKind.WhileStatement || currentParentKind == SyntaxKind.SwitchStatement ||
                 currentParentKind == SyntaxKind.ForStatement || currentParentKind == SyntaxKind.ForEachStatement || currentParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration))
+                previousParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.CloseParenToken &&
                 (currentParentKind == SyntaxKind.IfStatement || currentParentKind == SyntaxKind.WhileStatement || currentParentKind == SyntaxKind.SwitchStatement ||
                 currentParentKind == SyntaxKind.ForStatement || currentParentKind == SyntaxKind.ForEachStatement || currentParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement))
+                currentParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.CatchDeclaration))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4789,6 +4789,9 @@ class Program
         { }
         catch (System.Exception e)
         { }
+
+        using(somevar)
+        { }
     }
 }";
             var expected = @"
@@ -4820,9 +4823,87 @@ class Program
         { }
         catch ( System.Exception e )
         { }
+
+        using ( somevar )
+        { }
     }
 }";
             var optionSet = new Dictionary<OptionKey, object> { { CSharpFormattingOptions.SpaceWithinOtherParentheses, true } };
+            AssertFormat(expected, code, changedOptionSet: optionSet);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void TestSpacingOptionAfterControlFlowKeyword()
+        {
+            var code = @"
+class Program
+{
+    public void foo()
+    {
+        int i;
+        for (i=0; i<10; i++)
+        {}
+
+        foreach (i in new[] {1,2,3})
+        {}
+
+        if (i==10)
+        {}
+
+        while (i==10)
+        {}
+
+        switch (i)
+        {
+            default: break;
+        }
+
+        do {} while (true);
+
+        try
+        { }
+        catch (System.Exception e)
+        { }
+
+        using (somevar)
+        { }
+    }
+}";
+            var expected = @"
+class Program
+{
+    public void foo()
+    {
+        int i;
+        for(i = 0; i < 10; i++)
+        { }
+
+        foreach(i in new[] { 1, 2, 3 })
+        { }
+
+        if(i == 10)
+        { }
+
+        while(i == 10)
+        { }
+
+        switch(i)
+        {
+            default: break;
+        }
+
+        do { } while(true);
+
+        try
+        { }
+        catch(System.Exception e)
+        { }
+
+        using(somevar)
+        { }
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object> { { CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword, false } };
             AssertFormat(expected, code, changedOptionSet: optionSet);
         }
 


### PR DESCRIPTION
Makes `catch` and `using` follow `SpaceAfterControlFlowStatementKeyword` option.

Makes `using` follow `SpaceWithinOtherParentheses` option

Before, catch was always formatted as `catch (` and using as `using (var`

Now it is possible to have `catch(` and `using ( var`
