### PR TITLE
Fix for #441: Stop showing empty preview for dialog based refactorings

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -67,6 +67,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         {
             var telemetry = diagnostic == null ? false : diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry);
 
+            if ((diagnostic == null) && (previewContent == null))
+            {
+                // Bail out in cases where there is no diagnostic (which means there is nothing to put in
+                // the header section of the preview pane) as well as no preview content (i.e. no diff view).
+                return null;
+            }
+
             if ((diagnostic == null) || (diagnostic.Descriptor is TriggerDiagnosticDescriptor))
             {
                 return new PreviewPane(


### PR DESCRIPTION
Dialog based refactorings like 'Change Signature' have no associated diagnostic and don't offer a diff preview either. Instead of showing an empty lightbulb preview pane in such cases we should simply bail and return null.

This is fallout from my earlier fix bbcf72412c04bde2a74efca4d72a7acd0bf12982 where I got rid of the 'No Preview' section (before this fix, we would show a preview pane that said 'No Preview' in such cases).