### PR TITLE
TryPeek Methods

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine())
 
             ' leading whitespace until we see # should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -97,41 +97,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "Public interface"
         Friend Sub New(textToScan As SourceText, options As VisualBasicParseOptions, Optional isScanningForExpressionCompiler As Boolean = False)
             Debug.Assert(textToScan IsNot Nothing)
-
             _lineBufferOffset = 0
-            _buffer = textToScan
+            _buffer    = textToScan
             _bufferLen = textToScan.Length
-            _curPage = GetPage(0)
-            _options = options
+            _curPage   = GetPage(0)
+            _options   = options
 
             _scannerPreprocessorState = New PreprocessorState(GetPreprocessorConstants(options))
             _isScanningForExpressionCompiler = isScanningForExpressionCompiler
         End Sub
 
         Friend Sub Dispose() Implements IDisposable.Dispose
-            If Not _isDisposed Then
-                _isDisposed = True
+            If _isDisposed Then Exit Sub
+            _isDisposed = True
 
-                _KeywordsObjs.Free()
-                _quickTokenTable.Free()
-                _stringTable.Free()
-                _sbPooled.Free()
+            _KeywordsObjs.Free()
+            _quickTokenTable.Free()
+            _stringTable.Free()
+            _sbPooled.Free()
 
-                _idTablePool.Free(_idTable)
-                _kwTablePool.Free(_kwTable)
-                _punctTablePool.Free(_punctTable)
-                _literalTablePool.Free(_literalTable)
-                _wslTablePool.Free(_wslTable)
-                _wsTablePool.Free(_wsTable)
+            _idTablePool.Free(_idTable)
+            _kwTablePool.Free(_kwTable)
+            _punctTablePool.Free(_punctTable)
+            _literalTablePool.Free(_literalTable)
+            _wslTablePool.Free(_wslTable)
+            _wsTablePool.Free(_wsTable)
 
-                For Each p As Page In Me._pages
-                    If p IsNot Nothing Then
-                        p.Free()
-                    End If
-                Next
+            For Each p As Page In Me._pages
+                If p IsNot Nothing Then p.Free()
+            Next
 
-                Array.Clear(Me._pages, 0, Me._pages.Length)
-            End If
+            Array.Clear(Me._pages, 0, Me._pages.Length)
         End Sub
         Friend ReadOnly Property Options As VisualBasicParseOptions
             Get
@@ -140,16 +136,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Property
 
         Friend Shared Function GetPreprocessorConstants(options As VisualBasicParseOptions) As ImmutableDictionary(Of String, CConst)
-            If options.PreprocessorSymbols.IsDefaultOrEmpty Then
-                Return ImmutableDictionary(Of String, CConst).Empty
-            End If
-
+            If options.PreprocessorSymbols.IsDefaultOrEmpty Then Return ImmutableDictionary(Of String, CConst).Empty
             Dim result = ImmutableDictionary.CreateBuilder(Of String, CConst)(IdentifierComparison.Comparer)
             For Each symbol In options.PreprocessorSymbols
                 ' The values in options have already been verified
                 result(symbol.Key) = CConst.CreateChecked(symbol.Value)
             Next
-
             Return result.ToImmutable()
         End Function
 
@@ -162,8 +154,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 If token IsNot Nothing Then
                     AdvanceChar(quickToken.Length)
                     If quickToken.TerminatorLength <> 0 Then
-                        Me._endOfTerminatorTrivia = Me._lineBufferOffset
-                        Me._lineBufferOffset -= quickToken.TerminatorLength
+                        _endOfTerminatorTrivia = Me._lineBufferOffset
+                        _lineBufferOffset -= quickToken.TerminatorLength
                     End If
 
                     Return token
@@ -196,20 +188,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ' Special case where the remainder of the line is a comment.
                 Dim length = PeekStartComment(0)
-                If length > 0 Then
-                    Return MakeEmptyToken(leadingTrivia)
-                End If
+                If length > 0 Then Return MakeEmptyToken(leadingTrivia)
             End If
 
             Dim token = TryScanToken(leadingTrivia)
 
-            If token Is Nothing Then
-                token = ScanNextCharAsToken(leadingTrivia)
-            End If
-
-            If _lineBufferOffset > _endOfTerminatorTrivia Then
-                _endOfTerminatorTrivia = _lineBufferOffset
-            End If
+            If token Is Nothing Then token = ScanNextCharAsToken(leadingTrivia)
+            If _lineBufferOffset > _endOfTerminatorTrivia Then _endOfTerminatorTrivia = _lineBufferOffset
 
 #If DEBUG Then
             ' we must always consume as much as returned token's full length or things will go very bad
