### PR TITLE
Lazy doc comments for signature help

### DIFF
--- a/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
+                parameter.GetDocumentationPartsFactory(semanticModel, position, formatter),
                 parameter.ToMinimalDisplayParts(semanticModel, position));
         }
 

--- a/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.GetDocumentationParts(semanticModel, position, formatter, cancellationToken),
+                parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
                 parameter.ToMinimalDisplayParts(semanticModel, position));
         }
 

--- a/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic,
-                constructor.GetDocumentationParts(semanticModel, position, documentationCommentFormatter, cancellationToken),
+                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),
@@ -158,6 +158,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
 
             for (int i = 0; i < namedParameters.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var namedParameter = namedParameters[i];
 
                 var type = namedParameter is IFieldSymbol ? ((IFieldSymbol)namedParameter).Type : ((IPropertySymbol)namedParameter).Type;
@@ -175,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 yield return new SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional: true,
-                    documentation: namedParameter.GetDocumentationParts(semanticModel, position, documentationCommentFormatter, cancellationToken),
+                    documentationGetter: namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
                     displayParts: displayParts,
                     prefixDisplayParts: GetParameterPrefixDisplayParts(i));
             }

--- a/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 yield return new SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional: true,
-                    documentationGetter: namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
+                    documentationFactory: namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
                     displayParts: displayParts,
                     prefixDisplayParts: GetParameterPrefixDisplayParts(i));
             }

--- a/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic,
-                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
+                constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormatter),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 yield return new SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional: true,
-                    documentationFactory: namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormatter),
+                    documentationFactory: namedParameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormatter),
                     displayParts: displayParts,
                     prefixDisplayParts: GetParameterPrefixDisplayParts(i));
             }

--- a/src/EditorFeatures/CSharp/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),

--- a/src/EditorFeatures/CSharp/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),

--- a/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             var item = CreateItem(indexer, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 indexer.IsParams(),
-                indexer.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                indexer.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(indexer, position, semanticModel),
                 GetSeparatorParts(),
                 GetPostambleParts(indexer),

--- a/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             var item = CreateItem(indexer, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 indexer.IsParams(),
-                indexer.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                indexer.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(indexer, position, semanticModel),
                 GetSeparatorParts(),
                 GetPostambleParts(indexer),

--- a/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             return new SignatureHelpParameter(
                 parameter.Name,
                 isOptional: false,
-                documentationGetter: parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
+                documentationFactory: parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
                 displayParts: parameter.ToMinimalDisplayParts(semanticModel, position, s_minimallyQualifiedFormat),
                 selectedDisplayParts: GetSelectedDisplayParts(parameter, semanticModel, position, cancellationToken));
         }

--- a/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     false,
-                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                    symbol.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(namedType, semanticModel, position),
                     GetSeparatorParts(),
                     GetPostambleParts(namedType),
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             return new SignatureHelpParameter(
                 parameter.Name,
                 isOptional: false,
-                documentationFactory: parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
+                documentationFactory: parameter.GetDocumentationPartsFactory(semanticModel, position, formatter),
                 displayParts: parameter.ToMinimalDisplayParts(semanticModel, position, s_minimallyQualifiedFormat),
                 selectedDisplayParts: GetSelectedDisplayParts(parameter, semanticModel, position, cancellationToken));
         }

--- a/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     false,
-                    symbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(namedType, semanticModel, position),
                     GetSeparatorParts(),
                     GetPostambleParts(namedType),
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     false,
-                    symbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken).Concat(GetAwaitableUsage(method, semanticModel, position)),
+                    c => symbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, c).Concat(GetAwaitableUsage(method, semanticModel, position)),
                     GetPreambleParts(method, semanticModel, position),
                     GetSeparatorParts(),
                     GetPostambleParts(method, semanticModel, position),
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             return new SignatureHelpParameter(
                 parameter.Name,
                 isOptional: false,
-                documentation: parameter.GetDocumentationParts(semanticModel, position, formatter, cancellationToken),
+                documentationGetter: parameter.GetDocumentationPartsGetter(semanticModel, position, formatter),
                 displayParts: parameter.ToMinimalDisplayParts(semanticModel, position, s_minimallyQualifiedFormat),
                 selectedDisplayParts: GetSelectedDisplayParts(parameter, semanticModel, position, cancellationToken));
         }

--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 yield return new SignatureHelpParameter(
                     parameter.Name,
                     parameter.IsOptional,
-                    parameter.GetDocumentationPartsGetter(semanticModel, position, formattingService),
+                    parameter.GetDocumentationPartsFactory(semanticModel, position, formattingService),
                     parameter.ToMinimalDisplayParts(semanticModel, position));
             }
         }

--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic: invokeMethod.IsParams(),
-                documentationGetter: null,
+                documentationFactory: null,
                 prefixParts: GetDelegateInvokePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts: GetSeparatorParts(),
                 suffixParts: GetDelegateInvokePostambleParts(),

--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_DelegateInvoke.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic: invokeMethod.IsParams(),
-                documentation: SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>(),
+                documentationGetter: null,
                 prefixParts: GetDelegateInvokePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts: GetSeparatorParts(),
                 suffixParts: GetDelegateInvokePostambleParts(),
@@ -62,10 +62,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
         {
             foreach (var parameter in invokeMethod.Parameters)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return new SignatureHelpParameter(
                     parameter.Name,
                     parameter.IsOptional,
-                    parameter.GetDocumentationParts(semanticModel, position, formattingService, cancellationToken),
+                    parameter.GetDocumentationPartsGetter(semanticModel, position, formattingService),
                     parameter.ToMinimalDisplayParts(semanticModel, position));
             }
         }

--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 method, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 method.IsParams(),
-                method.OriginalDefinition.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken).Concat(GetAwaitableUsage(method, semanticModel, position)),
+                c => method.OriginalDefinition.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, c).Concat(GetAwaitableUsage(method, semanticModel, position)),
                 GetMethodGroupPreambleParts(method, semanticModel, position),
                 GetSeparatorParts(),
                 GetMethodGroupPostambleParts(method),

--- a/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDispalyService,
                 isVariadic: false,
-                documentation: SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>(),
+                documentationGetter: null,
                 prefixParts: GetDelegateTypePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts: GetSeparatorParts(),
                 suffixParts: GetDelegateTypePostambleParts(invokeMethod),
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             yield return new SignatureHelpParameter(
                 TargetName,
                 isOptional: false,
-                documentation: SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>(),
+                documentationGetter: null,
                 displayParts: parts);
         }
 

--- a/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDispalyService,
                 isVariadic: false,
-                documentationGetter: null,
+                documentationFactory: null,
                 prefixParts: GetDelegateTypePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts: GetSeparatorParts(),
                 suffixParts: GetDelegateTypePostambleParts(invokeMethod),
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
             yield return new SignatureHelpParameter(
                 TargetName,
                 isOptional: false,
-                documentationGetter: null,
+                documentationFactory: null,
                 displayParts: parts);
         }
 

--- a/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetNormalTypePreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetNormalTypePostambleParts(constructor),

--- a/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetNormalTypePreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetNormalTypePostambleParts(constructor),

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
@@ -16,21 +17,21 @@ namespace Microsoft.CodeAnalysis.Editor
         /// selected parameter index strictly goes past the number of defined parameters for this
         /// item.
         /// </summary>
-        public bool IsVariadic { get; private set; }
+        public bool IsVariadic { get; }
 
