### PR TITLE
Enable 64 bit test runs

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -13,7 +13,6 @@
     <RoslynSolution>$(MSBuildThisFileDirectory)\Src\Roslyn.sln</RoslynSolution>
     <RoslynSolution Condition="$(CIBuild) == 'true'">$(MSBuildThisFileDirectory)\Src\Roslyn2013.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ArgumentTest64></ArgumentTest64>
     <ArgumentTest64 Condition="'$(Test64)' == 'true'">-test64</ArgumentTest64>
   </PropertyGroup>

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -13,6 +13,9 @@
     <RoslynSolution>$(MSBuildThisFileDirectory)\Src\Roslyn.sln</RoslynSolution>
     <RoslynSolution Condition="$(CIBuild) == 'true'">$(MSBuildThisFileDirectory)\Src\Roslyn2013.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <ArgumentTest64></ArgumentTest64>
+    <ArgumentTest64 Condition="'$(Test64)' == 'true'">-test64</ArgumentTest64>
   </PropertyGroup>
 
   <Target Name="RestorePackages">
@@ -77,7 +80,7 @@
       <TestAssemblies Include="Binaries\Debug\Roslyn.Services.VisualBasic.UnitTests.dll" />
     </ItemGroup>
 
-    <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools\xunit.console.x86.exe @(TestAssemblies, ' ')" />
+    <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(ArgumentTest64) @(TestAssemblies, ' ')" />
 
   </Target>
 

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -89,9 +89,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -4761,7 +4761,7 @@ class C
 
             //Open as data
             IntPtr lib = LoadLibraryEx(Path.Combine(dir.Path, outputFileName), IntPtr.Zero, 0x00000002);
-            if (lib.ToInt32() == 0)
+            if (lib == IntPtr.Zero)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             const string resourceType = "#24";

--- a/src/Compilers/CSharp/Test/CommandLine/packages.config
+++ b/src/Compilers/CSharp/Test/CommandLine/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -182,9 +182,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -3775,8 +3775,7 @@ class C
         /// Reuse existing anonymous types.
         /// </summary>
         [WorkItem(825903, "DevDiv")]
-        [Fact]
-        [Trait("Require32", "true")]
+        [ConditionalFact(typeof(x86))]
         public void AnonymousTypes()
         {
             var source0 =

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -3776,6 +3776,7 @@ class C
         /// </summary>
         [WorkItem(825903, "DevDiv")]
         [Fact]
+        [Trait("Require32", "true")]
         public void AnonymousTypes()
         {
             var source0 =

--- a/src/Compilers/CSharp/Test/Emit/packages.config
+++ b/src/Compilers/CSharp/Test/Emit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -139,9 +139,9 @@
     <Compile Include="Semantics\VarianceTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Semantic/packages.config
+++ b/src/Compilers/CSharp/Test/Semantic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -61,9 +61,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />

--- a/src/Compilers/CSharp/Test/Symbol/packages.config
+++ b/src/Compilers/CSharp/Test/Symbol/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -167,9 +167,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Syntax/packages.config
+++ b/src/Compilers/CSharp/Test/Syntax/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -92,9 +92,9 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/src/Compilers/Core/CodeAnalysisTest/packages.config
+++ b/src/Compilers/Core/CodeAnalysisTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -105,9 +105,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections" />

--- a/src/Compilers/Core/VBCSCompilerTests/packages.config
+++ b/src/Compilers/Core/VBCSCompilerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />

--- a/src/Compilers/Test/Utilities/Core2/CompilerTestUtilities2.csproj
+++ b/src/Compilers/Test/Utilities/Core2/CompilerTestUtilities2.csproj
@@ -75,9 +75,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/Test/Utilities/Core2/packages.config
+++ b/src/Compilers/Test/Utilities/Core2/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
@@ -62,9 +62,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -5142,7 +5142,7 @@ End Module
             Assert.Equal(0, vbc.Run(New StringWriter(), Nothing))
 
             Dim library As IntPtr = LoadLibraryEx(Path.Combine(dir.Path, outputFileName), IntPtr.Zero, 2)
-            If library.ToInt32() = 0 Then
+            If library = IntPtr.Zero Then
                 Throw New Win32Exception(Marshal.GetLastWin32Error())
             End If
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/packages.config
+++ b/src/Compilers/VisualBasic/Test/CommandLine/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -89,9 +89,9 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Roslyn.Test.Utilities, Version=42.42.42.42, Culture=neutral, PublicKeyToken=fc793a00266884fb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueTests.vb
@@ -3277,6 +3277,7 @@ End Class
         End Sub
 
         <Fact()>
+        <Trait("Require32", "true")>
         Public Sub AnonymousTypes()
             Dim sources0 = <compilation>
                                <file name="a.vb"><![CDATA[

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueTests.vb
@@ -3276,8 +3276,7 @@ End Class
 ]]>.Value)
         End Sub
 
-        <Fact()>
-        <Trait("Require32", "true")>
+        <ConditionalFact(GetType(x86))>
         Public Sub AnonymousTypes()
             Dim sources0 = <compilation>
                                <file name="a.vb"><![CDATA[

--- a/src/Compilers/VisualBasic/Test/Emit/packages.config
+++ b/src/Compilers/VisualBasic/Test/Emit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -82,9 +82,9 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
@@ -3018,6 +3018,7 @@ End Class
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
+        <Trait("Require32", "true")>
         Public Sub Bug1108007_2()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
@@ -3058,7 +3059,7 @@ End Class
             Assert.Equal(SymbolKind.NamedType, symbol.Kind)
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
-            
+
             CompileAndVerify(compilation, expectedOutput:=<![CDATA[
 System.NullReferenceException: Reference to non-shared member 'Public Sub M(x As String)' requires an object reference.
    at Microsoft.VisualBasic.CompilerServices.Symbols.Container.InvokeMethod(Method TargetProcedure, Object[] Arguments, Boolean[] CopyBack, BindingFlags Flags)
@@ -3320,6 +3321,7 @@ End Class
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
+        <Trait("Require32", "true")>
         Public Sub Bug1108007_8()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
@@ -3017,8 +3017,7 @@ End Class
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
-        <Fact()>
-        <Trait("Require32", "true")>
+        <ConditionalFact(GetType(x86))>
         Public Sub Bug1108007_2()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
@@ -3320,8 +3319,7 @@ End Class
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
-        <Fact()>
-        <Trait("Require32", "true")>
+        <ConditionalFact(GetType(x86))>
         Public Sub Bug1108007_8()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingObjectInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingObjectInitializerTests.vb
@@ -1091,7 +1091,7 @@ End Class
         End Sub
 
         <Fact(), WorkItem(788522, "DevDiv")>
-        Sub ObjectInitializerNoStackOverflowFor250LevelsOfNesting()
+        Sub ObjectInitializerNoStackOverflowFor150LevelsOfNesting()
             Dim source =
 <compilation>
     <file name="a.vb">
@@ -1120,29 +1120,7 @@ Class C2
                         .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
                         .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
                         .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
-                        .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1, .x = New Cust With {.y = 1,
                         .x = nothing}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
-}}}}}}}}}}
 }}}}}}}}}}
 }}}}}}}}}}
 }}}}}}}}}}

