### PR TITLE
fix COM interface definition

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Interop/IVsSolutionWorkingFoldersEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/IVsSolutionWorkingFoldersEvents.cs
@@ -11,21 +11,23 @@ namespace Microsoft.Internal.VisualStudio.Shell.Interop
         SlnWF_StatePersistence = 1
     }
 
+    [ComImport]
     [Guid("774FAAAD-4311-4E92-8B8B-D2759666D9C6")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     internal interface IVsSolutionWorkingFolders
     {
-        void ClearOldWorkingFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location);
-        void ClearWorkingFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, bool fSaveAll, bool fReloadSolution);
         void GetFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, Guid guidProject, bool fVersionSpecific, bool fEnsureCreated, out bool pfIsTemporary, out string pszBstrFullPath);
         void GetMigrationFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, Guid guidProject, [ComAliasName("OLE.DWORD")]out uint pdwOldMajorVersion, out string pszOldLocation);
+        void ClearOldWorkingFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location);
+        void ClearWorkingFolder([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, bool fSaveAll, bool fReloadSolution);
     }
 
+    [ComImport]
     [Guid("3584678F-DA35-4F62-AB2A-8092B281C1FA")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     internal interface IVsSolutionWorkingFoldersEvents
     {
-        void OnAfterLocationChange([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, bool contentMoved);
         void OnQueryLocationChange([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, out bool pfCanMoveContent);
+        void OnAfterLocationChange([ComAliasName("Microsoft.Internal.VisualStudio.Shell.Interop.SolutionWorkingFolder")]uint location, bool contentMoved);
     }
 }


### PR DESCRIPTION
it looks like when we move to GitHub, we manually declared some COM interface defined in VS in roslyn code base and when we do that, we put methods in wrong order.

made it to match order of methods in idl.