@@ -222,13 +207,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanNextCharAsToken(leadingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Dim token As SyntaxToken
-
-            If Not CanGetChar() Then
+            Dim c As Char
+            If Not TryPeek(c) Then
                 token = MakeEofToken(leadingTrivia)
             Else
                 ' // Don't break up surrogate pairs
-                Dim c = PeekChar()
-                Dim length = If(IsHighSurrogate(c) AndAlso CanGetCharAtOffset(1) AndAlso IsLowSurrogate(PeekAheadChar(1)), 2, 1)
+                Dim length = If(IsHighSurrogate(c) AndAlso CanGetCharAtOffset(1) AndAlso IsLowSurrogate(Peek(1)), 2, 1)
                 token = MakeBadToken(leadingTrivia, length, ERRID.ERR_IllegalChar)
             End If
 
@@ -248,18 +232,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             ' if starting not from line start, skip to the next one.
             Dim prev = PrevToken
-            If Not IsAtNewLine() OrElse
-                (PrevToken IsNot Nothing AndAlso PrevToken.EndsWithEndOfLineOrColonTrivia) Then
-
-                EatThroughLine()
-            End If
+            If Not IsAtNewLine() OrElse (PrevToken IsNot Nothing AndAlso PrevToken.EndsWithEndOfLineOrColonTrivia) Then EatThroughLine()
 
             Dim condLineStart = _lineBufferOffset
-
-            While (CanGetChar())
-                Dim c As Char = PeekChar()
-
-                Select Case (c)
+            Dim c As Char
+            While TryPeek(c)
+                Select Case c
 
                     Case CARRIAGE_RETURN, LINE_FEED
                         EatThroughLineBreak(c)
@@ -267,16 +245,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Continue While
 
                     Case SPACE, CHARACTER_TABULATION
-                        Debug.Assert(IsWhitespace(PeekChar()))
+                        Debug.Assert(IsWhitespace(Peek()))
                         EatWhitespace()
                         Continue While
 
-                    Case _
-                        "a"c, "b"c, "c"c, "d"c, "e"c, "f"c, "g"c, "h"c, "i"c, "j"c, "k"c, "l"c,
-                        "m"c, "n"c, "o"c, "p"c, "q"c, "r"c, "s"c, "t"c, "u"c, "v"c, "w"c, "x"c,
-                        "y"c, "z"c, "A"c, "B"c, "C"c, "D"c, "E"c, "F"c, "G"c, "H"c, "I"c, "J"c,
-                        "K"c, "L"c, "M"c, "N"c, "O"c, "P"c, "Q"c, "R"c, "S"c, "T"c, "U"c, "V"c,
-                        "W"c, "X"c, "Y"c, "Z"c, "'"c, "_"c
+                    Case "a"c, "b"c, "c"c, "d"c, "e"c, "f"c, "g"c, "h"c, "i"c, "j"c, "k"c, "l"c, "m"c, "n"c, "o"c, "p"c, "q"c, "r"c, "s"c, "t"c, "u"c, "v"c, "w"c, "x"c, "y"c, "z"c,
+                         "A"c, "B"c, "C"c, "D"c, "E"c, "F"c, "G"c, "H"c, "I"c, "J"c, "K"c, "L"c, "M"c, "N"c, "O"c, "P"c, "Q"c, "R"c, "S"c, "T"c, "U"c, "V"c, "W"c, "X"c, "Y"c, "Z"c, "'"c, "_"c
 
                         EatThroughLine()
                         condLineStart = _lineBufferOffset
@@ -286,18 +260,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Exit While
 
                     Case Else
-                        If IsWhitespace(c) Then
-                            EatWhitespace()
-                            Continue While
-
-                        ElseIf IsNewLine(c) Then
-                            EatThroughLineBreak(c)
-                            condLineStart = _lineBufferOffset
-                            Continue While
-
-                        End If
-
-                        EatThroughLine()
+                        If IsWhitespace(c) Then EatWhitespace() : Continue While
+                        If IsNewLine(c) Then EatThroughLineBreak(c) Else EatThroughLine()
                         condLineStart = _lineBufferOffset
                         Continue While
                 End Select
@@ -312,15 +276,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub EatThroughLine()
-            While CanGetChar()
-                Dim c As Char = PeekChar()
-
-                If IsNewLine(c) Then
-                    EatThroughLineBreak(c)
-                    Return
-                Else
-                    AdvanceChar()
-                End If
+            Dim c As Char
+            While TryPeek(c)
+                If IsNewLine(c) Then EatThroughLineBreak(c) : Return
+                AdvanceChar()
             End While
         End Sub
 
@@ -330,10 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' <param name="span">The range of text.</param>
         ''' <returns>The DisabledCode node.</returns> 
         Friend Function GetDisabledTextAt(span As TextSpan) As SyntaxTrivia
-            If span.Start >= 0 AndAlso span.End <= _bufferLen Then
-                Return SyntaxFactory.DisabledTextTrivia(GetTextNotInterned(span.Start, span.Length))
-            End If
-
+            If span.Start >= 0 AndAlso span.End <= _bufferLen Then Return SyntaxFactory.DisabledTextTrivia(GetTextNotInterned(span.Start, span.Length))
             ' TODO: should this be a Require?
             Throw New ArgumentOutOfRangeException("span")
         End Function
@@ -348,12 +304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Shared Function GetScratchText(sb As StringBuilder) As String
             ' PERF: Special case for the very common case of a string containing a single space
-            Dim str As String
-            If sb.Length = 1 AndAlso sb(0) = " "c Then
-                str = " "
-            Else
-                str = sb.ToString
-            End If
+            Dim str As String = If(sb.Length = 1 AndAlso sb(0) = " "c, " ", sb.ToString)
             sb.Clear()
             Return str
         End Function
@@ -362,12 +313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' see if it matches the given string. If so, then the given string is returned, saving
         ' the allocation.
         Private Shared Function GetScratchText(sb As StringBuilder, text As String) As String
-            Dim str As String
-            If StringTable.TextEquals(text, sb) Then
-                str = text
-            Else
-                str = sb.ToString
-            End If
+            Dim str As String = If(StringTable.TextEquals(text, sb), text, sb.ToString)
             sb.Clear()
             Return str
         End Function
@@ -403,11 +349,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function GetText(length As Integer) As String
             Debug.Assert(length > 0)
             Debug.Assert(CanGetCharAtOffset(length - 1))
-
-            If length = 1 Then
-                Return GetNextChar()
-            End If
-
+            If length = 1 Then Return GetNextChar()
             Dim str = GetText(_lineBufferOffset, length)
             AdvanceChar(length)
             Return str
@@ -416,12 +358,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function GetTextNotInterned(length As Integer) As String
             Debug.Assert(length > 0)
             Debug.Assert(CanGetCharAtOffset(length - 1))
-
-            If length = 1 Then
-                ' we will still intern single chars. There could not be too many.
-                Return GetNextChar()
-            End If
-
+            If length = 1 Then Return GetNextChar() ' we will still intern single chars. There could not be too many.
             Dim str = GetTextNotInterned(_lineBufferOffset, length)
             AdvanceChar(length)
             Return str
@@ -430,16 +367,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Sub AdvanceChar(Optional howFar As Integer = 1)
             Debug.Assert(howFar > 0)
             Debug.Assert(CanGetCharAtOffset(howFar - 1))
-
             _lineBufferOffset += howFar
         End Sub
 
         Private Function GetNextChar() As String
             Debug.Assert(CanGetChar)
-
             Dim ch = GetChar()
             _lineBufferOffset += 1
-
             Return ch
         End Function
 
@@ -454,15 +388,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function LengthOfLineBreak(StartCharacter As Char, Optional here As Integer = 0) As Integer
             Debug.Assert(CanGetCharAtOffset(here))
             Debug.Assert(IsNewLine(StartCharacter))
-
-            Debug.Assert(StartCharacter = PeekAheadChar(here))
-
-            If StartCharacter = CARRIAGE_RETURN AndAlso
-                CanGetCharAtOffset(here + 1) AndAlso
-                PeekAheadChar(here + 1) = LINE_FEED Then
-
-                Return 2
-            End If
+            Debug.Assert(StartCharacter = Peek(here))
+            If StartCharacter = CARRIAGE_RETURN AndAlso IsPeek(here + 1, LINE_FEED) Then Return 2
             Return 1
         End Function
 #End Region
@@ -473,20 +400,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Make it a statement separator
         ''' </summary>        
         Private Function ScanNewlineAsStatementTerminator(startCharacter As Char, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            If _lineBufferOffset < _endOfTerminatorTrivia Then
-                Dim width = LengthOfLineBreak(startCharacter)
-                Return MakeStatementTerminatorToken(precedingTrivia, width)
-            Else
-                Return MakeEmptyToken(precedingTrivia)
-            End If
+            If _lineBufferOffset >= _endOfTerminatorTrivia Then Return MakeEmptyToken(precedingTrivia)
+            Dim width = LengthOfLineBreak(startCharacter)
+            Return MakeStatementTerminatorToken(precedingTrivia, width)
         End Function
 
         Private Function ScanColonAsStatementTerminator(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As SyntaxToken
-            If _lineBufferOffset < _endOfTerminatorTrivia Then
-                Return MakeColonToken(precedingTrivia, charIsFullWidth)
-            Else
-                Return MakeEmptyToken(precedingTrivia)
-            End If
+            If _lineBufferOffset < _endOfTerminatorTrivia Then Return MakeColonToken(precedingTrivia, charIsFullWidth)
+            Return MakeEmptyToken(precedingTrivia)
         End Function
 
         ''' <summary>
@@ -494,70 +415,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Make it a whitespace
         ''' </summary>
         Private Function ScanNewlineAsTrivia(StartCharacter As Char) As SyntaxTrivia
-            If LengthOfLineBreak(StartCharacter) = 2 Then
-                Return MakeEndOfLineTriviaCRLF()
-            End If
+            If LengthOfLineBreak(StartCharacter) = 2 Then Return MakeEndOfLineTriviaCRLF()
             Return MakeEndOfLineTrivia(GetNextChar)
         End Function
 
         Private Function ScanLineContinuation(tList As SyntaxListBuilder) As Boolean
-            If Not CanGetChar() Then
-                Return False
-            End If
-
-            If Not IsAfterWhitespace() Then
-                Return False
-            End If
-
-            Dim ch As Char = PeekChar()
-            If Not IsUnderscore(ch) Then
-                Return False
-            End If
-
+            Dim ch As Char
+            If Not TryPeek(ch) Then Return False
+            If Not IsAfterWhitespace() Then Return False
+            If Not IsUnderscore(ch) Then Return False
             Dim Here = 1
-            While CanGetCharAtOffset(Here)
-                ch = PeekAheadChar(Here)
-                If IsWhitespace(ch) Then
-                    Here += 1
-                Else
-                    Exit While
-                End If
+            While TryPeek(Here, ch) AndAlso IsWhitespace(ch)
+                Here += 1
             End While
-
-            ' Line continuation is valid at the end of the
-            ' line or at the end of file only.
+            ' Line continuation is valid at the end of the line or at the end of file only.
             Dim atNewLine = IsNewLine(ch)
-            If Not atNewLine AndAlso CanGetCharAtOffset(Here) Then
-                Return False
-            End If
-
+            If Not atNewLine AndAlso CanGetCharAtOffset(Here) Then Return False
             tList.Add(MakeLineContinuationTrivia(GetText(1)))
-            If Here > 1 Then
-                tList.Add(MakeWhiteSpaceTrivia(GetText(Here - 1)))
-            End If
-
+            If Here > 1 Then tList.Add(MakeWhiteSpaceTrivia(GetText(Here - 1)))
             If atNewLine Then
                 Dim newLine = SkipLineBreak(ch, 0)
                 Here = GetWhitespaceLength(newLine)
                 Dim spaces = Here - newLine
                 Dim startComment = PeekStartComment(Here)
-
                 ' If the line following the line continuation is blank, or blank with a comment,
                 ' do not include the new line character since that would confuse code handling
                 ' implicit line continuations. (See Scanner::EatLineContinuation.) Otherwise,
                 ' include the new line and any additional spaces as trivia.
-                If startComment = 0 AndAlso
-                    CanGetCharAtOffset(Here) AndAlso
-                    Not IsNewLine(PeekAheadChar(Here)) Then
-
+                If startComment = 0 AndAlso CanGetCharAtOffset(Here) AndAlso Not IsNewLine(Peek(Here)) Then
                     tList.Add(MakeEndOfLineTrivia(GetText(newLine)))
-                    If spaces > 0 Then
-                        tList.Add(MakeWhiteSpaceTrivia(GetText(spaces)))
-                    End If
+                    If spaces > 0 Then tList.Add(MakeWhiteSpaceTrivia(GetText(spaces)))
                 End If
-
             End If
-
             Return True
         End Function
 
@@ -569,22 +458,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Consumes all trivia until a nontrivia char is found
         ''' </summary>
         Friend Function ScanMultilineTrivia() As SyntaxList(Of VisualBasicSyntaxNode)
-            If Not CanGetChar() Then
-                Return Nothing
-            End If
-
-            Dim ch = PeekChar()
-
+            Dim ch As Char
+            If Not TryPeek(ch) Then Return Nothing
             ' optimization for a common case
             ' the ASCII range between ': and ~ , with exception of except "'", "_" and R cannot start trivia
-            If ch > ":"c AndAlso ch <= "~"c AndAlso ch <> "'"c AndAlso ch <> "_"c AndAlso ch <> "R"c AndAlso ch <> "r"c Then
-                Return Nothing
-            End If
-
+            If ch > ":"c AndAlso ch <= "~"c AndAlso ch <> "'"c AndAlso ch <> "_"c AndAlso ch <> "R"c AndAlso ch <> "r"c Then Return Nothing
             Dim triviaList = triviaListPool.Allocate()
             While TryScanSinglePieceOfMultilineTrivia(triviaList)
             End While
-
             Dim result = MakeTriviaArray(triviaList)
             triviaListPool.Free(triviaList)
             Return result
@@ -594,34 +475,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Scans a single piece of trivia
         ''' </summary>
         Private Function TryScanSinglePieceOfMultilineTrivia(tList As SyntaxListBuilder) As Boolean
-            If CanGetChar() Then
-
+            Dim ch As Char
+            If TryPeek(ch) Then
                 Dim atNewLine = IsAtNewLine()
-
                 ' check for XmlDocComment and directives
                 If atNewLine Then
-                    If StartsXmlDoc(0) Then
-                        Return TryScanXmlDocComment(tList)
-                    End If
-
-                    If StartsDirective(0) Then
-                        Return TryScanDirective(tList)
-                    End If
+                    If StartsXmlDoc(0)    Then Return TryScanXmlDocComment(tList)
+                    If StartsDirective(0) Then Return TryScanDirective(tList)
                 End If
-
-                Dim ch = PeekChar()
                 If IsWhitespace(ch) Then
                     ' eat until linebreak or nonwhitespace
                     Dim wslen = GetWhitespaceLength(1)
-
                     If atNewLine Then
-                        If StartsXmlDoc(wslen) Then
-                            Return TryScanXmlDocComment(tList)
-                        End If
-
-                        If StartsDirective(wslen) Then
-                            Return TryScanDirective(tList)
-                        End If
+                        If StartsXmlDoc(wslen)    Then Return TryScanXmlDocComment(tList)
+                        If StartsDirective(wslen) Then Return TryScanDirective(tList)
                     End If
                     tList.Add(MakeWhiteSpaceTrivia(GetText(wslen)))
                     Return True
@@ -634,7 +501,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     tList.Add(ScanColonAsTrivia())
                     Return True
                 End If
-
                 ' try get a comment
                 Return ScanCommentIfAny(tList)
             End If
@@ -644,33 +510,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         ' check for '''(~')
         Private Function StartsXmlDoc(Here As Integer) As Boolean
-            Return _options.DocumentationMode >= DocumentationMode.Parse AndAlso
-                CanGetCharAtOffset(Here + 3) AndAlso
-                IsSingleQuote(PeekAheadChar(Here)) AndAlso
-                IsSingleQuote(PeekAheadChar(Here + 1)) AndAlso
-                IsSingleQuote(PeekAheadChar(Here + 2)) AndAlso
-                Not IsSingleQuote(PeekAheadChar(Here + 3))
+            Return _options.DocumentationMode >= DocumentationMode.Parse AndAlso CanGetCharAtOffset(Here + 3) AndAlso IsSingleQuote(Peek(Here)) AndAlso
+                   IsSingleQuote(Peek(Here + 1)) AndAlso IsSingleQuote(Peek(Here + 2)) AndAlso Not IsSingleQuote(Peek(Here + 3))
         End Function
 
         ' check for #
         Private Function StartsDirective(Here As Integer) As Boolean
-            If CanGetCharAtOffset(Here) Then
-                Dim ch = PeekAheadChar(Here)
-                Return IsHash(ch)
-            End If
-            Return False
+            Dim ch As Char
+            Return TryPeek(Here, ch) AndAlso IsHash(ch)
         End Function
 
         Private Function IsAtNewLine() As Boolean
-            Return _lineBufferOffset = 0 OrElse IsNewLine(PeekAheadChar(-1))
+            Return _lineBufferOffset = 0 OrElse IsNewLine(Peek(-1))
         End Function
 
         Private Function IsAfterWhitespace() As Boolean
-            If _lineBufferOffset = 0 Then
-                Return True
-            End If
-
-            Dim prevChar = PeekAheadChar(-1)
+            If _lineBufferOffset = 0 Then Return True
+            Dim prevChar = Peek(-1)
             Return IsWhitespace(prevChar)
         End Function
 
@@ -698,9 +554,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         Private Sub ScanSingleLineTriviaInXmlDoc(tList As SyntaxListBuilder)
-            If CanGetChar() Then
-                Dim c As Char = PeekChar()
-                Select Case (c)
+            Dim c As Char
+            If TryPeek(c) Then
+                Select Case c
                     ' // Whitespace
                     ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
                     Case CARRIAGE_RETURN, LINE_FEED, " "c, CHARACTER_TABULATION
@@ -731,7 +587,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub ScanWhitespaceAndLineContinuations(tList As SyntaxListBuilder)
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 tList.Add(ScanWhitespace(1))
                 ' collect { lineCont, ws }
                 While ScanLineContinuation(tList)
@@ -748,17 +604,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 While True
                     Dim offsets = CreateOffsetRestorePoint()
-
                     _lineBufferOffset = _endOfTerminatorTrivia
                     ScanSingleLineTrivia(more)
-
-                    If Not IsBlankLine(more) Then
-                        offsets.Restore()
-                        Exit While
-                    End If
-
-                    Dim n = more.Count
-                    For i = 0 To n - 1
+                    If Not IsBlankLine(more) Then offsets.Restore : Exit While
+                    For i = 0 To more.Count  - 1
                         tList.Add(more(i))
                     Next
                     more.Clear()
@@ -778,13 +627,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Private Shared Function IsBlankLine(tList As SyntaxListBuilder) As Boolean
             Dim n = tList.Count
-            If n = 0 OrElse tList(n - 1).Kind <> SyntaxKind.EndOfLineTrivia Then
-                Return False
-            End If
+            If n = 0 OrElse tList(n - 1).Kind <> SyntaxKind.EndOfLineTrivia Then Return False
             For i = 0 To n - 2
-                If tList(i).Kind <> SyntaxKind.WhitespaceTrivia Then
-                    Return False
-                End If
+                If tList(i).Kind <> SyntaxKind.WhitespaceTrivia Then Return False
             Next
             Return True
         End Function
@@ -800,10 +645,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             ' Case 3 is required to parse single line if's and numeric labels. 
             ' Case 4 is required to limit explicit line continuations to single new line
-
-            If CanGetChar() Then
-
-                Dim ch As Char = PeekChar()
+            Dim ch As Char
+            If TryPeek(ch) Then
                 Dim startOfTerminatorTrivia = _lineBufferOffset
 
                 If IsNewLine(ch) Then
@@ -815,19 +658,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     ' collect { ws, colon }
                     Do
                         Dim len = GetWhitespaceLength(0)
-                        If Not CanGetCharAtOffset(len) Then
-                            Exit Do
-                        End If
-
-                        ch = PeekAheadChar(len)
-                        If Not IsColonAndNotColonEquals(ch, offset:=len) Then
-                            Exit Do
-                        End If
-
-                        If len > 0 Then
-                            tList.Add(MakeWhiteSpaceTrivia(GetText(len)))
-                        End If
-
+                        If Not TryPeek(len, ch) Then Exit Do
+                        If Not IsColonAndNotColonEquals(ch, offset:=len) Then Exit Do
+                        If len > 0 Then tList.Add(MakeWhiteSpaceTrivia(GetText(len)))
                         startOfTerminatorTrivia = _lineBufferOffset
                         tList.Add(ScanColonAsTrivia())
                     Loop
@@ -845,17 +678,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             If CanGetChar() Then
                 ' check for comment
                 Dim comment = ScanComment()
-                If comment IsNot Nothing Then
-                    tList.Add(comment)
-                    Return True
-                End If
+                If comment IsNot Nothing Then tList.Add(comment) : Return True
             End If
             Return False
         End Function
 
         Private Function GetWhitespaceLength(len As Integer) As Integer
             ' eat until linebreak or nonwhitespace
-            While CanGetCharAtOffset(len) AndAlso IsWhitespace(PeekAheadChar(len))
+            While CanGetCharAtOffset(len) AndAlso IsWhitespace(Peek(len))
                 len += 1
             End While
             Return len
@@ -863,7 +693,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function GetXmlWhitespaceLength(len As Integer) As Integer
             ' eat until linebreak or nonwhitespace
-            While CanGetCharAtOffset(len) AndAlso IsXmlWhitespace(PeekAheadChar(len))
+            While CanGetCharAtOffset(len) AndAlso IsXmlWhitespace(Peek(len))
                 len += 1
             End While
             Return len
@@ -871,50 +701,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanWhitespace(Optional len As Integer = 0) As VisualBasicSyntaxNode
             len = GetWhitespaceLength(len)
-            If len > 0 Then
-                Return MakeWhiteSpaceTrivia(GetText(len))
-            End If
-            Return Nothing
+            Return If(len > 0, MakeWhiteSpaceTrivia(GetText(len)), Nothing)
         End Function
 
         Private Function ScanXmlWhitespace(Optional len As Integer = 0) As VisualBasicSyntaxNode
             len = GetXmlWhitespaceLength(len)
-            If len > 0 Then
-                Return MakeWhiteSpaceTrivia(GetText(len))
-            End If
-            Return Nothing
+            Return If(len > 0, MakeWhiteSpaceTrivia(GetText(len)), Nothing)
         End Function
 
         Private Sub EatWhitespace()
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsWhitespace(PeekChar()))
+            Debug.Assert(IsWhitespace(Peek()))
 
             AdvanceChar()
 
             ' eat until linebreak or nonwhitespace
-            While CanGetChar() AndAlso IsWhitespace(PeekChar)
+            Dim ch As Char
+            While TryPeek(ch) AndAlso IsWhitespace(ch)
                 AdvanceChar()
             End While
         End Sub
 
         Private Function PeekStartComment(i As Integer) As Integer
-
-            If CanGetCharAtOffset(i) Then
-                Dim ch = PeekAheadChar(i)
-
-                If IsSingleQuote(ch) Then
-                    Return 1
-                ElseIf MatchOneOrAnotherOrFullwidth(ch, "R"c, "r"c) AndAlso
-                    CanGetCharAtOffset(i + 2) AndAlso MatchOneOrAnotherOrFullwidth(PeekAheadChar(i + 1), "E"c, "e"c) AndAlso
-                    MatchOneOrAnotherOrFullwidth(PeekAheadChar(i + 2), "M"c, "m"c) Then
-
-                    If Not CanGetCharAtOffset(i + 3) OrElse IsNewLine(PeekAheadChar(i + 3)) Then
-                        ' have only 'REM'
-                        Return 3
-                    ElseIf Not IsIdentifierPartCharacter(PeekAheadChar(i + 3)) Then
-                        ' have 'REM '
-                        Return 4
-                    End If
+            Dim ch As Char
+            If TryPeek(i, ch) Then
+                If IsSingleQuote(ch) Then Return 1
+                If MatchOneOrAnotherOrFullwidth(ch, "R"c, "r"c) AndAlso
+                    CanGetCharAtOffset(i + 2) AndAlso MatchOneOrAnotherOrFullwidth(Peek(i + 1), "E"c, "e"c) AndAlso
+                    MatchOneOrAnotherOrFullwidth(Peek(i + 2), "M"c, "m"c) Then
+                    If Not TryPeek(i + 3, ch) OrElse IsNewLine(ch) Then Return 3 ' have only 'REM'
+                    If Not IsIdentifierPartCharacter(ch) Then Return 4 ' have 'REM '
                 End If
             End If
 
@@ -923,27 +739,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanComment() As SyntaxTrivia
             Debug.Assert(CanGetChar())
-
             Dim length = PeekStartComment(0)
             If length > 0 Then
                 Dim looksLikeDocComment As Boolean = StartsXmlDoc(0)
-
+                Dim c As Char
                 ' eat all chars until EoL
-                While CanGetCharAtOffset(length) AndAlso
-                    Not IsNewLine(PeekAheadChar(length))
-
+                While TryPeek(length,c) AndAlso Not IsNewLine(c)
                     length += 1
                 End While
-
                 Dim commentTrivia As SyntaxTrivia = MakeCommentTrivia(GetTextNotInterned(length))
-
-                If looksLikeDocComment AndAlso _options.DocumentationMode >= DocumentationMode.Diagnose Then
-                    commentTrivia = commentTrivia.WithDiagnostics(ErrorFactory.ErrorInfo(ERRID.WRN_XMLDocNotFirstOnLine))
-                End If
-
+                If looksLikeDocComment AndAlso
+                    _options.DocumentationMode >= DocumentationMode.Diagnose Then Return commentTrivia.WithDiagnostics(ErrorFactory.ErrorInfo(ERRID.WRN_XMLDocNotFirstOnLine))
                 Return commentTrivia
             End If
-
             Return Nothing
         End Function
 
@@ -956,7 +764,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanColonAsTrivia() As SyntaxTrivia
             Debug.Assert(CanGetChar())
-            Debug.Assert(IsColonAndNotColonEquals(PeekChar(), offset:=0))
+            Debug.Assert(IsColonAndNotColonEquals(Peek(), offset:=0))
 
             Return MakeColonTrivia(GetText(1))
         End Function
@@ -966,12 +774,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' at this point it is very likely that we are located at 
         ' the beginning of a token        
         Private Function TryScanToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-
-            If Not CanGetChar() Then
-                Return MakeEofToken(precedingTrivia)
-            End If
-
-            Dim ch As Char = PeekChar()
+            Dim ch, ch2 As Char
+            If Not TryPeek(ch) Then Return MakeEofToken(precedingTrivia)
             Select Case ch
                 Case CARRIAGE_RETURN, LINE_FEED, NEXT_LINE, LINE_SEPARATOR, PARAGRAPH_SEPARATOR
                     Return ScanNewlineAsStatementTerminator(ch, precedingTrivia)
@@ -980,175 +784,95 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Debug.Assert(False, String.Format("Unexpected char: &H{0:x}", AscW(ch)))
                     Return Nothing ' trivia cannot start a token
 
-                Case "@"c
-                    Return MakeAtToken(precedingTrivia, False)
-
-                Case "("c
-                    Return MakeOpenParenToken(precedingTrivia, False)
-
-                Case ")"c
-                    Return MakeCloseParenToken(precedingTrivia, False)
-
-                Case "{"c
-                    Return MakeOpenBraceToken(precedingTrivia, False)
-
-                Case "}"c
-                    Return MakeCloseBraceToken(precedingTrivia, False)
-
-                Case ","c
-                    Return MakeCommaToken(precedingTrivia, False)
-
+                Case "@"c : Return MakeAtToken(precedingTrivia, False)
+                Case "("c : Return MakeOpenParenToken(precedingTrivia, False)
+                Case ")"c : Return MakeCloseParenToken(precedingTrivia, False)
+                Case "{"c : Return MakeOpenBraceToken(precedingTrivia, False)
+                Case "}"c : Return MakeCloseBraceToken(precedingTrivia, False)
+                Case ","c : Return MakeCommaToken(precedingTrivia, False)
                 Case "#"c
                     Dim dl = ScanDateLiteral(precedingTrivia)
-                    If dl IsNot Nothing Then
-                        Return dl
-                    Else
-                        Return MakeHashToken(precedingTrivia, False)
-                    End If
+                    Return If(dl, MakeHashToken(precedingTrivia, False))
 
                 Case "&"c
-                    If CanGetCharAtOffset(1) AndAlso BeginsBaseLiteral(PeekAheadChar(1)) Then
-                        Return ScanNumericLiteral(precedingTrivia)
-                    End If
-
+                    If TryPeek(1, ch2) AndAlso BeginsBaseLiteral(ch2) Then Return ScanNumericLiteral(precedingTrivia)
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeAmpersandEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeAmpersandToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAmpersandEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeAmpersandToken(precedingTrivia, False)
 
-                Case "="c
-                    Return MakeEqualsToken(precedingTrivia, False)
-
-                Case "<"c
-                    Return ScanLeftAngleBracket(precedingTrivia, False, _scanSingleLineTriviaFunc)
-
-                Case ">"c
-                    Return ScanRightAngleBracket(precedingTrivia, False)
-
+                Case "="c : Return MakeEqualsToken(precedingTrivia, False)
+                Case "<"c : Return ScanLeftAngleBracket(precedingTrivia, False, _scanSingleLineTriviaFunc)
+                Case ">"c : Return ScanRightAngleBracket(precedingTrivia, False)
                 Case ":"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeColonEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return ScanColonAsStatementTerminator(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeColonEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return ScanColonAsStatementTerminator(precedingTrivia, False)
 
                 Case "+"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakePlusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakePlusToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakePlusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakePlusToken(precedingTrivia, False)
 
                 Case "-"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeMinusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeMinusToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeMinusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeMinusToken(precedingTrivia, False)
 
                 Case "*"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeAsteriskEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeAsteriskToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAsteriskEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeAsteriskToken(precedingTrivia, False)
 
                 Case "/"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeSlashToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeSlashToken(precedingTrivia, False)
 
                 Case "\"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeBackSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeBackslashToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeBackSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeBackslashToken(precedingTrivia, False)
 
                 Case "^"c
                     Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeCaretEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeCaretToken(precedingTrivia, False)
-                    End If
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeCaretEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeCaretToken(precedingTrivia, False)
 
-                Case "!"c
-                    Return MakeExclamationToken(precedingTrivia, False)
+                Case "!"c : Return MakeExclamationToken(precedingTrivia, False)
 
                 Case "."c
-                    If CanGetCharAtOffset(1) AndAlso IsDecimalDigit(PeekAheadChar(1)) Then
-                        Return ScanNumericLiteral(precedingTrivia)
-                    Else
-                        Return MakeDotToken(precedingTrivia, False)
-                    End If
-
-                Case "0"c,
-                      "1"c,
-                      "2"c,
-                      "3"c,
-                      "4"c,
-                      "5"c,
-                      "6"c,
-                      "7"c,
-                      "8"c,
-                      "9"c
+                    If TryPeek(1, ch2) AndAlso IsDecimalDigit(ch2) Then Return ScanNumericLiteral(precedingTrivia)
+                    Return MakeDotToken(precedingTrivia, False)
+                Case "0"c, "1"c, "2"c, "3"c, "4"c, "5"c, "6"c, "7"c, "8"c, "9"c
                     Return ScanNumericLiteral(precedingTrivia)
 
-                Case """"c
-                    Return ScanStringLiteral(precedingTrivia)
+                Case """"c : Return ScanStringLiteral(precedingTrivia)
 
                 Case "A"c
-                    If CanGetCharAtOffset(2) AndAlso
-                       PeekAheadChar(1) = "s"c AndAlso
-                       PeekAheadChar(2) = " "c Then
-
-                        ' TODO: do we allow widechars in keywords?
-                        Dim spelling = "As"
-                        AdvanceChar(2)
-                        Return MakeKeyword(SyntaxKind.AsKeyword, spelling, precedingTrivia)
-                    Else
-                        Return ScanIdentifierOrKeyword(precedingTrivia)
-                    End If
+                    If ArePeek(2, "s ") Then AdvanceChar(2) : Return MakeKeyword(SyntaxKind.AsKeyword, "As", precedingTrivia) ' TODO: do we allow widechars in keywords?
+                    Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "E"c
-                    If CanGetCharAtOffset(3) AndAlso
-                        PeekAheadChar(1) = "n"c AndAlso
-                        PeekAheadChar(2) = "d"c AndAlso
-                        PeekAheadChar(3) = " "c Then
-
+                    If ArePeek(3, "nd ") Then
                         ' TODO: do we allow widechars in keywords?
-                        Dim spelling = "End"
                         AdvanceChar(3)
-                        Return MakeKeyword(SyntaxKind.EndKeyword, spelling, precedingTrivia)
+                        Return MakeKeyword(SyntaxKind.EndKeyword, "End", precedingTrivia)
                     Else
                         Return ScanIdentifierOrKeyword(precedingTrivia)
                     End If
 
                 Case "I"c
-                    If CanGetCharAtOffset(2) AndAlso
-                                           PeekAheadChar(1) = "f"c AndAlso
-                                           PeekAheadChar(2) = " "c Then
-
+                    If ArePeek(2, "f ") Then
                         ' TODO: do we allow widechars in keywords?
-                        Dim spelling = "If"
+                        Const spelling = "If"
                         AdvanceChar(2)
                         Return MakeKeyword(SyntaxKind.IfKeyword, spelling, precedingTrivia)
                     Else
                         Return ScanIdentifierOrKeyword(precedingTrivia)
                     End If
 
-                Case "a"c To "z"c
+                Case "a"c, "b"c, "c"c, "d"c, "e"c, "f"c, "g"c, "h"c, "i"c, "j"c, "k"c, "l"c, "m"c,
+                     "n"c, "o"c, "p"c, "q"c, "r"c, "s"c, "t"c, "u"c, "v"c, "w"c, "x"c, "y"c, "z"c
                     Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "B"c, "C"c, "D"c, "F"c, "G"c, "H"c, "J"c, "K"c, "L"c, "M"c, "N"c, "O"c, "P"c, "Q"c,
@@ -1156,58 +880,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "_"c
-                    If CanGetCharAtOffset(1) AndAlso IsIdentifierPartCharacter(PeekAheadChar(1)) Then
-                        Return ScanIdentifierOrKeyword(precedingTrivia)
-                    End If
-
+                    If TryPeek(1, ch2) AndAlso IsIdentifierPartCharacter(ch2) Then Return ScanIdentifierOrKeyword(precedingTrivia)
                     Dim err As ERRID = ERRID.ERR_ExpectedIdentifier
                     Dim len = GetWhitespaceLength(1)
-                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(PeekAheadChar(len)) OrElse PeekStartComment(len) > 0 Then
+                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(Peek(len)) OrElse PeekStartComment(len) > 0 Then
                         err = ERRID.ERR_LineContWithCommentOrNoPrecSpace
                     End If
-
                     ' not a line continuation and cannot start identifier.
                     Return MakeBadToken(precedingTrivia, 1, err)
 
-                Case "["c
-                    Return ScanBracketedIdentifier(precedingTrivia)
-
-                Case "?"c
-                    Return MakeQuestionToken(precedingTrivia, False)
-
-                Case "%"c
-                    If CanGetCharAtOffset(1) AndAlso
-                        PeekAheadChar(1) = ">"c Then
-                        Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
-                    End If
-
+                Case "["c : Return ScanBracketedIdentifier(precedingTrivia)
+                Case "?"c : Return MakeQuestionToken(precedingTrivia, False)
+                Case "%"c : If IsPeek(1, ">"c) Then Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
                 Case "$"c, FULLWIDTH_DOLLAR_SIGN
-                    If CanGetCharAtOffset(1) AndAlso IsDoubleQuote(PeekAheadChar(1)) Then
-                        Return MakePunctuationToken(precedingTrivia, 2, SyntaxKind.DollarSignDoubleQuoteToken)
-                    End If
-
+                    If TryPeek(1, ch2) AndAlso IsDoubleQuote(ch2) Then Return MakePunctuationToken(precedingTrivia, 2, SyntaxKind.DollarSignDoubleQuoteToken)
             End Select
 
-            If IsIdentifierStartCharacter(ch) Then
-                Return ScanIdentifierOrKeyword(precedingTrivia)
-            End If
+            If IsIdentifierStartCharacter(ch) Then Return ScanIdentifierOrKeyword(precedingTrivia)
 
             Debug.Assert(Not IsNewLine(ch))
 
-            If IsDoubleQuote(ch) Then
-                Return ScanStringLiteral(precedingTrivia)
-            End If
-
-            If IsFullWidth(ch) Then
-                ch = MakeHalfWidth(ch)
-                Return ScanTokenFullWidth(precedingTrivia, ch)
-            End If
-
+            If IsDoubleQuote(ch) Then Return ScanStringLiteral(precedingTrivia)
+            If IsFullWidth(ch) Then ch = MakeHalfWidth(ch) : Return ScanTokenFullWidth(precedingTrivia, ch)
             Return Nothing
         End Function
-
         ' REVIEW: Is there a better way to reuse this logic? 
         Private Function ScanTokenFullWidth(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), ch As Char) As SyntaxToken
+         Const lengthWithMaybeEquals = 1
+            Dim ch2 As Char
             Select Case ch
                 Case CARRIAGE_RETURN, LINE_FEED
                     Return ScanNewlineAsStatementTerminator(ch, precedingTrivia)
@@ -1216,162 +916,56 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Debug.Assert(False, String.Format("Unexpected char: &H{0:x}", AscW(ch)))
                     Return Nothing ' trivia cannot start a token
 
-                Case "@"c
-                    Return MakeAtToken(precedingTrivia, True)
-
-                Case "("c
-                    Return MakeOpenParenToken(precedingTrivia, True)
-
-                Case ")"c
-                    Return MakeCloseParenToken(precedingTrivia, True)
-
-                Case "{"c
-                    Return MakeOpenBraceToken(precedingTrivia, True)
-
-                Case "}"c
-                    Return MakeCloseBraceToken(precedingTrivia, True)
-
-                Case ","c
-                    Return MakeCommaToken(precedingTrivia, True)
-
-                Case "#"c
-                    Dim dl = ScanDateLiteral(precedingTrivia)
-                    If dl IsNot Nothing Then
-                        Return dl
-                    Else
-                        Return MakeHashToken(precedingTrivia, True)
-                    End If
-
+                Case "@"c : Return MakeAtToken(precedingTrivia, True)
+                Case "("c : Return MakeOpenParenToken(precedingTrivia, True)
+                Case ")"c : Return MakeCloseParenToken(precedingTrivia, True)
+                Case "{"c : Return MakeOpenBraceToken(precedingTrivia, True)
+                Case "}"c : Return MakeCloseBraceToken(precedingTrivia, True)
+                Case ","c : Return MakeCommaToken(precedingTrivia, True)
+                Case "#"c : Dim dl = ScanDateLiteral(precedingTrivia) : Return If(dl, MakeHashToken(precedingTrivia, True))
                 Case "&"c
-                    If CanGetCharAtOffset(1) AndAlso BeginsBaseLiteral(PeekAheadChar(1)) Then
-                        Return ScanNumericLiteral(precedingTrivia)
-                    End If
-
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeAmpersandEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeAmpersandToken(precedingTrivia, True)
-                    End If
-
-                Case "="c
-                    Return MakeEqualsToken(precedingTrivia, True)
-
-                Case "<"c
-                    Return ScanLeftAngleBracket(precedingTrivia, True, _scanSingleLineTriviaFunc)
-
-                Case ">"c
-                    Return ScanRightAngleBracket(precedingTrivia, True)
-
+                    If TryPeek(1, ch2) AndAlso BeginsBaseLiteral(ch2) Then Return ScanNumericLiteral(precedingTrivia)
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAmpersandEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeAmpersandToken(precedingTrivia, True)
+                Case "="c : Return MakeEqualsToken(precedingTrivia, True)
+                Case "<"c : Return ScanLeftAngleBracket(precedingTrivia, True, _scanSingleLineTriviaFunc)
+                Case ">"c : Return ScanRightAngleBracket(precedingTrivia, True)
                 Case ":"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeColonEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return ScanColonAsStatementTerminator(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeColonEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return ScanColonAsStatementTerminator(precedingTrivia, True)
                 Case "+"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakePlusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakePlusToken(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakePlusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakePlusToken(precedingTrivia, True)
                 Case "-"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeMinusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeMinusToken(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeMinusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeMinusToken(precedingTrivia, True)
                 Case "*"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeAsteriskEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeAsteriskToken(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAsteriskEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeAsteriskToken(precedingTrivia, True)
                 Case "/"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeSlashToken(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeSlashToken(precedingTrivia, True)
                 Case "\"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeBackSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeBackslashToken(precedingTrivia, True)
-                    End If
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeBackSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeBackslashToken(precedingTrivia, True)
                 Case "^"c
-                    Dim lengthWithMaybeEquals = 1
-                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then
-                        Return MakeCaretEqualsToken(precedingTrivia, lengthWithMaybeEquals)
-                    Else
-                        Return MakeCaretToken(precedingTrivia, True)
-                    End If
-
-                Case "!"c
-                    Return MakeExclamationToken(precedingTrivia, True)
-
+                    If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeCaretEqualsToken(precedingTrivia, lengthWithMaybeEquals)
+                    Return MakeCaretToken(precedingTrivia, True)
+                Case "!"c : Return MakeExclamationToken(precedingTrivia, True)
                 Case "."c
-                    If CanGetCharAtOffset(1) AndAlso IsDecimalDigit(PeekAheadChar(1)) Then
-                        Return ScanNumericLiteral(precedingTrivia)
-                    Else
-                        Return MakeDotToken(precedingTrivia, True)
-                    End If
-
-                Case "0"c,
-                      "1"c,
-                      "2"c,
-                      "3"c,
-                      "4"c,
-                      "5"c,
-                      "6"c,
-                      "7"c,
-                      "8"c,
-                      "9"c
+                    If TryPeek(1, ch2) AndAlso IsDecimalDigit(ch2) Then Return ScanNumericLiteral(precedingTrivia)
+                    Return MakeDotToken(precedingTrivia, True)
+                Case "0"c, "1"c, "2"c, "3"c, "4"c, "5"c, "6"c, "7"c, "8"c, "9"c
                     Return ScanNumericLiteral(precedingTrivia)
-
-                Case """"c
-                    Return ScanStringLiteral(precedingTrivia)
-
+                Case """"c : Return ScanStringLiteral(precedingTrivia)
                 Case "A"c
-                    If CanGetCharAtOffset(2) AndAlso
-                       PeekAheadChar(1) = "s"c AndAlso
-                       PeekAheadChar(2) = " "c Then
-
-                        Dim spelling = GetText(2)
-                        Return MakeKeyword(SyntaxKind.AsKeyword, spelling, precedingTrivia)
-                    Else
-                        Return ScanIdentifierOrKeyword(precedingTrivia)
-                    End If
-
+                    If ArePeek(2,"s ") Then Return MakeKeyword(SyntaxKind.AsKeyword,  GetText(2), precedingTrivia)
+                    Return ScanIdentifierOrKeyword(precedingTrivia)
                 Case "E"c
-                    If CanGetCharAtOffset(3) AndAlso
-                        PeekAheadChar(1) = "n"c AndAlso
-                        PeekAheadChar(2) = "d"c AndAlso
-                        PeekAheadChar(3) = " "c Then
-
-                        Dim spelling = GetText(3)
-                        Return MakeKeyword(SyntaxKind.EndKeyword, spelling, precedingTrivia)
-                    Else
-                        Return ScanIdentifierOrKeyword(precedingTrivia)
-                    End If
-
+                    If ArePeek(3, "nd ") Then Return MakeKeyword(SyntaxKind.EndKeyword,  GetText(3), precedingTrivia)
+                    Return ScanIdentifierOrKeyword(precedingTrivia)
                 Case "I"c
-                    If CanGetCharAtOffset(2) AndAlso
-                                           PeekAheadChar(1) = "f"c AndAlso
-                                           PeekAheadChar(2) = " "c Then
-
+                    If ArePeek(2, "f ") Then
                         ' TODO: do we allow widechars in keywords?
                         Dim spelling = GetText(2)
                         Return MakeKeyword(SyntaxKind.IfKeyword, spelling, precedingTrivia)
@@ -1387,36 +981,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "_"c
-                    If CanGetCharAtOffset(1) AndAlso IsIdentifierPartCharacter(PeekAheadChar(1)) Then
-                        Return ScanIdentifierOrKeyword(precedingTrivia)
-                    End If
+                    If TryPeek(1, ch2) AndAlso IsIdentifierPartCharacter(ch2) Then Return ScanIdentifierOrKeyword(precedingTrivia)
 
                     Dim err As ERRID = ERRID.ERR_ExpectedIdentifier
                     Dim len = GetWhitespaceLength(1)
-                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(PeekAheadChar(len)) OrElse PeekStartComment(len) > 0 Then
+                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(Peek(len)) OrElse PeekStartComment(len) > 0 Then
                         err = ERRID.ERR_LineContWithCommentOrNoPrecSpace
                     End If
 
                     ' not a line continuation and cannot start identifier.
                     Return MakeBadToken(precedingTrivia, 1, err)
 
-                Case "["c
-                    Return ScanBracketedIdentifier(precedingTrivia)
-
-                Case "?"c
-                    Return MakeQuestionToken(precedingTrivia, True)
-
-                Case "%"c
-                    If CanGetCharAtOffset(1) AndAlso
-                        PeekAheadChar(1) = ">"c Then
-                        Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
-                    End If
-
+                Case "["c : Return ScanBracketedIdentifier(precedingTrivia)
+                Case "?"c : Return MakeQuestionToken(precedingTrivia, True)
+                Case "%"c : If IsPeek(1, ">"c) Then Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
             End Select
 
-            If IsIdentifierStartCharacter(ch) Then
-                Return ScanIdentifierOrKeyword(precedingTrivia)
-            End If
+            If IsIdentifierStartCharacter(ch) Then Return ScanIdentifierOrKeyword(precedingTrivia)
 
             Debug.Assert(Not IsNewLine(ch))
             Debug.Assert(Not IsDoubleQuote(ch))
@@ -1432,16 +1013,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim Here = Index
             Dim eq As Char
 
-            While CanGetCharAtOffset(Here)
-                eq = PeekAheadChar(Here)
+            While TryPeek(Here, eq)
                 Here += 1
                 If Not IsWhitespace(eq) Then
-                    If eq = "="c OrElse eq = FULLWIDTH_EQUALS_SIGN Then
-                        Index = Here
-                        Return True
-                    Else
-                        Return False
-                    End If
+                    If eq = "="c OrElse eq = FULLWIDTH_EQUALS_SIGN Then Index = Here : Return True
+                    Return False
                 End If
             End While
             Return False
@@ -1449,26 +1025,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanRightAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As SyntaxToken
             Debug.Assert(CanGetChar)  ' > 
-            Debug.Assert(PeekChar() = ">"c OrElse PeekChar() = FULLWIDTH_GREATER_THAN_SIGN)
+            Debug.Assert(Peek() = ">"c OrElse Peek() = FULLWIDTH_GREATER_THAN_SIGN)
 
             Dim length As Integer = 1
 
             ' // Allow whitespace between the characters of a two-character token.
             length = GetWhitespaceLength(length)
-
-            If CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
-
-                If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN Then
+            Dim c As Char
+            If TryPeek(length, c) Then
+                If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN Then length += 1 : Return MakeGreaterThanEqualsToken(precedingTrivia, length)
+                If c = ">"c OrElse c = FULLWIDTH_GREATER_THAN_SIGN Then
                     length += 1
-                    Return MakeGreaterThanEqualsToken(precedingTrivia, length)
-                ElseIf c = ">"c OrElse c = FULLWIDTH_GREATER_THAN_SIGN Then
-                    length += 1
-                    If TrySkipFollowingEquals(length) Then
-                        Return MakeGreaterThanGreaterThanEqualsToken(precedingTrivia, length)
-                    Else
-                        Return MakeGreaterThanGreaterThanToken(precedingTrivia, length)
-                    End If
+                    If TrySkipFollowingEquals(length) Then Return MakeGreaterThanGreaterThanEqualsToken(precedingTrivia, length)
+                    Return MakeGreaterThanGreaterThanToken(precedingTrivia, length)
                 End If
             End If
             Return MakeGreaterThanToken(precedingTrivia, charIsFullWidth)
@@ -1476,67 +1045,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanLeftAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean, scanTrailingTrivia As ScanTriviaFunc) As SyntaxToken
             Debug.Assert(CanGetChar)  ' < 
-            Debug.Assert(PeekChar() = "<"c OrElse PeekChar() = FULLWIDTH_LESS_THAN_SIGN)
+            Debug.Assert(Peek() = "<"c OrElse Peek() = FULLWIDTH_LESS_THAN_SIGN)
 
-            Dim length As Integer = 1
-
+            Dim x As Integer = 1
+            Dim c As Char
             ' Check for XML tokens
-            If Not charIsFullWidth AndAlso CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
+            If Not charIsFullWidth AndAlso TryPeek(x, c) Then
                 Select Case c
                     Case "!"c
-                        If CanGetCharAtOffset(length + 2) Then
-                            Select Case (PeekAheadChar(length + 1))
+                        If CanGetCharAtOffset(x + 2) Then
+                            Select Case (Peek(x + 1))
                                 Case "-"c
-                                    If CanGetCharAtOffset(length + 3) AndAlso PeekAheadChar(length + 2) = "-"c Then
-                                        Return XmlMakeBeginCommentToken(precedingTrivia, scanTrailingTrivia)
-                                    End If
+                                    If CanGetCharAtOffset(x + 3) AndAlso Peek(x + 2) = "-"c Then Return XmlMakeBeginCommentToken(precedingTrivia, scanTrailingTrivia)
                                 Case "["c
-                                    If CanGetCharAtOffset(length + 8) AndAlso
-                                        PeekAheadChar(length + 2) = "C"c AndAlso
-                                        PeekAheadChar(length + 3) = "D"c AndAlso
-                                        PeekAheadChar(length + 4) = "A"c AndAlso
-                                        PeekAheadChar(length + 5) = "T"c AndAlso
-                                        PeekAheadChar(length + 6) = "A"c AndAlso
-                                        PeekAheadChar(length + 7) = "["c Then
-
-                                        Return XmlMakeBeginCDataToken(precedingTrivia, scanTrailingTrivia)
-                                    End If
+                                    If ArePeek(x,8,2,"CDATA[") Then Return XmlMakeBeginCDataToken(precedingTrivia, scanTrailingTrivia)
                             End Select
                         End If
-                    Case "?"c
-                        Return XmlMakeBeginProcessingInstructionToken(precedingTrivia, scanTrailingTrivia)
-
-                    Case "/"c
-                        Return XmlMakeBeginEndElementToken(precedingTrivia, _scanSingleLineTriviaFunc)
+                    Case "?"c : Return XmlMakeBeginProcessingInstructionToken(precedingTrivia, scanTrailingTrivia)
+                    Case "/"c : Return XmlMakeBeginEndElementToken(precedingTrivia, _scanSingleLineTriviaFunc)
                 End Select
             End If
 
             ' // Allow whitespace between the characters of a two-character token.
-            length = GetWhitespaceLength(length)
-
-            If CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
-
-                If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN Then
-                    length += 1
-                    Return MakeLessThanEqualsToken(precedingTrivia, length)
-                ElseIf c = ">"c OrElse c = FULLWIDTH_GREATER_THAN_SIGN Then
-                    length += 1
-                    Return MakeLessThanGreaterThanToken(precedingTrivia, length)
-                ElseIf c = "<"c OrElse c = FULLWIDTH_LESS_THAN_SIGN Then
-                    length += 1
-
-                    If CanGetCharAtOffset(length) Then
-                        c = PeekAheadChar(length)
-
+            x = GetWhitespaceLength(x)
+            If TryPeek(x, c) Then
+                If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN       Then x += 1 : Return MakeLessThanEqualsToken(precedingTrivia, x)
+                If c = ">"c OrElse c = FULLWIDTH_GREATER_THAN_SIGN Then x += 1 : Return MakeLessThanGreaterThanToken(precedingTrivia, x)
+                If c = "<"c OrElse c = FULLWIDTH_LESS_THAN_SIGN Then
+                    x += 1
+                    If TryPeek(x,c) Then
                         'if the second "<" is a part of "<%" - like in "<<%" , we do not want to use it.
                         If c <> "%"c AndAlso c <> FULLWIDTH_PERCENT_SIGN Then
-                            If TrySkipFollowingEquals(length) Then
-                                Return MakeLessThanLessThanEqualsToken(precedingTrivia, length)
-                            Else
-                                Return MakeLessThanLessThanToken(precedingTrivia, length)
-                            End If
+                            If TrySkipFollowingEquals(x) Then Return MakeLessThanLessThanEqualsToken(precedingTrivia, x)
+                            Return MakeLessThanLessThanToken(precedingTrivia, x)
                         End If
                     End If
                 End If
@@ -1550,9 +1091,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </remarks>
         Friend Shared Function IsIdentifier(spelling As String) As Boolean
             Dim spellingLength As Integer = spelling.Length
-            If spellingLength = 0 Then
-                Return False
-            End If
+            If spellingLength = 0 Then Return False
 
             Dim c = spelling(0)
             If SyntaxFacts.IsIdentifierStartCharacter(c) Then
@@ -1560,14 +1099,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 '  SPEC:     exception: identifiers may begin with an underscore (connector) character. 
                 '  SPEC:     If an identifier begins with an underscore, it must contain at least one other 
                 '  SPEC:     valid identifier character to disambiguate it from a line continuation. 
-                If IsConnectorPunctuation(c) AndAlso spellingLength = 1 Then
-                    Return False
-                End If
-
-                For i = 1 To spellingLength - 1
-                    If Not IsIdentifierPartCharacter(spelling(i)) Then
-                        Return False
-                    End If
+                If IsConnectorPunctuation(c) AndAlso spellingLength = 1 Then Return False
+                   For i = 1 To spellingLength - 1
+                    If Not IsIdentifierPartCharacter(spelling(i)) Then Return False
                 Next
             End If
 
@@ -1576,15 +1110,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanIdentifierOrKeyword(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsIdentifierStartCharacter(PeekChar))
+            Debug.Assert(IsIdentifierStartCharacter(Peek))
             Debug.Assert(PeekStartComment(0) = 0) ' comment should be handled by caller
 
-            Dim ch = PeekChar()
-            If CanGetCharAtOffset(1) Then
-                Dim ch1 = PeekAheadChar(1)
-                If IsConnectorPunctuation(ch) AndAlso Not IsIdentifierPartCharacter(ch1) Then
-                    Return MakeBadToken(precedingTrivia, 1, ERRID.ERR_ExpectedIdentifier)
-                End If
+            Dim ch = Peek()
+            Dim ch1 As Char
+            If TryPeek(1, ch1) AndAlso (IsConnectorPunctuation(ch) AndAlso Not IsIdentifierPartCharacter(ch1)) Then
+                Return MakeBadToken(precedingTrivia, 1, ERRID.ERR_ExpectedIdentifier)
             End If
 
             Dim len = 1 ' we know that the first char was good
@@ -1592,13 +1124,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' // The C++ compiler refuses to inline IsIdentifierCharacter, so the
             ' // < 128 test is inline here. (This loop gets a *lot* of traffic.)
             ' TODO: make sure we get good perf here
-            While CanGetCharAtOffset(len)
-                ch = PeekAheadChar(len)
-
-                Dim code = Convert.ToUInt16(ch)
-                If code < 128 AndAlso IsNarrowIdentifierCharacter(code) OrElse
-                    IsWideIdentifierCharacter(ch) Then
-
+            While TryPeek(len,ch)
+               Dim code = Convert.ToUInt16(ch)
+                If code < 128 AndAlso IsNarrowIdentifierCharacter(code) OrElse IsWideIdentifierCharacter(ch) Then
                     len += 1
                 Else
                     Exit While
@@ -1607,16 +1135,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             'Check for a type character
             Dim TypeCharacter As TypeCharacter = TypeCharacter.None
-            If CanGetCharAtOffset(len) Then
-                ch = PeekAheadChar(len)
 
+            If TryPeek(len,ch) Then
 FullWidthRepeat:
                 Select Case ch
                     Case "!"c
                         ' // If the ! is followed by an identifier it is a dictionary lookup operator, not a type character.
-                        If CanGetCharAtOffset(len + 1) Then
-                            Dim NextChar As Char = PeekAheadChar(len + 1)
-
+                        Dim NextChar As Char
+                        If TryPeek(len + 1,NextChar) Then
                             If IsIdentifierStartCharacter(NextChar) OrElse
                                 MatchOneOrAnotherOrFullwidth(NextChar, "["c, "]"c) Then
                                 Exit Select
@@ -1625,31 +1151,13 @@ FullWidthRepeat:
                         TypeCharacter = TypeCharacter.Single  'typeChars.chType_sR4
                         len += 1
 
-                    Case "#"c
-                        TypeCharacter = TypeCharacter.Double ' typeChars.chType_sR8
-                        len += 1
-
-                    Case "$"c
-                        TypeCharacter = TypeCharacter.String 'typeChars.chType_String
-                        len += 1
-
-                    Case "%"c
-                        TypeCharacter = TypeCharacter.Integer ' typeChars.chType_sI4
-                        len += 1
-
-                    Case "&"c
-                        TypeCharacter = TypeCharacter.Long 'typeChars.chType_sI8
-                        len += 1
-
-                    Case "@"c
-                        TypeCharacter = TypeCharacter.Decimal 'chType_sDecimal
-                        len += 1
-
+                    Case "#"c : len += 1 : TypeCharacter = TypeCharacter.Double  ' typeChars.chType_sR8
+                    Case "$"c : len += 1 : TypeCharacter = TypeCharacter.String  ' typeChars.chType_String
+                    Case "%"c : len += 1 : TypeCharacter = TypeCharacter.Integer ' typeChars.chType_sI4
+                    Case "&"c : len += 1 : TypeCharacter = TypeCharacter.Long    ' typeChars.chType_sI8
+                    Case "@"c : len += 1 : TypeCharacter = TypeCharacter.Decimal ' chType_sDecimal
                     Case Else
-                        If IsFullWidth(ch) Then
-                            ch = MakeHalfWidth(ch)
-                            GoTo FullWidthRepeat
-                        End If
+                        If IsFullWidth(ch) Then ch = MakeHalfWidth(ch) : GoTo FullWidthRepeat
                 End Select
             End If
 
@@ -1657,9 +1165,7 @@ FullWidthRepeat:
             Dim contextualKind As SyntaxKind = SyntaxKind.IdentifierToken
             Dim spelling = GetText(len)
 
-            Dim BaseSpelling = If(TypeCharacter = TypeCharacter.None,
-                                   spelling,
-                                   Intern(spelling, 0, len - 1))
+            Dim BaseSpelling = If(TypeCharacter = TypeCharacter.None, spelling, Intern(spelling, 0, len - 1))
 
             ' this can be keyword only if it has no type character, or if it is Mid$
             If TypeCharacter = TypeCharacter.None Then
@@ -1674,52 +1180,40 @@ FullWidthRepeat:
                 tokenType = SyntaxKind.IdentifierToken
             End If
 
-            If tokenType <> SyntaxKind.IdentifierToken Then
-                ' KEYWORD
-                Return MakeKeyword(tokenType, spelling, precedingTrivia)
-            Else
-                ' IDENTIFIER or CONTEXTUAL
-                Dim id As SyntaxToken = MakeIdentifier(spelling, contextualKind, False, BaseSpelling, TypeCharacter, precedingTrivia)
-                Return id
-            End If
+            If tokenType <> SyntaxKind.IdentifierToken Then Return MakeKeyword(tokenType, spelling, precedingTrivia)   ' KEYWORD
+            ' IDENTIFIER or CONTEXTUAL
+             Dim id As SyntaxToken = MakeIdentifier(spelling, contextualKind, False, BaseSpelling, TypeCharacter, precedingTrivia)
+            Return id
         End Function
 
         Private Function TokenOfStringCached(spelling As String, Optional kind As SyntaxKind = SyntaxKind.IdentifierToken) As SyntaxKind
-            If spelling.Length = 1 OrElse spelling.Length > 16 Then
-                Return kind
-            End If
-
+            If spelling.Length = 1 OrElse spelling.Length > 16 Then Return kind
             Return _KeywordsObjs.GetOrMakeValue(spelling)
         End Function
 
         Private Function ScanBracketedIdentifier(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)  ' [
-            Debug.Assert(PeekChar() = "["c OrElse PeekChar() = FULLWIDTH_LEFT_SQUARE_BRACKET)
+            Debug.Assert(Peek() = "["c OrElse Peek() = FULLWIDTH_LEFT_SQUARE_BRACKET)
 
             Dim IdStart As Integer = 1
             Dim Here As Integer = IdStart
 
             Dim InvalidIdentifier As Boolean = False
+            Dim ch, ch1 As Char
 
-            If Not CanGetCharAtOffset(Here) Then
-                Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_MissingEndBrack)
-            End If
-
-            Dim ch = PeekAheadChar(Here)
+            If Not TryPeek(Here, ch) Then Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_MissingEndBrack)
 
             ' check if we can start an ident.
             If Not IsIdentifierStartCharacter(ch) OrElse
                 (IsConnectorPunctuation(ch) AndAlso
-                    Not (CanGetCharAtOffset(Here + 1) AndAlso
-                         IsIdentifierPartCharacter(PeekAheadChar(Here + 1)))) Then
+                    Not (TryPeek(Here + 1, ch1) AndAlso
+                         IsIdentifierPartCharacter(ch1))) Then
 
                 InvalidIdentifier = True
             End If
-
+            Dim [Next] As Char
             ' check ident until ]
-            While CanGetCharAtOffset(Here)
-                Dim [Next] As Char = PeekAheadChar(Here)
-
+            While TryPeek(Here, [Next])
                 If [Next] = "]"c OrElse [Next] = FULLWIDTH_RIGHT_SQUARE_BRACKET Then
                     Dim IdStringLength As Integer = Here - IdStart
 
@@ -1752,11 +1246,8 @@ FullWidthRepeat:
                 Here += 1
             End While
 
-            If Here > 1 Then
-                Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_MissingEndBrack)
-            Else
-                Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_ExpectedIdentifier)
-            End If
+            If Here > 1 Then Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_MissingEndBrack)
+            Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_ExpectedIdentifier)
         End Function
 
         Private Enum NumericLiteralKind
