### PR TITLE
Reduce the amount of work done in the pattern matcher.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             private readonly ItemDisplayFactory _displayFactory;
             private readonly INavigateToCallback _callback;
             private readonly string _searchPattern;
-            private readonly PatternMatcher _patternMatcher;
             private readonly ProgressTracker _progress;
             private readonly IAsynchronousOperationListener _asyncListener;
             private readonly CancellationToken _cancellationToken;
@@ -37,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 _displayFactory = displayFactory;
                 _callback = callback;
                 _searchPattern = searchPattern;
-                _patternMatcher = new PatternMatcher();
                 _cancellationToken = cancellationToken;
                 _progress = new ProgressTracker(callback.ReportProgress);
                 _asyncListener = asyncListener;

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 
         internal static async Task<IEnumerable<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>> FindNavigableDeclaredSymbolInfos(Project project, string pattern, CancellationToken cancellationToken)
         {
-            var patternMatcher = new PatternMatcher();
+            var patternMatcher = new PatternMatcher(pattern);
 
             var result = new List<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>();
             foreach (var document in project.Documents)
@@ -28,10 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 foreach (var declaredSymbolInfo in declaredSymbolInfos)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var patternMatches = patternMatcher.MatchPattern(
+                    var patternMatches = patternMatcher.GetMatches(
                         GetSearchName(declaredSymbolInfo),
-                        declaredSymbolInfo.FullyQualifiedContainerName,
-                        pattern);
+                        declaredSymbolInfo.FullyQualifiedContainerName);
 
                     if (patternMatches != null)
                     {

--- a/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
+++ b/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
@@ -709,12 +709,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
         private static PatternMatch? TryMatchSingleWordPattern(string candidate, string pattern)
         {
-            return new PatternMatcher().MatchSingleWordPattern_ForTestingOnly(candidate, pattern);
+            return new PatternMatcher(pattern).MatchSingleWordPattern_ForTestingOnly(candidate);
         }
 
         private static IEnumerable<PatternMatch> TryMatchMultiWordPattern(string candidate, string pattern)
         {
-            return new PatternMatcher().MatchPattern(candidate, pattern);
+            return new PatternMatcher(pattern).GetMatches(candidate);
         }
     }
 }

--- a/src/Features/Core/Completion/AbstractCompletionService.CompletionRules.cs
+++ b/src/Features/Core/Completion/AbstractCompletionService.CompletionRules.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Completion.Rules;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
@@ -8,17 +9,33 @@ namespace Microsoft.CodeAnalysis.Completion
 {
     internal partial class AbstractCompletionService
     {
-        private class CompletionRules : ICompletionRules
+        protected class CompletionRules : ICompletionRules
         {
+            private readonly object _gate = new object();
             private readonly AbstractCompletionService _completionService;
-            private readonly PatternMatcher _patternMatcher = new PatternMatcher(verbatimIdentifierPrefixIsWordCharacter: true);
+            private readonly Dictionary<string, PatternMatcher> patternMatcherMap = new Dictionary<string, PatternMatcher>();
 
             public CompletionRules(AbstractCompletionService completionService)
             {
                 _completionService = completionService;
             }
 
-            public bool? MatchesFilterText(CompletionItem item, string filterText, CompletionTriggerInfo triggerInfo, CompletionFilterReason filterReason)
+            protected PatternMatcher GetPatternMatcher(string value)
+            {
+                lock (_gate)
+                {
+                    PatternMatcher patternMatcher;
+                    if (!patternMatcherMap.TryGetValue(value, out patternMatcher))
+                    {
+                        patternMatcher = new PatternMatcher(value, verbatimIdentifierPrefixIsWordCharacter: true);
+                        patternMatcherMap.Add(value, patternMatcher);
+                    }
+
+                    return patternMatcher;
+                }
+            }
+
+            public virtual bool? MatchesFilterText(CompletionItem item, string filterText, CompletionTriggerInfo triggerInfo, CompletionFilterReason filterReason)
             {
                 // If the user hasn't typed anything, and this item was preselected, or was in the
                 // MRU list, then we definitely want to include it.
@@ -37,9 +54,8 @@ namespace Microsoft.CodeAnalysis.Completion
                     return false;
                 }
 
-                var match = _patternMatcher.MatchPatternFirstOrNullable(
-                            _completionService.GetCultureSpecificQuirks(item.FilterText),
-                            _completionService.GetCultureSpecificQuirks(filterText));
+                var patternMatcher = this.GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText));
+                var match = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item.FilterText));
                 return match != null;
             }
 
@@ -56,14 +72,11 @@ namespace Microsoft.CodeAnalysis.Completion
                 return true;
             }
 
-            public bool? IsBetterFilterMatch(CompletionItem item1, CompletionItem item2, string filterText, CompletionTriggerInfo triggerInfo, CompletionFilterReason filterReason)
+            public virtual bool? IsBetterFilterMatch(CompletionItem item1, CompletionItem item2, string filterText, CompletionTriggerInfo triggerInfo, CompletionFilterReason filterReason)
             {
-                var match1 = _patternMatcher.MatchPatternFirstOrNullable(
-                            _completionService.GetCultureSpecificQuirks(item1.FilterText),
-                            _completionService.GetCultureSpecificQuirks(filterText));
-                var match2 = _patternMatcher.MatchPatternFirstOrNullable(
-                            _completionService.GetCultureSpecificQuirks(item2.FilterText),
-                            _completionService.GetCultureSpecificQuirks(filterText));
+                var patternMatcher = GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText));
+                var match1 = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item1.FilterText));
+                var match2 = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item2.FilterText));
 
                 if (match1 != null && match2 != null)
                 {
@@ -105,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return item1MRUIndex < item2MRUIndex;
             }
 
-            public bool? ShouldSoftSelectItem(CompletionItem item, string filterText, CompletionTriggerInfo triggerInfo)
+            public virtual bool? ShouldSoftSelectItem(CompletionItem item, string filterText, CompletionTriggerInfo triggerInfo)
             {
                 return filterText.Length == 0 && !item.Preselect;
             }
@@ -115,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 _completionService.CompletionItemComitted(item);
             }
 