-        public IList<SymbolDisplayPart> PrefixDisplayParts { get; private set; }
-        public IList<SymbolDisplayPart> SuffixDisplayParts { get; private set; }
+        public ImmutableArray<SymbolDisplayPart> PrefixDisplayParts { get; }
+        public ImmutableArray<SymbolDisplayPart> SuffixDisplayParts { get; }
 
-        // TODO(cyrusn): This probably won't be sufficient for VB query signature help.  It has
+        // TODO: This probably won't be sufficient for VB query signature help.  It has
         // arbitrary separators between parameters.
-        public IList<SymbolDisplayPart> SeparatorDisplayParts { get; private set; }
+        public ImmutableArray<SymbolDisplayPart> SeparatorDisplayParts { get; }
 
-        public IList<SignatureHelpParameter> Parameters { get; private set; }
+        public ImmutableArray<SignatureHelpParameter> Parameters { get;  }
 
-        public IList<SymbolDisplayPart> DescriptionParts { get; internal set; }
+        public ImmutableArray<SymbolDisplayPart> DescriptionParts { get; internal set; }
 
-        // TODO(cyrusn): This may be unnecessary.  How would a user ever see this.
-        public IList<SymbolDisplayPart> Documentation { get; set; }
+        // Note: IEnumerable instead of ImmutableArray because we want lazy evaluation.
+        public IEnumerable<SymbolDisplayPart> Documentation { get; }
 
         public SignatureHelpItem(
             bool isVariadic,
@@ -47,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor
             }
 
             this.IsVariadic = isVariadic;
-            this.Documentation = documentation.ToImmutableArrayOrEmpty();
+            this.Documentation = documentation ?? SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
             this.PrefixDisplayParts = prefixParts.ToImmutableArrayOrEmpty();
             this.SeparatorDisplayParts = separatorParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor
         // arbitrary separators between parameters.
         public ImmutableArray<SymbolDisplayPart> SeparatorDisplayParts { get; }
 
-        public ImmutableArray<SignatureHelpParameter> Parameters { get;  }
+        public ImmutableArray<SignatureHelpParameter> Parameters { get; }
 
         public ImmutableArray<SymbolDisplayPart> DescriptionParts { get; internal set; }
 

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
@@ -31,13 +31,13 @@ namespace Microsoft.CodeAnalysis.Editor
 
         public ImmutableArray<SymbolDisplayPart> DescriptionParts { get; internal set; }
 
-        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumentationGetter { get; }
+        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumenationFactory { get; }
 
-        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationGetter = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
+        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationFactory = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
 
         public SignatureHelpItem(
             bool isVariadic,
-            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationFactory,
             IEnumerable<SymbolDisplayPart> prefixParts,
             IEnumerable<SymbolDisplayPart> separatorParts,
             IEnumerable<SymbolDisplayPart> suffixParts,
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor
             }
 
             this.IsVariadic = isVariadic;
-            this.DocumentationGetter = documentationGetter ?? s_emptyDocumentationGetter;
+            this.DocumenationFactory = documentationFactory ?? s_emptyDocumentationFactory;
             this.PrefixDisplayParts = prefixParts.ToImmutableArrayOrEmpty();
             this.SeparatorDisplayParts = separatorParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItem.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
@@ -30,12 +31,13 @@ namespace Microsoft.CodeAnalysis.Editor
 
         public ImmutableArray<SymbolDisplayPart> DescriptionParts { get; internal set; }
 
-        // Note: IEnumerable instead of ImmutableArray because we want lazy evaluation.
-        public IEnumerable<SymbolDisplayPart> Documentation { get; }
+        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumentationGetter { get; }
+
+        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationGetter = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
 
         public SignatureHelpItem(
             bool isVariadic,
-            IEnumerable<SymbolDisplayPart> documentation,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
             IEnumerable<SymbolDisplayPart> prefixParts,
             IEnumerable<SymbolDisplayPart> separatorParts,
             IEnumerable<SymbolDisplayPart> suffixParts,
@@ -48,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor
             }
 
             this.IsVariadic = isVariadic;
-            this.Documentation = documentation ?? SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
+            this.DocumentationGetter = documentationGetter ?? s_emptyDocumentationGetter;
             this.PrefixDisplayParts = prefixParts.ToImmutableArrayOrEmpty();
             this.SeparatorDisplayParts = separatorParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
@@ -13,41 +13,44 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// The name of this parameter.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Documentation for this parameter.  This should normally be presented to the user when
         /// this parameter is selected.
         /// </summary>
-        public IList<SymbolDisplayPart> Documentation { get; private set; }
+        /// <remarks>
+        /// Note that this is an IEnumerable, not an IList because we want lazy evaluation.
+        /// </remarks>
+        public IEnumerable<SymbolDisplayPart> Documentation { get; }
 
         /// <summary>
         /// Display parts to show before the normal display parts for the parameter.
         /// </summary>
-        public IList<SymbolDisplayPart> PrefixDisplayParts { get; private set; }
+        public IList<SymbolDisplayPart> PrefixDisplayParts { get; }
 
         /// <summary>
         /// Display parts to show after the normal display parts for the parameter.
         /// </summary>
-        public IList<SymbolDisplayPart> SuffixDisplayParts { get; private set; }
+        public IList<SymbolDisplayPart> SuffixDisplayParts { get; }
 
         /// <summary>
         /// Display parts for this parameter.  This should normally be presented to the user as part
         /// of the entire signature display.
         /// </summary>
-        public IList<SymbolDisplayPart> DisplayParts { get; private set; }
+        public IList<SymbolDisplayPart> DisplayParts { get; }
 
         /// <summary>
         /// True if this parameter is optional or not.  Optional parameters may be presented in a
         /// different manner to users.
         /// </summary>
-        public bool IsOptional { get; private set; }
+        public bool IsOptional { get; }
 
         /// <summary>
         /// Display parts for this parameter that should be presented to the user when this
         /// parameter is selected.
         /// </summary>