@@ -1780,10 +1271,10 @@ FullWidthRepeat:
 
             ' // First read a leading base specifier, if present, followed by a sequence of zero
             ' // or more digits.
-            Dim ch = PeekChar()
+            Dim ch = Peek()
             If ch = "&"c OrElse ch = FULLWIDTH_AMPERSAND Then
                 Here += 1
-                ch = If(CanGetCharAtOffset(Here), PeekAheadChar(Here), ChrW(0))
+                ch = If(CanGetCharAtOffset(Here), Peek(Here), ChrW(0))
 
 FullWidthRepeat:
                 Select Case ch
@@ -1792,11 +1283,7 @@ FullWidthRepeat:
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Hexadecimal
 
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
-                            If Not IsHexDigit(ch) Then
-                                Exit While
-                            End If
+                        While TryPeek(Here,ch) AndAlso IsHexDigit(ch)
                             Here += 1
                         End While
 
@@ -1805,54 +1292,36 @@ FullWidthRepeat:
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Octal
 
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
-                            If Not IsOctalDigit(ch) Then
-                                Exit While
-                            End If
+                        While TryPeek(Here, ch) AndAlso IsOctalDigit(ch)
                             Here += 1
                         End While
 
                     Case Else
-                        If IsFullWidth(ch) Then
-                            ch = MakeHalfWidth(ch)
-                            GoTo FullWidthRepeat
-                        End If
-
+                        If IsFullWidth(ch) Then ch = MakeHalfWidth(ch) : GoTo FullWidthRepeat
                         Throw ExceptionUtilities.UnexpectedValue(ch)
                 End Select
             Else
                 ' no base specifier - just go through decimal digits.
                 IntegerLiteralStart = Here
