### PR TITLE
Start Documentation for Compiler Specification

### DIFF
--- a/docs/compilers/CSharp/COM Interop.md
+++ b/docs/compilers/CSharp/COM Interop.md
@@ -1,0 +1,6 @@
+COM interop
+===========
+
+[This is a placeholder. We need some more documentation here]
+
+We have a number of features in the compiler/language to support COM interop, none of which is described in the language specification.

--- a/docs/compilers/CSharp/Definite Assignment And Partials.md
+++ b/docs/compilers/CSharp/Definite Assignment And Partials.md
@@ -1,0 +1,29 @@
+Definite Assignment For Partial And Conditional Methods
+=======================================================
+
+The C# language specification for definite assignment of an invocation expression [5.3.2.2] assumes incorrectly that the invocation expression and its arguments will be evaluated at runtime if it is reached. That may not be correct for *partial methods* [10.2.7] and methods marked with a *conditional attribute* [17.4.2].
+
+The C# compiler correctly takes into account that the method invocation (and argument evaluation) may be omitted.
+
+```cs
+using System.Diagnostics;
+
+ static partial class A
+{
+    static void Main()
+    {
+        int x;
+        x.Foo(); // OK
+        Bar(x); // OK
+
+        Bar(x = 1);
+        x.ToString(); // error CS0165: Use of unassigned local variable 'x'
+    }
+
+    static partial void Foo(this int y);
+
+    [Conditional("xxxxxx")]
+    static void Bar(int y) { }
+
+}
+```

--- a/docs/compilers/CSharp/Definite Assignment.md
+++ b/docs/compilers/CSharp/Definite Assignment.md
@@ -1,0 +1,41 @@
+Definite Assignment
+===================
+
+The definite assignment rules for C# were reimplemented in Roslyn, and we discovered some shortcomings of the specification and native compiler, which we document here.
+
+### Constant boolean expressions
+
+There are two foundations definite assignment rules missing from the C# language specification, and from the implementation of definite assignment in the native compiler. Absence of these two rules causes a large number of cases of nonintuitive behavior of the compiler, and so the native compiler also includes a large number of ad-hoc rules to patch these examples.
+
+The Roslyn compiler implements the C# language specification with two additional foundational rules. With these rules added, the ad-hoc rules implemented by the native compiler are no longer needed. The new rules are more precise than those implemented by the native compiler; for example, the Roslyn C# compiler accepts the following code, but the native compiler rejects it:
+
+```cs
+    static void Main(string[] args)
+    {
+        int x;
+        if (false && x == 3)
+        {
+            x = x + 1; // Dev10 does not consider x definitely assigned
+        }
+    }
+```
+
+The new foundational rules are:
+
+> #### 5.3.3.N Constant Expressions
+For a constant expression with value true:
+ - If *v* is definitely assigned before the expression,
+   then *v* is definitely assigned after the expression.
+ - Otherwise *v* is “definitely assigned after false expression”
+   after the expression.
+
+>For a constant expression with value false:
+ - If *v* is definitely assigned before the expression,
+   then *v* is definitely assigned after the expression.
+ - Otherwise *v* is “definitely assigned after true expression” after the expression.
+
+>For all other constant expressions, the definite assignment state of *v* after the expression is the same as the definite assignment state of *v* before the expression.
+
+### Control transfers and intervening finally blocks
+
+The specification for definite assignment and reachability in the C# language specification do not properly take into account the possibility of "intervening" finally blocks between the origin of the control transfer and the destination. These finally blocks can assign to variables, this changing the definite assignment status, or change the control transfer behavior (e.g. by throwing an exception). Both the native compiler and the Roslyn C# compilers account for them in computing definite assignment and reachability of statements.

