### PR TITLE
Handle failing conversion in synthesized code

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/PseudoVariableExpressions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/PseudoVariableExpressions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal abstract class PseudoVariableExpressions
     {
-        internal abstract BoundExpression GetValue(BoundPseudoVariable variable);
+        internal abstract BoundExpression GetValue(BoundPseudoVariable variable, DiagnosticBag diagnostics);
         internal abstract BoundExpression GetAddress(BoundPseudoVariable variable);
     }
 }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitPseudoVariableValue(BoundPseudoVariable expression, bool used)
         {
-            EmitExpression(expression.EmitExpressions.GetValue(expression), used);
+            EmitExpression(expression.EmitExpressions.GetValue(expression, _diagnostics), used);
         }
 
         private void EmitSequencePointExpression(BoundSequencePointExpression node, bool used)

--- a/src/Compilers/VisualBasic/Portable/BoundTree/PseudoVariableExpressions.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/PseudoVariableExpressions.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' </summary>
     Friend MustInherit Class PseudoVariableExpressions
         Friend MustOverride Function GetAddress(variable As BoundPseudoVariable) As BoundExpression
-        Friend MustOverride Function GetValue(variable As BoundPseudoVariable) As BoundExpression
+        Friend MustOverride Function GetValue(variable As BoundPseudoVariable, diagnostics As DiagnosticBag) As BoundExpression
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -373,7 +373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         End Sub
 
         Private Sub EmitPseudoVariableValue(expression As BoundPseudoVariable, used As Boolean)
-            EmitExpression(expression.EmitExpressions.GetValue(expression), used)
+            EmitExpression(expression.EmitExpressions.GetValue(expression, _diagnostics), used)
         End Sub
 
         Private Sub EmitSequenceExpression(sequence As BoundSequence, used As Boolean)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     foreach (var argument in arguments)
                     {
                         var identity = (argument as AssemblyIdentity) ?? (argument as AssemblySymbol)?.Identity;
-                        if (identity != null)
+                        if (identity != null && !identity.Equals(MissingCorLibrarySymbol.Instance.Identity))
                         {
                             return ImmutableArray.Create(identity);
                         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.cs
@@ -8,21 +8,23 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     internal sealed class PlaceholderLocalRewriter : BoundTreeRewriter
     {
-        internal static BoundNode Rewrite(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, BoundNode node)
+        internal static BoundNode Rewrite(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, BoundNode node, DiagnosticBag diagnostics)
         {
-            var rewriter = new PlaceholderLocalRewriter(compilation, container, declaredLocals);
+            var rewriter = new PlaceholderLocalRewriter(compilation, container, declaredLocals, diagnostics);
             return rewriter.Visit(node);
         }
 
         private readonly CSharpCompilation _compilation;
         private readonly EENamedTypeSymbol _container;
         private readonly HashSet<LocalSymbol> _declaredLocals;
+        private readonly DiagnosticBag _diagnostics;
 
-        private PlaceholderLocalRewriter(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals)
+        private PlaceholderLocalRewriter(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, DiagnosticBag diagnostics)
         {
             _compilation = compilation;
             _container = container;
             _declaredLocals = declaredLocals;
+            _diagnostics = diagnostics;
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
@@ -38,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var placeholder = local as PlaceholderLocalSymbol;
             if ((object)placeholder != null)
             {
-                return placeholder.RewriteLocal(_compilation, _container, node.Syntax);
+                return placeholder.RewriteLocal(_compilation, _container, node.Syntax, _diagnostics);
             }
             if (_declaredLocals.Contains(local))
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -439,7 +439,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 }
 
                 // Rewrite references to placeholder "locals".
-                body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, _container, declaredLocals, body);
+                body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, _container, declaredLocals, body, diagnostics);
+
+                if (diagnostics.HasAnyErrors())
+                {
+                    return;
+                }
             }
             finally
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
-        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax)
+        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             Debug.Assert(this.Name == this.Name.ToLowerInvariant());
             var method = container.GetOrAddSynthesizedMethod(
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         m => ImmutableArray<ParameterSymbol>.Empty);
                 });
             var call = BoundCall.Synthesized(syntax, receiverOpt: null, method: method);