-                While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
-                    If Not IsDecimalDigit(ch) Then
-                        Exit While
-                    End If
+                While TryPeek(Here,ch) AndAlso IsDecimalDigit(ch)
                     Here += 1
                 End While
             End If
 
             ' we may have a dot, and then it is a float, but if this is an integral, then we have seen it all.
             Dim IntegerLiteralEnd As Integer = Here
+            Dim ch1 As Char
 
             ' // Unless there was an explicit base specifier (which indicates an integer literal),
             ' // read the rest of a float literal.
-            If Base = LiteralBase.Decimal AndAlso CanGetCharAtOffset(Here) Then
+            If Base = LiteralBase.Decimal AndAlso TryPeek(Here,ch) Then
                 ' // First read a '.' followed by a sequence of one or more digits.
-                ch = PeekAheadChar(Here)
-                If (ch = "."c Or ch = FULLWIDTH_FULL_STOP) AndAlso
-                        CanGetCharAtOffset(Here + 1) AndAlso
-                        IsDecimalDigit(PeekAheadChar(Here + 1)) Then
+                If (ch = "."c Or ch = FULLWIDTH_FULL_STOP) AndAlso TryPeek(Here + 1,ch1) AndAlso IsDecimalDigit(ch1) Then
 
                     Here += 2   ' skip dot and first digit
 
                     ' all following decimal digits belong to the literal (fractional part)
