### PR TITLE
Implement VB Code Model's AddAttribute method for several declaration kinds

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -138,6 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 case SyntaxKind.DestructorDeclaration:
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
@@ -2139,6 +2140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     return EnvDTE.vsCMFunction.vsCMFunctionDestructor;
 
                 case MethodKind.UserDefinedOperator:
+                case MethodKind.Conversion:
                     return EnvDTE.vsCMFunction.vsCMFunctionOperator;
 
                 case MethodKind.PropertyGet:

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeEventTests.vb
@@ -68,6 +68,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return Sub(value) codeElement.Type = value
         End Function
 
+        Protected Overrides Function AddAttribute(codeElement As EnvDTE80.CodeEvent, data As AttributeData) As EnvDTE.CodeAttribute
+            Return codeElement.AddAttribute(data.Name, data.Value, data.Position)
+        End Function
+
         Protected Sub TestIsPropertyStyleEvent(code As XElement, expected As Boolean)
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
                 Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeEvent)()

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
@@ -94,6 +94,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return Sub(value) codeElement.Type = value
         End Function
 
+        Protected Overrides Function AddAttribute(codeElement As EnvDTE80.CodeFunction2, data As AttributeData) As EnvDTE.CodeAttribute
+            Return codeElement.AddAttribute(data.Name, data.Value, data.Position)
+        End Function
+
         Protected Overrides Function AddParameter(codeElement As EnvDTE80.CodeFunction2, data As ParameterData) As EnvDTE.CodeParameter
             Return codeElement.AddParameter(data.Name, data.Type, data.Position)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
@@ -80,6 +80,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return Sub(value) codeElement.Type = value
         End Function
 
+        Protected Overrides Function AddAttribute(codeElement As EnvDTE80.CodeProperty2, data As AttributeData) As EnvDTE.CodeAttribute
+            Return codeElement.AddAttribute(data.Name, data.Value, data.Position)
+        End Function
+
         Protected Overrides Function AddParameter(codeElement As EnvDTE80.CodeProperty2, data As ParameterData) As EnvDTE.CodeParameter
             Return codeElement.AddParameter(data.Name, data.Type, data.Position)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -226,13 +226,58 @@ public interface I1
 
 public class C1: I1
 {
-   void I1.f1$$()
-   {
-   }
+    void I1.f1$$()
+    {
+    }
 }
 </Code>
 
             TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionFunction)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind_Operator()
+            Dim code =
+<Code>
+public class C
+{
+    public static C operator $$+(C c1, C c2)
+    {
+    }
+}
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionOperator)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind_ExplicitConversion()
+            Dim code =
+<Code>
+public class C
+{
+    public static static $$explicit C(int x)
+    {
+    }
+}
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionOperator)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind_ImplicitConversion()
+            Dim code =
+<Code>
+public class C
+{
+    public static static $$implicit C(int x)
+    {
+    }
+}
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionOperator)
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
@@ -648,7 +648,7 @@ End Class
 #Region "AddAttribute tests"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Sub AddAttribut_SimpleEvent()
+        Public Sub AddAttribute_SimpleEvent()
             Dim code =
 <Code>
 Imports System

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
@@ -645,6 +645,70 @@ End Class
 
 #End Region
 
+#Region "AddAttribute tests"
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribut_SimpleEvent()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Event $$E()
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Public Event E()
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_CustomEvent()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Custom Event $$E As EventHandler
+        AddHandler(ByVal value As EventHandler)
+        End AddHandler
+        RemoveHandler(ByVal value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
+     End Event
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Public Custom Event E As EventHandler
+        AddHandler(ByVal value As EventHandler)
+        End AddHandler
+        RemoveHandler(ByVal value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
+     End Event
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+#End Region
+
 #Region "Set IsShared tests"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
@@ -854,6 +854,227 @@ End Class
 
 #End Region
 
+#Region "AddAttribute tests"
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Sub()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Sub $$M()
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Sub M()
+    End Sub
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Function()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Function $$M() As integer
+    End Function
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Function M() As integer
+    End Function
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Sub_MustOverride()
+            Dim code =
+<Code>
+Imports System
+
+MustInherit Class C
+    MustOverride Sub $$M()
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+MustInherit Class C
+    &lt;Serializable()&gt;
+    MustOverride Sub M()
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Function_MustOverride()
+            Dim code =
+<Code>
+Imports System
+
+MustInherit Class C
+    MustOverride Function $$M() As integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+MustInherit Class C
+    &lt;Serializable()&gt;
+    MustOverride Function M() As integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_DeclareSub()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Declare Sub $$M() Lib "MyDll.dll"
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Declare Sub M() Lib "MyDll.dll"
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_DeclareFunction()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Declare Function $$M() Lib "MyDll.dll" As Integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Declare Function M() Lib "MyDll.dll" As Integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Constructor()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Sub $$New()
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Sub New()
+    End Sub
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Operator()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Shared Operator $$+(x As C, y As C) As C
+    End Operator
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Public Shared Operator +(x As C, y As C) As C
+    End Operator
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Conversion()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Shared Operator Widening $$CType(x As Integer) As C
+    End Operator
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Public Shared Operator Widening CType(x As Integer) As C
+    End Operator
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+#End Region
+
 #Region "AddParameter tests"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
@@ -423,6 +423,36 @@ End Clas
             TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionFunction)
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind__Operator()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Shared Operator $$+(x As C, y As C) As C
+    End Operator
+End Class
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionOperator)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind_Conversion()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Public Shared Operator Widening $$CType(x As Integer) As C
+    End Operator
+End Class
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionOperator)
+        End Sub
+
 #End Region
 
 #Region "MustImplement tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -835,6 +835,66 @@ End Class
 
 #End Region
 
