### PR TITLE
Correct System.Windows.Forms.dll casing

### DIFF
--- a/src/Compilers/CSharp/csc/csc.rsp
+++ b/src/Compilers/CSharp/csc/csc.rsp
@@ -38,7 +38,7 @@
 /r:System.Web.Mobile.dll
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
-/r:System.Windows.Forms.Dll
+/r:System.Windows.Forms.dll
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll
 /r:System.Workflow.Runtime.dll

--- a/src/Compilers/VisualBasic/vbc/vbc.rsp
+++ b/src/Compilers/VisualBasic/vbc/vbc.rsp
@@ -29,7 +29,7 @@
 /r:System.Web.Mobile.dll
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
-/r:System.Windows.Forms.Dll
+/r:System.Windows.Forms.dll
 /r:System.XML.dll
 
 /r:System.Workflow.Activities.dll


### PR DESCRIPTION
Correct System.Windows.Forms.dll file name in csc/vbc response file to work on case sensitive file systems