-                    While CanGetCharAtOffset(Here)
-                        ch = PeekAheadChar(Here)
-                        If Not IsDecimalDigit(ch) Then
-                            Exit While
-                        End If
+                    While TryPeek(Here,ch) AndAlso IsDecimalDigit(ch)
                         Here += 1
                     End While
                     literalKind = NumericLiteralKind.Float
@@ -1860,24 +1329,13 @@ FullWidthRepeat:
 
                 ' // Read an exponent symbol followed by an optional sign and a sequence of
                 ' // one or more digits.
-                If CanGetCharAtOffset(Here) AndAlso BeginsExponent(PeekAheadChar(Here)) Then
+                If TryPeek(Here,ch1) AndAlso BeginsExponent(ch1) Then
                     Here += 1
 
-                    If CanGetCharAtOffset(Here) Then
-                        ch = PeekAheadChar(Here)
-
-                        If MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c) Then
-                            Here += 1
-                        End If
-                    End If
-
-                    If CanGetCharAtOffset(Here) AndAlso IsDecimalDigit(PeekAheadChar(Here)) Then
+                    If TryPeek(Here,ch)  AndAlso MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c) Then Here += 1
+                    If TryPeek(Here,ch1) AndAlso IsDecimalDigit(ch1) Then
                         Here += 1
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
-                            If Not IsDecimalDigit(ch) Then
-                                Exit While
-                            End If
+                        While TryPeek(Here,ch) AndAlso IsDecimalDigit(ch) 
                             Here += 1
                         End While
                     Else
@@ -1896,97 +1354,44 @@ FullWidthRepeat:
 
             Dim TypeCharacter As TypeCharacter = TypeCharacter.None
 
-            If CanGetCharAtOffset(Here) Then
-                ch = PeekAheadChar(Here)
-
+            If TryPeek(Here,ch) Then
 FullWidthRepeat2:
                 Select Case ch
                     Case "!"c
-                        If Base = LiteralBase.Decimal Then
-                            TypeCharacter = TypeCharacter.Single
-                            literalKind = NumericLiteralKind.Float
-                            Here += 1
-                        End If
-
+                        If Base = LiteralBase.Decimal Then TypeCharacter = TypeCharacter.Single : literalKind = NumericLiteralKind.Float : Here += 1
                     Case "F"c, "f"c
-                        If Base = LiteralBase.Decimal Then
-                            TypeCharacter = TypeCharacter.SingleLiteral
-                            literalKind = NumericLiteralKind.Float
-                            Here += 1
-                        End If
-
+                        If Base = LiteralBase.Decimal Then TypeCharacter = TypeCharacter.SingleLiteral : literalKind = NumericLiteralKind.Float : Here += 1
                     Case "#"c
-                        If Base = LiteralBase.Decimal Then
-                            TypeCharacter = TypeCharacter.Double
-                            literalKind = NumericLiteralKind.Float
-                            Here += 1
-                        End If
-
+                        If Base = LiteralBase.Decimal Then TypeCharacter = TypeCharacter.Double : literalKind = NumericLiteralKind.Float : Here += 1
                     Case "R"c, "r"c
-                        If Base = LiteralBase.Decimal Then
-                            TypeCharacter = TypeCharacter.DoubleLiteral
-                            literalKind = NumericLiteralKind.Float
-                            Here += 1
-                        End If
-
+                        If Base = LiteralBase.Decimal Then TypeCharacter = TypeCharacter.DoubleLiteral : literalKind = NumericLiteralKind.Float : Here += 1
                     Case "S"c, "s"c
-
-                        If literalKind <> NumericLiteralKind.Float Then
-                            TypeCharacter = TypeCharacter.ShortLiteral
-                            Here += 1
-                        End If
-
+                        If literalKind <> NumericLiteralKind.Float Then TypeCharacter = TypeCharacter.ShortLiteral : Here += 1
                     Case "%"c
-                        If literalKind <> NumericLiteralKind.Float Then
-                            TypeCharacter = TypeCharacter.Integer
-                            Here += 1
-                        End If
-
+                        If literalKind <> NumericLiteralKind.Float Then TypeCharacter = TypeCharacter.Integer : Here += 1
                     Case "I"c, "i"c
-                        If literalKind <> NumericLiteralKind.Float Then
-                            TypeCharacter = TypeCharacter.IntegerLiteral
-                            Here += 1
-                        End If
-
+                        If literalKind <> NumericLiteralKind.Float Then TypeCharacter = TypeCharacter.IntegerLiteral : Here += 1
                     Case "&"c
-                        If literalKind <> NumericLiteralKind.Float Then
-                            TypeCharacter = TypeCharacter.Long
-                            Here += 1
-                        End If
-
+                        If literalKind <> NumericLiteralKind.Float Then TypeCharacter = TypeCharacter.Long : Here += 1
                     Case "L"c, "l"c
-                        If literalKind <> NumericLiteralKind.Float Then
-                            TypeCharacter = TypeCharacter.LongLiteral
-                            Here += 1
-                        End If
-
+                        If literalKind <> NumericLiteralKind.Float Then TypeCharacter = TypeCharacter.LongLiteral : Here += 1     
                     Case "@"c
-                        If Base = LiteralBase.Decimal Then
-                            TypeCharacter = TypeCharacter.Decimal
-                            literalKind = NumericLiteralKind.Decimal
-                            Here += 1
-                        End If
-
+                        If Base = LiteralBase.Decimal Then TypeCharacter = TypeCharacter.Decimal : literalKind = NumericLiteralKind.Decimal : Here += 1
                     Case "D"c, "d"c
                         If Base = LiteralBase.Decimal Then
                             TypeCharacter = TypeCharacter.DecimalLiteral
                             literalKind = NumericLiteralKind.Decimal
 
                             ' check if this was not attempt to use obsolete exponent
-                            If CanGetCharAtOffset(Here + 1) Then
-                                ch = PeekAheadChar(Here + 1)
-
-                                If IsDecimalDigit(ch) OrElse MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c) Then
+                            If TryPeek(Here + 1,ch) AndAlso (IsDecimalDigit(ch) OrElse MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c)) Then
                                     Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_ObsoleteExponent)
-                                End If
                             End If
-
                             Here += 1
                         End If
 
                     Case "U"c, "u"c
                         If literalKind <> NumericLiteralKind.Float AndAlso CanGetCharAtOffset(Here + 1) Then
-                            Dim NextChar As Char = PeekAheadChar(Here + 1)
+                            Dim NextChar As Char = Peek(Here + 1)
 
                             'unsigned suffixes - US, UL, UI
                             If MatchOneOrAnotherOrFullwidth(NextChar, "S"c, "s"c) Then
@@ -2022,12 +1427,12 @@ FullWidthRepeat2:
                 If IntegerLiteralStart = IntegerLiteralEnd Then
                     Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_Syntax)
                 Else
-                    IntegralValue = IntegralLiteralCharacterValue(PeekAheadChar(IntegerLiteralStart))
+                    IntegralValue = IntegralLiteralCharacterValue(Peek(IntegerLiteralStart))
 
                     If Base = LiteralBase.Decimal Then
                         ' Init For loop
                         For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1
-                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(PeekAheadChar(LiteralCharacter))
+                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(Peek(LiteralCharacter))
 
                             If IntegralValue < 1844674407370955161UL OrElse
                               (IntegralValue = 1844674407370955161UL AndAlso NextCharacterValue <= 5UI) Then
@@ -2039,62 +1444,41 @@ FullWidthRepeat2:
                             End If
                         Next
 
-                        If TypeCharacter <> TypeCharacter.ULongLiteral AndAlso IntegralValue > Long.MaxValue Then
-                            Overflows = True
-                        End If
+                        If TypeCharacter <> TypeCharacter.ULongLiteral AndAlso IntegralValue > Long.MaxValue Then Overflows = True
                     Else
-                        Dim Shift As Integer = If(Base = LiteralBase.Hexadecimal, 4, 3)
-                        Dim OverflowMask As UInt64 = If(Base = LiteralBase.Hexadecimal, &HF000000000000000UL, &HE000000000000000UL)
+                        Dim Shift        = If(Base = LiteralBase.Hexadecimal, 4, 3)
+                        Dim OverflowMask = If(Base = LiteralBase.Hexadecimal, &HF000000000000000UL, &HE000000000000000UL)
 
                         ' Init For loop
                         For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1
-                            If (IntegralValue And OverflowMask) <> 0 Then
-                                Overflows = True
-                            End If
-
-                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(PeekAheadChar(LiteralCharacter))
+                            If (IntegralValue And OverflowMask) <> 0 Then Overflows = True
+                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(Peek(LiteralCharacter))
                         Next
                     End If
-
-                    If TypeCharacter = TypeCharacter.None Then
-                        ' nothing to do
-                    ElseIf TypeCharacter = TypeCharacter.Integer OrElse TypeCharacter = TypeCharacter.IntegerLiteral Then
-                        If (Base = LiteralBase.Decimal AndAlso IntegralValue > &H7FFFFFFF) OrElse
-                            IntegralValue > &HFFFFFFFFUI Then
-
-                            Overflows = True
-                        End If
-
-                    ElseIf TypeCharacter = TypeCharacter.UIntegerLiteral Then
-                        If IntegralValue > &HFFFFFFFFUI Then
-                            Overflows = True
-                        End If
-
-                    ElseIf TypeCharacter = TypeCharacter.ShortLiteral Then
-                        If (Base = LiteralBase.Decimal AndAlso IntegralValue > &H7FFF) OrElse
-                            IntegralValue > &HFFFF Then
-
-                            Overflows = True
-                        End If
-
-                    ElseIf TypeCharacter = TypeCharacter.UShortLiteral Then
-                        If IntegralValue > &HFFFF Then
-                            Overflows = True
-                        End If
-
-                    Else
-                        Debug.Assert(TypeCharacter = TypeCharacter.Long OrElse
+                    Select Case TypeCharacter
+                        Case TypeCharacter.None ' nothing to do
+                        Case TypeCharacter.Integer,
+                             TypeCharacter.IntegerLiteral 
+                            If (Base = LiteralBase.Decimal AndAlso IntegralValue > &H7FFFFFFF) OrElse IntegralValue > &HFFFFFFFFUI Then Overflows = True
+                        Case TypeCharacter.UIntegerLiteral
+                            If IntegralValue > &HFFFFFFFFUI Then Overflows = True
+                        Case TypeCharacter.ShortLiteral
+                            If (Base = LiteralBase.Decimal AndAlso IntegralValue > &H7FFF) OrElse IntegralValue > &HFFFF Then Overflows = True
+                        Case  TypeCharacter.UShortLiteral
+                            If IntegralValue > &HFFFF Then Overflows = True
+                        Case Else
+                            Debug.Assert(TypeCharacter = TypeCharacter.Long OrElse
                                  TypeCharacter = TypeCharacter.LongLiteral OrElse
                                  TypeCharacter = TypeCharacter.ULongLiteral,
                         "Integral literal value computation is lost.")
-                    End If
+                    End Select
                 End If
 
             Else
                 ' // Copy the text of the literal to deal with fullwidth 
                 Dim scratch = GetScratch()
                 For i = 0 To literalWithoutTypeChar - 1
-                    Dim curCh = PeekAheadChar(i)
+                    Dim curCh = Peek(i)
                     scratch.Append(If(IsFullWidth(curCh), MakeHalfWidth(curCh), curCh))
                 Next
                 Dim LiteralSpelling = GetScratchTextInterned(scratch)
@@ -2113,28 +1497,21 @@ FullWidthRepeat2:
                         End If
                     Else
                         ' // Attempt to convert to double.
-                        If Not Double.TryParse(LiteralSpelling, NumberStyles.Float, CultureInfo.InvariantCulture, FloatingValue) Then
-                            Overflows = True
-                        End If
+                        If Not Double.TryParse(LiteralSpelling, NumberStyles.Float, CultureInfo.InvariantCulture, FloatingValue) Then Overflows = True
                     End If
                 End If
             End If
 
             Dim result As SyntaxToken
             Select Case literalKind
-                Case NumericLiteralKind.Integral
-                    result = MakeIntegerLiteralToken(precedingTrivia, Base, TypeCharacter, If(Overflows, 0UL, IntegralValue), Here)
-                Case NumericLiteralKind.Float
-                    result = MakeFloatingLiteralToken(precedingTrivia, TypeCharacter, If(Overflows, 0.0F, FloatingValue), Here)
-                Case NumericLiteralKind.Decimal
-                    result = MakeDecimalLiteralToken(precedingTrivia, TypeCharacter, If(Overflows, 0D, DecimalValue), Here)
+                Case NumericLiteralKind.Integral : result = MakeIntegerLiteralToken (precedingTrivia, Base, TypeCharacter, If(Overflows, 0UL, IntegralValue), Here)
+                Case NumericLiteralKind.Float    : result = MakeFloatingLiteralToken(precedingTrivia, TypeCharacter, If(Overflows, 0.0F, FloatingValue), Here)
+                Case NumericLiteralKind.Decimal  : result = MakeDecimalLiteralToken (precedingTrivia, TypeCharacter, If(Overflows, 0D, DecimalValue), Here)
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(literalKind)
             End Select
 
-            If Overflows Then
-                result = DirectCast(result.AddError(ErrorFactory.ErrorInfo(ERRID.ERR_Overflow)), SyntaxToken)
-            End If
+            If Overflows Then result = DirectCast(result.AddError(ErrorFactory.ErrorInfo(ERRID.ERR_Overflow)), SyntaxToken)
 
             Return result
         End Function
@@ -2158,35 +1535,18 @@ FullWidthRepeat2:
             Return Decimal.TryParse(text, NumberStyles.AllowDecimalPoint Or NumberStyles.AllowExponent, CultureInfo.InvariantCulture, value)
         End Function
 
-        Private Function ScanIntLiteral(
-               ByRef ReturnValue As Integer,
-               ByRef Here As Integer
-           ) As Boolean
+        Private Function ScanIntLiteral ( ByRef ReturnValue As Integer, ByRef Here As Integer ) As Boolean
             Debug.Assert(Here >= 0)
-
-            If Not CanGetCharAtOffset(Here) Then
-                Return False
-            End If
-
-            Dim ch = PeekAheadChar(Here)
-            If Not IsDecimalDigit(ch) Then
-                Return False
-            End If
-
+            Dim ch As Char
+            If Not TryPeek(Here,ch)   Then Return False
+            If Not IsDecimalDigit(ch) Then Return False
             Dim IntegralValue As Integer = IntegralLiteralCharacterValue(ch)
             Here += 1
 
-            While CanGetCharAtOffset(Here)
-                ch = PeekAheadChar(Here)
-
-                If Not IsDecimalDigit(ch) Then
-                    Exit While
-                End If
-
+            While TryPeek(Here,ch)
+                If Not IsDecimalDigit(ch) Then Exit While
                 Dim nextDigit = IntegralLiteralCharacterValue(ch)
-                If IntegralValue < 214748364 OrElse
-                    (IntegralValue = 214748364 AndAlso nextDigit < 8) Then
-
+                If IntegralValue < 214748364 OrElse (IntegralValue = 214748364 AndAlso nextDigit < 8) Then
                     IntegralValue = IntegralValue * 10 + nextDigit
                     Here += 1
                 Else
@@ -2200,20 +1560,11 @@ FullWidthRepeat2:
 
         Private Function ScanDateLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsHash(PeekChar()))
+            Debug.Assert(IsHash(Peek()))
 
             Dim Here As Integer = 1 'skip #
-            Dim FirstValue As Integer
-            Dim YearValue, MonthValue, DayValue, HourValue, MinuteValue, SecondValue As Integer
-            Dim HaveDateValue As Boolean = False
-            Dim HaveYearValue As Boolean = False
-            Dim HaveTimeValue As Boolean = False
-            Dim HaveMinuteValue As Boolean = False
-            Dim HaveSecondValue As Boolean = False
-            Dim HaveAM As Boolean = False
-            Dim HavePM As Boolean = False
-            Dim DateIsInvalid As Boolean = False
-            Dim YearIsTwoDigits As Boolean = False
+            Dim FirstValue, YearValue, MonthValue, DayValue, HourValue, MinuteValue, SecondValue As Integer
+            Dim HaveDateValue, HaveYearValue, HaveTimeValue, HaveMinuteValue, HaveSecondValue, HaveAM, HavePM, DateIsInvalid, YearIsTwoDigits As Boolean
             Dim DaysToMonth As Integer() = Nothing
 
             ' // Unfortunately, we can't fall back on OLE Automation's date parsing because
@@ -2225,79 +1576,48 @@ FullWidthRepeat2:
             Dim FirstValueStart As Integer = Here
 
             ' // The first thing has to be an integer, although it's not clear what it is yet
-            If Not ScanIntLiteral(FirstValue, Here) Then
-                Return Nothing
+            If Not ScanIntLiteral(FirstValue, Here) Then Return Nothing
 
-            End If
 
             ' // If we see a /, then it's a date
-
-            If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+            Dim ch, ch1 As Char
+            If TryPeek(Here, ch) AndAlso IsDateSeparatorCharacter(ch) Then
                 Dim FirstDateSeparator As Integer = Here
-
                 ' // We've got a date
                 HaveDateValue = True
                 Here += 1