-            return ConvertToLocalType(compilation, call, this.Type);
+            return ConvertToLocalType(compilation, call, this.Type, diagnostics);
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
-        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax)
+        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             var method = container.GetOrAddSynthesizedMethod(
                 ExpressionCompilerConstants.GetObjectAtAddressMethodName,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return _isWritable; }
         }
 
-        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax)
+        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             return RewriteLocalInternal(compilation, container, syntax, this);
         }
@@ -81,11 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 _getAddressMethod = getAddressMethod;
             }
 
-            internal override BoundExpression GetValue(BoundPseudoVariable variable)
+            internal override BoundExpression GetValue(BoundPseudoVariable variable, DiagnosticBag diagnostics)
             {
                 var local = variable.LocalSymbol;
                 var expr = InvokeGetMethod(_getValueMethod, variable.Syntax, local.Name);
-                return ConvertToLocalType(_compilation, expr, local.Type);
+                return ConvertToLocalType(_compilation, expr, local.Type, diagnostics);
             }
 
             internal override BoundExpression GetAddress(BoundPseudoVariable variable)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Roslyn.Utilities;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
@@ -84,14 +82,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         /// <summary>
         /// Rewrite the local reference as a call to a synthesized method.
         /// </summary>
-        internal abstract BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax);
+        internal abstract BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax, DiagnosticBag diagnostics);
 
