### PR TITLE
Support setting the active rule set from Solution Explorer

### DIFF
--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             public const int SetSeverityHidden = 0x0113;
             public const int SetSeverityNone = 0x0114;
             public const int OpenDiagnosticHelpLink = 0x0116;
+            public const int SetActiveRuleSet = 0x0118;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -7,10 +7,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     internal static class IVsHierarchyExtensions
     {
-        public static bool TryGetProperty<T>(this IVsHierarchy hierarchy, int propertyId, out T value)
+        public static bool TryGetItemProperty<T>(this IVsHierarchy hierarchy, uint itemId, int propertyId, out T value)
         {
             object property;
-            if (ErrorHandler.Failed(hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, propertyId, out property)) ||
+            if (ErrorHandler.Failed(hierarchy.GetProperty(itemId, propertyId, out property)) ||
                 !(property is T))
             {
                 value = default(T);
@@ -22,9 +22,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return true;
         }
 
+        public static bool TryGetProperty<T>(this IVsHierarchy hierarchy, int propertyId, out T value)
+        {
+            const uint root = VSConstants.VSITEMID_ROOT;
+            return hierarchy.TryGetItemProperty(root, propertyId, out value);
+        }
+
         public static bool TryGetProperty<T>(this IVsHierarchy hierarchy, __VSHPROPID propertyId, out T value)
         {
             return hierarchy.TryGetProperty((int)propertyId, out value);
+        }
+
+        public static bool TryGetItemProperty<T>(this IVsHierarchy hierarchy, uint itemId, __VSHPROPID propertyId, out T value)
+        {
+            return hierarchy.TryGetItemProperty(itemId, (int)propertyId, out value);
         }
 
         public static bool TryGetGuidProperty(this IVsHierarchy hierarchy, int propertyId, out Guid guid)
@@ -45,6 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public static bool TryGetName(this IVsHierarchy hierarchy, out string name)
         {
             return hierarchy.TryGetProperty(__VSHPROPID.VSHPROPID_Name, out name);
+        }
+
+        public static bool TryGetItemName(this IVsHierarchy hierarchy, uint itemId, out string name)
+        {
+            return hierarchy.TryGetItemProperty(itemId, __VSHPROPID.VSHPROPID_Name, out name);
         }
 
         public static bool TryGetParentHierarchy(this IVsHierarchy hierarchy, out IVsHierarchy parentHierarchy)

--- a/src/VisualStudio/Setup/Commands.vsct
+++ b/src/VisualStudio/Setup/Commands.vsct
@@ -53,6 +53,9 @@
       <Group guid="guidRoslynGrpId" id="grpDiagnosticProperties" priority="0x002">
         <Parent guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu"/>
       </Group>
+    
+      <Group guid="guidRoslynGrpId" id="grpSetActiveRuleSet">
+      </Group>
     </Groups>
 
     <Buttons>
@@ -242,7 +245,7 @@
           <CommandName>SetSeverityNone</CommandName>
         </Strings>
       </Button>
-      <!-- Buttons to open the diagnostic help link -->
+      <!-- Button to open the diagnostic help link -->
       <Button guid="guidRoslynGrpId" id="cmdidOpenDiagnosticHelpLink" priority="100" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticProperties" />
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -252,6 +255,18 @@
           <CanonicalName>ViewHelp</CanonicalName>
           <LocCanonicalName>ViewHelp</LocCanonicalName>
           <CommandName>ViewHelp</CommandName>
+        </Strings>
+      </Button>
+      <!-- Button to set the active rule set -->
+      <Button guid="guidRoslynGrpId" id="cmdidSetActiveRuleSet" priority="100" type="Button">
+        <Parent guid="guidRoslynGrpId" id="grpSetActiveRuleSet" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Set as Active Rule Set</ButtonText>
+          <CanonicalName>SetAsActiveRuleSet</CanonicalName>
+          <LocCanonicalName>SetAsActiveRuleSet</LocCanonicalName>
+          <CommandName>SetAsActiveRuleSet</CommandName>
         </Strings>
       </Button>
     </Buttons>
@@ -323,6 +338,15 @@
     <CommandPlacement guid="guidVSStd97" id="cmdidPropSheetOrProperties" priority="200">
       <Parent guid="guidRoslynGrpId" id="grpDiagnosticProperties" />
     </CommandPlacement>
+  
+    <!-- "Set as Active Rule Set" entries -->
+    <CommandPlacement guid="guidRoslynGrpId" id="grpSetActiveRuleSet" priority="0x0200">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+    </CommandPlacement>
+    
+    <CommandPlacement guid="guidRoslynGrpId" id="grpSetActiveRuleSet" priority="0x0200">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_WEBITEMNODE"/>
+    </CommandPlacement>
   </CommandPlacements>
 
   <UsedCommands>
@@ -372,6 +396,8 @@
       <IDSymbol name="cmdidSetSeverityNone"           value="0x0114" />
       <IDSymbol name="grpDiagnosticProperties"        value="0x0115" />
       <IDSymbol name="cmdidOpenDiagnosticHelpLink"    value="0x0116" />
+      <IDSymbol name="grpSetActiveRuleSet"            value="0x0117" />
+      <IDSymbol name="cmdidSetActiveRuleSet"          value="0x0118" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
Fixes #90.

Currently you have to open a project's Code Analysis property page to
pick the rule set file in effect for that project. With this change we
allow the user to simply right-click on a .ruleset file in the project
in Solution Explorer and choose "Set as Active Rule Set".