-
                 ' Is the first value a year? 
                 ' It is a year if it consists of exactly 4 digits.
                 ' Condition below uses 5 because we already skipped the separator.
                 If Here - FirstValueStart = 5 Then
                     HaveYearValue = True
                     YearValue = FirstValue
-
                     ' // We have to have a month value
-                    If Not ScanIntLiteral(MonthValue, Here) Then
-                        GoTo baddate
-                    End If
-
+                    If Not ScanIntLiteral(MonthValue, Here) Then GoTo baddate
                     ' Do we have a day value?
-                    If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+                    If TryPeek(Here, ch1) AndAlso IsDateSeparatorCharacter(ch1) Then
                         ' // Check to see they used a consistent separator
-
-                        If PeekAheadChar(Here) <> PeekAheadChar(FirstDateSeparator) Then
-                            GoTo baddate
-                        End If
-
+                        If ch1 <> Peek(FirstDateSeparator) Then GoTo baddate
                         ' // Yes.
                         Here += 1
-
-                        If Not ScanIntLiteral(DayValue, Here) Then
-                            GoTo baddate
-                        End If
+                        If Not ScanIntLiteral(DayValue, Here) Then GoTo baddate
                     End If
                 Else
                     ' First value is month
                     MonthValue = FirstValue
-
                     ' // We have to have a day value
-
-                    If Not ScanIntLiteral(DayValue, Here) Then
-                        GoTo baddate
-                    End If
-
+                    If Not ScanIntLiteral(DayValue, Here) Then GoTo baddate
                     ' // Do we have a year value?
-
-                    If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+                    If TryPeek(Here, ch1) AndAlso IsDateSeparatorCharacter(ch1) Then
                         ' // Check to see they used a consistent separator
-
-                        If PeekAheadChar(Here) <> PeekAheadChar(FirstDateSeparator) Then
-                            GoTo baddate
-                        End If
-
+                        If ch1 <> Peek(FirstDateSeparator) Then GoTo baddate
                         ' // Yes.
                         HaveYearValue = True
                         Here += 1
-
                         Dim YearStart As Integer = Here
+                        If Not ScanIntLiteral(YearValue, Here) Then GoTo baddate
+                        If (Here - YearStart) = 2 Then YearIsTwoDigits = True
 
-                        If Not ScanIntLiteral(YearValue, Here) Then
-                            GoTo baddate
-                        End If
-
-                        If (Here - YearStart) = 2 Then
-                            YearIsTwoDigits = True
-                        End If
                     End If
                 End If
 
@@ -2311,119 +1631,70 @@ FullWidthRepeat2:
                 HourValue = FirstValue
             Else
                 ' // We did see a date. See if we see a time value...
-
-                If ScanIntLiteral(HourValue, Here) Then
-                    ' // Yup.
-                    HaveTimeValue = True
-                End If
+                If ScanIntLiteral(HourValue, Here) Then HaveTimeValue = True ' // Yup.
             End If
 
             If HaveTimeValue Then
                 ' // Do we see a :?
 
-                If CanGetCharAtOffset(Here) AndAlso IsColon(PeekAheadChar(Here)) Then
+                If TryPeek(Here, ch1) AndAlso IsColon(ch1) Then
                     Here += 1
-
                     ' // Now let's get the minute value
-
-                    If Not ScanIntLiteral(MinuteValue, Here) Then
-                        GoTo baddate
-                    End If
-
+                    If Not ScanIntLiteral(MinuteValue, Here) Then GoTo baddate
                     HaveMinuteValue = True
-
                     ' // Do we have a second value?
-
-                    If CanGetCharAtOffset(Here) AndAlso IsColon(PeekAheadChar(Here)) Then
+                    If TryPeek(Here, ch1) AndAlso IsColon(ch1) Then
                         ' // Yes.
                         HaveSecondValue = True
                         Here += 1
-
-                        If Not ScanIntLiteral(SecondValue, Here) Then
-                            GoTo baddate
-                        End If
+                        If Not ScanIntLiteral(SecondValue, Here) Then GoTo baddate
                     End If
                 End If
-
                 Here = GetWhitespaceLength(Here)
-
                 ' // Check AM/PM
-
-                If CanGetCharAtOffset(Here) Then
-                    If PeekAheadChar(Here) = "A"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_A OrElse
-                        PeekAheadChar(Here) = "a"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_A Then
-
+                If TryPeek(Here, ch1) Then
+                    If ch1 = "A"c OrElse ch1 = FULLWIDTH_LATIN_CAPITAL_LETTER_A OrElse ch1 = "a"c OrElse ch1 = FULLWIDTH_LATIN_SMALL_LETTER_A Then
                         HaveAM = True
                         Here += 1
-
-                    ElseIf PeekAheadChar(Here) = "P"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_P OrElse
-                           PeekAheadChar(Here) = "p"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_P Then
-
+                    ElseIf ch1 = "P"c OrElse ch1 = FULLWIDTH_LATIN_CAPITAL_LETTER_P OrElse ch1 = "p"c OrElse ch1 = FULLWIDTH_LATIN_SMALL_LETTER_P Then
                         HavePM = True
                         Here += 1
-
                     End If
 
-                    If CanGetCharAtOffset(Here) AndAlso (HaveAM OrElse HavePM) Then
-                        If PeekAheadChar(Here) = "M"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_M OrElse
-                           PeekAheadChar(Here) = "m"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_M Then
-
+                    If TryPeek(Here, ch1) AndAlso (HaveAM OrElse HavePM) Then
+                        If ch1 = "M"c OrElse ch1 = FULLWIDTH_LATIN_CAPITAL_LETTER_M OrElse
+                            ch1 = "m"c OrElse ch1 = FULLWIDTH_LATIN_SMALL_LETTER_M Then
                             Here = GetWhitespaceLength(Here + 1)
-
                         Else
                             GoTo baddate
                         End If
                     End If
                 End If
-
                 ' // If there's no minute/second value and no AM/PM, it's invalid
-
-                If Not HaveMinuteValue AndAlso Not HaveAM AndAlso Not HavePM Then
-                    GoTo baddate
-                End If
+                If Not HaveMinuteValue AndAlso Not HaveAM AndAlso Not HavePM Then GoTo baddate
             End If
 
-            If Not CanGetCharAtOffset(Here) OrElse Not IsHash(PeekAheadChar(Here)) Then
-                GoTo baddate
-            End If
-
+            If Not TryPeek(Here, ch1) OrElse Not IsHash(ch1) Then GoTo baddate
             Here += 1
 
             ' // OK, now we've got all the values, let's see if we've got a valid date
             If HaveDateValue Then
-                If MonthValue < 1 OrElse MonthValue > 12 Then
-                    DateIsInvalid = True
-                End If
-
+                If MonthValue < 1 OrElse MonthValue > 12 Then DateIsInvalid = True
                 ' // We'll check Days in a moment...
-
                 If Not HaveYearValue Then
                     DateIsInvalid = True
                     YearValue = 1
                 End If
-
                 ' // Check if not a leap year
-
                 If Not ((YearValue Mod 4 = 0) AndAlso (Not (YearValue Mod 100 = 0) OrElse (YearValue Mod 400 = 0))) Then
                     DaysToMonth = DaysToMonth365
                 Else
                     DaysToMonth = DaysToMonth366
                 End If
 
-                If DayValue < 1 OrElse
-                   (Not DateIsInvalid AndAlso DayValue > DaysToMonth(MonthValue) - DaysToMonth(MonthValue - 1)) Then
-
-                    DateIsInvalid = True
-                End If
-
-                If YearIsTwoDigits Then
-                    DateIsInvalid = True
-                End If
-
-                If YearValue < 1 OrElse YearValue > 9999 Then
-                    DateIsInvalid = True
-                End If
-
+                If DayValue < 1 OrElse (Not DateIsInvalid AndAlso DayValue > DaysToMonth(MonthValue) - DaysToMonth(MonthValue - 1)) Then DateIsInvalid = True
+                If YearIsTwoDigits Then DateIsInvalid = True
+                If YearValue < 1 OrElse YearValue > 9999 Then DateIsInvalid = True
             Else
                 MonthValue = 1
                 DayValue = 1
@@ -2434,39 +1705,25 @@ FullWidthRepeat2:
             If HaveTimeValue Then
                 If HaveAM OrElse HavePM Then
                     ' // 12-hour value
-
-                    If HourValue < 1 OrElse HourValue > 12 Then
-                        DateIsInvalid = True
-                    End If
-
+                    If HourValue < 1 OrElse HourValue > 12 Then DateIsInvalid = True
                     If HaveAM Then
                         HourValue = HourValue Mod 12
                     ElseIf HavePM Then
                         HourValue = HourValue + 12
-
-                        If HourValue = 24 Then
-                            HourValue = 12
-                        End If
+                        If HourValue = 24 Then HourValue = 12
                     End If
-
                 Else
-                    If HourValue < 0 OrElse HourValue > 23 Then
-                        DateIsInvalid = True
-                    End If
+                    If HourValue < 0 OrElse HourValue > 23 Then DateIsInvalid = True
                 End If
 
                 If HaveMinuteValue Then
-                    If MinuteValue < 0 OrElse MinuteValue > 59 Then
-                        DateIsInvalid = True
-                    End If
+                    If MinuteValue < 0 OrElse MinuteValue > 59 Then DateIsInvalid = True
                 Else
                     MinuteValue = 0
                 End If
 
                 If HaveSecondValue Then
-                    If SecondValue < 0 OrElse SecondValue > 59 Then
-                        DateIsInvalid = True
-                    End If
+                    If SecondValue < 0 OrElse SecondValue > 59 Then DateIsInvalid = True
                 Else
                     SecondValue = 0
                 End If
@@ -2489,27 +1746,19 @@ baddate:
             ' // If we can find a closing #, then assume it's a malformed date,
             ' // otherwise, it's not a date
 
-            While CanGetCharAtOffset(Here)
-                Dim ch As Char = PeekAheadChar(Here)
-                If IsHash(ch) OrElse IsNewLine(ch) Then
-                    Exit While
-                End If
+            While TryPeek(Here, ch) AndAlso Not (IsHash(ch) OrElse IsNewLine(ch))
                 Here += 1
             End While
 
-            If Not CanGetCharAtOffset(Here) OrElse IsNewLine(PeekAheadChar(Here)) Then
-                ' // No closing #
-                Return Nothing
-            Else
-                Debug.Assert(IsHash(PeekAheadChar(Here)))
-                Here += 1  ' consume trailing #
-                Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_InvalidDate)
-            End If
+            If Not CanGetCharAtOffset(Here) OrElse IsNewLine(Peek(Here)) Then Return Nothing ' // No closing #
+            Debug.Assert(IsHash(Peek(Here)))
+            Here += 1  ' consume trailing #
+            Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_InvalidDate)
         End Function
 
         Private Function ScanStringLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsDoubleQuote(PeekChar))
+            Debug.Assert(IsDoubleQuote(Peek))
 
             Dim length As Integer = 1
             Dim ch As Char
@@ -2518,38 +1767,31 @@ baddate:
             ' // Check for a Char literal, which can be of the form:
             ' // """"c or "<anycharacter-except-">"c
 
-            If CanGetCharAtOffset(3) AndAlso IsDoubleQuote(PeekAheadChar(2)) Then
-                If IsDoubleQuote(PeekAheadChar(1)) Then
-                    If IsDoubleQuote(PeekAheadChar(3)) AndAlso
+            If CanGetCharAtOffset(3) AndAlso IsDoubleQuote(Peek(2)) Then
+                If IsDoubleQuote(Peek(1)) Then
+                    If IsDoubleQuote(Peek(3)) AndAlso
                        CanGetCharAtOffset(4) AndAlso