-            public bool? ItemsMatch(CompletionItem item1, CompletionItem item2)
+            public virtual bool? ItemsMatch(CompletionItem item1, CompletionItem item2)
             {
                 return
                     item1.FilterSpan == item2.FilterSpan &&

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -19,19 +19,129 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     /// </summary>
     internal sealed class PatternMatcher
     {
+        // First we break up the pattern given by dots.  Each portion of the pattern between the
+        // dots is a 'Segment'.  The 'Segment' contains information about the entire section of 
+        // text between the dots, as well as information about any individual 'Words' that we 
+        // can break the segment into.
+        private struct Segment
+        {
+            // Information about the entire piece of text between the dots.  For example, if the 
+            // text between the dots is 'GetKeyword', then TotalTextChunk.Text will be 'GetKeyword' and 
+            // TotalTextChunk.CharacterSpans will correspond to 'G', 'et', 'K' and 'eyword'.
+            public readonly TextChunk TotalTextChunk;
+
+            // Information about the subwords compromising the total word.  For example, if the 
+            // text between the dots is 'GetKeyword', then the subwords will be 'Get' and 'Keyword'
+            // Those individual words will have CharacterSpans of ('G' and 'et') and ('K' and 'eyword')
+            // respectively.
+            public readonly TextChunk[] SubWordTextChunks;
+
+            public Segment(string text, bool verbatimIdentifierPrefixIsWordCharacter)
+            {
+                this.TotalTextChunk = new TextChunk(text);
+                this.SubWordTextChunks = BreakPatternIntoTextChunks(text, verbatimIdentifierPrefixIsWordCharacter);
+            }
+
+            public bool IsInvalid => this.SubWordTextChunks.Length == 0;
+
+            private static int CountTextChunks(string pattern, bool verbatimIdentifierPrefixIsWordCharacter)
+            {
+                int count = 0;
+                int wordLength = 0;
+
+                for (int i = 0; i < pattern.Length; i++)
+                {
+                    if (IsWordChar(pattern[i], verbatimIdentifierPrefixIsWordCharacter))
+                    {
+                        wordLength++;
+                    }
+                    else
+                    {
+                        if (wordLength > 0)
+                        {
+                            count++;
+                            wordLength = 0;
+                        }
+                    }
+                }
+
+                if (wordLength > 0)
+                {
+                    count++;
+                }
+
+                return count;
+            }
+
+            private static TextChunk[] BreakPatternIntoTextChunks(string pattern, bool verbatimIdentifierPrefixIsWordCharacter)
+            {
+                int partCount = CountTextChunks(pattern, verbatimIdentifierPrefixIsWordCharacter);
+
+                if (partCount == 0)
+                {
+                    return SpecializedCollections.EmptyArray<TextChunk>();
+                }
+
+                var result = new TextChunk[partCount];
+                int resultIndex = 0;
+                int wordStart = 0;
+                int wordLength = 0;
+
+                for (int i = 0; i < pattern.Length; i++)
+                {
+                    var ch = pattern[i];
+                    if (IsWordChar(ch, verbatimIdentifierPrefixIsWordCharacter))
+                    {
+                        if (wordLength++ == 0)
+                        {
+                            wordStart = i;
+                        }
+                    }
+                    else
+                    {
+                        if (wordLength > 0)
+                        {
+                            result[resultIndex++] = new TextChunk(pattern.Substring(wordStart, wordLength));
+                            wordLength = 0;
+                        }
+                    }
+                }
+
+                if (wordLength > 0)
+                {
+                    result[resultIndex++] = new TextChunk(pattern.Substring(wordStart, wordLength));
+                }
+
+                return result;
+            }
+        }
+
+        // Information about a chunk of text from the pattern.  The chunk is a piece of text, with 
+        // cached information about the character spans within in.  Character spans separate out
+        // capitalized runs and lowercase runs.  i.e. if you have AAbb, then there will be two 
+        // character spans, one for AA and one for BB.
+        private struct TextChunk
+        {
+            public readonly string Text;
+            public readonly List<TextSpan> CharacterSpans;
+
+            public TextChunk(string text)
+            {
+                this.Text = text;
+                this.CharacterSpans = StringBreaker.BreakIntoCharacterParts(text);
+            }
+        }
+
         private static readonly char[] DotCharacterArray = new[] { '.' };
 
         private readonly object _gate = new object();
+
+        private readonly bool _invalidPattern;
+        private readonly Segment _fullPatternSegment;
+        private readonly Segment[] _dotSeparatedSegements;
+
         private readonly Dictionary<string, List<TextSpan>> _stringToWordSpans = new Dictionary<string, List<TextSpan>>();
-        private readonly Dictionary<string, List<TextSpan>> _stringToCharacterSpans = new Dictionary<string, List<TextSpan>>();
         private readonly Func<string, List<TextSpan>> _breakIntoWordSpans = StringBreaker.BreakIntoWordParts;
-        private readonly Func<string, List<TextSpan>> _breakIntoCharacterSpans = StringBreaker.BreakIntoCharacterParts;
-
-        private readonly Dictionary<string, string[]> _patternToWordParts = new Dictionary<string, string[]>();
-        private readonly Dictionary<string, string[]> _patternToDotSeparatedParts = new Dictionary<string, string[]>();
-
-        private readonly Func<string, string[]> _breakPatternIntoWordParts;
-        private readonly Func<string, string[]> _breakPatternIntoDotSeparatedParts;
 
         // PERF: Cache the culture's compareInfo to avoid the overhead of asking for them repeatedly in inner loops
         private readonly CompareInfo _compareInfo;
@@ -39,40 +149,147 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// Construct a new PatternMatcher using the calling thread's culture for string searching and comparison.
         /// </summary>
-        public PatternMatcher(bool verbatimIdentifierPrefixIsWordCharacter = false) : this(CultureInfo.CurrentCulture, verbatimIdentifierPrefixIsWordCharacter)
+        public PatternMatcher(string pattern, bool verbatimIdentifierPrefixIsWordCharacter = false) : this(pattern, CultureInfo.CurrentCulture, verbatimIdentifierPrefixIsWordCharacter)
         {
         }
 
         /// <summary>
         /// Construct a new PatternMatcher using the specified culture.
         /// </summary>
+        /// <param name="pattern">The pattern to make the pattern matcher for.</param>
         /// <param name="culture">The culture to use for string searching and comparison.</param>
         /// <param name="verbatimIdentifierPrefixIsWordCharacter">Whether to consider "@" as a word character</param>
-        public PatternMatcher(CultureInfo culture, bool verbatimIdentifierPrefixIsWordCharacter)
+        public PatternMatcher(string pattern, CultureInfo culture, bool verbatimIdentifierPrefixIsWordCharacter)
         {
+            pattern = pattern.Trim();
             _compareInfo = culture.CompareInfo;
-            _breakPatternIntoWordParts = pattern => BreakPatternIntoParts(pattern, verbatimIdentifierPrefixIsWordCharacter);
-            _breakPatternIntoDotSeparatedParts = BreakIntoDotSeparatedParts;
+
+            _fullPatternSegment = new Segment(pattern, verbatimIdentifierPrefixIsWordCharacter);
+            _dotSeparatedSegements = pattern.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
+                                            .Select(text => new Segment(text.Trim(), verbatimIdentifierPrefixIsWordCharacter))
+                                            .ToArray();
+            _invalidPattern = _dotSeparatedSegements.Length == 0 || _dotSeparatedSegements.Any(s => s.IsInvalid);
         }
 
-        private static string[] BreakIntoDotSeparatedParts(string value)
-        {
-            if (value.IndexOf('.') >= 0) {
-                var split = value.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
-                if (split.Length > 0) {
-                    return split;
-                }
-            }
+        public bool IsDottedPattern => _dotSeparatedSegements.Length > 1;
 
-            return null;
+        private bool SkipMatch(string candidate)
+        {
+            return _invalidPattern || string.IsNullOrWhiteSpace(candidate);
         }
 
-        private List<TextSpan> GetCharacterSpans(string pattern)
+        /// <summary>
+        /// Determines if a given candidate string matches under a multiple word query text, as you
+        /// would find in features like Navigate To.
+        /// </summary>
+        /// <param name="candidate">The word being tested.</param>
+        /// <returns>If this was a match, a set of match types that occurred while matching the
+        /// patterns. If it was not a match, it returns null.</returns>
+        public IEnumerable<PatternMatch> GetMatches(string candidate)
         {
-            lock (_gate)
+            if (SkipMatch(candidate))
             {
-                return _stringToCharacterSpans.GetOrAdd(pattern, _breakIntoCharacterSpans);
+                return null;
             }
+
+            return MatchSegment(candidate, _fullPatternSegment);
+        }
+
+        public IEnumerable<PatternMatch> GetMatchesForLastSegmentOfPattern(string candidate)
+        {
+            if (SkipMatch(candidate))
+            {
+                return null;
+            }
+
+            return MatchSegment(candidate, _dotSeparatedSegements.Last());
+        }
+
+        /// <summary>
+        /// Matches a pattern against a candidate, and an optional dotted container for the 
+        /// candidate. If the container is provided, and the pattern itself contains dots, then
+        /// the pattern will be tested against the candidate and container.  Specifically,
+        /// the part of the pattern after the last dot will be tested against the candidate. If
+        /// a match occurs there, then the remaining dot-separated portions of the pattern will
+        /// be tested against every successive portion of the container from right to left.
+        /// 
+        /// i.e. if you have a pattern of "Con.WL" and the candidate is "WriteLine" with a 
+        /// dotted container of "System.Console", then "WL" will be tested against "WriteLine".
+        /// With a match found there, "Con" will then be tested against "Console".
+        /// </summary>
+        public IEnumerable<PatternMatch> GetMatches(string candidate, string dottedContainer)
+        {
+            if (SkipMatch(candidate))
+            {
+                return null;
+            }
+
+            // First, check that the last part of the dot separated pattern matches the name of the
+            // candidate.  If not, then there's no point in proceeding and doing the more
+            // expensive work.
+            var candidateMatch = MatchSegment(candidate, _dotSeparatedSegements.Last());
+            if (candidateMatch == null)
+            {
+                return null;
+            }
+
+            dottedContainer = dottedContainer ?? string.Empty;
+            var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
+
+            // -1 because the last part was checked against the name, and only the rest
+            // of the parts are checked against the container.
+            if (_dotSeparatedSegements.Length - 1 > containerParts.Length)
+            {
+                // There weren't enough container parts to match against the pattern parts.
+                // So this definitely doesn't match.
+                return null;
+            }
+
+            // So far so good.  Now break up the container for the candidate and check if all
+            // the dotted parts match up correctly.
+            var totalMatch = candidateMatch.ToList();
+
+            for (int i = _dotSeparatedSegements.Length - 2, j = containerParts.Length - 1;
+                    i >= 0;
+                    i--, j--)
+            {
+                var segment = _dotSeparatedSegements[i];
+                var containerName = containerParts[j];
+                var containerMatch = MatchSegment(containerName, segment);
+                if (containerMatch == null)
+                {
+                    // This container didn't match the pattern piece.  So there's no match at all.
+                    return null;
+                }
+
+                totalMatch.AddRange(containerMatch);
+            }
+
+            // Success, this symbol's full name matched against the dotted name the user was asking
+            // about.
+            return totalMatch;
+        }
+
+        /// <summary>
+        /// Determines if a given candidate string matches under a multiple word query text, as you
+        /// would find in features like Navigate To.
+        /// </summary>
+        /// <remarks>
+        /// PERF: This is slightly faster and uses less memory than <see cref="GetMatches(string)"/>
+        /// so, unless you need to know the full set of matches, use this version.
+        /// </remarks>
+        /// <param name="candidate">The word being tested.</param>
+        /// <returns>If this was a match, the first element of the set of match types that occurred while matching the
+        /// patterns. If it was not a match, it returns null.</returns>
+        public PatternMatch? GetFirstMatch(string candidate)
+        {
+            if (SkipMatch(candidate))
+            {
+                return null;
+            }
+
+            PatternMatch[] ignored;
+            return MatchSegment(candidate, _fullPatternSegment, wantAllMatches: false, allMatches: out ignored);
         }
 
         private List<TextSpan> GetWordSpans(string word)
@@ -83,30 +300,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             }
         }
 
-        private string[] GetWordParts(string pattern)
+        internal PatternMatch? MatchSingleWordPattern_ForTestingOnly(string candidate)
         {
-            lock (_gate)
-            {
-                return _patternToWordParts.GetOrAdd(pattern, _breakPatternIntoWordParts);
-            }
-        }
-
-        private string[] GetDotSeparatedParts(string pattern)
-        {
-            if (pattern == null)
-            {
-                return null;
-            }
-
-            lock (_gate)
-            {
-                return _patternToDotSeparatedParts.GetOrAdd(pattern, _breakPatternIntoDotSeparatedParts);
-            }
-        }
-
-        internal PatternMatch? MatchSingleWordPattern_ForTestingOnly(string candidate, string pattern)
-        {
-            return MatchSingleWordPattern(candidate, pattern, punctuationStripped: false);
+            return MatchTextChunk(candidate, _fullPatternSegment.TotalTextChunk, punctuationStripped: false);
         }
 
         private static bool ContainsUpperCaseLetter(string pattern)
@@ -123,77 +319,26 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return false;
         }
 