-        internal static BoundExpression ConvertToLocalType(CSharpCompilation compilation, BoundExpression expr, TypeSymbol type)
+        internal static BoundExpression ConvertToLocalType(CSharpCompilation compilation, BoundExpression expr, TypeSymbol type, DiagnosticBag diagnostics)
         {
-            HashSet<DiagnosticInfo> unusedUseSiteDiagnostics = null;
-            var conversion = compilation.Conversions.ClassifyConversionFromExpression(expr, type, ref unusedUseSiteDiagnostics);
-            Debug.Assert(conversion.IsValid);
-            Debug.Assert(unusedUseSiteDiagnostics == null || unusedUseSiteDiagnostics.All(d => d.Severity < DiagnosticSeverity.Error));
+            // NOTE: This conversion can fail if some of the types involved are from not-yet-loaded modules.
+            // For example, if System.Exception hasn't been loaded, then this call will fail for $stowedexception.
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            var conversion = compilation.Conversions.ClassifyConversionFromExpression(expr, type, ref useSiteDiagnostics);
+            diagnostics.Add(expr.Syntax, useSiteDiagnostics);
 
             return BoundConversion.Synthesized(
                 expr.Syntax,
@@ -100,7 +99,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 @checked: false,
                 explicitCastInCode: false,
                 constantValueOpt: null,
-                type: type);
+                type: type,
+                hasErrors: !conversion.IsValid);
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
-        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax)
+        internal override BoundExpression RewriteLocal(CSharpCompilation compilation, EENamedTypeSymbol container, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             var method = container.GetOrAddSynthesizedMethod(
                 ExpressionCompilerConstants.GetReturnValueMethodName,
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 receiverOpt: null,
                 method: method,
                 arguments: ImmutableArray.Create<BoundExpression>(argument));
-            return ConvertToLocalType(compilation, call, this.Type);
+            return ConvertToLocalType(compilation, call, this.Type, diagnostics);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -392,12 +392,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 case COR_E_BADIMAGEFORMAT:
                     // Some callers may not be able to provide a module name (the name may need to be read from
                     // metadata, and this Exception indicates that we cannot construct a MetadataReader).
-                    Debug.WriteLine("Module '{0}' contains corrupt metadata.", new string[] { moduleName ?? "<unspecified>" });
+                    Debug.WriteLine($"Module '{moduleName ?? "<unspecified>"}' contains corrupt metadata.");
                     return true;
                 case CORDBG_E_MISSING_METADATA:
                     // All callers that pass this Exception should also have a module name available (from the DkmClrModuleInstance).
                     Debug.Assert(moduleName != null);
-                    Debug.WriteLine("Module '{0}' is missing metadata.", moduleName);
+                    Debug.WriteLine($"Module '{moduleName}' is missing metadata.");
                     return true;
                 default:
                     return false;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -584,24 +584,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' </remarks>
         Friend Shared Function GetMissingAssemblyIdentitiesHelper(code As ERRID, arguments As IReadOnlyList(Of Object)) As ImmutableArray(Of AssemblyIdentity)
 			Select Case code
-				Case ERRID.ERR_UnreferencedAssemblyEvent3, ERRID.ERR_UnreferencedAssembly3
-					For Each argument As Object In arguments
+                Case ERRID.ERR_UnreferencedAssemblyEvent3, ERRID.ERR_UnreferencedAssembly3
+                    For Each argument As Object In arguments
 						Dim identity = If(TryCast(argument, AssemblyIdentity), TryCast(argument, AssemblySymbol)?.Identity)
-						If identity IsNot Nothing Then
-							Return ImmutableArray.Create(identity)
-						End If
-					Next
-				Case ERRID.ERR_ForwardedTypeUnavailable3
-					If arguments.Count = 3 Then
-						Return ImmutableArray.Create(TryCast(arguments(2), AssemblySymbol)?.Identity)
-					End If
-				Case ERRID.ERR_XmlFeaturesNotAvailable
-					Return ImmutableArray.Create(SystemIdentity, SystemCoreIdentity, SystemXmlIdentity, SystemXmlLinqIdentity)
-			End Select
+                        If IsValidMissingAssemblyIdentity(identity) Then
+                            Return ImmutableArray.Create(identity)
+                        End If
+                    Next
+                Case ERRID.ERR_ForwardedTypeUnavailable3
+                    If arguments.Count = 3 Then
+                        Dim identity As AssemblyIdentity = TryCast(arguments(2), AssemblySymbol)?.Identity
+                        If IsValidMissingAssemblyIdentity(identity) Then
+                            Return ImmutableArray.Create(identity)
+                        End If
+                    End If
+                Case ERRID.ERR_XmlFeaturesNotAvailable
+                    Return ImmutableArray.Create(SystemIdentity, SystemCoreIdentity, SystemXmlIdentity, SystemXmlLinqIdentity)
+            End Select
 
-			Return Nothing
+            Return Nothing
         End Function
 
+        Private Shared Function IsValidMissingAssemblyIdentity(identity As AssemblyIdentity) As Boolean
+            Return identity IsNot Nothing AndAlso Not identity.Equals(MissingCorLibrarySymbol.Instance.Identity)
+        End Function
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
@@ -7,34 +7,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend NotInheritable Class PlaceholderLocalRewriter
         Inherits BoundTreeRewriter
 
-        Friend Shared Function Rewrite(compilation As VisualBasicCompilation, container As EENamedTypeSymbol, node As BoundNode) As BoundNode
-            Dim rewriter As New PlaceholderLocalRewriter(compilation, container)
+        Friend Shared Function Rewrite(compilation As VisualBasicCompilation, container As EENamedTypeSymbol, node As BoundNode, diagnostics As DiagnosticBag) As BoundNode
+            Dim rewriter As New PlaceholderLocalRewriter(compilation, container, diagnostics)
             Return rewriter.Visit(node)
         End Function
 
         Private ReadOnly _compilation As VisualBasicCompilation
         Private ReadOnly _container As EENamedTypeSymbol
+        Private ReadOnly _diagnostics As DiagnosticBag
 
-        Private Sub New(compilation As VisualBasicCompilation, container As EENamedTypeSymbol)
+        Private Sub New(compilation As VisualBasicCompilation, container As EENamedTypeSymbol, diagnostics As DiagnosticBag)
             _compilation = compilation
             _container = container
+            _diagnostics = diagnostics
         End Sub
 
         Public Overrides Function VisitLocal(node As BoundLocal) As BoundNode
-            Dim result = RewriteLocal(node)
+            Dim result = RewriteLocal(node, _diagnostics)
             Debug.Assert(result.Type = node.Type)
             Debug.Assert(result.IsLValue = node.IsLValue)
             Return result
         End Function
 
-        Private Function RewriteLocal(node As BoundLocal) As BoundExpression
+        Private Function RewriteLocal(node As BoundLocal, diagnostics As DiagnosticBag) As BoundExpression
             Dim local = node.LocalSymbol
             If local.DeclarationKind = LocalDeclarationKind.ImplicitVariable Then
                 Return ObjectIdLocalSymbol.RewriteLocal(_compilation, _container, node.Syntax, local, node.IsLValue)
             End If
             Dim placeholder = TryCast(local, PlaceholderLocalSymbol)
             If placeholder IsNot Nothing Then
-                Return placeholder.RewriteLocal(_compilation, _container, node.Syntax, node.IsLValue)
+                Return placeholder.RewriteLocal(_compilation, _container, node.Syntax, node.IsLValue, diagnostics)
             End If
             Return node
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -465,7 +465,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             newBody = LocalDeclarationRewriter.Rewrite(_compilation, _container, newBody)
 
             ' Rewrite pseudo-variable references to helper method calls.
-            newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody), BoundBlock)
+            newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody, diagnostics), BoundBlock)
+            If diagnostics.HasAnyErrors() Then
+                Return newBody
+            End If
 
             ' Create a map from original local to target local.
             Dim localMap = PooledDictionary(Of LocalSymbol, LocalSymbol).GetInstance()

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.vb
@@ -22,7 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             compilation As VisualBasicCompilation,
             container As EENamedTypeSymbol,
             syntax As VisualBasicSyntaxNode,