-                       IsLetterC(PeekAheadChar(4)) Then
+                       IsLetterC(Peek(4)) Then
 
                         ' // Double-quote Char literal: """"c
                         Return MakeCharacterLiteralToken(precedingTrivia, """"c, 5)
                     End If
 
-                ElseIf IsLetterC(PeekAheadChar(3)) Then
+                ElseIf IsLetterC(Peek(3)) Then
                     ' // Char literal.  "x"c
-                    Return MakeCharacterLiteralToken(precedingTrivia, PeekAheadChar(1), 4)
+                    Return MakeCharacterLiteralToken(precedingTrivia, Peek(1), 4)
                 End If
             End If
 
-            If CanGetCharAtOffset(2) AndAlso
-               IsDoubleQuote(PeekAheadChar(1)) AndAlso
-               IsLetterC(PeekAheadChar(2)) Then
-
+            If CanGetCharAtOffset(2) AndAlso IsDoubleQuote(Peek(1)) AndAlso IsLetterC(Peek(2)) Then
                 ' // Error. ""c is not a legal char constant
                 Return MakeBadToken(precedingTrivia, 3, ERRID.ERR_IllegalCharConstant)
             End If
 
             Dim scratch = GetScratch()
-            While CanGetCharAtOffset(length)
-                ch = PeekAheadChar(length)
-
+            While TryPeek(length,ch)
                 If IsDoubleQuote(ch) Then
-                    If CanGetCharAtOffset(length + 1) Then
-                        ch = PeekAheadChar(length + 1)
-
+                    If TryPeek(length + 1,ch) Then
                         If IsDoubleQuote(ch) Then
                             ' // An escaped double quote
                             scratch.Append(""""c)
@@ -2559,7 +1801,6 @@ baddate:
                             ' // The end of the char literal.
                             If IsLetterC(ch) Then
                                 ' // Error. "aad"c is not a legal char constant
-
                                 ' // +2 to include both " and c in the token span
                                 scratch.Clear()
                                 Return MakeBadToken(precedingTrivia, length + 2, ERRID.ERR_IllegalCharConstant)
@@ -2600,13 +1841,9 @@ baddate:
 
         Friend Shared Function TryIdentifierAsContextualKeyword(id As IdentifierTokenSyntax, ByRef k As SyntaxKind) As Boolean
             Debug.Assert(id IsNot Nothing)
-
-            If id.PossibleKeywordKind <> SyntaxKind.IdentifierToken Then
-                k = id.PossibleKeywordKind
-                Return True
-            End If
-
-            Return False
+            If id.PossibleKeywordKind = SyntaxKind.IdentifierToken Then Return True
+            k = id.PossibleKeywordKind
+            Return True
         End Function
 
         ''' <summary>
@@ -2615,51 +1852,27 @@ baddate:
         ''' </summary>
         Friend Function TryIdentifierAsContextualKeyword(id As IdentifierTokenSyntax, ByRef k As KeywordSyntax) As Boolean
             Debug.Assert(id IsNot Nothing)
-
             Dim kind As SyntaxKind = SyntaxKind.IdentifierToken
-            If TryIdentifierAsContextualKeyword(id, kind) Then
-                k = MakeKeyword(id)
-                Return True
-            End If
-
+            If TryIdentifierAsContextualKeyword(id, kind) Then k = MakeKeyword(id) : Return True
             Return False
         End Function
 
         Friend Function TryTokenAsContextualKeyword(t As SyntaxToken, ByRef k As KeywordSyntax) As Boolean
-            If t Is Nothing Then
-                Return False
-            End If
-
-            If t.Kind = SyntaxKind.IdentifierToken Then
-                Return TryIdentifierAsContextualKeyword(DirectCast(t, IdentifierTokenSyntax), k)
-            End If
-
+            If t Is Nothing Then Return False
+            If t.Kind = SyntaxKind.IdentifierToken Then Return TryIdentifierAsContextualKeyword(DirectCast(t, IdentifierTokenSyntax), k)
             Return False
         End Function
 
         Friend Shared Function TryTokenAsKeyword(t As SyntaxToken, ByRef kind As SyntaxKind) As Boolean
-
-            If t Is Nothing Then
-                Return False
-            End If
-
-            If t.IsKeyword Then
-                kind = t.Kind
-                Return True
-            End If
-
-            If t.Kind = SyntaxKind.IdentifierToken Then
-                Return TryIdentifierAsContextualKeyword(DirectCast(t, IdentifierTokenSyntax), kind)
-            End If
-
+            If t Is Nothing Then Return False
+            If t.IsKeyword Then kind = t.Kind : Return True
+            If t.Kind = SyntaxKind.IdentifierToken Then Return TryIdentifierAsContextualKeyword(DirectCast(t, IdentifierTokenSyntax), kind)
             Return False
         End Function
 
         Friend Shared Function IsContextualKeyword(t As SyntaxToken, ParamArray kinds As SyntaxKind()) As Boolean
             Dim kind As SyntaxKind = Nothing
-            If TryTokenAsKeyword(t, kind) Then
-                Return Array.IndexOf(kinds, kind) >= 0
-            End If
+            If TryTokenAsKeyword(t, kind) Then Return Array.IndexOf(kinds, kind) >= 0
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -1841,7 +1841,8 @@ baddate:
 
         Friend Shared Function TryIdentifierAsContextualKeyword(id As IdentifierTokenSyntax, ByRef k As SyntaxKind) As Boolean
             Debug.Assert(id IsNot Nothing)
-            If id.PossibleKeywordKind = SyntaxKind.IdentifierToken Then Return True
+
+            If id.PossibleKeywordKind = SyntaxKind.IdentifierToken Then Return False
             k = id.PossibleKeywordKind
             Return True
         End Function

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -775,7 +775,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' the beginning of a token        
         Private Function TryScanToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Dim ch, ch2 As Char
-            If Not TryPeek(ch) Then Return MakeEofToken(precedingTrivia) #
+            If Not TryPeek(ch) Then Return MakeEofToken(precedingTrivia)
             Const lengthWithMaybeEquals = 1
 
             Select Case ch

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -775,7 +775,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' the beginning of a token        
         Private Function TryScanToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Dim ch, ch2 As Char
-            If Not TryPeek(ch) Then Return MakeEofToken(precedingTrivia)
+            If Not TryPeek(ch) Then Return MakeEofToken(precedingTrivia) #
+            Const lengthWithMaybeEquals = 1
+
             Select Case ch
                 Case CARRIAGE_RETURN, LINE_FEED, NEXT_LINE, LINE_SEPARATOR, PARAGRAPH_SEPARATOR
                     Return ScanNewlineAsStatementTerminator(ch, precedingTrivia)
@@ -796,7 +798,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Case "&"c
                     If TryPeek(1, ch2) AndAlso BeginsBaseLiteral(ch2) Then Return ScanNumericLiteral(precedingTrivia)
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAmpersandEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeAmpersandToken(precedingTrivia, False)
 
@@ -804,37 +805,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case "<"c : Return ScanLeftAngleBracket(precedingTrivia, False, _scanSingleLineTriviaFunc)
                 Case ">"c : Return ScanRightAngleBracket(precedingTrivia, False)
                 Case ":"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeColonEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return ScanColonAsStatementTerminator(precedingTrivia, False)
 
                 Case "+"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakePlusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakePlusToken(precedingTrivia, False)
 
                 Case "-"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeMinusEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeMinusToken(precedingTrivia, False)
 
                 Case "*"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeAsteriskEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeAsteriskToken(precedingTrivia, False)
 
                 Case "/"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeSlashToken(precedingTrivia, False)
 
                 Case "\"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeBackSlashEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeBackslashToken(precedingTrivia, False)
 
                 Case "^"c
-                    Dim lengthWithMaybeEquals = 1
                     If TrySkipFollowingEquals(lengthWithMaybeEquals) Then Return MakeCaretEqualsToken(precedingTrivia, lengthWithMaybeEquals)
                     Return MakeCaretToken(precedingTrivia, False)
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
@@ -189,25 +189,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return TryPeek(at, c) AndAlso (c = isChar)
         End Function
 
-        Private Function ArePeek(at As Integer, s As String) As Boolean
-            If Not CanGetCharAtOffset(at) Then Return False
-            If s Is Nothing Then Return False
-            For i = 1 To s.Length - 1
-                If Peek(i) <> s(i) Then Return False
-            Next
-            Return True
-        End Function
-        Private Function ArePeek(at    As Integer,
-                                 size  As Integer,
-                                 skip  As Integer,
-                                 chars As String) As Boolean
-            If chars Is Nothing Then Return False
-            If Not CanGetCharAtOffset(at) Then Return False
-            For i = skip To chars.Length - 1
-                If Peek(at+i) <> chars(i) Then Return False
-            Next
-            Return True
-        End Function
+        'Private Function ArePeek(at As Integer, s As String) As Boolean
+        '    If Not CanGetCharAtOffset(at) Then Return False
+        '    If s Is Nothing Then Return False
+        '    For i = 1 To s.Length - 1
+        '        If Peek(i) <> s(i-1) Then Return False
+        '    Next
+        '    Return True
+        'End Function
+        'Private Function ArePeek(at    As Integer,
+        '                         size  As Integer,
+        '                         skip  As Integer,
+        '                         chars As String) As Boolean
+        '    If chars Is Nothing Then Return False
+        '    If Not CanGetCharAtOffset(at) Then Return False
+        '    For i = skip To chars.Length - 1
+        '        If Peek(at+i) <> chars(i-1) Then Return False
+        '    Next
+        '    Return True
+        'End Function
 
         Friend Function GetChar() As String
             Return Intern(Peek())

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         ' PERF CRITICAL
-        Private Function PeekAheadChar(skip As Integer) As Char
+        Private Function Peek(skip As Integer) As Char
             Debug.Assert(CanGetCharAtOffset(skip))
             Debug.Assert(skip >= -MaxCharsLookBehind)
 
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         ' PERF CRITICAL
-        Friend Function PeekChar() As Char
+        Friend Function Peek() As Char
             Dim page = _curPage
             Dim position = _lineBufferOffset
             Dim ch = page._arr(position And PAGE_MASK)
@@ -134,8 +134,83 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return ch
         End Function
 
+        Friend Function TryPeek(ByRef c As Char) As Boolean
+            If _lineBufferOffset >= _bufferLen Then Return False
+            Dim page = _curPage
+            Dim pos = _lineBufferOffset
+            Dim ch = page._arr(pos And PAGE_MASK)
+            Dim start = page._pageStart
+            Dim expectedStart = pos And NOT_PAGE_MASK
+            If start <> expectedStart Then
+                page = GetPage(pos)
+                ch = page._arr(pos And PAGE_MASK)
+            End If
+            c = ch
+            Return True
+        End Function
+
+        Friend Function TryGet(ByRef c As String) As Boolean
+            If _lineBufferOffset >= _bufferLen Then Return False
+            Dim page = _curPage
+            Dim pos = _lineBufferOffset
+            Dim ch = page._arr(pos And PAGE_MASK)
+            Dim start = page._pageStart
+            Dim expectedStart = pos And NOT_PAGE_MASK
+
+            If start <> expectedStart Then
+                page = GetPage(pos)
+                ch = page._arr(pos And PAGE_MASK)
+            End If
+            c = Intern(ch)
+            Return True
+        End Function
+
+        ' PERF CRITICAL
+        Private Function TryPeek(skip As Integer, ByRef c As Char) As Boolean
+            ' CanGetCharAtOffset( )
+            If _lineBufferOffset + skip >= _bufferLen Then Return False
+            If skip < -MaxCharsLookBehind Then Return False
+            Dim pos = _lineBufferOffset
+            Dim page = _curPage
+            pos += skip
+            Dim ch = page._arr(pos And PAGE_MASK)
+            Dim start = page._pageStart
+            Dim expectedStart = pos And NOT_PAGE_MASK
+            If start <> expectedStart Then
+                page = GetPage(pos)
+                ch = page._arr(pos And PAGE_MASK)
+            End If
+            c = ch
+            Return True
+        End Function
+
+        Private Function IsPeek(at As Integer, isChar As Char) As Boolean
+            Dim c As Char
+            Return TryPeek(at, c) AndAlso (c = isChar)
+        End Function
+
+        Private Function ArePeek(at As Integer, s As String) As Boolean
+            If Not CanGetCharAtOffset(at) Then Return False
+            If s Is Nothing Then Return False
+            For i = 1 To s.Length - 1
+                If Peek(i) <> s(i) Then Return False
+            Next
+            Return True
+        End Function
+        Private Function ArePeek(at    As Integer,
+                                 size  As Integer,
+                                 skip  As Integer,
+                                 chars As String) As Boolean
+            If chars Is Nothing Then Return False
+            If Not CanGetCharAtOffset(at) Then Return False
+            For i = skip To chars.Length - 1
+                If Peek(at+i) <> chars(i) Then Return False
+            Next
+            Return True
+        End Function
+
         Friend Function GetChar() As String
-            Return Intern(PeekChar())
+            Return Intern(Peek())
         End Function
 
         Friend Function GetText(start As Integer, length As Integer) As String

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
@@ -24,21 +24,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return MakeEndOfInterpolatedStringToken()
             End If
 
-            Dim c = PeekAheadChar(offset)
+            Dim c = Peek(offset)
 
             ' This should only ever happen for $" or }
             Debug.Assert(leadingTriviaLength = 0 OrElse c = "$"c OrElse c = FULLWIDTH_DOLLAR_SIGN OrElse IsRightCurlyBracket(c))
 
             ' Another } may follow the close brace of an interpolation if the interpolation lacked a format clause.
             ' This is because the normal escaping rules only apply when parsing the format string.
-            Debug.Assert(Not CanGetCharAtOffset(1) OrElse PeekAheadChar(offset + 1) <> c OrElse IsRightCurlyBracket(c), "Escape sequence not detected.")
+            Debug.Assert(Not CanGetCharAtOffset(1) OrElse Peek(offset + 1) <> c OrElse IsRightCurlyBracket(c), "Escape sequence not detected.")
 
             Dim scanTrailingTrivia As Boolean
 
             Select Case c
                 Case "$"c, FULLWIDTH_DOLLAR_SIGN
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(PeekAheadChar(offset + 1)) Then
+                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(Peek(offset + 1)) Then
                         kind = SyntaxKind.DollarSignDoubleQuoteToken
                         length = 2
                         scanTrailingTrivia = False ' Trailing whitespace should be scanned as interpolated string text.
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case Else
 
                     If IsDoubleQuote(c) Then
-                        Debug.Assert(Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(PeekAheadChar(offset + 1)))
+                        Debug.Assert(Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(Peek(offset + 1)))
 
                         kind = SyntaxKind.DoubleQuoteToken
                         length = 1
@@ -114,20 +114,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function IsInterpolatedStringPunctuation(Optional offset As Integer = 0) As Boolean
             If Not CanGetCharAtOffset(offset) Then Return False
 
-            Dim c = PeekAheadChar(offset)
+            Dim c = Peek(offset)
 
             If IsLeftCurlyBracket(c) Then
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsLeftCurlyBracket(PeekAheadChar(offset + 1))
+                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsLeftCurlyBracket(Peek(offset + 1))
 
             ElseIf IsRightCurlyBracket(c) Then
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsRightCurlyBracket(PeekAheadChar(offset + 1))
+                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsRightCurlyBracket(Peek(offset + 1))
 
             ElseIf IsDoubleQuote(c)
                 'A subtle difference between this case and the one above.
                 ' In both interpolated and literal strings the two quote characters used in an escape sequence don't have to match.
                 ' It's enough that the next character is *a* quote char. It doesn't have to be the same quote.
                 ' If we want to preserve consistency the quotes need to be special cased.
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(PeekAheadChar(offset + 1))
+                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(Peek(offset + 1))
 
             Else
                 Return False
@@ -143,14 +143,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Do While CanGetCharAtOffset(offset)
 
-                Dim c = PeekAheadChar(offset)
+                Dim c = Peek(offset)
 
                 ' Any combination of fullwidth and ASCII curly braces of the same direction is an escaping sequence for the corresponding ASCII curly brace.
                 ' We insert that curly brace doubled and because this is the escaping sequence understood by String.Format, that will be replaced by a single brace.
                 ' This is deliberate design and it aligns with existing rules for double quote escaping in strings.
                 If IsLeftCurlyBracket(c) Then
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsLeftCurlyBracket(PeekAheadChar(offset + 1)) Then
+                    If CanGetCharAtOffset(offset + 1) AndAlso IsLeftCurlyBracket(Peek(offset + 1)) Then
                         ' This is an escape sequence.
 
                         valueBuilder.Append("{{")
@@ -164,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ElseIf IsRightCurlyBracket(c) Then
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsRightCurlyBracket(PeekAheadChar(offset + 1)) Then
+                    If CanGetCharAtOffset(offset + 1) AndAlso IsRightCurlyBracket(Peek(offset + 1)) Then
                         ' This is an escape sequence.
 
                         valueBuilder.Append("}}")
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ElseIf IsDoubleQuote(c)
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(PeekAheadChar(offset + 1)) Then
+                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(Peek(offset + 1)) Then
                         ' This is a VB double quote escape. Oddly enough this logic allows mixing and matching of
                         ' smart and dumb double quotes in any order. Regardless we always emit as a standard double quote.
                         ' This is consistent with their handling in string literals.

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 If Not CanGetCharAtOffset(len) Then
                     Exit Do
                 End If
-                c = PeekAheadChar(len)
+                c = Peek(len)
             Loop
 
             If len > 0 Then
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim leadingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
 
             While CanGetChar()
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         leadingTrivia = ScanXmlTrivia(c)
 
                     Case "/"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">" Then
+                        If CanGetCharAtOffset(1) AndAlso Peek(1) = ">" Then
                             Return XmlMakeEndEmptyElementToken(leadingTrivia)
                         End If
                         Return XmlMakeDivToken(leadingTrivia)
@@ -114,34 +114,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "<"c
                         If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
                                     If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGetCharAtOffset(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(leadingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "["c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "C"c AndAlso
-                                                    PeekAheadChar(4) = "D"c AndAlso
-                                                    PeekAheadChar(5) = "A"c AndAlso
-                                                    PeekAheadChar(6) = "T"c AndAlso
-                                                    PeekAheadChar(7) = "A"c AndAlso
-                                                    PeekAheadChar(8) = "["c Then
+                                                    Peek(3) = "C"c AndAlso
+                                                    Peek(4) = "D"c AndAlso
+                                                    Peek(5) = "A"c AndAlso
+                                                    Peek(6) = "T"c AndAlso
+                                                    Peek(7) = "A"c AndAlso
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(leadingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(leadingTrivia)
                                                 End If
                                         End Select
@@ -149,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     Return XmlLessThanExclamationToken(state, leadingTrivia)
                                 Case "%"c
                                     If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(leadingTrivia)
                                     End If
@@ -164,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "?"c
 
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">"c Then
+                        If CanGetCharAtOffset(1) AndAlso Peek(1) = ">"c Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(leadingTrivia)
                         End If
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim token As SyntaxToken
             Dim possibleStatement As Boolean = False
             Dim offsets = CreateOffsetRestorePoint()
-            Dim c As Char = PeekChar()
+            Dim c As Char = Peek()
 
             Select Case c
                 Case "#"c,
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     If name IsNot Nothing AndAlso Not name.IsMissing Then
                         If name.PossibleKeywordKind <> SyntaxKind.XmlNameToken Then
                             leadingTrivia = ScanSingleLineTrivia()
-                            c = PeekChar()
+                            c = Peek()
                             possibleStatement =
                                 c = "("c OrElse c = FULLWIDTH_LEFT_PARENTHESIS
                         End If
@@ -320,7 +320,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim IsAllWhitespace As Boolean = True
             ' lets do an unusual peek-behind to make sure we are not restarting after a non-Ws char.
             If _lineBufferOffset > 0 Then
-                Dim prevChar = PeekAheadChar(-1)
+                Dim prevChar = Peek(-1)
                 If prevChar <> ">"c AndAlso Not XmlCharType.IsWhiteSpace(prevChar) Then
                     IsAllWhitespace = False
                 End If
@@ -329,7 +329,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim scratch = GetScratch()
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -356,47 +356,47 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                             Else
                                 scratch.Clear() ' will not use this
                                 Here = 0        ' consumed chars. 
-                                precedingTrivia = ScanXmlTrivia(PeekChar)
+                                precedingTrivia = ScanXmlTrivia(Peek)
                             End If
                         End If
 
                         Debug.Assert(Here = 0)
                         If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
                                     If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGetCharAtOffset(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "["c
                                                 If CanGetCharAtOffset(8) AndAlso _
-                                                    PeekAheadChar(3) = "C"c AndAlso _
-                                                    PeekAheadChar(4) = "D"c AndAlso _
-                                                    PeekAheadChar(5) = "A"c AndAlso _
-                                                    PeekAheadChar(6) = "T"c AndAlso _
-                                                    PeekAheadChar(7) = "A"c AndAlso _
-                                                    PeekAheadChar(8) = "["c Then
+                                                    Peek(3) = "C"c AndAlso _
+                                                    Peek(4) = "D"c AndAlso _
+                                                    Peek(5) = "A"c AndAlso _
+                                                    Peek(6) = "T"c AndAlso _
+                                                    Peek(7) = "A"c AndAlso _
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
                                     End If
                                 Case "%"c
                                     If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
@@ -411,8 +411,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "]"c
                         If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -529,7 +529,7 @@ ScanChars:
 
             Dim Here = 0
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -537,7 +537,7 @@ ScanChars:
 
                     Case "-"c
                         If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = "-"c Then
+                           Peek(Here + 1) = "-"c Then
 
                             ' // --> terminates an Xml comment but otherwise -- is an illegal character sequence.
                             ' // The scanner will always returns "--" as a separate comment data string and the
@@ -550,7 +550,7 @@ ScanChars:
 
                             If CanGetCharAtOffset(Here + 2) Then
 
-                                c = PeekAheadChar(Here + 2)
+                                c = Peek(Here + 2)
                                 Here += 2
                                 ' // if > is not found then this is an error.  Return the -- string
 
@@ -622,7 +622,7 @@ ScanChars:
             Dim Here = 0
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -632,8 +632,8 @@ ScanChars:
 
                     Case "]"c
                         If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -690,7 +690,7 @@ ScanChars:
             If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
-                Dim c = PeekChar()
+                Dim c = Peek()
                 Select Case c
                     Case CARRIAGE_RETURN, LINE_FEED, " "c, CHARACTER_TABULATION
                         Dim wsTrivia = ScanXmlTrivia(c)
@@ -700,7 +700,7 @@ ScanChars:
 
             Dim Here = 0
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -709,7 +709,7 @@ ScanChars:
 
                     Case "?"c
                         If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = ">"c Then
+                           Peek(Here + 1) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -761,7 +761,7 @@ CleanUp:
 
             Dim precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
             While CanGetChar()
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -773,27 +773,27 @@ CleanUp:
 
                     Case "<"c
                         If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
                                     If CanGetCharAtOffset(3) AndAlso
-                                        PeekAheadChar(2) = "-"c AndAlso
-                                        PeekAheadChar(3) = "-"c Then
+                                        Peek(2) = "-"c AndAlso
+                                        Peek(3) = "-"c Then
 
                                         Return XmlMakeBeginCommentToken(precedingTrivia, _scanNoTriviaFunc)
                                     ElseIf CanGetCharAtOffset(8) AndAlso
-                                            PeekAheadChar(2) = "D"c AndAlso
-                                            PeekAheadChar(3) = "O"c AndAlso
-                                            PeekAheadChar(4) = "C"c AndAlso
-                                            PeekAheadChar(5) = "T"c AndAlso
-                                            PeekAheadChar(6) = "Y"c AndAlso
-                                            PeekAheadChar(7) = "P"c AndAlso
-                                            PeekAheadChar(8) = "E"c Then
+                                            Peek(2) = "D"c AndAlso
+                                            Peek(3) = "O"c AndAlso
+                                            Peek(4) = "C"c AndAlso
+                                            Peek(5) = "T"c AndAlso
+                                            Peek(6) = "Y"c AndAlso
+                                            Peek(7) = "P"c AndAlso
+                                            Peek(8) = "E"c Then
                                         Return XmlMakeBeginDTDToken(precedingTrivia)
                                     End If
                                 Case "%"c
                                     If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
@@ -849,7 +849,7 @@ CleanUp:
             Dim scratch = GetScratch()
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
 
@@ -876,7 +876,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGetCharAtOffset(Here + 1) AndAlso PeekAheadChar(Here + 1) = ">"c Then
+                        If CanGetCharAtOffset(Here + 1) AndAlso Peek(Here + 1) = ">"c Then
                             If Here <> 0 Then
                                 Return XmlMakeAttributeDataToken(Nothing, Here, scratch)
                             Else
@@ -942,7 +942,7 @@ ScanChars:
             Dim scratch = GetScratch()
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
                 If c = terminatingChar Or c = altTerminatingChar Then
                     If Here > 0 Then
                         result = XmlMakeAttributeDataToken(precedingTrivia, Here, scratch)
@@ -976,8 +976,8 @@ ScanChars:
                         Else
                             ' report unexpected <%= in a special way.
                             If CanGetCharAtOffset(2) AndAlso
-                                PeekAheadChar(1) = "%"c AndAlso
-                                PeekAheadChar(2) = "=" Then
+                                Peek(1) = "%"c AndAlso
+                                Peek(2) = "=" Then
 
                                 Dim errEmbedStart = XmlMakeAttributeDataToken(precedingTrivia, 3, "<%=")
                                 Dim errEmberinfo = ErrorFactory.ErrorInfo(ERRID.ERR_QuotedEmbeddedExpression)
@@ -1045,10 +1045,10 @@ CleanUp:
         Private Function ScanSurrogatePair(c1 As Char, Here As Integer) As XmlCharResult
             Debug.Assert(Here >= 0)
             Debug.Assert(CanGetCharAtOffset(Here))
-            Debug.Assert(PeekAheadChar(Here) = c1)
+            Debug.Assert(Peek(Here) = c1)
 
             If IsHighSurrogate(c1) AndAlso CanGetCharAtOffset(Here + 1) Then
-                Dim c2 = PeekAheadChar(Here + 1)
+                Dim c2 = Peek(Here + 1)
 
                 If IsLowSurrogate(c2) Then
                     Return New XmlCharResult(c1, c2)
@@ -1090,7 +1090,7 @@ CleanUp:
             Debug.Assert(Here >= 0)
             Debug.Assert(CanGetCharAtOffset(Here))
 
-            Dim c = PeekAheadChar(Here)
+            Dim c = Peek(Here)
 
             If Not isValidUtf16(c) Then
                 Return Nothing
@@ -1122,7 +1122,7 @@ CleanUp:
             'TODO - Fix ScanXmlNCName to conform to XML spec instead of old loose scanning.
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
 
@@ -1199,11 +1199,11 @@ CreateNCNameToken:
 
         Private Function ScanXmlReference(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As XmlTextTokenSyntax
             Debug.Assert(CanGetChar)
-            Debug.Assert(PeekChar() = "&"c)
+            Debug.Assert(Peek() = "&"c)
 
             ' skip 1 char for "&"
             If CanGetCharAtOffset(1) Then
-                Dim c As Char = PeekAheadChar(1)
+                Dim c As Char = Peek(1)
 
                 Select Case (c)
                     Case "#"c
@@ -1218,7 +1218,7 @@ CreateNCNameToken:
                                 value = Intern({result.Char1, result.Char2})
                             End If
 
-                            If CanGetCharAtOffset(Here) AndAlso PeekAheadChar(Here) = ";"c Then
+                            If CanGetCharAtOffset(Here) AndAlso Peek(Here) = ";"c Then
                                 Return XmlMakeEntityLiteralToken(precedingTrivia, Here + 1, value)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, Here, value)
@@ -1232,10 +1232,10 @@ CreateNCNameToken:
                         ' // &apos;
 
                         If CanGetCharAtOffset(4) AndAlso
-                           PeekAheadChar(2) = "m"c AndAlso
-                           PeekAheadChar(3) = "p"c Then
+                           Peek(2) = "m"c AndAlso
+                           Peek(3) = "p"c Then
 
-                            If PeekAheadChar(4) = ";"c Then
+                            If Peek(4) = ";"c Then
                                 Return XmlMakeAmpLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 4, "&")
@@ -1244,11 +1244,11 @@ CreateNCNameToken:
                             End If
 
                         ElseIf CanGetCharAtOffset(5) AndAlso
-                               PeekAheadChar(2) = "p"c AndAlso
-                               PeekAheadChar(3) = "o"c AndAlso
-                               PeekAheadChar(4) = "s"c Then
+                               Peek(2) = "p"c AndAlso
+                               Peek(3) = "o"c AndAlso
+                               Peek(4) = "s"c Then
 
-                            If PeekAheadChar(5) = ";"c Then
+                            If Peek(5) = ";"c Then
                                 Return XmlMakeAposLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 5, "'")
@@ -1261,9 +1261,9 @@ CreateNCNameToken:
                         ' // &lt;
 
                         If CanGetCharAtOffset(3) AndAlso
-                           PeekAheadChar(2) = "t"c Then
+                           Peek(2) = "t"c Then
 
-                            If PeekAheadChar(3) = ";"c Then
+                            If Peek(3) = ";"c Then
                                 Return XmlMakeLtLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 3, "<")
@@ -1276,9 +1276,9 @@ CreateNCNameToken:
                         ' // &gt;
 
                         If CanGetCharAtOffset(3) AndAlso
-                           PeekAheadChar(2) = "t"c Then
+                           Peek(2) = "t"c Then
 
-                            If PeekAheadChar(3) = ";"c Then
+                            If Peek(3) = ";"c Then
                                 Return XmlMakeGtLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 3, ">")
@@ -1291,11 +1291,11 @@ CreateNCNameToken:
                         ' // &quot;
 
                         If CanGetCharAtOffset(5) AndAlso
-                           PeekAheadChar(2) = "u"c AndAlso
-                           PeekAheadChar(3) = "o"c AndAlso
-                           PeekAheadChar(4) = "t"c Then
+                           Peek(2) = "u"c AndAlso
+                           Peek(3) = "o"c AndAlso
+                           Peek(4) = "t"c Then
 
-                            If PeekAheadChar(5) = ";"c Then
+                            If Peek(5) = ";"c Then
                                 Return XmlMakeQuotLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 5, """")
@@ -1324,12 +1324,12 @@ CreateNCNameToken:
             Dim charRefSb As New StringBuilder
             Dim Here = index
 
-            Dim ch = PeekAheadChar(Here)
+            Dim ch = Peek(Here)
             If ch = "x"c Then
                 Here += 1
 
                 While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
+                    ch = Peek(Here)
                     If XmlCharType.IsHexDigit(ch) Then
                         charRefSb.Append(ch)
                     Else
@@ -1346,7 +1346,7 @@ CreateNCNameToken:
                 End If
             Else
                 While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
+                    ch = Peek(Here)
                     If XmlCharType.IsDigit(ch) Then
                         charRefSb.Append(ch)
                     Else

--- a/src/Compilers/VisualBasic/Portable/Scanner/TokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/TokenFactories.vb
@@ -448,7 +448,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function MakeColonToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = If(charIsFullWidth, FULLWIDTH_COLON, ":"c))
+            Debug.Assert(Peek() = If(charIsFullWidth, FULLWIDTH_COLON, ":"c))
             Debug.Assert(Not precedingTrivia.Any())
 
             Dim width = _endOfTerminatorTrivia - _lineBufferOffset

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine)
 
             ' leading whitespace until we see ''' should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If
@@ -149,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function TrySkipXmlDocMarker(ByRef len As Integer) As Boolean
             Dim Here = len
             While CanGetCharAtOffset(Here)
-                Dim c = PeekAheadChar(Here)
+                Dim c = Peek(Here)
                 If IsWhitespace(c) Then
                     Here += 1
                 Else
@@ -212,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Exit Do
                 End If
 
-                c = PeekAheadChar(len)
+                c = Peek(len)
             Loop
 
             If len > 0 Then
@@ -242,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim scratch = GetScratch()
 
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -283,34 +283,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                         Debug.Assert(Here = 0)
                         If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
                                     If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGetCharAtOffset(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "["c
                                                 If CanGetCharAtOffset(8) AndAlso _
-                                                    PeekAheadChar(3) = "C"c AndAlso _
-                                                    PeekAheadChar(4) = "D"c AndAlso _
-                                                    PeekAheadChar(5) = "A"c AndAlso _
-                                                    PeekAheadChar(6) = "T"c AndAlso _
-                                                    PeekAheadChar(7) = "A"c AndAlso _
-                                                    PeekAheadChar(8) = "["c Then
+                                                    Peek(3) = "C"c AndAlso _
+                                                    Peek(4) = "D"c AndAlso _
+                                                    Peek(5) = "A"c AndAlso _
+                                                    Peek(6) = "T"c AndAlso _
+                                                    Peek(7) = "A"c AndAlso _
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -326,8 +326,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "]"c
                         If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -388,7 +388,7 @@ ScanChars:
             If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
-                Dim c = PeekChar()
+                Dim c = Peek()
                 Select Case c
                     Case CARRIAGE_RETURN, LINE_FEED, " "c, CHARACTER_TABULATION
                         Dim offsets = CreateOffsetRestorePoint()
@@ -403,7 +403,7 @@ ScanChars:
 
             Dim Here = 0
             While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -412,7 +412,7 @@ ScanChars:
 
                     Case "?"c
                         If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = ">"c Then
+                           Peek(Here + 1) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -485,7 +485,7 @@ CleanUp:
                     Return MakeEofToken(precedingTrivia)
                 End If
 
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -504,7 +504,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">" Then
+                        If CanGetCharAtOffset(1) AndAlso Peek(1) = ">" Then
                             Return XmlMakeEndEmptyElementToken(precedingTrivia)
                         End If
                         Return XmlMakeDivToken(precedingTrivia)
@@ -523,34 +523,34 @@ CleanUp:
 
                     Case "<"c
                         If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
                                     If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGetCharAtOffset(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "["c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "C"c AndAlso
-                                                    PeekAheadChar(4) = "D"c AndAlso
-                                                    PeekAheadChar(5) = "A"c AndAlso
-                                                    PeekAheadChar(6) = "T"c AndAlso
-                                                    PeekAheadChar(7) = "A"c AndAlso
-                                                    PeekAheadChar(8) = "["c Then
+                                                    Peek(3) = "C"c AndAlso
+                                                    Peek(4) = "D"c AndAlso
+                                                    Peek(5) = "A"c AndAlso
+                                                    Peek(6) = "T"c AndAlso
+                                                    Peek(7) = "A"c AndAlso
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, _scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
                                                 If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -566,7 +566,7 @@ CleanUp:
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "?"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">"c Then
+                        If CanGetCharAtOffset(1) AndAlso Peek(1) = ">"c Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(precedingTrivia)
                         End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function XmlMakeSingleQuoteToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode),
                                                  spelling As Char,
                                                  isOpening As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = spelling)
+            Debug.Assert(Peek() = spelling)
 
             AdvanceChar()
 
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function XmlMakeDoubleQuoteToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode),
                                                  spelling As Char,
                                                  isOpening As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = spelling)
+            Debug.Assert(Peek() = spelling)
 
             AdvanceChar()
 
@@ -297,8 +297,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeBeginEndElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "/"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "/"c)
 
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
@@ -306,8 +306,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndEmptyElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "/"c)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "/"c)
+            Debug.Assert(Peek(1) = ">"c)
 
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.SlashGreaterThanToken, "/>", precedingTrivia, Nothing)
@@ -315,20 +315,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "EmbeddedToken"
         Private Function XmlMakeBeginEmbeddedToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "%"c)
-            Debug.Assert(PeekAheadChar(2) = "="c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "%"c)
+            Debug.Assert(Peek(2) = "="c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.LessThanPercentEqualsToken, "<%=", precedingTrivia, Nothing)
         End Function
 
         Private Function XmlMakeEndEmbeddedToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "%"c OrElse PeekChar() = FULLWIDTH_PERCENT_SIGN)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "%"c OrElse Peek() = FULLWIDTH_PERCENT_SIGN)
+            Debug.Assert(Peek(1) = ">"c)
 
             Dim spelling As String
-            If PeekChar() = "%"c Then
+            If Peek() = "%"c Then
                 AdvanceChar(2)
                 spelling = "%>"
             Else
@@ -343,34 +343,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "DTD"
         Private Function XmlMakeBeginDTDToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "D"c)
-            Debug.Assert(PeekAheadChar(3) = "O"c)
-            Debug.Assert(PeekAheadChar(4) = "C"c)
-            Debug.Assert(PeekAheadChar(5) = "T"c)
-            Debug.Assert(PeekAheadChar(6) = "Y"c)
-            Debug.Assert(PeekAheadChar(7) = "P"c)
-            Debug.Assert(PeekAheadChar(8) = "E"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "D"c)
+            Debug.Assert(Peek(3) = "O"c)
+            Debug.Assert(Peek(4) = "C"c)
+            Debug.Assert(Peek(5) = "T"c)
+            Debug.Assert(Peek(6) = "Y"c)
+            Debug.Assert(Peek(7) = "P"c)
+            Debug.Assert(Peek(8) = "E"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.BeginDocTypeToken, precedingTrivia, 9, ERRID.ERR_DTDNotSupported)
         End Function
 
         Private Function XmlLessThanExclamationToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.LessThanExclamationToken, precedingTrivia, 2, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_Syntax))
         End Function
 
         Private Function XmlMakeOpenBracketToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "["c)
+            Debug.Assert(Peek() = "["c)
 
             Return XmlMakeBadToken(SyntaxSubKind.OpenBracketToken, precedingTrivia, 1, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_IllegalXmlNameChar))
         End Function
 
         Private Function XmlMakeCloseBracketToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "]"c)
+            Debug.Assert(Peek() = "]"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.CloseBracketToken, precedingTrivia, 1, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_IllegalXmlNameChar))
         End Function
@@ -379,8 +379,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "ProcessingInstruction"
 
         Private Function XmlMakeBeginProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "?"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "?"c)
 
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
@@ -397,8 +397,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "?"c)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "?"c)
+            Debug.Assert(Peek(1) = ">"c)
 
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.QuestionGreaterThanToken, "?>", precedingTrivia, Nothing)
@@ -408,10 +408,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "Comment"
 
         Private Function XmlMakeBeginCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "-"c)
-            Debug.Assert(PeekAheadChar(3) = "-"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "-"c)
+            Debug.Assert(Peek(3) = "-"c)
 
             AdvanceChar(4)
             Dim followingTrivia = scanTrailingTrivia()
@@ -428,9 +428,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "-"c)
-            Debug.Assert(PeekAheadChar(1) = "-"c)
-            Debug.Assert(PeekAheadChar(2) = ">"c)
+            Debug.Assert(Peek() = "-"c)
+            Debug.Assert(Peek(1) = "-"c)
+            Debug.Assert(Peek(2) = ">"c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.MinusMinusGreaterThanToken, "-->", precedingTrivia, Nothing)
@@ -440,15 +440,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "CData"
         Private Function XmlMakeBeginCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "["c)
-            Debug.Assert(PeekAheadChar(3) = "C"c)
-            Debug.Assert(PeekAheadChar(4) = "D"c)
-            Debug.Assert(PeekAheadChar(5) = "A"c)
-            Debug.Assert(PeekAheadChar(6) = "T"c)
-            Debug.Assert(PeekAheadChar(7) = "A"c)
-            Debug.Assert(PeekAheadChar(8) = "["c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "["c)
+            Debug.Assert(Peek(3) = "C"c)
+            Debug.Assert(Peek(4) = "D"c)
+            Debug.Assert(Peek(5) = "A"c)
+            Debug.Assert(Peek(6) = "T"c)
+            Debug.Assert(Peek(7) = "A"c)
+            Debug.Assert(Peek(8) = "["c)
 
             AdvanceChar(9)
             Dim followingTrivia = scanTrailingTrivia()
@@ -460,9 +460,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "]"c)
-            Debug.Assert(PeekAheadChar(1) = "]"c)
-            Debug.Assert(PeekAheadChar(2) = ">"c)
+            Debug.Assert(Peek() = "]"c)
+            Debug.Assert(Peek(1) = "]"c)
+            Debug.Assert(Peek(2) = ">"c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.EndCDataToken, "]]>", precedingTrivia, Nothing)


### PR DESCRIPTION
Added some method to deal with the common pattern of
`CanGetCharAt(  )` being followed by `PeekCharAt( )`

* TryPeek(ByRef c As Char) As Boolean
* TryPeek(At As Integer,ByRef c As Char) As Boolean
* IsPeek( at As Integer, c As Char) As Boolean
This compares the character the at skip position with character c.
* ArePeek( at As Integer, size As Integer, skip As Integer, chars As String) As Boolean
This compares the character at the at + skip position against the character of chars.

Rename `PeakAheadChar` to just `Peek`