### PR TITLE
Correctly handle duplicate WellKnownType values

### DIFF
--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -496,13 +496,23 @@ namespace Microsoft.CodeAnalysis
 
         static WellKnownTypes()
         {
+            AssertEnumAndTableInSync();
+
             for (int i = 0; i < s_metadataNames.Length; i++)
             {
                 var name = s_metadataNames[i];
                 var typeId = (WellKnownType)(i + WellKnownType.First);
+                s_nameToTypeIdMap.Add(name, typeId);
+            }
+        }
 
-#if DEBUG
-                // Ensure the WellKnownType enumeration and s_metadataNames field stay in sync
+        [Conditional("DEBUG")]
+        private static void AssertEnumAndTableInSync()
+        {
+            for (int i = 0; i < s_metadataNames.Length; i++)
+            {
+                var name = s_metadataNames[i];
+                var typeId = (WellKnownType)(i + WellKnownType.First);
 
                 string typeIdName;
                 if (typeId == WellKnownType.First)
@@ -521,9 +531,6 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(name == "Microsoft.VisualBasic.CompilerServices.ObjectFlowControl+ForLoopControl"
                           || name.IndexOf('`') > 0 // a generic type
                           || name == typeIdName);
-#endif
-
-                s_nameToTypeIdMap.Add(name, typeId);
             }
         }
 

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -500,9 +500,29 @@ namespace Microsoft.CodeAnalysis
             {
                 var name = s_metadataNames[i];
                 var typeId = (WellKnownType)(i + WellKnownType.First);
+
+#if DEBUG
+                // Ensure the WellKnownType enumeration and s_metadataNames field stay in sync
+
+                string typeIdName;
+                if (typeId == WellKnownType.First)
+                {
+                    typeIdName = "System.Math";
+                }
+                else if (typeId == WellKnownType.Last) 
+                {
+                    typeIdName = "System.IFormatProvider";
+                }
+                else
+                {
+                    typeIdName = typeId.ToString().Replace("__", "+").Replace('_', '.');
+                }
+
                 Debug.Assert(name == "Microsoft.VisualBasic.CompilerServices.ObjectFlowControl+ForLoopControl"
                           || name.IndexOf('`') > 0 // a generic type
-                          || name == (typeId.ToString() == "First" ? "System.Math" : typeId.ToString().Replace("__", "+").Replace('_', '.')));
+                          || name == typeIdName);
+#endif
+
                 s_nameToTypeIdMap.Add(name, typeId);
             }
         }


### PR DESCRIPTION
The WellKnownType enumeration contains several named items that have the
same underlying value.  Both First and Last share a value with an actual
type entry in the enumeration.  A ToString call on those values can
return either the type name or First / Last, the runtime does not define
which will happen.

This comes into play in the static constructor of WellKnownTypes where
we assert that the enumeration and s_metadataNames table stay in sync.
The code already accounts for First being ambiguous but failed to for
Last.

This change removes the assumption for Last as well.  It also expands
out the assert as it was getting to difficult to follow when I added
another level of ternary expressions into the mix.