-            isLValue As Boolean) As BoundExpression
+            isLValue As Boolean,
+            diagnostics As DiagnosticBag) As BoundExpression
 
             ' The intrinsic accessor method has the same name as the pseudo-variable (normalized to lowercase).
             Dim method = container.GetOrAddSynthesizedMethod(
@@ -45,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 constantValueOpt:=Nothing,
                 suppressObjectClone:=False, ' Doesn't matter, since no arguments.
                 type:=method.ReturnType)
-            Return ConvertToLocalType(compilation, [call], Type)
+            Return ConvertToLocalType(compilation, [call], Type, diagnostics)
         End Function
 
     End Class

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.vb
@@ -28,7 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             compilation As VisualBasicCompilation,
             container As EENamedTypeSymbol,
             syntax As VisualBasicSyntaxNode,
-            isLValue As Boolean) As BoundExpression
+            isLValue As Boolean,
+            diagnostics As DiagnosticBag) As BoundExpression
 
             Return RewriteLocalInternal(compilation, container, syntax, Me, isLValue:=isLValue)
         End Function
@@ -104,10 +105,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 _getAddressMethod = getAddressMethod
             End Sub
 
-            Friend Overrides Function GetValue(variable As BoundPseudoVariable) As BoundExpression
+            Friend Overrides Function GetValue(variable As BoundPseudoVariable, diagnostics As DiagnosticBag) As BoundExpression
                 Dim local = variable.LocalSymbol
                 Dim expr = InvokeGetMethod(_getValueMethod, variable.Syntax, local.Name)
-                Return ConvertToLocalType(_compilation, expr, local.Type)
+                Return ConvertToLocalType(_compilation, expr, local.Type, diagnostics)
             End Function
 
             Friend Overrides Function GetAddress(variable As BoundPseudoVariable) As BoundExpression

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
@@ -64,26 +64,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             compilation As VisualBasicCompilation,
             container As EENamedTypeSymbol,
             syntax As VisualBasicSyntaxNode,
-            isLValue As Boolean) As BoundExpression
+            isLValue As Boolean,
+            diagnostics As DiagnosticBag) As BoundExpression
 
         Friend Shared Function ConvertToLocalType(
             compilation As VisualBasicCompilation,
             expr As BoundExpression,
-            type As TypeSymbol) As BoundExpression
+            type As TypeSymbol,
+            diagnostics As DiagnosticBag) As BoundExpression
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim pair = Conversions.ClassifyConversion(expr.Type, type, useSiteDiagnostics)
-            Debug.Assert(pair.Value Is Nothing)
+            Dim syntax = expr.Syntax
+            Dim exprType = expr.Type
 
