### PR TITLE
Fixing the assembly name of BasicSystemRuntimeAnalyzers project which ha...

### DIFF
--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
@@ -12,7 +12,7 @@
     <ProjectGuid>{D835C05E-9D83-40B2-9D25-19EB652F10D7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AnalyzerProject>true</AnalyzerProject>
-    <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Analyzers</AssemblyName>
+    <AssemblyName>System.Runtime.VisualBasic.Analyzers</AssemblyName>
     <ProjectTypeGuids>{14182A97-F7F0-4C62-8B27-98AA8AE2109A};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>


### PR DESCRIPTION
...d the same name as another project (copy\paste error)