--- a/src/Compilers/VisualBasic/Test/Semantic/packages.config
+++ b/src/Compilers/VisualBasic/Test/Semantic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
@@ -90,9 +90,9 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Compilers/VisualBasic/Test/Symbol/packages.config
+++ b/src/Compilers/VisualBasic/Test/Symbol/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
@@ -98,9 +98,9 @@
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SerializationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SerializationTests.vb
@@ -217,7 +217,7 @@ End Class
             Assert.Equal(annotation, dannotation) ' but are equivalent
         End Sub
 
-        <Fact()>
+        <ConditionalFact(GetType(x86))>
         <WorkItem(530374, "DevDiv")>
         Public Sub RoundtripSerializeDeepExpression()
             Dim text = <Foo><![CDATA[

--- a/src/Compilers/VisualBasic/Test/Syntax/packages.config
+++ b/src/Compilers/VisualBasic/Test/Syntax/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -12,9 +12,9 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/EditorFeatures/CSharpTest/packages.config
+++ b/src/EditorFeatures/CSharpTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.48.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" />

--- a/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Composition;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes

--- a/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
         private readonly ExportProvider _exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
 
         [Fact]
+        [Trait("Require32", "true")]
         public void TestNoCyclesInFixProviders()
         {
             // This test will fail if a cycle is detected in the ordering of our code fix providers.

--- a/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/ExtensionOrderingTests.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
     {
         private readonly ExportProvider _exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
 
-        [Fact]
-        [Trait("Require32", "true")]
+        [ConditionalFact(typeof(x86))]
         public void TestNoCyclesInFixProviders()
         {
             // This test will fail if a cycle is detected in the ordering of our code fix providers.

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -19,9 +19,9 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/EditorFeatures/VisualBasicTest/packages.config
+++ b/src/EditorFeatures/VisualBasicTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Roslyn.sln
+++ b/src/Roslyn.sln
@@ -321,8 +321,8 @@ Global
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
 		Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{a1bcd0ce-6c2f-4f8c-9a48-d9d93928e26d}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
-		Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{3973b09a-4fbf-44a5-8359-3d22ceb71f71}*SharedItemsImports = 4
 		Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
@@ -1900,6 +1900,7 @@ Global
 		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{E637AD92-8397-4337-A9CD-9F2570078E59} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{97CC7ABF-7E07-4F3A-947B-8C2D8F916450} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
+		{1A3941F1-1E1F-4EF7-8064-7729C4C2E2AA} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{43026D51-3083-4850-928D-07E1883D5B1A} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{A1BCD0CE-6C2F-4F8C-9A48-D9D93928E26D} = {3E5FE3DB-45F7-4D83-9097-8F05D3B3AEC6}
 		{3973B09A-4FBF-44A5-8359-3D22CEB71F71} = {3E5FE3DB-45F7-4D83-9097-8F05D3B3AEC6}

--- a/src/Test/Utilities/TestUtilities.csproj
+++ b/src/Test/Utilities/TestUtilities.csproj
@@ -99,9 +99,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.0.7.4091001-beta\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="0.7.4091001-beta" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -39,7 +39,7 @@ namespace RunTests
                 ? Path.Combine(xunitPath, "xunit.console.exe")
                 : Path.Combine(xunitPath, "xunit.console.x86.exe");
 
-            var testRunner = new TestRunner(xunit, test64);
+            var testRunner = new TestRunner(xunit);
             var start = DateTime.Now;
             Console.WriteLine("Running {0} tests", list.Count);
             var result = testRunner.RunAll(list).Result;

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -19,9 +19,27 @@ namespace RunTests
                 return 1;
             }
 
-            var xunit = args[0];
-            var list = new List<string>(args.Skip(1));
-            var testRunner = new TestRunner(xunit);
+            var xunitPath = args[0];
+            var skipCount = 1;
+            var test64 = false;
+            if (StringComparer.OrdinalIgnoreCase.Equals(args[1], "-test64"))
+            {
+                skipCount = 2;
+                test64 = true;
+            }
+
+            var list = new List<string>(args.Skip(skipCount));
+            if (list.Count == 0)
+            {
+                PrintUsage();
+                return 1;
+            }
+
+            var xunit = test64
+                ? Path.Combine(xunitPath, "xunit.console.exe")
+                : Path.Combine(xunitPath, "xunit.console.x86.exe");
+
+            var testRunner = new TestRunner(xunit, test64);
             var start = DateTime.Now;
             Console.WriteLine("Running {0} tests", list.Count);
             var result = testRunner.RunAll(list).Result;

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RunTests
@@ -39,10 +40,17 @@ namespace RunTests
                 ? Path.Combine(xunitPath, "xunit.console.exe")
                 : Path.Combine(xunitPath, "xunit.console.x86.exe");
 
+            // Setup cancellation for ctrl-c key presses
+            var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += delegate
+            {
+                cts.Cancel();
+            };
+
             var testRunner = new TestRunner(xunit);
             var start = DateTime.Now;
             Console.WriteLine("Running {0} tests", list.Count);
-            var result = testRunner.RunAll(list).Result;
+            var result = testRunner.RunAllAsync(list, cts.Token).Result;
             var span = DateTime.Now - start;
             if (!result)
             {

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -31,12 +31,10 @@ namespace RunTests
         }
 
         private readonly string _xunitConsolePath;
-        private readonly bool _use64;
 
-        internal TestRunner(string xunitConsolePath, bool use64)
+        internal TestRunner(string xunitConsolePath)
         {
             _xunitConsolePath = xunitConsolePath;
-            _use64 = use64;
         }
 
         internal async Task<bool> RunAll(IEnumerable<string> assemblyList)
@@ -108,14 +106,10 @@ namespace RunTests
         {
             var assemblyName = Path.GetFileName(assemblyPath);
             var resultsPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.ChangeExtension(assemblyName, ".html"));
+            DeleteFile(resultsPath);
+
             var builder = new StringBuilder();
             builder.AppendFormat(@"""{0}""", assemblyPath);
-
-            if (_use64)
-            {
-                builder.Append(@" -notrait ""Require32=true""");
-            }
-
             builder.AppendFormat(@" -html ""{0}""", resultsPath);
             builder.Append(" -noshadow");
 
@@ -162,6 +156,21 @@ namespace RunTests
             }
 
             return new TestResult(processOutput.ExitCode == 0, assemblyName, span, errorOutput);
+        }
+
+        private static void DeleteFile(string filePath)
+        {
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+            catch
+            {
+                // Ignore
+            }
         }
     }
 }


### PR DESCRIPTION
This change allows provides the option of running our tests in 64 bit
mode.  Simply invoke BuildAndTest.proj in the following manner:

> msbuild /v:m /m BuildAndTest.proj /p:Test64=true

There are a set of tests today that don't run correctly in 64.  All have
been annotated with the trait

> Require32=true

We need to push on these to get a clean 64 bit run.  But short term this
will at least give us protection against regressions.