### PR TITLE
fix a bug where we gave wrong value for length in tagger

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractAggregatedDiagnosticsTagSource.InteractiveMode.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractAggregatedDiagnosticsTagSource.InteractiveMode.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 var result = new List<ITagSpan<TTag>>();
                 foreach (var tagSource in _tagSources.Values)
                 {
-                    tagSource.AppendIntersectingSpans(snapshotSpan.Start, snapshotSpan.End, introspector, result);
+                    tagSource.AppendIntersectingSpans(snapshotSpan.Start, snapshotSpan.Length, introspector, result);
                 }
 
                 return result;

--- a/src/EditorFeatures/Core/Shared/Tagging/AsynchronousTagger.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/AsynchronousTagger.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -128,6 +129,15 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
                 return SpecializedCollections.EmptyEnumerable<ITagSpan<TTag>>();
             }
 
+            var result = GetTags(requestedSpans, tags);
+
+            DebugVerifyTags(requestedSpans, result);
+
+            return result;
+        }
+
+        private static IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans, ITagSpanIntervalTree<TTag> tags)
+        {
             // Special case the case where there is only one requested span.  In that case, we don't
             // need to allocate any intermediate collections
             return requestedSpans.Count == 1
@@ -215,6 +225,25 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             finally
             {
                 enumerator.Dispose();
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void DebugVerifyTags(NormalizedSnapshotSpanCollection requestedSpans, IEnumerable<ITagSpan<TTag>> tags)
+        {
+            if (tags == null)
+            {
+                return;
+            }
+
+            foreach (var tag in tags)
+            {
+                var span = tag.Span;
+
+                if (!requestedSpans.Any(s => s.IntersectsWith(span)))
+                {
+                    Contract.Fail(tag + " doesn't intersects with any requested span");
+                }
             }
         }
     }


### PR DESCRIPTION
this is reported by editor team where we returning wrong tags for given span. it looks like we gave end position as length. this is a second time we did this mistake. probably because this code was based on the code that had this issue originally.

to prevent this from happening again, I added assert in base tagger class.

* this is hard to do in unit test since each unit test tests one specific tagger. if we forgot to add unit test to tests this specific issue for new tagger added, it will go unnoticed again.