### PR TITLE
PERF: Use Binarysearch extension method 

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList.WithLotsOfChildren.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList.WithLotsOfChildren.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             public override int FindSlotIndexContainingOffset(int offset)
             {
                 Debug.Assert(offset >= 0 && offset < FullWidth);
-                int idx = Array.BinarySearch(_childOffsets, offset);
+                int idx = _childOffsets.BinarySearch(offset);
                 return idx >= 0 ? idx : (~idx - 1);
             }
 

--- a/src/Compilers/Core/Desktop/LargeEncodedText.cs
+++ b/src/Compilers/Core/Desktop/LargeEncodedText.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Text;
 using System.Threading;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
 {
@@ -109,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Text
         private int GetIndexFromPosition(int position)
         {
             // Binary search to find the chunk that contains the given position.
-            int idx = Array.BinarySearch(_chunkStartOffsets, position);
+            int idx = _chunkStartOffsets.BinarySearch(position);
             return idx >= 0 ? idx : (~idx - 1);
         }
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
@@ -466,7 +466,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ''' </remarks>
             Public Overrides Function FindSlotIndexContainingOffset(offset As Integer) As Integer
                 Debug.Assert(offset >= 0 AndAlso offset < FullWidth)
-                Dim idx = Array.BinarySearch(_childOffsets, offset)
+                Dim idx = _childOffsets.BinarySearch(offset)
                 Return If(idx >= 0, idx, (Not idx) - 1)
             End Function
 


### PR DESCRIPTION
While investigating #516 I realized that we have a couple of places that could benefit from the extension method we have for doing BinarySearch over integer arrays.