-        public IList<SymbolDisplayPart> SelectedDisplayParts { get; private set; }
+        public IList<SymbolDisplayPart> SelectedDisplayParts { get; }
 
         public SignatureHelpParameter(
             string name,
@@ -60,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             this.Name = name ?? string.Empty;
             this.IsOptional = isOptional;
-            this.Documentation = documentation.ToImmutableArrayOrEmpty();
+            this.Documentation = documentation;
             this.DisplayParts = displayParts.ToImmutableArrayOrEmpty();
             this.PrefixDisplayParts = prefixDisplayParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixDisplayParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor
         /// Documentation for this parameter.  This should normally be presented to the user when
         /// this parameter is selected.
         /// </summary>
-        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumentationGetter { get; }
+        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumentationFactory { get; }
 
         /// <summary>
         /// Display parts to show before the normal display parts for the parameter.
@@ -50,12 +50,12 @@ namespace Microsoft.CodeAnalysis.Editor
         /// </summary>
         public IList<SymbolDisplayPart> SelectedDisplayParts { get; }
 
-        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationGetter = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
+        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationFactory = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
 
         public SignatureHelpParameter(
             string name,
             bool isOptional,
-            Func<CancellationToken, IEnumerable<SymbolDisplayPart>>  documentationGetter,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>>  documentationFactory,
             IEnumerable<SymbolDisplayPart> displayParts,
             IEnumerable<SymbolDisplayPart> prefixDisplayParts = null,
             IEnumerable<SymbolDisplayPart> suffixDisplayParts = null,
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             this.Name = name ?? string.Empty;
             this.IsOptional = isOptional;
-            this.DocumentationGetter = documentationGetter ?? s_emptyDocumentationGetter;
+            this.DocumentationFactory = documentationFactory ?? s_emptyDocumentationFactory;
             this.DisplayParts = displayParts.ToImmutableArrayOrEmpty();
             this.PrefixDisplayParts = prefixDisplayParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixDisplayParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
@@ -19,10 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor
         /// Documentation for this parameter.  This should normally be presented to the user when
         /// this parameter is selected.
         /// </summary>
-        /// <remarks>
-        /// Note that this is an IEnumerable, not an IList because we want lazy evaluation.
-        /// </remarks>
-        public IEnumerable<SymbolDisplayPart> Documentation { get; }
+        public Func<CancellationToken, IEnumerable<SymbolDisplayPart>> DocumentationGetter { get; }
 
         /// <summary>
         /// Display parts to show before the normal display parts for the parameter.
@@ -52,10 +50,12 @@ namespace Microsoft.CodeAnalysis.Editor
         /// </summary>
         public IList<SymbolDisplayPart> SelectedDisplayParts { get; }
 
+        private static readonly Func<CancellationToken, IEnumerable<SymbolDisplayPart>> s_emptyDocumentationGetter = _ => SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
+
         public SignatureHelpParameter(
             string name,
             bool isOptional,
-            IEnumerable<SymbolDisplayPart> documentation,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>>  documentationGetter,
             IEnumerable<SymbolDisplayPart> displayParts,
             IEnumerable<SymbolDisplayPart> prefixDisplayParts = null,
             IEnumerable<SymbolDisplayPart> suffixDisplayParts = null,
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             this.Name = name ?? string.Empty;
             this.IsOptional = isOptional;
-            this.Documentation = documentation;
+            this.DocumentationGetter = documentationGetter ?? s_emptyDocumentationGetter;
             this.DisplayParts = displayParts.ToImmutableArrayOrEmpty();
             this.PrefixDisplayParts = prefixDisplayParts.ToImmutableArrayOrEmpty();
             this.SuffixDisplayParts = suffixDisplayParts.ToImmutableArrayOrEmpty();

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpParameter.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor
         public SignatureHelpParameter(
             string name,
             bool isOptional,
-            Func<CancellationToken, IEnumerable<SymbolDisplayPart>>  documentationFactory,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationFactory,
             IEnumerable<SymbolDisplayPart> displayParts,
             IEnumerable<SymbolDisplayPart> prefixDisplayParts = null,
             IEnumerable<SymbolDisplayPart> suffixDisplayParts = null,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
@@ -17,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             public SymbolKeySignatureHelpItem(
                 ISymbol symbol,
                 bool isVariadic,
-                IEnumerable<SymbolDisplayPart> documentation,
+                Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
                 IEnumerable<SymbolDisplayPart> prefixParts,
                 IEnumerable<SymbolDisplayPart> separatorParts,
                 IEnumerable<SymbolDisplayPart> suffixParts,
                 IEnumerable<SignatureHelpParameter> parameters,
-                IEnumerable<SymbolDisplayPart> descriptionParts) : base(isVariadic, documentation, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
+                IEnumerable<SymbolDisplayPart> descriptionParts) : base(isVariadic, documentationGetter, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
             {
                 this.SymbolKey = symbol == null ? null : symbol.GetSymbolKey();
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
     {
         internal class SymbolKeySignatureHelpItem : SignatureHelpItem, IEquatable<SymbolKeySignatureHelpItem>
         {
-            public SymbolKey SymbolKey { get; private set; }
+            public SymbolKey SymbolKey { get; }
 
             public SymbolKeySignatureHelpItem(
                 ISymbol symbol,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             public SymbolKeySignatureHelpItem(
                 ISymbol symbol,
                 bool isVariadic,
-                Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
+                Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationFactory,
                 IEnumerable<SymbolDisplayPart> prefixParts,
                 IEnumerable<SymbolDisplayPart> separatorParts,
                 IEnumerable<SymbolDisplayPart> suffixParts,
                 IEnumerable<SignatureHelpParameter> parameters,
-                IEnumerable<SymbolDisplayPart> descriptionParts) : base(isVariadic, documentationGetter, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
+                IEnumerable<SymbolDisplayPart> descriptionParts) : base(isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
             {
                 this.SymbolKey = symbol == null ? null : symbol.GetSymbolKey();
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 ? item.DescriptionParts.Concat(startingNewLine.Concat(platformParts))
                 : startingNewLine.Concat(platformParts);
 
-            item.DescriptionParts = updatedDescription.ToList();
+            item.DescriptionParts = updatedDescription.ToImmutableArrayOrEmpty();
             return item;
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             ISymbolDisplayService symbolDisplayService,
             IAnonymousTypeDisplayService anonymousTypeDisplayService,
             bool isVariadic,
-            IEnumerable<SymbolDisplayPart> documentation,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
             IEnumerable<SymbolDisplayPart> prefixParts,
             IEnumerable<SymbolDisplayPart> separatorParts,
             IEnumerable<SymbolDisplayPart> suffixParts,
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             IEnumerable<SymbolDisplayPart> descriptionParts = null)
         {
             var item = new SymbolKeySignatureHelpItem(
-                orderSymbol, isVariadic, documentation, prefixParts, separatorParts,
+                orderSymbol, isVariadic, documentationGetter, prefixParts, separatorParts,
                 suffixParts, parameters, descriptionParts);
 
             return FixAnonymousTypeParts(orderSymbol, item, semanticModel, position, symbolDisplayService, anonymousTypeDisplayService);
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             ISymbol orderSymbol, SignatureHelpItem item, SemanticModel semanticModel, int position, ISymbolDisplayService symbolDisplayService, IAnonymousTypeDisplayService anonymousTypeDisplayService)
         {
             var currentItem = new SymbolKeySignatureHelpItem(
-                orderSymbol, item.IsVariadic, item.Documentation,
+                orderSymbol, item.IsVariadic, item.DocumentationGetter,
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.PrefixDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.SeparatorDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.SuffixDisplayParts, semanticModel, position, symbolDisplayService),
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 currentItem = new SymbolKeySignatureHelpItem(
                     orderSymbol,
                     currentItem.IsVariadic,
-                    currentItem.Documentation,
+                    currentItem.DocumentationGetter,
                     info.ReplaceAnonymousTypes(currentItem.PrefixDisplayParts),
                     info.ReplaceAnonymousTypes(currentItem.SeparatorDisplayParts),
                     info.ReplaceAnonymousTypes(currentItem.SuffixDisplayParts),
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.Documentation,
+                parameter.DocumentationGetter,
                 info.ReplaceAnonymousTypes(parameter.DisplayParts),
                 info.ReplaceAnonymousTypes(parameter.SelectedDisplayParts));
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.Documentation,
+                parameter.DocumentationGetter,
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.DisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.PrefixDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.SuffixDisplayParts, semanticModel, position, symbolDisplayService),

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             ISymbolDisplayService symbolDisplayService,
             IAnonymousTypeDisplayService anonymousTypeDisplayService,
             bool isVariadic,
-            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationGetter,
+            Func<CancellationToken, IEnumerable<SymbolDisplayPart>> documentationFactory,
             IEnumerable<SymbolDisplayPart> prefixParts,
             IEnumerable<SymbolDisplayPart> separatorParts,
             IEnumerable<SymbolDisplayPart> suffixParts,
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             IEnumerable<SymbolDisplayPart> descriptionParts = null)
         {
             var item = new SymbolKeySignatureHelpItem(
-                orderSymbol, isVariadic, documentationGetter, prefixParts, separatorParts,
+                orderSymbol, isVariadic, documentationFactory, prefixParts, separatorParts,
                 suffixParts, parameters, descriptionParts);
 
             return FixAnonymousTypeParts(orderSymbol, item, semanticModel, position, symbolDisplayService, anonymousTypeDisplayService);
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             ISymbol orderSymbol, SignatureHelpItem item, SemanticModel semanticModel, int position, ISymbolDisplayService symbolDisplayService, IAnonymousTypeDisplayService anonymousTypeDisplayService)
         {
             var currentItem = new SymbolKeySignatureHelpItem(
-                orderSymbol, item.IsVariadic, item.DocumentationGetter,
+                orderSymbol, item.IsVariadic, item.DocumenationFactory,
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.PrefixDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.SeparatorDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(item.SuffixDisplayParts, semanticModel, position, symbolDisplayService),
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 currentItem = new SymbolKeySignatureHelpItem(
                     orderSymbol,
                     currentItem.IsVariadic,
-                    currentItem.DocumentationGetter,
+                    currentItem.DocumenationFactory,
                     info.ReplaceAnonymousTypes(currentItem.PrefixDisplayParts),
                     info.ReplaceAnonymousTypes(currentItem.SeparatorDisplayParts),
                     info.ReplaceAnonymousTypes(currentItem.SuffixDisplayParts),
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.DocumentationGetter,
+                parameter.DocumentationFactory,
                 info.ReplaceAnonymousTypes(parameter.DisplayParts),
                 info.ReplaceAnonymousTypes(parameter.SelectedDisplayParts));
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return new SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.DocumentationGetter,
+                parameter.DocumentationFactory,
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.DisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.PrefixDisplayParts, semanticModel, position, symbolDisplayService),
                 anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parameter.SuffixDisplayParts, semanticModel, position, symbolDisplayService),

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     // If we don't have an item that can take that number of parameters, then just pick
                     // the last item.  Or stick with the current item if the last item isn't any better.
                     var lastItem = filteredItems.Last();
-                    if (currentItem.IsVariadic || currentItem.Parameters.Count == lastItem.Parameters.Count)
+                    if (currentItem.IsVariadic || currentItem.Parameters.Length == lastItem.Parameters.Length)
                     {
                         return currentItem;
                     }
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     // parameter index.  i.e. if it has 2 parameters and we're at index 0 or 1 then it's
                     // applicable.  However, if it has 2 parameters and we're at index 2, then it's not
                     // applicable.  
-                    if (item.Parameters.Count >= argumentCount)
+                    if (item.Parameters.Length >= argumentCount)
                     {
                         return true;
                     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Parameter.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Parameter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
         private readonly int _index;
         private readonly int _prettyPrintedIndex;
 
-        public string Documentation => _documentation ?? (_documentation = _parameter.DocumentationGetter(CancellationToken.None).GetFullText());
+        public string Documentation => _documentation ?? (_documentation = _parameter.DocumentationFactory(CancellationToken.None).GetFullText());
         public string Name => _parameter.Name;
         public Span Locus => new Span(_index, _contentLength);
         public Span PrettyPrintedLocus => new Span(_prettyPrintedIndex, _contentLength);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Parameter.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Parameter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
@@ -8,11 +9,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 {
     internal class Parameter : IParameter
     {
-        public string Documentation { get; internal set; }
-        public string Name { get; internal set; }
-        public Span Locus { get; internal set; }
-        public Span PrettyPrintedLocus { get; internal set; }
-        public ISignature Signature { get; internal set; }
+        private readonly SignatureHelpParameter _parameter;
+        private string _documentation;
+        private readonly int _contentLength;
+        private readonly int _index;
+        private readonly int _prettyPrintedIndex;
+
+        public string Documentation => _documentation ?? (_documentation = _parameter.DocumentationGetter(CancellationToken.None).GetFullText());
+        public string Name => _parameter.Name;
+        public Span Locus => new Span(_index, _contentLength);
+        public Span PrettyPrintedLocus => new Span(_prettyPrintedIndex, _contentLength);
+        public ISignature Signature { get; }
 
         public Parameter(
             Signature signature,
@@ -21,12 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             int index,
             int prettyPrintedIndex)
         {
+            _parameter = parameter;
             this.Signature = signature;
-            this.Name = parameter.Name;
-            this.Documentation = parameter.Documentation.GetFullText();
-
-            this.Locus = new Span(index, content.Length);
-            this.PrettyPrintedLocus = new Span(prettyPrintedIndex, content.Length);
+            _contentLength = content.Length;
+            _index = index;
+            _prettyPrintedIndex = prettyPrintedIndex;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp.Presentation
 {
@@ -192,9 +193,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             AddRange(_signatureHelpItem.DescriptionParts, parts, prettyPrintedParts);
             Append(_signatureHelpItem.DescriptionParts.GetFullText(), content, prettyPrintedContent);
 
-            // Note: This is where we realize the lazy Documentation. Be careful not to do so more than once.
-            var documentation = _signatureHelpItem.Documentation.ToArray();
-            if (documentation.Length > 0)
+            var documentation = _signatureHelpItem.DocumentationGetter(CancellationToken.None).ToList();
+            if (documentation.Count > 0)
             {
                 AddRange(new[] { newLinePart }, parts, prettyPrintedParts);
                 Append(newLineContent, content, prettyPrintedContent);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
         public Signature(ITrackingSpan applicableToSpan, SignatureHelpItem signatureHelpItem, int selectedParameterIndex)
         {
-            if (selectedParameterIndex < -1 || selectedParameterIndex >= _signatureHelpItem.Parameters.Length)
+            if (selectedParameterIndex < -1 || selectedParameterIndex >= signatureHelpItem.Parameters.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(selectedParameterIndex));
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
@@ -16,26 +17,99 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
         private const int MaxParamColumnCount = 100;
 
         private readonly SignatureHelpItem _signatureHelpItem;
-        private IParameter _currentParameter;
-        internal IList<SymbolDisplayPart> DisplayParts { get; private set; }
-        private IList<SymbolDisplayPart> _prettyPrintedDisplayParts;
 
-        public ITrackingSpan ApplicableToSpan { get; internal set; }
-        public string Content { get; private set; }
-        public string PrettyPrintedContent { get; private set; }
-        public ReadOnlyCollection<IParameter> Parameters { get; private set; }
-        public string Documentation { get; private set; }
-
-        public event EventHandler<CurrentParameterChangedEventArgs> CurrentParameterChanged;
-
-        public Signature(ITrackingSpan applicableToSpan, SignatureHelpItem signatureHelpItem)
+        public Signature(ITrackingSpan applicableToSpan, SignatureHelpItem signatureHelpItem, int selectedParameterIndex)
         {
             this.ApplicableToSpan = applicableToSpan;
             _signatureHelpItem = signatureHelpItem;
-            this.Initialize(setParameters: true);
+            _parameterIndex = selectedParameterIndex;
         }
 
-        private void Initialize(bool setParameters)
+        private bool _isInitialized;
+        private void EnsureInitialized()
+        {
+            if (!_isInitialized)
+            {
+                _isInitialized = true;
+                Initialize();
+            }
+        }
+
+        private IList<SymbolDisplayPart> _displayParts;
+        internal IList<SymbolDisplayPart> DisplayParts
+        {
+            get
+            {
+                EnsureInitialized();
+                return _displayParts;
+            }
+        }
+
+        private IList<SymbolDisplayPart> _prettyPrintedDisplayParts;
+
+        public ITrackingSpan ApplicableToSpan { get; }
+
+        private string _content;
+        public string Content
+        {
+            get
+            {
+                EnsureInitialized();
+                return _content;
+            }
+        }
+
+        private int _parameterIndex = -1;
+        public IParameter CurrentParameter
+        {
+            get
+            {
+                EnsureInitialized();
+                return _parameterIndex >= 0 && _parameters != null ? _parameters[_parameterIndex] : null;
+            }
+        }
+
+        public string Documentation
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        private ReadOnlyCollection<IParameter> _parameters;
+        public ReadOnlyCollection<IParameter> Parameters
+        {
+            get
+            {
+                EnsureInitialized();
+                return _parameters;
+            }
+        }
+
+        private string _prettyPrintedContent;
+        public string PrettyPrintedContent
+        {
+            get
+            {
+                EnsureInitialized();
+                return _prettyPrintedContent;
+            }
+        }
+
+        // This event is required by the ISignature interface but it's not actually used
+        // (once created the CurrentParameter property cannot change)
+        public event EventHandler<CurrentParameterChangedEventArgs> CurrentParameterChanged
+        {
+            add
+            {
+            }
+            remove
+            {
+            }
+        }
+
+        private void Initialize()
         {
             var content = new StringBuilder();
             var prettyPrintedContent = new StringBuilder();
@@ -61,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
             var paramColumnCount = 0;
 
-            for (int i = 0; i < _signatureHelpItem.Parameters.Count; i++)
+            for (int i = 0; i < _signatureHelpItem.Parameters.Length; i++)
             {
                 var sigHelpParameter = _signatureHelpItem.Parameters[i];
 
@@ -107,9 +181,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             AddRange(_signatureHelpItem.SuffixDisplayParts, parts, prettyPrintedParts);
             Append(_signatureHelpItem.SuffixDisplayParts.GetFullText(), content, prettyPrintedContent);
 
-            if (_currentParameter != null)
+            if (_parameterIndex >= 0)
             {
-                var sigHelpParameter = _signatureHelpItem.Parameters[this.Parameters.IndexOf(_currentParameter)];
+                var sigHelpParameter = _signatureHelpItem.Parameters[_parameterIndex];
 
                 AddRange(sigHelpParameter.SelectedDisplayParts, parts, prettyPrintedParts);
                 Append(sigHelpParameter.SelectedDisplayParts.GetFullText(), content, prettyPrintedContent);
@@ -118,24 +192,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             AddRange(_signatureHelpItem.DescriptionParts, parts, prettyPrintedParts);
             Append(_signatureHelpItem.DescriptionParts.GetFullText(), content, prettyPrintedContent);
 
-            if (_signatureHelpItem.Documentation.Count > 0)
+            // Note: This is where we realize the lazy Documentation. Be careful not to do so more than once.
+            var documentation = _signatureHelpItem.Documentation.ToArray();
+            if (documentation.Length > 0)
             {
                 AddRange(new[] { newLinePart }, parts, prettyPrintedParts);
                 Append(newLineContent, content, prettyPrintedContent);
 
-                AddRange(_signatureHelpItem.Documentation, parts, prettyPrintedParts);
-                Append(_signatureHelpItem.Documentation.GetFullText(), content, prettyPrintedContent);
+                AddRange(documentation, parts, prettyPrintedParts);
+                Append(documentation.GetFullText(), content, prettyPrintedContent);
             }
 
-            this.Content = content.ToString();
-            this.PrettyPrintedContent = prettyPrintedContent.ToString();
-            this.DisplayParts = parts.ToImmutableArrayOrEmpty();
-            this.PrettyPrintedDisplayParts = prettyPrintedParts.ToImmutableArrayOrEmpty();
-
-            if (setParameters)
-            {
-                this.Parameters = parameters.ToReadOnlyCollection();
-            }
+            _content = content.ToString();
+            _prettyPrintedContent = prettyPrintedContent.ToString();
+            _displayParts = parts.ToImmutableArrayOrEmpty();
+            _prettyPrintedDisplayParts = prettyPrintedParts.ToImmutableArrayOrEmpty();
+            _parameters = parameters.ToReadOnlyCollection();
         }
 
         private void AddRange(IList<SymbolDisplayPart> values, List<SymbolDisplayPart> parts, List<SymbolDisplayPart> prettyPrintedParts)
@@ -162,33 +234,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             }
 
             return list;
-        }
-
-        public IParameter CurrentParameter
-        {
-            get
-            {
-                return _currentParameter;
-            }
-
-            set
-            {
-                if (value == _currentParameter)
-                {
-                    return;
-                }
-
-                var oldValue = _currentParameter;
-                _currentParameter = value;
-
-                Initialize(setParameters: false);
-
-                var currentParameterChanged = this.CurrentParameterChanged;
-                if (currentParameterChanged != null)
-                {
-                    currentParameterChanged(this, new CurrentParameterChangedEventArgs(oldValue, value));
-                }
-            }
         }
 
         internal IList<SymbolDisplayPart> PrettyPrintedDisplayParts

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             AddRange(_signatureHelpItem.DescriptionParts, parts, prettyPrintedParts);
             Append(_signatureHelpItem.DescriptionParts.GetFullText(), content, prettyPrintedContent);
 
-            var documentation = _signatureHelpItem.DocumentationGetter(CancellationToken.None).ToList();
+            var documentation = _signatureHelpItem.DocumenationFactory(CancellationToken.None).ToList();
             if (documentation.Count > 0)
             {
                 AddRange(new[] { newLinePart }, parts, prettyPrintedParts);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/Signature.cs
@@ -21,6 +21,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
         public Signature(ITrackingSpan applicableToSpan, SignatureHelpItem signatureHelpItem, int selectedParameterIndex)
         {
+            if (selectedParameterIndex < -1 || selectedParameterIndex >= _signatureHelpItem.Parameters.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(selectedParameterIndex));
+            }
+
             this.ApplicableToSpan = applicableToSpan;
             _signatureHelpItem = signatureHelpItem;
             _parameterIndex = selectedParameterIndex;
@@ -36,29 +41,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             }
         }
 
-        private IList<SymbolDisplayPart> _displayParts;
-        internal IList<SymbolDisplayPart> DisplayParts
+        private Signature InitializedThis
         {
             get
             {
                 EnsureInitialized();
-                return _displayParts;
+                return this;
             }
         }
 
-        private IList<SymbolDisplayPart> _prettyPrintedDisplayParts;
+        private IList<SymbolDisplayPart> _displayParts;
+        internal IList<SymbolDisplayPart> DisplayParts => InitializedThis._displayParts;
 
         public ITrackingSpan ApplicableToSpan { get; }
 
         private string _content;
-        public string Content
-        {
-            get
-            {
-                EnsureInitialized();
-                return _content;
-            }
-        }
+        public string Content => InitializedThis._content;
 
         private int _parameterIndex = -1;
         public IParameter CurrentParameter
@@ -70,33 +68,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             }
         }
 
-        public string Documentation
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public string Documentation => null;
 
         private ReadOnlyCollection<IParameter> _parameters;
-        public ReadOnlyCollection<IParameter> Parameters
-        {
-            get
-            {
-                EnsureInitialized();
-                return _parameters;
-            }
-        }
+        public ReadOnlyCollection<IParameter> Parameters => InitializedThis._parameters;
 
         private string _prettyPrintedContent;
-        public string PrettyPrintedContent
-        {
-            get
-            {
-                EnsureInitialized();
-                return _prettyPrintedContent;
-            }
-        }
+        public string PrettyPrintedContent => InitializedThis._prettyPrintedContent;
 
         // This event is required by the ISignature interface but it's not actually used
         // (once created the CurrentParameter property cannot change)
@@ -107,6 +85,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             }
             remove
             {
+            }
+        }
+
+        private IList<SymbolDisplayPart> _prettyPrintedDisplayParts;
+        internal IList<SymbolDisplayPart> PrettyPrintedDisplayParts
+        {
+            get
+            {
+                return InitializedThis._prettyPrintedDisplayParts;
+            }
+
+            set
+            {
+                _prettyPrintedDisplayParts = value;
             }
         }
 
@@ -234,19 +226,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             }
 
             return list;
-        }
-
-        internal IList<SymbolDisplayPart> PrettyPrintedDisplayParts
-        {
-            get
-            {
-                return _prettyPrintedDisplayParts;
-            }
-
-            set
-            {
-                _prettyPrintedDisplayParts = value;
-            }
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
@@ -116,45 +116,30 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
                 foreach (var item in _signatureHelpItems)
                 {
-                    _signatureMap = _signatureMap.Add(item, new Signature(triggerSpan, item));
-                }
-
-                this.SetCurrentParameterForAllItems(selectedParameter);
-            }
-
-            private void SetCurrentParameterForAllItems(int? selectedParameter)
-            {
-                foreach (var item in _signatureHelpItems)
-                {
-                    this.SetCurrentParameter(item, selectedParameter);
+                    _signatureMap = _signatureMap.Add(item, new Signature(triggerSpan, item, GetParameterIndexForItem(item, selectedParameter)));
                 }
             }
 
-            private void SetCurrentParameter(SignatureHelpItem item, int? selectedParameter)
+            private static int GetParameterIndexForItem(SignatureHelpItem item, int? selectedParameter)
             {
-                Contract.ThrowIfFalse(_signatureMap.ContainsKey(item));
-                var signature = _signatureMap.GetValueOrDefault(item);
-
                 if (selectedParameter.HasValue)
                 {
-                    if (selectedParameter.Value < item.Parameters.Count)
+                    if (selectedParameter.Value < item.Parameters.Length)
                     {
                         // If the selected parameter is within the range of parameters of this item then set
                         // that as the current parameter.
-                        signature.CurrentParameter = signature.Parameters[selectedParameter.Value];
-                        return;
+                        return selectedParameter.Value;
                     }
                     else if (item.IsVariadic)
                     {
-                        // It wasn't in range, but the item takes an unlmiited number of parameters.  So
+                        // It wasn't in range, but the item takes an unlimited number of parameters.  So
                         // just set current parameter to the last parameter (the variadic one).
-                        signature.CurrentParameter = signature.Parameters.Last();
-                        return;
+                        return item.Parameters.Length - 1;
                     }
                 }
 
                 // It was out of bounds, there is no current parameter now.
-                signature.CurrentParameter = null;
+                return -1;
             }
 
             private void OnEditorSessionDismissed()

--- a/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -200,14 +200,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             int cursorPosition,
             TextSpan applicableSpan)
         {
-            var signature = new Signature(applicableToSpan: null, signatureHelpItem: actualSignatureHelpItem);
+            int currentParameterIndex = -1;
             if (expectedTestItem.CurrentParameterIndex != null)
             {
-                if (expectedTestItem.CurrentParameterIndex.Value >= 0 && expectedTestItem.CurrentParameterIndex.Value < signature.Parameters.Count)
+                if (expectedTestItem.CurrentParameterIndex.Value >= 0 && expectedTestItem.CurrentParameterIndex.Value < actualSignatureHelpItem.Parameters.Length)
                 {
-                    signature.CurrentParameter = signature.Parameters[expectedTestItem.CurrentParameterIndex.Value];
+                    currentParameterIndex = expectedTestItem.CurrentParameterIndex.Value;
                 }
             }
+
+            var signature = new Signature(applicableToSpan: null, signatureHelpItem: actualSignatureHelpItem, selectedParameterIndex: currentParameterIndex);
 
             // We're a match if the signature matches...
             // We're now combining the signature and documentation to make classification work.

--- a/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 
             if (expectedTestItem.MethodDocumentation != null)
             {
-                Assert.Equal(expectedTestItem.MethodDocumentation, actualSignatureHelpItem.Documentation.GetFullText());
+                Assert.Equal(expectedTestItem.MethodDocumentation, actualSignatureHelpItem.DocumentationGetter(CancellationToken.None).GetFullText());
             }
 
             if (expectedTestItem.ParameterDocumentation != null)

--- a/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 
             if (expectedTestItem.MethodDocumentation != null)
             {
-                Assert.Equal(expectedTestItem.MethodDocumentation, actualSignatureHelpItem.DocumentationGetter(CancellationToken.None).GetFullText());
+                Assert.Equal(expectedTestItem.MethodDocumentation, actualSignatureHelpItem.DocumenationFactory(CancellationToken.None).GetFullText());
             }
 
             if (expectedTestItem.ParameterDocumentation != null)

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -205,7 +205,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Function
 
         Private Shared Function CreateItems(count As Integer) As IList(Of SignatureHelpItem)
-            Return Enumerable.Range(0, count).Select(Function(i) New SignatureHelpItem(isVariadic:=False, documentation:={}, prefixParts:={}, separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={})).ToList()
+            Return Enumerable.Range(0, count).Select(Function(i) New SignatureHelpItem(isVariadic:=False, documentationGetter:=Nothing, prefixParts:={}, separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={})).ToList()
         End Function
 
         Friend Class MockSignatureHelpProvider

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -205,7 +205,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Function
 
         Private Shared Function CreateItems(count As Integer) As IList(Of SignatureHelpItem)
-            Return Enumerable.Range(0, count).Select(Function(i) New SignatureHelpItem(isVariadic:=False, documentationGetter:=Nothing, prefixParts:={}, separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={})).ToList()
+            Return Enumerable.Range(0, count).Select(Function(i) New SignatureHelpItem(isVariadic:=False, documentationFactory:=Nothing, prefixParts:={}, separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={})).ToList()
         End Function
 
         Friend Class MockSignatureHelpProvider

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -2,6 +2,7 @@
 
 Imports System.ComponentModel.Composition.Hosting
 Imports System.ComponentModel.Composition.Primitives
+Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
@@ -388,7 +389,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End If
 
             If documentation IsNot Nothing Then
-                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.Documentation.GetFullText())
+                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumentationGetter(CancellationToken.None).GetFullText())
             End If
 
             If selectedParameter IsNot Nothing Then

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -389,7 +389,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End If
 
             If documentation IsNot Nothing Then
-                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumentationGetter(CancellationToken.None).GetFullText())
+                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumenationFactory(CancellationToken.None).GetFullText())
             End If
 
             If selectedParameter IsNot Nothing Then

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     New SignatureHelpParameter(
                         name:=documentation.GetParameterName(i),
                         isOptional:=False,
-                        documentationGetter:=Function(c As CancellationToken) documentation.GetParameterDocumentation(capturedIndex).ToSymbolDisplayParts(),
+                        documentationFactory:=Function(c As CancellationToken) documentation.GetParameterDocumentation(capturedIndex).ToSymbolDisplayParts(),
                         displayParts:=documentation.GetParameterDisplayParts(i)))
             Next
 
@@ -73,7 +73,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 Nothing, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=False,
-                documentationGetter:=Function(c As CancellationToken) SpecializedCollections.SingletonEnumerable(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, documentation.DocumentationText)),
+                documentationFactory:=Function(c As CancellationToken) SpecializedCollections.SingletonEnumerable(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, documentation.DocumentationText)),
                 prefixParts:=documentation.PrefixParts,
                 separatorParts:=GetSeparatorParts(),
                 suffixParts:=suffixParts,

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
@@ -55,11 +55,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Dim parameters As New List(Of SignatureHelpParameter)
 
             For i = 0 To documentation.ParameterCount - 1
+                Dim capturedIndex = i
                 parameters.Add(
                     New SignatureHelpParameter(
                         name:=documentation.GetParameterName(i),
                         isOptional:=False,
-                        documentation:=documentation.GetParameterDocumentation(i).ToSymbolDisplayParts(),
+                        documentationGetter:=Function(c As CancellationToken) documentation.GetParameterDocumentation(capturedIndex).ToSymbolDisplayParts(),
                         displayParts:=documentation.GetParameterDisplayParts(i)))
             Next
 
@@ -72,7 +73,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 Nothing, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=False,
-                documentation:=SpecializedCollections.SingletonEnumerable(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, documentation.DocumentationText)),
+                documentationGetter:=Function(c As CancellationToken) SpecializedCollections.SingletonEnumerable(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, documentation.DocumentationText)),
                 prefixParts:=documentation.PrefixParts,
                 separatorParts:=GetSeparatorParts(),
                 suffixParts:=suffixParts,

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractSignatureHelpProvider.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return New SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                parameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 parameter.ToMinimalDisplayParts(semanticModel, position))
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AbstractSignatureHelpProvider.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return New SignatureHelpParameter(
                 parameter.Name,
                 parameter.IsOptional,
-                parameter.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 parameter.ToMinimalDisplayParts(semanticModel, position))
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic,
-                constructor.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),
@@ -151,7 +151,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 result.Add(New SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional:=True,
-                    documentation:=namedParameter.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                    documentationGetter:=namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                     displayParts:=displayParts,
                     prefixDisplayParts:=GetParameterPrefixDisplayParts(i)))
             Next

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
@@ -151,7 +151,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 result.Add(New SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional:=True,
-                    documentationGetter:=namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                    documentationFactory:=namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                     displayParts:=displayParts,
                     prefixDisplayParts:=GetParameterPrefixDisplayParts(i)))
             Next

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/AttributeSignatureHelpProvider.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic,
-                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(constructor, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(constructor),
@@ -151,7 +151,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 result.Add(New SignatureHelpParameter(
                     namedParameter.Name,
                     isOptional:=True,
-                    documentationFactory:=namedParameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                    documentationFactory:=namedParameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                     displayParts:=displayParts,
                     prefixDisplayParts:=GetParameterPrefixDisplayParts(i)))
             Next

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 method, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 False,
-                method.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                method.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(method, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(method, semanticModel, position),
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     Dim sigHelpParameter = New SignatureHelpParameter(
                         "<expression>",
                         parameter.IsOptional,
-                        parameter.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                        parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                         parts)
 
                     Return SpecializedCollections.SingletonEnumerable(sigHelpParameter)

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 method, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 False,
-                method.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                method.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(method, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(method, semanticModel, position),
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     Dim sigHelpParameter = New SignatureHelpParameter(
                         "<expression>",
                         parameter.IsOptional,
-                        parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                        parameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                         parts)
 
                     Return SpecializedCollections.SingletonEnumerable(sigHelpParameter)

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     False,
-                    symbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(namedType, semanticModel, position), GetSeparatorParts(), GetPostambleParts(namedType), namedType.TypeParameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             Else
                 Dim method = DirectCast(symbol, IMethodSymbol)
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     False,
-                    symbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(method, semanticModel, position), GetSeparatorParts(), GetPostambleParts(method, semanticModel, position), method.TypeParameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             End If
 
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return New SignatureHelpParameter(
                 parameter.Name,
                 isOptional:=False,
-                documentation:=parameter.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                documentationGetter:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 displayParts:=parts)
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return New SignatureHelpParameter(
                 parameter.Name,
                 isOptional:=False,
-                documentationGetter:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                documentationFactory:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 displayParts:=parts)
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/GenericNameSignatureHelpProvider.vb
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     False,
-                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                    symbol.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(namedType, semanticModel, position), GetSeparatorParts(), GetPostambleParts(namedType), namedType.TypeParameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             Else
                 Dim method = DirectCast(symbol, IMethodSymbol)
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                     symbol, semanticModel, position,
                     symbolDisplayService, anonymousTypeDisplayService,
                     False,
-                    symbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                    symbol.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                     GetPreambleParts(method, semanticModel, position), GetSeparatorParts(), GetPostambleParts(method, semanticModel, position), method.TypeParameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             End If
 
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return New SignatureHelpParameter(
                 parameter.Name,
                 isOptional:=False,
-                documentationFactory:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                documentationFactory:=parameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 displayParts:=parts)
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=invokeMethod.IsParams(),
-                documentationGetter:=Nothing,
+                documentationFactory:=Nothing,
                 prefixParts:=GetDelegateInvokePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts:=GetSeparatorParts(),
                 suffixParts:=GetDelegateInvokePostambleParts(invokeMethod, semanticModel, position),
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 parameters.Add(New SignatureHelpParameter(
                     parameter.Name,
                     isOptional:=False,
-                    documentationGetter:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentoFormattingService),
+                    documentationFactory:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentoFormattingService),
                     displayParts:=parameter.ToMinimalDisplayParts(semanticModel, position)))
             Next
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 parameters.Add(New SignatureHelpParameter(
                     parameter.Name,
                     isOptional:=False,
-                    documentationFactory:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentoFormattingService),
+                    documentationFactory:=parameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentoFormattingService),
                     displayParts:=parameter.ToMinimalDisplayParts(semanticModel, position)))
             Next
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=invokeMethod.IsParams(),
-                documentation:=SpecializedCollections.EmptyEnumerable(Of SymbolDisplayPart)(),
+                documentationGetter:=Nothing,
                 prefixParts:=GetDelegateInvokePreambleParts(invokeMethod, semanticModel, position),
                 separatorParts:=GetSeparatorParts(),
                 suffixParts:=GetDelegateInvokePostambleParts(invokeMethod, semanticModel, position),
