### PR TITLE
Emit XML output in Jenkins

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -13,8 +13,11 @@
     <RoslynSolution>$(MSBuildThisFileDirectory)\Src\Roslyn.sln</RoslynSolution>
     <RoslynSolution Condition="$(CIBuild) == 'true'">$(MSBuildThisFileDirectory)\Src\Roslyn2013.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <ArgumentTest64></ArgumentTest64>
-    <ArgumentTest64 Condition="'$(Test64)' == 'true'">-test64</ArgumentTest64>
+    <RunTestArgs></RunTestArgs>
+    <RunTestArgs Condition="'$(Test64)' == 'true'">-test64</RunTestArgs>
+
+    <!-- Emit XML in a CIBuild in order to get structured test results -->
+    <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) -xml</RunTestArgs>
   </PropertyGroup>
 
   <Target Name="RestorePackages">
@@ -79,7 +82,7 @@
       <TestAssemblies Include="Binaries\Debug\Roslyn.Services.VisualBasic.UnitTests.dll" />
     </ItemGroup>
 
-    <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(ArgumentTest64) @(TestAssemblies, ' ')" />
+    <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(RunTestArgs) @(TestAssemblies, ' ')" />
 
   </Target>
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -21,15 +21,12 @@ namespace RunTests
             }
 
             var xunitPath = args[0];
-            var skipCount = 1;
+            var index = 1;
             var test64 = false;
-            if (StringComparer.OrdinalIgnoreCase.Equals(args[1], "-test64"))
-            {
-                skipCount = 2;
-                test64 = true;
-            }
+            var useHtml = false;
+            ParseArgs(args, ref index, ref test64, ref useHtml);
 
-            var list = new List<string>(args.Skip(skipCount));
+            var list = new List<string>(args.Skip(index));
             if (list.Count == 0)
             {
                 PrintUsage();
@@ -47,7 +44,7 @@ namespace RunTests
                 cts.Cancel();
             };
 
-            var testRunner = new TestRunner(xunit);
+            var testRunner = new TestRunner(xunit, useHtml);
             var start = DateTime.Now;
             Console.WriteLine("Running {0} tests", list.Count);
             var result = testRunner.RunAllAsync(list, cts.Token).Result;
@@ -65,6 +62,29 @@ namespace RunTests
         private static void PrintUsage()
         {
             Console.WriteLine("runtests [xunit-console-runner] [assembly1] [assembly2] [...]");
+        }
+
+        private static void ParseArgs(string[] args, ref int index, ref bool test64, ref bool useHtml)
+        {
+            var comp = StringComparer.OrdinalIgnoreCase;
+            while (index < args.Length)
+            {
+                var current = args[index];
+                if (comp.Equals(current, "-test64"))
+                {
+                    test64 = true;
+                    index++;
+                }
+                else if (comp.Equals(current, "-xml"))
+                {
+                    useHtml = false;
+                    index++;
+                }
+                else
+                {
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -31,10 +31,12 @@ namespace RunTests
         }
 
         private readonly string _xunitConsolePath;
+        private readonly bool _useHtml;
 
-        internal TestRunner(string xunitConsolePath)
+        internal TestRunner(string xunitConsolePath, bool useHtml)
         {
             _xunitConsolePath = xunitConsolePath;
+            _useHtml = useHtml;
         }
 
         internal async Task<bool> RunAllAsync(IEnumerable<string> assemblyList, CancellationToken cancellationToken)
@@ -107,12 +109,13 @@ namespace RunTests
         private async Task<TestResult> RunTest(string assemblyPath, CancellationToken cancellationToken)
         {
             var assemblyName = Path.GetFileName(assemblyPath);
-            var resultsPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.ChangeExtension(assemblyName, ".html"));
+            var extension = _useHtml ? ".TestResults.html" : ".TestResults.xml";
+            var resultsPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.ChangeExtension(assemblyName, extension));
             DeleteFile(resultsPath);
 
             var builder = new StringBuilder();
             builder.AppendFormat(@"""{0}""", assemblyPath);
-            builder.AppendFormat(@" -html ""{0}""", resultsPath);
+            builder.AppendFormat(@" -{0} ""{1}""", _useHtml ? "html" : "xml", resultsPath);
             builder.Append(" -noshadow");
 
             var errorOutput = string.Empty;


### PR DESCRIPTION
This change causes us to emit XML for xunit test results when run inside
of Jenkins.  Having XML output enables Jenkins to provide a structured
display of the test results instead of the raw console output that we
see today.