-            Dim conversionKind = pair.Key
-            Debug.Assert(Conversions.ConversionExists(conversionKind))
-            Debug.Assert((useSiteDiagnostics Is Nothing) OrElse useSiteDiagnostics.All(Function(d) d.Severity < DiagnosticSeverity.Error))
+            Dim conversionKind As ConversionKind
+            If type.IsErrorType() Then
+                diagnostics.Add(type.GetUseSiteErrorInfo(), syntax.GetLocation())
+                conversionKind = Nothing
+            ElseIf exprType.IsErrorType() Then
+                diagnostics.Add(exprType.GetUseSiteErrorInfo(), syntax.GetLocation())
+                conversionKind = Nothing
+            Else
+                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim pair = Conversions.ClassifyConversion(exprType, type, useSiteDiagnostics)
+                Debug.Assert(useSiteDiagnostics Is Nothing, "If this happens, please add a test")
+
+                diagnostics.Add(syntax, useSiteDiagnostics)
+
+                Debug.Assert(pair.Value Is Nothing) ' Conversion method.
+                conversionKind = pair.Key
+            End If
 
             Return New BoundDirectCast(
-                expr.Syntax,
+                syntax,
                 expr,
                 conversionKind,
-                type).MakeCompilerGenerated()
+                type,
+                hasErrors:=Not Conversions.ConversionExists(conversionKind)).MakeCompilerGenerated()
         End Function
 
     End Class

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.vb
@@ -26,7 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             compilation As VisualBasicCompilation,
             container As EENamedTypeSymbol,
             syntax As VisualBasicSyntaxNode,
-            isLValue As Boolean) As BoundExpression
+            isLValue As Boolean,
+            diagnostics As DiagnosticBag) As BoundExpression
 
             Dim method = container.GetOrAddSynthesizedMethod(
                 ExpressionCompilerConstants.GetReturnValueMethodName,
@@ -53,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 constantValueOpt:=Nothing,
                 suppressObjectClone:=False,
                 type:=method.ReturnType)
-            Return ConvertToLocalType(compilation, [call], Type)
+            Return ConvertToLocalType(compilation, [call], Type, diagnostics)
         End Function
 
     End Class

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.Utilities
 Imports Xunit
@@ -189,6 +190,43 @@ End Class
                               EvaluationContextBase.SystemCoreIdentity,
                               EvaluationContextBase.SystemXmlIdentity,
                               EvaluationContextBase.SystemXmlLinqIdentity)
+        End Sub
+
+        <WorkItem(1124725, "DevDiv")>
+        <WorkItem(597, "GitHub")>
+        <Fact>
+        Public Sub PseudoVariableType()
+            Const source = "
+Public Class C
+    Public Sub M()
+    End Sub
+End Class
+"
+            Dim comp = CreateCompilationWithMscorlib({source}, {}, TestOptions.DebugDll)
+            Dim context = CreateMethodContextWithReferences(comp, "C.M", CSharpRef)
+
+            Const expectedError = "(1,1): error BC30002: Type 'System.Void' is not defined."
+
+            Dim resultProperties As ResultProperties = Nothing
+            Dim actualError As String = Nothing
+            Dim actualMissingAssemblyIdentities As ImmutableArray(Of AssemblyIdentity) = Nothing
+
+            context.CompileExpression(
+                InspectionContextFactory.Empty.Add("$stowedexception", "Microsoft.CSharp.RuntimeBinder.RuntimeBinderException, Microsoft.CSharp, Version = 4.0.0.0, Culture = neutral, PublicKeyToken = b03f5f7f11d50a3a"),
+                "$stowedexception",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                resultProperties,
+                actualError,
+                actualMissingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData:=Nothing)
+
+            ' This behavior is reasonable, but it would be much nicer to report that comp.Assembly.CorLibrary.Identity
+            ' is missing, as in C# (GitHub #597).
+
+            Assert.Equal(expectedError, actualError)
+            Assert.Empty(actualMissingAssemblyIdentities)
         End Sub
 
         Private Function CreateMethodContextWithReferences(comp As Compilation, methodName As String, ParamArray references As MetadataReference()) As EvaluationContext


### PR DESCRIPTION
We used to assume that the conversion from the static return type of an
intrinsic method to the runtime type of the corresponding pseudo-variable
could never fail.  However, in the presence of not-yet-loaded modules (esp
corlib), it can.  Propagate the resulting diagnostic out to a point where
it can be used to attempt loading of the not-yet-loaded module.

Caveat: This doesn't work as well in VB, which tends to encounter
MissingCorLibrarySymbol before it encounters a missing assembly with a
useful identity (GitHub #597).

Fixes DevDiv #1124725.