@@ -52,10 +52,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
         Private Function GetDelegateInvokeParameters(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer, documentationCommentoFormattingService As IDocumentationCommentFormattingService, cancellationToken As CancellationToken) As IEnumerable(Of SignatureHelpParameter)
             Dim parameters = New List(Of SignatureHelpParameter)
             For Each parameter In invokeMethod.Parameters
+                cancellationToken.ThrowIfCancellationRequested()
                 parameters.Add(New SignatureHelpParameter(
                     parameter.Name,
                     isOptional:=False,
-                    documentation:=parameter.GetDocumentationParts(semanticModel, position, documentationCommentoFormattingService, cancellationToken),
+                    documentationGetter:=parameter.GetDocumentationPartsGetter(semanticModel, position, documentationCommentoFormattingService),
                     displayParts:=parameter.ToMinimalDisplayParts(semanticModel, position)))
             Next
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 indexer, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 indexer.IsParams(),
-                indexer.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                indexer.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetIndexerPreambleParts(indexer, semanticModel, position),
                 GetSeparatorParts(),
                 GetIndexerPostambleParts(indexer, semanticModel, position),

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 indexer, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 indexer.IsParams(),
-                indexer.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                indexer.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetIndexerPreambleParts(indexer, semanticModel, position),
                 GetSeparatorParts(),
                 GetIndexerPostambleParts(indexer, semanticModel, position),

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 member, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 member.IsParams(),
-                member.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken).Concat(GetAwaitableDescription(member, semanticModel, position)),
+                Function(c) member.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, c).Concat(GetAwaitableDescription(member, semanticModel, position)),
                 GetMemberGroupPreambleParts(member, semanticModel, position),
                 GetSeparatorParts(),
                 GetMemberGroupPostambleParts(member, semanticModel, position),

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=False,
-                documentationFactory:=invokeMethod.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                documentationFactory:=invokeMethod.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 prefixParts:=GetDelegateTypePreambleParts(invokeMethod, semanticModel, position), separatorParts:=GetSeparatorParts(), suffixParts:=GetDelegateTypePostambleParts(invokeMethod), parameters:=GetDelegateTypeParameters(invokeMethod, semanticModel, position, cancellationToken))
             Return SpecializedCollections.SingletonEnumerable(item)
         End Function

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=False,
-                documentation:=invokeMethod.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                documentationGetter:=invokeMethod.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 prefixParts:=GetDelegateTypePreambleParts(invokeMethod, semanticModel, position), separatorParts:=GetSeparatorParts(), suffixParts:=GetDelegateTypePostambleParts(invokeMethod), parameters:=GetDelegateTypeParameters(invokeMethod, semanticModel, position, cancellationToken))
             Return SpecializedCollections.SingletonEnumerable(item)
         End Function
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return {New SignatureHelpParameter(
                 TargetName,
                 isOptional:=False,
-                documentation:=String.Empty.ToSymbolDisplayParts(),
+                documentationGetter:=Nothing,
                 displayParts:=parts)}
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 invokeMethod, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 isVariadic:=False,
-                documentationGetter:=invokeMethod.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                documentationFactory:=invokeMethod.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 prefixParts:=GetDelegateTypePreambleParts(invokeMethod, semanticModel, position), separatorParts:=GetSeparatorParts(), suffixParts:=GetDelegateTypePostambleParts(invokeMethod), parameters:=GetDelegateTypeParameters(invokeMethod, semanticModel, position, cancellationToken))
             Return SpecializedCollections.SingletonEnumerable(item)
         End Function
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Return {New SignatureHelpParameter(
                 TargetName,
                 isOptional:=False,
-                documentationGetter:=Nothing,
+                documentationFactory:=Nothing,
                 displayParts:=parts)}
         End Function
 

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetNormalTypePreambleParts(constructor, semanticModel, position), GetSeparatorParts(), GetNormalTypePostambleParts(constructor), constructor.Parameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             Return item
         End Function

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 constructor, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 constructor.IsParams(),
-                constructor.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                constructor.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetNormalTypePreambleParts(constructor, semanticModel, position), GetSeparatorParts(), GetNormalTypePostambleParts(constructor), constructor.Parameters.[Select](Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService, cancellationToken)))
             Return item
         End Function

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
@@ -109,7 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 eventSymbol, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 False,
-                eventSymbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
+                eventSymbol.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(eventSymbol, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(eventSymbol, semanticModel, position),

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
@@ -109,7 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                 eventSymbol, semanticModel, position,
                 symbolDisplayService, anonymousTypeDisplayService,
                 False,
-                eventSymbol.GetDocumentationParts(semanticModel, position, documentationCommentFormattingService, cancellationToken),
+                eventSymbol.GetDocumentationPartsGetter(semanticModel, position, documentationCommentFormattingService),
                 GetPreambleParts(eventSymbol, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(eventSymbol, semanticModel, position),

--- a/src/Features/CSharp/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -121,7 +121,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private INamedTypeSymbol GetCompletionListType(ITypeSymbol type, INamedTypeSymbol within, Compilation compilation)
         {
-            var documentation = type.GetDocumentationComment();
+            // PERF: Avoid parsing XML unless the text contains the word "completionlist".
+            string xmlText = type.GetDocumentationCommentXml();
+            if (xmlText == null || !xmlText.Contains(DocumentationCommentXmlNames.CompletionListElementName))
+            {
+                return null;
+            }
+
+            var documentation = Shared.Utilities.DocumentationComment.FromXmlFragment(xmlText);
 
             var completionListType = documentation.CompletionListCref != null
                 ? DocumentationCommentId.GetSymbolsForDeclarationId(documentation.CompletionListCref, compilation).OfType<INamedTypeSymbol>().FirstOrDefault()

--- a/src/Features/Core/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Shared/Extensions/ISymbolExtensions_2.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 : SpecializedCollections.EmptyEnumerable<SymbolDisplayPart>();
         }
 
-        public static Func<CancellationToken, IEnumerable<SymbolDisplayPart>> GetDocumentationPartsGetter(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter)
+        public static Func<CancellationToken, IEnumerable<SymbolDisplayPart>> GetDocumentationPartsFactory(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter)
         {
             return c => symbol.GetDocumentationParts(semanticModel, position, formatter, cancellationToken: c);
         }

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -366,7 +366,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             End If
 
             If documentation IsNot Nothing Then
-                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumentationGetter(CancellationToken.None).GetFullText())
+                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumenationFactory(CancellationToken.None).GetFullText())
             End If
 
             If selectedParameter IsNot Nothing Then

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition.Hosting
+Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
@@ -8,7 +9,7 @@ Imports Microsoft.CodeAnalysis.Completion.Rules
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
 Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Implementation.Intellisense.Completion
+Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 Imports Microsoft.CodeAnalysis.Host.Mef
@@ -365,7 +366,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             End If
 
             If documentation IsNot Nothing Then
-                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.Documentation.GetFullText())
+                Assert.Equal(documentation, Me.CurrentSignatureHelpPresenterSession.SelectedItem.DocumentationGetter(CancellationToken.None).GetFullText())
             End If
 
             If selectedParameter IsNot Nothing Then

--- a/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Xml;
 using XmlNames = Roslyn.Utilities.DocumentationCommentXmlNames;
 
@@ -72,13 +73,26 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         }
 
         /// <summary>
+        /// Cache of the most recently parsed fragment and the resulting DocumentationComment
+        /// </summary>
+        private static volatile DocumentationComment s_cacheLastXmlFragmentParse;
+
+        /// <summary>
         /// Parses and constructs a <see cref="DocumentationComment" /> from the given fragment of XML.
         /// </summary>
         /// <param name="xml">The fragment of XML to parse.</param>
         /// <returns>A DocumentationComment instance.</returns>
         public static DocumentationComment FromXmlFragment(string xml)
         {
-            return CommentBuilder.Parse(xml);
+            var result = s_cacheLastXmlFragmentParse;
+            if (result == null || result.FullXmlFragment != xml)
+            {
+                // Cache miss
+                result = CommentBuilder.Parse(xml);
+                s_cacheLastXmlFragmentParse = result;
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
This change makes XML documentation comment lookup and parsing for signature help lazy.