### PR TITLE
Add regression test for Issue #62

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5872,5 +5872,46 @@ class Program
     }
 }");
         }
+
+        [WorkItem(62)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void SpaceAfterWhenInExceptionFilter()
+        {
+            const string expected = @"class C
+{
+    void M()
+    {
+        try
+        {
+            if (x)
+            {
+                G();
+            }
+        }
+        catch (Exception e) when (H(e))
+        {
+
+        }
+    }
+}";
+
+            const string code = @"class C
+{
+    void M()
+    {
+        try
+        {
+            if(x){
+                G();
+            }
+        }
+        catch(Exception e) when (H(e))
+        {
+
+        }
+    }
+}";
+            AssertFormat(expected, code);
+        }
     }
 }


### PR DESCRIPTION
Issue #62 (formatter does not insert space after when in exception filter) must've gotten fixed as it doesn't repro any longer. This PR adds a regression test.