-        /// <summary>
-        /// Determines if a candidate string should matched given the user's pattern. 
-        /// </summary>
-        /// <param name="candidate">The string to test.</param>
-        /// <param name="pattern">The pattern to match against, which may use things like
-        /// Camel-Cased patterns.</param>
-        /// <param name="punctuationStripped">Whether punctuation (space or asterisk) was stripped
-        /// from the pattern.</param>
-        private PatternMatch? MatchSingleWordPattern(string candidate, string pattern, bool punctuationStripped)
+        private PatternMatch? MatchTextChunk(string candidate, TextChunk chunk, bool punctuationStripped)
         {
-            // We never match whitespace only
-            if (string.IsNullOrWhiteSpace(pattern) || string.IsNullOrWhiteSpace(candidate))
-            {
-                return null;
-            }
-
-            // The logic for pattern matching is now as follows:
-            //
-            // 1) Break the pattern passed in into pattern parts.  Breaking is rather simple and a
-            //    good way to think about it that if gives you all the individual alphanumeric chunks
-            //    of the pattern.
-            //
-            // 2) For each part try to match the part against the candidate value.
-            //
-            // 3) Matching is as follows:
-            //
-            //   a) Check if the part matches the candidate entirely, in an case insensitive or
-            //    sensitive manner.  If it does, return that there was an exact match.
-            //
-            //   b) Check if the part is a prefix of the candidate, in a case insensitive or
-            //      sensitive manner.  If it does, return that there was a prefix match.
-            //
-            //   c) If the part is entirely lowercase, then check if it is contained anywhere in the
-            //      candidate in a case insensitive manner.  If so, return that there was a substring
-            //      match. 
-            //
-            //      Note: We only have a substring match if the lowercase part is prefix match of
-            //      some word part. That way we don't match something like 'Class' when the user
-            //      types 'a'. But we would match 'FooAttribute' (since 'Attribute' starts with
-            //      'a').
-            //
-            //   d) If the part was not entirely lowercase, then check if it is contained in the
-            //      candidate in a case *sensitive* manner. If so, return that there was a substring
-            //      match.
-            //
-            //   e) If the part was not entirely lowercase, then attempt a camel cased match as
-            //      well.
-            //
-            //   f) The pattern is all lower case. Is it a case insensitive substring of the candidate starting 
-            //      on a part boundary of the candidate?
-            //
-            // Only if all parts have some sort of match is the pattern considered matched.
-
-            int index = _compareInfo.IndexOf(candidate, pattern, CompareOptions.IgnoreCase);
+            int index = _compareInfo.IndexOf(candidate, chunk.Text, CompareOptions.IgnoreCase);
             if (index == 0)
             {
-                if (pattern.Length == candidate.Length)
+                if (chunk.Text.Length == candidate.Length)
                 {
                     // a) Check if the part matches the candidate entirely, in an case insensitive or
                     //    sensitive manner.  If it does, return that there was an exact match.
-                    return new PatternMatch(PatternMatchKind.Exact, punctuationStripped, isCaseSensitive: candidate == pattern);
+                    return new PatternMatch(PatternMatchKind.Exact, punctuationStripped, isCaseSensitive: candidate == chunk.Text);
                 }
                 else
                 {
                     // b) Check if the part is a prefix of the candidate, in a case insensitive or sensitive
                     //    manner.  If it does, return that there was a prefix match.
-                    return new PatternMatch(PatternMatchKind.Prefix, punctuationStripped, isCaseSensitive: _compareInfo.IsPrefix(candidate, pattern));
+                    return new PatternMatch(PatternMatchKind.Prefix, punctuationStripped, isCaseSensitive: _compareInfo.IsPrefix(candidate, chunk.Text));
                 }
             }
 
-            var isLowercase = !ContainsUpperCaseLetter(pattern);
+            var isLowercase = !ContainsUpperCaseLetter(chunk.Text);
             if (isLowercase)
             {
                 if (index > 0)
@@ -208,9 +353,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     var wordSpans = GetWordSpans(candidate);
                     foreach (var span in wordSpans)
                     {
-                        if (PartStartsWith(candidate, span, pattern, CompareOptions.IgnoreCase))
+                        if (PartStartsWith(candidate, span, chunk.Text, CompareOptions.IgnoreCase))
                         {
-                            return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: PartStartsWith(candidate, span, pattern, CompareOptions.None));
+                            return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, 
+                                isCaseSensitive: PartStartsWith(candidate, span, chunk.Text, CompareOptions.None));
                         }
                     }
                 }
