### PR TITLE
Add a context menu item to open diagnostic help links

### DIFF
--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             public const int SetSeverityInfo = 0x0112;
             public const int SetSeverityHidden = 0x0113;
             public const int SetSeverityNone = 0x0114;
+            public const int OpenDiagnosticHelpLink = 0x0116;
         }
     }
 }


### PR DESCRIPTION
Fixes #93

There are currently three ways to open the help link for a diagnostic:
  1. Click the link in the Error List when the diagnostic is reported.
  2. Open the rule set editor, enable online help, and select the rule.
  3. Select the diagnostic in Solution Explorer, and copy the link from
     the Properties window.

None of these is particularly discoverable. This change adds another
option, a "View Help" menu item that shows up when you right-click on a
diagnostic in Solution Explorer.