--- a/docs/compilers/CSharp/Indexed Property Access.md
+++ b/docs/compilers/CSharp/Indexed Property Access.md
@@ -1,0 +1,13 @@
+Indexed Property Access
+=======================
+
+[This is a placeholder. We need some more documentation here]
+
+An indexed property declared in VB can be used in C#.  We should describe exactly what we do.
+
+Actually it seems that it won't be usable with indexed props syntax unless you put [ComVisible] on it in VB.
+
+If a type has `[System.Runtime.InteropServices.ComImportAttribute]` attribute and has one or more parameterized properties, those properties can be referenced from C# (provided they have appropriate visibility etc). The motivating scenario for this feature is support for COM libraries that often contain such properties. Before this feature, it was only possible to call accessors of such properties by their method names (P_set, P_get). But it’s also possible to declare such properties in VB, that we often use for testing this feature (note that when you specify `[ComImport]` attribute, you should also specify `[System.Runtime.InteropServices.GuidAttribute("…")]` attribute with a valid `GUID` as its argument, otherwise you get a compile-time error).
+
+Note that it's possible to declare multiple parameterized properties with different names, and it's also possible to declare multiple overloaded signatures for each name. In the latter case, properties with the same name form a property group (it's similar to the method group concept explained in the C# spec). To determine a particular property to invoke C# employs overload resolution, that proceeds by exactly same rules as overload resolution in indexer invocations.
+

--- a/docs/compilers/CSharp/Internal Access.md
+++ b/docs/compilers/CSharp/Internal Access.md
@@ -1,0 +1,6 @@
+Internal Accessibility
+======================
+
+The C# language specification is very vague when it describes internal visibility.  We map "the program" to the assembly being compiled; `internal` accessibility is not extended to assemblies that import the compilation unless specifically granted that access by the use of `InternalsVisibleToAttribute`.
+
+There are many places where this affects the semantics of the language without supporting language from the C# language specification.  For example, if there is a type name in the current assembly that conflicts with the same name from another assembly, we allow the reference to the name and treat it as a reference to the name from the current assembly. Furthermore, the rule that a using alias may not conflict with a type of the same name is not enforced if the conflicting type comes from another assembly.

--- a/docs/compilers/CSharp/Source-Metadata Conflict.md
+++ b/docs/compilers/CSharp/Source-Metadata Conflict.md
@@ -1,0 +1,4 @@
+Conflict Between Name From Metadata And Name In Source
+======================================================
+
+When the compiler tries to bind a type name, and the same fully-qualified name designates both a name in the current (source) assembly and also a name imported from metadata, the compiler emits a warning (see ErrorCode.WRM_SameFullName*) and resolves to the one in source.

--- a/docs/compilers/CSharp/System.TypedReference.md
+++ b/docs/compilers/CSharp/System.TypedReference.md
@@ -1,0 +1,63 @@
+System.TypedReference
+=====================
+
+[This is a placeholder. We need some more documentation here]
+
+This is an old email conversation that gives some context about the interop support in the C# compiler. Ironically, the conversation suggests that we'll never document it!
+
+-------------------
+Subject: RE: error CS0610: Field or property cannot be of type 'System.TypedReference'
+From: Eric Lippert
+To: Aleksey Tsingauz; Neal Gafter; Roslyn Compiler Dev Team
+Sent: Monday, January 24, 2011 9:42 AM
+
+Basically what’s going on here is we have some undocumented features which enable you to pass around a reference to a **variable** without knowing the type of the variable at compile time. The reason why we have this feature is to enable C-style “varargs” in the CLR; you might have a method that takes an unspecified number of arguments and some of those arguments might be references to variables. 
+
+Because a `TypedReference` can contain the address of a stack-allocated variable, you’re not allowed to store them in fields, same as you’re not allowed to make a field of ref type. That way we know we’re never storing a reference to a “dead” stack variable.
+
+We have a bunch of goo in the native compiler to make sure that typed references (and a few other similarly magical types) are not used incorrectly; we’ll have to do the same thing in Roslyn at some point.
+
+None of this stuff is well documented. We have four undocumented language keywords that allow you to manipulate typed references; we have no intention as far as I know of ever documenting them. They are only there for rare situations where C# code needs to interoperate with a C-style method.
+
+Some various articles on these features that might give you more background if you’re interested:
+
+http://www.eggheadcafe.com/articles/20030114.asp
+
+http://stackoverflow.com/questions/4764573/why-is-typedreference-behind-the-scenes-its-so-fast-and-safe-almost-magical
+
+http://stackoverflow.com/questions/1711393/practical-uses-of-typedreference
+
+http://stackoverflow.com/questions/2064509/c-type-parameters-specification
+
+http://stackoverflow.com/questions/4046397/generic-variadic-parameters
+
+http://bartdesmet.net/blogs/bart/archive/2006/09/28/4473.aspx
+
+Cheers,
+Eric
+
+---------------------
+From: Aleksey Tsingauz 
+Sent: Sunday, January 23, 2011 11:00 PM
+To: Neal Gafter; Roslyn Compiler Dev Team
+Subject: RE: error CS0610: Field or property cannot be of type 'System.TypedReference'
+ 
+I believe it is about ECMA-335 §8.2.1.1 Managed pointers and related types:
+ 
+A **managed pointer** (§12.1.1.2), or **byref** (§8.6.1.3, §12.4.1.5.2), can point to a local variable, parameter, field of a compound type, or element of an array. However, when a call crosses a remoting boundary (see §12.5) a conforming implementation can use a copy-in/copy-out mechanism instead of a managed pointer. Thus programs shall not rely on the aliasing behavior of true pointers. Managed pointer types are only allowed for local variable (§8.6.1.3) and parameter signatures (§8.6.1.4); they cannot be used for field signatures (§8.6.1.2), as the element type of an array (§8.9.1), and boxing a value of managed pointer type is disallowed (§8.2.4). Using a managed pointer type for the return type of methods (§8.6.1.5) is not verifiable (§8.8). 
+
+[Rationale: For performance reasons items on the GC heap may not contain references to the interior of other GC objects, this motivates the restrictions on fields and boxing. Further returning a managed pointer which references a local or parameter variable may cause the reference to outlive the variable, hence it is not verifiable . end rationale]
+
+There are three value types in the Base Class Library (see Partition IV Library): `System.TypedReference`, `System.RuntimeArgumentHandle`, and `System.ArgIterator`; which are treated specially by the CLI. 
+The value type `System.TypedReference`, or *typed reference* or *typedref* , (§8.2.2, §8.6.1.3, §12.4.1.5.3) contains both a managed pointer to a location and a runtime representation of the type that can be stored at that location. Typed references have the same restrictions as byrefs. Typed references are created by the CIL instruction `mkrefany` (see Partition III).
+
+The value types `System.RuntimeArgumentHandle` and `System.ArgIterator` (see Partition IV and CIL instruction `arglist` in Partition III), contain pointers into the VES stack. They can be used for local variable and parameter signatures. The use of these types for fields, method return types, the element type of an array, or in boxing is not verifiable (§8.8). These two types are referred to as *byref-like* types.
+
+----------------
+From: Neal Gafter 
+Sent: Sunday, January 23, 2011 8:37 PM
+To: Roslyn Compiler Dev Team
+Cc: Neal Gafter
+Subject: error CS0610: Field or property cannot be of type 'System.TypedReference'
+ 
+What is this error all about?  Where is it documented?

--- a/docs/compilers/CSharp/Win32 Resources.md
+++ b/docs/compilers/CSharp/Win32 Resources.md
@@ -1,0 +1,11 @@
+Win32 Resources
+===============
+
+The compiler accepts these native resource types:
+ - Arbitrary data in a file (presumed to be text) via /win32manifest. This data is added to the output binary as a resource with type #24 and number #2 for a DLL and #1 for an EXE.
+ - A resource file (.RES) whose format is defined [here](http://msdn.microsoft.com/en-us/library/ms648007(VS.85).aspx) via /win32res
+ - An icon whose format is described [here](http://msdn.microsoft.com/en-us/library/ms997538.aspx) via /win32icon
+	
+Specifying either /win32icon or /win32manifest along with /win32res is an error. The user is expected to either supply all of the resources (via /win32res) or parts of them (with the other switches), but the compiler doesn't combine the contents of a user-supplied .RES file with individual resources.
+
+A version resource is added to the output unless /win32res is specified. In the absence of the attributes that affect version numbers, the compiler constructs a default version number.

--- a/docs/compilers/CSharp/__arglist.md
+++ b/docs/compilers/CSharp/__arglist.md
@@ -1,0 +1,9 @@
+__arglist
+=========
+
+[This is a placeholder. We need some more documentation here]
+
+What is the __arglist language extension, exactly?
+AFAIK it's an undocumented C# feature that mimics C++'s varargs and is present to support interop with managed C and C++..
+
+See also [http://bartdesmet.net/blogs/bart/archive/2006/09/28/4473.aspx](http://bartdesmet.net/blogs/bart/archive/2006/09/28/4473.aspx)

--- a/docs/compilers/README.md
+++ b/docs/compilers/README.md
@@ -1,0 +1,19 @@
+Compiler Specification
+======================
+
+The compiler specification details the supported (and semi-supported) surface area of the Roslyn VB and C# compilers. This includes
+
+0. Command-line switches and their meaning
+0. Breaking changes from previous versions of the compilers
+0. Compiler behaviors that are (intentionally) contrary to the specification
+0. Compiler features not described by the language specification
+  - COM-specific and other Microsoft-specific features
+  - "Well-known" attributes that affect compiler behavior
+  - The "ruleset" file syntax and semantics
+0. Features included for interoperability between C# and VB, for example
+  - Named Indexers use from C#
+0. Places where the compiler behavior diverges from the language specification
+0. Limitations (e.g. identifier length)
+0. History of language changes per version
+
+The language specification itself is not included here.

--- a/docs/compilers/Ruleset File.md
+++ b/docs/compilers/Ruleset File.md
@@ -1,0 +1,6 @@
+The Ruleset File
+================
+
+The ruleset file was introduced to the compilers in Roslyn (C# 7 and VB 14). It started with the ruleset syntax of [fxcop](http://en.wikipedia.org/wiki/FxCop), and is used to control user-written code analyzers that are run alongside the compiler.
+
+***This is a placeholder for documentation that is not yet available.***


### PR DESCRIPTION
This is the start of documentation ported from our internal OneNote compiler specification.
Fixes #515

<!---
@huboard:{"order":7.03125,"milestone_order":536,"custom_state":""}
-->