@@ -220,7 +366,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // d) If the part was not entirely lowercase, then check if it is contained in the
                 //    candidate in a case *sensitive* manner. If so, return that there was a substring
                 //    match.
-                if (_compareInfo.IndexOf(candidate, pattern) > 0)
+                if (_compareInfo.IndexOf(candidate, chunk.Text) > 0)
                 {
                     return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: true);
                 }
@@ -229,17 +375,16 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (!isLowercase)
             {
                 // e) If the part was not entirely lowercase, then attempt a camel cased match as well.
-                var characterSpans = GetCharacterSpans(pattern);
-                if (characterSpans.Count > 0)
+                if (chunk.CharacterSpans.Count > 0)
                 {
                     var candidateParts = GetWordSpans(candidate);
-                    var camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, characterSpans, CompareOptions.None);
+                    var camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, chunk, CompareOptions.None);
                     if (camelCaseWeight.HasValue)
                     {
                         return new PatternMatch(PatternMatchKind.CamelCase, punctuationStripped, isCaseSensitive: true, camelCaseWeight: camelCaseWeight);
                     }
 
-                    camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, pattern, characterSpans, CompareOptions.IgnoreCase);
+                    camelCaseWeight = TryCamelCaseMatch(candidate, candidateParts, chunk, CompareOptions.IgnoreCase);
                     if (camelCaseWeight.HasValue)
                     {
                         return new PatternMatch(PatternMatchKind.CamelCase, punctuationStripped, isCaseSensitive: false, camelCaseWeight: camelCaseWeight);
@@ -256,9 +401,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // substring, and see if it starts on a capital letter. It seems unlikely that the user will try to 
                 // filter the list based on a substring that starts on a capital letter and also with a lowercase one.
                 // (Pattern: fogbar, Candidate: quuxfogbarFogBar).
-                if (pattern.Length < candidate.Length)
+                if (chunk.Text.Length < candidate.Length)
                 {
-                    var firstInstance = _compareInfo.IndexOf(candidate, pattern, CompareOptions.IgnoreCase);
+                    var firstInstance = _compareInfo.IndexOf(candidate, chunk.Text, CompareOptions.IgnoreCase);
                     if (firstInstance != -1 && char.IsUpper(candidate[firstInstance]))
                     {
                         return new PatternMatch(PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: false);
@@ -283,116 +428,16 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return false;
         }
 
-        /// <summary>
-        /// Determines if a given candidate string matches under a multiple word query text, as you
-        /// would find in features like Navigate To.
-        /// </summary>
-        /// <param name="candidate">The word being tested.</param>
-        /// <param name="pattern">The multiple-word query pattern.</param>
-        /// <returns>If this was a match, a set of match types that occurred while matching the
-        /// patterns. If it was not a match, it returns null.</returns>
-        public IEnumerable<PatternMatch> MatchPattern(string candidate, string pattern)
-        {
-            return MatchNonDottedPattern(candidate, pattern);
-        }
-
-        /// <summary>
-        /// Matches a pattern against a candidate, and an optional dotted container for the 
-        /// candidate. If the container is provided, and the pattern itself contains dots, then
-        /// the pattern will be tested against the candidate and container.  Specifically,
-        /// the part of the pattern after the last dot will be tested against the candidate. If
-        /// a match occurs there, then the remaining dot-separated portions of the pattern will
-        /// be tested against every successive portion of the container from right to left.
-        /// 
-        /// i.e. if you have a pattern of "Con.WL" and the candidate is "WriteLine" with a 
-        /// dotted container of "System.Console", then "WL" will be tested against "WriteLine".
-        /// With a match found there, "Con" will then be tested against "Console".
-        /// </summary>
-        public IEnumerable<PatternMatch> MatchPattern(string candidate, string dottedContainer, string pattern)
-        {
-            var dotParts = GetDotSeparatedParts(pattern);
-            return dotParts == null
-                ? MatchNonDottedPattern(candidate, pattern)
-                : MatchDottedPattern(candidate, dottedContainer, pattern, dotParts);
-        }
-
-        private IEnumerable<PatternMatch> MatchDottedPattern(string candidate, string dottedContainer, string pattern, string[] patternParts)
-        {
-            Debug.Assert(patternParts.Length > 0);
-
-            // First, check that the last part of the dot separated pattern matches the name of the
-            // candidate.  If not, then there's no point in proceeding and doing the more
-            // expensive work.
-            var candidateMatch = MatchNonDottedPattern(candidate, patternParts.Last());
-            if (candidateMatch == null)
-            {
-                return null;
-            }
-
-             var containerParts = dottedContainer.Split(DotCharacterArray, StringSplitOptions.RemoveEmptyEntries);
-
-            // -1 because the last part was checked against the name, and only the rest
-            // of the parts are checked against the container.
-            if (patternParts.Length - 1 > containerParts.Length)
-            {
-                // There weren't enough container parts to match against the pattern parts.
-                // So this definitely doesn't match.
-                return null;
-            }
-
-            // So far so good.  Now break up the container for the candidate and check if all
-            // the dotted parts match up correctly.
-            var totalMatch = candidateMatch.ToList();
-
-            for (int i = patternParts.Length - 2, j = containerParts.Length - 1;
-                    i >= 0;
-                    i--, j--)
-            {
-                var patternPart = patternParts[i];
-                var containerName = containerParts[j];
-                var containerMatch = MatchNonDottedPattern(containerName, patternPart);
-                if (containerMatch == null)
-                {
-                    // This container didn't match the pattern piece.  So there's no match at all.
-                    return null;
-                }
-
-                totalMatch.AddRange(containerMatch);
-            }
-
-            // Success, this symbol's full name matched against the dotted name the user was asking
-            // about.
-            return totalMatch;
-        }
-
-        private IEnumerable<PatternMatch> MatchNonDottedPattern(string candidate, string pattern)
+        private IEnumerable<PatternMatch> MatchSegment(string candidate, Segment segment)
         {
             PatternMatch[] matches;
-            var singleMatch = MatchNonDottedPattern(candidate, pattern, wantAllMatches: true, allMatches: out matches);
+            var singleMatch = MatchSegment(candidate, segment, wantAllMatches: true, allMatches: out matches);
             if (singleMatch.HasValue)
             {
                 return SpecializedCollections.SingletonEnumerable(singleMatch.Value);
             }
 
             return matches;
-        }
-
-        /// <summary>
-        /// Determines if a given candidate string matches under a multiple word query text, as you
-        /// would find in features like Navigate To.
-        /// </summary>
-        /// <remarks>
-        /// PERF: This is slightly faster and uses less memory than <see cref="MatchPattern(string, string)"/>
-        /// so, unless you need to know the full set of matches, use this version.
-        /// </remarks>
-        /// <param name="candidate">The word being tested.</param>
-        /// <param name="pattern">The multiple-word query pattern.</param>
-        /// <returns>If this was a match, the first element of the set of match types that occurred while matching the
-        /// patterns. If it was not a match, it returns null.</returns>
-        public PatternMatch? MatchPatternFirstOrNullable(string candidate, string pattern)
-        {
-            PatternMatch[] ignored;
-            return MatchNonDottedPattern(candidate, pattern, wantAllMatches: false, allMatches: out ignored);
         }
 
         /// <summary>
@@ -405,61 +450,88 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// If there are multiple matches, and the caller wants them all, then a List is allocated.
         /// </remarks>
         /// <param name="candidate">The word being tested.</param>
-        /// <param name="pattern">The multiple-word query pattern.</param>
+        /// <param name="segment">The segment of the pattern to check against the candidate.</param>
         /// <param name="wantAllMatches">Does the caller want all matches or just the first?</param>
         /// <param name="allMatches">If <paramref name="wantAllMatches"/> is true, and there's more than one match, then the list of all matches.</param>
         /// <returns>If there's only one match, then the return value is that match. Otherwise it is null.</returns>
-        private PatternMatch? MatchNonDottedPattern(string candidate, string pattern, bool wantAllMatches, out PatternMatch[] allMatches)
+        private PatternMatch? MatchSegment(string candidate, Segment segment, bool wantAllMatches, out PatternMatch[] allMatches)
         {
             allMatches = null;
 
-            // We never match whitespace only
-            if (string.IsNullOrWhiteSpace(pattern) || string.IsNullOrWhiteSpace(candidate))
-            {
-                return null;
-            }
-
-            // First check if the pattern matches as is.  This is also useful if the pattern contains
+            // First check if the segment matches as is.  This is also useful if the segment contains
             // characters we would normally strip when splitting into parts that we also may want to
-            // match in the candidate.  For example if the pattern is "@int" and the candidate is
+            // match in the candidate.  For example if the segment is "@int" and the candidate is
             // "@int", then that will show up as an exact match here.
             //
-            // Note: if the pattern contains a space or an asterisk then we must assume that it's a
-            // multi-word pattern.
-            if (!ContainsSpaceOrAsterisk(pattern))
+            // Note: if the segment contains a space or an asterisk then we must assume that it's a
+            // multi-word segment.
+            if (!ContainsSpaceOrAsterisk(segment.TotalTextChunk.Text))
             {
-                var match = MatchSingleWordPattern(candidate, pattern, punctuationStripped: false);
+                var match = MatchTextChunk(candidate, segment.TotalTextChunk, punctuationStripped: false);
                 if (match != null)
                 {
                     return match;
                 }
             }
 
-            var patternParts = GetWordParts(pattern);
+            // The logic for pattern matching is now as follows:
+            //
+            // 1) Break the segment passed in into words.  Breaking is rather simple and a
+            //    good way to think about it that if gives you all the individual alphanumeric words
+            //    of the pattern.
+            //
+            // 2) For each word try to match the word against the candidate value.
+            //
+            // 3) Matching is as follows:
+            //
+            //   a) Check if the word matches the candidate entirely, in an case insensitive or
+            //    sensitive manner.  If it does, return that there was an exact match.
+            //
+            //   b) Check if the word is a prefix of the candidate, in a case insensitive or
+            //      sensitive manner.  If it does, return that there was a prefix match.
+            //
+            //   c) If the word is entirely lowercase, then check if it is contained anywhere in the
+            //      candidate in a case insensitive manner.  If so, return that there was a substring
+            //      match. 
+            //
+            //      Note: We only have a substring match if the lowercase part is prefix match of
+            //      some word part. That way we don't match something like 'Class' when the user
+            //      types 'a'. But we would match 'FooAttribute' (since 'Attribute' starts with
+            //      'a').
+            //
+            //   d) If the word was not entirely lowercase, then check if it is contained in the
+            //      candidate in a case *sensitive* manner. If so, return that there was a substring
+            //      match.
+            //
+            //   e) If the word was not entirely lowercase, then attempt a camel cased match as
+            //      well.
+            //
+            //   f) The word is all lower case. Is it a case insensitive substring of the candidate starting 
+            //      on a part boundary of the candidate?
+            //
+            // Only if all words have some sort of match is the pattern considered matched.
+
+            var subWordTextChunks = segment.SubWordTextChunks;
             PatternMatch[] matches = null;
 
-            for (int i = 0; i < patternParts.Length; i++)
+            for (int i = 0; i < subWordTextChunks.Length; i++)
             {
-                var word = patternParts[i];
+                var subWordTextChunk = subWordTextChunks[i];
 
                 // Try to match the candidate with this word
-                var result = MatchSingleWordPattern(candidate, word, punctuationStripped: true);
+                var result = MatchTextChunk(candidate, subWordTextChunk, punctuationStripped: true);
                 if (result == null)
                 {
                     return null;
                 }
 
-                if (!wantAllMatches || patternParts.Length == 1)
+                if (!wantAllMatches || subWordTextChunks.Length == 1)
                 {
                     // Stop at the first word
                     return result;
                 }
 
-                if (matches == null)
-                {
-                    matches = new PatternMatch[patternParts.Length];
-                }
-
+                matches = matches ?? new PatternMatch[subWordTextChunks.Length];
                 matches[i] = result.Value;
             }
 
@@ -470,77 +542,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         private static bool IsWordChar(char ch, bool verbatimIdentifierPrefixIsWordCharacter)
         {
             return char.IsLetterOrDigit(ch) || ch == '_' || (verbatimIdentifierPrefixIsWordCharacter && ch == '@');
-        }
-
-        private static int CountParts(string pattern, bool verbatimIdentifierPrefixIsWordCharacter)
-        {
-            int count = 0;
-            int wordLength = 0;
-
-            for (int i = 0; i < pattern.Length; i++)
-            {
-                if (IsWordChar(pattern[i], verbatimIdentifierPrefixIsWordCharacter))
-                {
-                    wordLength++;
-                }
-                else
-                {
-                    if (wordLength > 0)
-                    {
-                        count++;
-                        wordLength = 0;
-                    }
-                }
-            }
-
-            if (wordLength > 0)
-            {
-                count++;
-            }
-
-            return count;
-        }
-
-        private static string[] BreakPatternIntoParts(string pattern, bool verbatimIdentifierPrefixIsWordCharacter)
-        {
-            int partCount = CountParts(pattern, verbatimIdentifierPrefixIsWordCharacter);
-
-            if (partCount == 0)
-            {
-                return SpecializedCollections.EmptyArray<string>();
-            }
-
-            var result = new string[partCount];
-            int resultIndex = 0;
-            int wordStart = 0;
-            int wordLength = 0;
-
-            for (int i = 0; i < pattern.Length; i++)
-            {
-                var ch = pattern[i];
-                if (IsWordChar(ch, verbatimIdentifierPrefixIsWordCharacter))
-                {
-                    if (wordLength++ == 0)
-                    {
-                        wordStart = i;
-                    }
-                }
-                else
-                {
-                    if (wordLength > 0)
-                    {
-                        result[resultIndex++] = pattern.Substring(wordStart, wordLength);
-                        wordLength = 0;
-                    }
-                }
-            }
-
-            if (wordLength > 0)
-            {
-                result[resultIndex++] = pattern.Substring(wordStart, wordLength);
-            }
-
-            return result;
         }
 
         /// <summary>
@@ -577,22 +578,24 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return PartStartsWith(candidate, candidatePart, pattern, new TextSpan(0, pattern.Length), compareOptions);
         }
 
-        private int? TryCamelCaseMatch(string candidate, List<TextSpan> candidateParts, string pattern, List<TextSpan> patternParts, CompareOptions compareOption)
+        private int? TryCamelCaseMatch(string candidate, List<TextSpan> candidateParts, TextChunk chunk, CompareOptions compareOption)
         {
+            var chunkCharacterSpans = chunk.CharacterSpans;
+
             // Note: we may have more pattern parts than candidate parts.  This is because multiple
             // pattern parts may match a candidate part.  For example "SiUI" against "SimpleUI".
             // We'll have 3 pattern parts Si/U/I against two candidate parts Simple/UI.  However, U
             // and I will both match in UI. 
 
             int candidateCurrent = 0;
-            int patternCurrent = 0;
+            int chunkCharacterSpansCurrent = 0;
             int? firstMatch = null;
             bool? contiguous = null;
 
             while (true)
             {
                 // Let's consider our termination cases
-                if (patternCurrent == patternParts.Count)
+                if (chunkCharacterSpansCurrent == chunkCharacterSpans.Count)
                 {
                     Contract.Requires(firstMatch.HasValue);
                     Contract.Requires(contiguous.HasValue);
@@ -627,23 +630,23 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // will be Simple/UI/Element, and the pattern parts will be Si/U/I.  We'll match 'Si'
                 // against 'Simple' first.  Then we'll match 'U' against 'UI'. However, we want to
                 // still keep matching pattern parts against that candidate part. 
-                for (; patternCurrent < patternParts.Count; patternCurrent++)
+                for (; chunkCharacterSpansCurrent < chunkCharacterSpans.Count; chunkCharacterSpansCurrent++)
                 {
-                    var patternPart = patternParts[patternCurrent];
+                    var chunkCharacterSpan = chunkCharacterSpans[chunkCharacterSpansCurrent];
 
                     if (gotOneMatchThisCandidate)
                     {
                         // We've already gotten one pattern part match in this candidate.  We will
                         // only continue trying to consumer pattern parts if the last part and this
                         // part are both upper case.  
-                        if (!char.IsUpper(pattern[patternParts[patternCurrent - 1].Start]) ||
-                            !char.IsUpper(pattern[patternParts[patternCurrent].Start]))
+                        if (!char.IsUpper(chunk.Text[chunkCharacterSpans[chunkCharacterSpansCurrent - 1].Start]) ||
+                            !char.IsUpper(chunk.Text[chunkCharacterSpans[chunkCharacterSpansCurrent].Start]))
                         {
                             break;
                         }
                     }
 
-                    if (!PartStartsWith(candidate, candidatePart, pattern, patternPart, compareOption))
+                    if (!PartStartsWith(candidate, candidatePart, chunk.Text, chunkCharacterSpan, compareOption))
                     {
                         break;
                     }
@@ -657,7 +660,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     // obviously contiguous.
                     contiguous = contiguous ?? true;
 
-                    candidatePart = new TextSpan(candidatePart.Start + patternPart.Length, candidatePart.Length - patternPart.Length);
+                    candidatePart = new TextSpan(candidatePart.Start + chunkCharacterSpan.Length, candidatePart.Length - chunkCharacterSpan.Length);
                 }
 
                 // Check if we matched anything at all.  If we didn't, then we need to unset the

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -587,15 +587,15 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             // We'll have 3 pattern parts Si/U/I against two candidate parts Simple/UI.  However, U
             // and I will both match in UI. 
 
-            int candidateCurrent = 0;
-            int chunkCharacterSpansCurrent = 0;
+            int currentCandidate = 0;
+            int currentChunkSpan = 0;
             int? firstMatch = null;
             bool? contiguous = null;
 
             while (true)
             {
                 // Let's consider our termination cases
-                if (chunkCharacterSpansCurrent == chunkCharacterSpans.Count)
+                if (currentChunkSpan == chunkCharacterSpans.Count)
                 {
                     Contract.Requires(firstMatch.HasValue);
                     Contract.Requires(contiguous.HasValue);
@@ -617,30 +617,30 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                     return weight;
                 }
-                else if (candidateCurrent == candidateParts.Count)
+                else if (currentCandidate == candidateParts.Count)
                 {
                     // No match, since we still have more of the pattern to hit
                     return null;
                 }
 
-                var candidatePart = candidateParts[candidateCurrent];
+                var candidatePart = candidateParts[currentCandidate];
                 bool gotOneMatchThisCandidate = false;
 
                 // Consider the case of matching SiUI against SimpleUIElement. The candidate parts
                 // will be Simple/UI/Element, and the pattern parts will be Si/U/I.  We'll match 'Si'
                 // against 'Simple' first.  Then we'll match 'U' against 'UI'. However, we want to
                 // still keep matching pattern parts against that candidate part. 
-                for (; chunkCharacterSpansCurrent < chunkCharacterSpans.Count; chunkCharacterSpansCurrent++)
+                for (; currentChunkSpan < chunkCharacterSpans.Count; currentChunkSpan++)
                 {
-                    var chunkCharacterSpan = chunkCharacterSpans[chunkCharacterSpansCurrent];
+                    var chunkCharacterSpan = chunkCharacterSpans[currentChunkSpan];
 
                     if (gotOneMatchThisCandidate)
                     {
                         // We've already gotten one pattern part match in this candidate.  We will
                         // only continue trying to consumer pattern parts if the last part and this
                         // part are both upper case.  
-                        if (!char.IsUpper(chunk.Text[chunkCharacterSpans[chunkCharacterSpansCurrent - 1].Start]) ||
-                            !char.IsUpper(chunk.Text[chunkCharacterSpans[chunkCharacterSpansCurrent].Start]))
+                        if (!char.IsUpper(chunk.Text[chunkCharacterSpans[currentChunkSpan - 1].Start]) ||
+                            !char.IsUpper(chunk.Text[chunkCharacterSpans[currentChunkSpan].Start]))
                         {
                             break;
                         }
@@ -653,7 +653,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                     gotOneMatchThisCandidate = true;
 
-                    firstMatch = firstMatch ?? candidateCurrent;
+                    firstMatch = firstMatch ?? currentCandidate;
 
                     // If we were contiguous, then keep that value.  If we weren't, then keep that
                     // value.  If we don't know, then set the value to 'true' as an initial match is
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 }
 
                 // Move onto the next candidate.
-                candidateCurrent++;
+                currentCandidate++;
             }
         }
     }

--- a/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
@@ -6,102 +6,98 @@ Imports Microsoft.CodeAnalysis.Completion.Rules
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
-    Friend Class VisualBasicCompletionRules
-        Implements ICompletionRules
+    Partial Friend Class VisualBasicCompletionService
+        Private Class VisualBasicCompletionRules
+            Inherits CompletionRules
 
-        Private _baseRules As ICompletionRules
-        Private ReadOnly patternMatcher As PatternMatcher = New PatternMatcher()
+            Public Sub New(service As AbstractCompletionService)
+                MyBase.New(service)
+            End Sub
 
-        Public Sub New(baseRules As ICompletionRules)
-            _baseRules = baseRules
-        End Sub
+            Public Overrides Function IsBetterFilterMatch(item1 As CompletionItem, item2 As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo, filterReason As CompletionFilterReason) As Boolean?
+                If filterReason = CompletionFilterReason.BackspaceOrDelete Then
+                    Dim prefixLength1 = GetPrefixLength(item1.FilterText, filterText)
+                    Dim prefixLength2 = GetPrefixLength(item2.FilterText, filterText)
 
-        Public Sub CompletionItemComitted(item As CompletionItem) Implements ICompletionRules.CompletionItemComitted
-            _baseRules.CompletionItemComitted(item)
-        End Sub
+                    Return prefixLength1 > prefixLength2 OrElse ((item1.Preselect AndAlso Not item2.Preselect) AndAlso TypeOf item1.CompletionProvider IsNot EnumCompletionProvider)
+                End If
 
-        Public Function IsBetterFilterMatch(item1 As CompletionItem, item2 As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo, filterReason As CompletionFilterReason) As Boolean? Implements ICompletionRules.IsBetterFilterMatch
-            If filterReason = CompletionFilterReason.BackspaceOrDelete Then
-                Dim prefixLength1 = GetPrefixLength(item1.FilterText, filterText)
-                Dim prefixLength2 = GetPrefixLength(item2.FilterText, filterText)
+                If TypeOf item2.CompletionProvider Is EnumCompletionProvider Then
+                    Dim patternMatcher = GetPatternMatcher(filterText)
+                    Dim match1 = patternMatcher.GetFirstMatch(item1.FilterText)
+                    Dim match2 = patternMatcher.GetFirstMatch(item2.FilterText)
 
-                Return prefixLength1 > prefixLength2 OrElse ((item1.Preselect AndAlso Not item2.Preselect) AndAlso TypeOf item1.CompletionProvider IsNot EnumCompletionProvider)
-            End If
+                    If match1.HasValue AndAlso match2.HasValue Then
+                        If match1.Value.Kind = PatternMatchKind.Prefix AndAlso match2.Value.Kind = PatternMatchKind.Substring Then
+                            ' If an item from Enum completion is an equally good match apart from
+                            ' being a substring rather than prefix match, take it.
 
-            If TypeOf item2.CompletionProvider Is EnumCompletionProvider Then
-                Dim match1 = patternMatcher.MatchPatternFirstOrNullable(item1.FilterText, filterText)
-                Dim match2 = patternMatcher.MatchPatternFirstOrNullable(item2.FilterText, filterText)
-
-                If match1.HasValue AndAlso match2.HasValue Then
-                    If match1.Value.Kind = PatternMatchKind.Prefix AndAlso match2.Value.Kind = PatternMatchKind.Substring Then
-                        ' If an item from Enum completion is an equally good match apart from
-                        ' being a substring rather than prefix match, take it.
-
-                        If TypeOf item2.CompletionProvider Is EnumCompletionProvider AndAlso
-                            match1.Value.CamelCaseWeight.GetValueOrDefault() = match2.Value.CamelCaseWeight.GetValueOrDefault() AndAlso
-                            match1.Value.IsCaseSensitive = match2.Value.IsCaseSensitive Then
-                            Return False
+                            If TypeOf item2.CompletionProvider Is EnumCompletionProvider AndAlso
+                                match1.Value.CamelCaseWeight.GetValueOrDefault() = match2.Value.CamelCaseWeight.GetValueOrDefault() AndAlso
+                                match1.Value.IsCaseSensitive = match2.Value.IsCaseSensitive Then
+                                Return False
+                            End If
                         End If
                     End If
                 End If
-            End If
 
-            Return _baseRules.IsBetterFilterMatch(item1, item2, filterText, triggerInfo, filterReason)
-        End Function
+                Return MyBase.IsBetterFilterMatch(item1, item2, filterText, triggerInfo, filterReason)
+            End Function
 
-        Private Function GetPrefixLength(text As String, pattern As String) As Integer
-            Dim x As Integer = 0
-            While x < text.Length AndAlso x < pattern.Length AndAlso Char.ToUpper(text(x)) = Char.ToUpper(pattern(x))
-                x += 1
-            End While
+            Private Function GetPrefixLength(text As String, pattern As String) As Integer
+                Dim x As Integer = 0
+                While x < text.Length AndAlso x < pattern.Length AndAlso Char.ToUpper(text(x)) = Char.ToUpper(pattern(x))
+                    x += 1
+                End While
 
-            Return x
-        End Function
+                Return x
+            End Function
 
-        Public Function MatchesFilterText(item As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo, filterReason As CompletionFilterReason) As Boolean? Implements ICompletionRules.MatchesFilterText
-            ' If this is a session started on backspace, we use a much looser prefix match check
-            ' to see if an item matches
-            If filterReason = CompletionFilterReason.BackspaceOrDelete AndAlso triggerInfo.TriggerReason = CompletionTriggerReason.BackspaceOrDeleteCommand Then
-                Return GetPrefixLength(item.FilterText, filterText) > 0
-            End If
+            Public Overrides Function MatchesFilterText(item As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo, filterReason As CompletionFilterReason) As Boolean?
+                ' If this is a session started on backspace, we use a much looser prefix match check
+                ' to see if an item matches
+                If filterReason = CompletionFilterReason.BackspaceOrDelete AndAlso triggerInfo.TriggerReason = CompletionTriggerReason.BackspaceOrDeleteCommand Then
+                    Return GetPrefixLength(item.FilterText, filterText) > 0
+                End If
 
-            Return _baseRules.MatchesFilterText(item, filterText, triggerInfo, filterReason)
-        End Function
+                Return MyBase.MatchesFilterText(item, filterText, triggerInfo, filterReason)
+            End Function
 
-        Public Function ShouldSoftSelectItem(item As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo) As Boolean? Implements ICompletionRules.ShouldSoftSelectItem
-            ' VB has additional specialized logic for soft selecting an item in completion when the only filter text is "_"
-            If (filterText.Length = 0 OrElse filterText = "_") Then
-                ' Object Creation hard selects even with no selected item
-                Return Not TypeOf item.CompletionProvider Is ObjectCreationCompletionProvider
-            End If
-
-            Return False
-        End Function
-
-        Public Function ItemsMatch(item1 As CompletionItem, item2 As CompletionItem) As Boolean? Implements ICompletionRules.ItemsMatch
-            Return _baseRules.ItemsMatch(item1, item2) AndAlso MatchGlyph(item1, item2)
-        End Function
-
-        Private Function MatchGlyph(item1 As CompletionItem, item2 As CompletionItem) As Boolean?
-            ' DevDiv 957450: Normally, we want to show items with the same display text and
-            ' different glyphs. That way, the we won't hide user-defined symbols that happen
-            ' to match a keyword (like Select). However, we want to avoid showing the keyword
-            ' for an intrinsic right next to the item for the corresponding symbol. 
-            ' Therefore, if a keyword claims to represent an "intrinsic" item, we'll ignore
-            ' the glyph when matching.
-            Dim keywordCompletionItem = If(TryCast(item2, KeywordCompletionItem), TryCast(item1, KeywordCompletionItem))
-            If keywordCompletionItem IsNot Nothing AndAlso
-                keywordCompletionItem.IsIntrinsic Then
-
-                Dim otherItem = If(keywordCompletionItem Is item1, item2, item1)
-                If otherItem.CompletionProvider.GetTextChange(otherItem).NewText = keywordCompletionItem.DisplayText Then
-                    Return True
+            Public Overrides Function ShouldSoftSelectItem(item As CompletionItem, filterText As String, triggerInfo As CompletionTriggerInfo) As Boolean?
+                ' VB has additional specialized logic for soft selecting an item in completion when the only filter text is "_"
+                If (filterText.Length = 0 OrElse filterText = "_") Then
+                    ' Object Creation hard selects even with no selected item
+                    Return Not TypeOf item.CompletionProvider Is ObjectCreationCompletionProvider
                 End If
 
                 Return False
-            End If
+            End Function
 
-            Return item1.Glyph = item2.Glyph
-        End Function
+            Public Overrides Function ItemsMatch(item1 As CompletionItem, item2 As CompletionItem) As Boolean?
+                Return MyBase.ItemsMatch(item1, item2) AndAlso MatchGlyph(item1, item2)
+            End Function
+
+            Private Function MatchGlyph(item1 As CompletionItem, item2 As CompletionItem) As Boolean?
+                ' DevDiv 957450: Normally, we want to show items with the same display text and
+                ' different glyphs. That way, the we won't hide user-defined symbols that happen
+                ' to match a keyword (like Select). However, we want to avoid showing the keyword
+                ' for an intrinsic right next to the item for the corresponding symbol. 
+                ' Therefore, if a keyword claims to represent an "intrinsic" item, we'll ignore
+                ' the glyph when matching.
+                Dim keywordCompletionItem = If(TryCast(item2, KeywordCompletionItem), TryCast(item1, KeywordCompletionItem))
+                If keywordCompletionItem IsNot Nothing AndAlso
+                    keywordCompletionItem.IsIntrinsic Then
+
+                    Dim otherItem = If(keywordCompletionItem Is item1, item2, item1)
+                    If otherItem.CompletionProvider.GetTextChange(otherItem).NewText = keywordCompletionItem.DisplayText Then
+                        Return True
+                    End If
+
+                    Return False
+                End If
+
+                Return item1.Glyph = item2.Glyph
+            End Function
+        End Class
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Completion/VisualBasicCompletionRules.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
     Partial Friend Class VisualBasicCompletionService
-        Private Class VisualBasicCompletionRules
+        Private NotInheritable Class VisualBasicCompletionRules
             Inherits CompletionRules
 
             Public Sub New(service As AbstractCompletionService)

--- a/src/Features/VisualBasic/Completion/VisualBasicCompletionService.vb
+++ b/src/Features/VisualBasic/Completion/VisualBasicCompletionService.vb
@@ -17,7 +17,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
     <ExportLanguageService(GetType(ICompletionService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicCompletionService
+    Partial Friend Class VisualBasicCompletionService
         Inherits AbstractCompletionService
 
         Private ReadOnly completionProviders As IEnumerable(Of ICompletionProvider) = New ICompletionProvider() {
@@ -41,9 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
         End Function
 
         Public Overrides Function GetDefaultCompletionRules() As ICompletionRules
-            Dim baseRules = MyBase.GetDefaultCompletionRules()
-
-            Return New VisualBasicCompletionRules(baseRules)
+            Return New VisualBasicCompletionRules(Me)
         End Function
 
         ''' <summary>


### PR DESCRIPTION
Previously, the way one used a patter matcher was the following:

    var matcher = new PatternMatcher();
    Loop {
        var result = matcher.MatchPattern(candidate, pattern)
    }

Because of this, each time you called MatchPattern, the matcher would have to deconstruct the
pattern into its relevant components (for example, splitting it on dots and decomposing words out
of it).  Now, this decomposition was cached.  However, that still meant checking the cache on each
call to MatchPattern.  This check involved a lock as well as a dictionary lookup.

The new way to use a pattern matcher is:

    var matcher = new PatternMatcher(pattern);
    Loop {
        var result = matcher.MatchPattern(candidate)
    }

This approach means that we only need to decompose the pattern once.  From then on we can reuse
that decomposition for each value we test against.