+#Region "AddAttribute tests"
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_NormalProperty()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Property P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_AutoProperty()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    Property $$P As Integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    &lt;Serializable()&gt;
+    Property P As Integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+#End Region
+
 #Region "AddParameter tests"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -3715,6 +3715,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Dim propertyBlock = DirectCast(container, PropertyBlockSyntax)
                 Dim attributeLists = propertyBlock.PropertyStatement.AttributeLists.Insert(index, attributeList)
                 Return propertyBlock.WithPropertyStatement(propertyBlock.PropertyStatement.WithAttributeLists(attributeLists))
+            ElseIf TypeOf container Is EventStatementSyntax Then
+                Dim eventStatement = DirectCast(container, EventStatementSyntax)
+                Dim attributeLists = eventStatement.AttributeLists.Insert(index, attributeList)
+                Return eventStatement.WithAttributeLists(attributeLists)
             ElseIf TypeOf container Is EventBlockSyntax
                 Dim eventBlock = DirectCast(container, EventBlockSyntax)
                 Dim attributeLists = eventBlock.EventStatement.AttributeLists.Insert(index, attributeList)

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -354,6 +354,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Return GetAttributeNodes(DirectCast(node, EnumBlockSyntax).EnumStatement.AttributeLists)
             ElseIf TypeOf node Is DelegateStatementSyntax Then
                 Return GetAttributeNodes(DirectCast(node, DelegateStatementSyntax).AttributeLists)
+            ElseIf TypeOf node Is DeclareStatementSyntax Then
+                Return GetAttributeNodes(DirectCast(node, DeclareStatementSyntax).AttributeLists)
+            ElseIf TypeOf node Is MethodStatementSyntax Then
+                Return GetAttributeNodes(DirectCast(node, MethodStatementSyntax).AttributeLists)
             ElseIf TypeOf node Is MethodBlockBaseSyntax Then
                 Return GetAttributeNodes(DirectCast(node, MethodBlockBaseSyntax).BlockStatement.AttributeLists)
             ElseIf TypeOf node Is PropertyBlockSyntax Then
@@ -3680,6 +3684,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Dim member = DirectCast(container, EnumMemberDeclarationSyntax)
                 Dim attributeLists = member.AttributeLists.Insert(index, attributeList)
                 Return member.WithAttributeLists(attributeLists)
+            ElseIf TypeOf container Is DeclareStatementSyntax Then
+                Dim declareStatement = DirectCast(container, DeclareStatementSyntax)
+                Dim attributeLists = declareStatement.AttributeLists.Insert(index, attributeList)
+                Return declareStatement.WithAttributeLists(attributeLists)
+            ElseIf TypeOf container Is MethodStatementSyntax Then
+                Dim methodStatement = DirectCast(container, MethodStatementSyntax)
+                Dim attributeLists = methodStatement.AttributeLists.Insert(index, attributeList)
+                Return methodStatement.WithAttributeLists(attributeLists)
             ElseIf TypeOf container Is MethodBlockBaseSyntax Then
                 Dim method = DirectCast(container, MethodBlockBaseSyntax)
                 If TypeOf method.BlockStatement Is SubNewStatementSyntax Then
@@ -3690,11 +3702,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                     Dim operatorStatement = DirectCast(method.BlockStatement, OperatorStatementSyntax)
                     Dim attributeLists = operatorStatement.AttributeLists.Insert(index, attributeList)
                     Return DirectCast(method, OperatorBlockSyntax).WithBlockStatement(operatorStatement.WithAttributeLists(attributeLists))
+                ElseIf TypeOf method.BlockStatement Is MethodStatementSyntax Then
+                    Dim methodStatement = DirectCast(method.BlockStatement, MethodStatementSyntax)
+                    Dim attributeLists = methodStatement.AttributeLists.Insert(index, attributeList)
+                    Return DirectCast(method, MethodBlockSyntax).WithBlockStatement(methodStatement.WithAttributeLists(attributeLists))
                 End If
+            ElseIf TypeOf container Is PropertyStatementSyntax Then
+                Dim propertyStatement = DirectCast(container, PropertyStatementSyntax)
+                Dim attributeLists = propertyStatement.AttributeLists.Insert(index, attributeList)
+                Return propertyStatement.WithAttributeLists(attributeLists)
             ElseIf TypeOf container Is PropertyBlockSyntax Then
                 Dim propertyBlock = DirectCast(container, PropertyBlockSyntax)
                 Dim attributeLists = propertyBlock.PropertyStatement.AttributeLists.Insert(index, attributeList)
                 Return propertyBlock.WithPropertyStatement(propertyBlock.PropertyStatement.WithAttributeLists(attributeLists))
+            ElseIf TypeOf container Is EventBlockSyntax
+                Dim eventBlock = DirectCast(container, EventBlockSyntax)
+                Dim attributeLists = eventBlock.EventStatement.AttributeLists.Insert(index, attributeList)
+                Return eventBlock.WithEventStatement(eventBlock.EventStatement.WithAttributeLists(attributeLists))
             ElseIf TypeOf container Is FieldDeclarationSyntax Then
                 Dim field = DirectCast(container, FieldDeclarationSyntax)
                 Dim attributeLists = field.AttributeLists.Insert(index, attributeList)


### PR DESCRIPTION
In VB Code Model, AddAttribute is now implemented for the following declaration kinds, fixing Issue #596:

* Subs/Functions
* MustOverride Subs/Functions
* Declare Subs/Functions
* Auto-properties
* Simple Events
* Custom Events

Also, I added more unit test coverage for some other declaration kinds, such as constructors and operator overloads.