### PR TITLE
Fix CompileAndVerifyOnWin8Only test utility

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -151,12 +151,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             TestEmitters emitOptions = TestEmitters.All,
             string expectedOutput = null)
         {
+            var isWin8 = OSVersion.IsWin8;
             return CompileAndVerifyWinRt(
                 source,
                 additionalRefs: additionalRefs,
-                expectedOutput: expectedOutput,
+                expectedOutput: isWin8 ? expectedOutput : null,
                 emitOptions: emitOptions,
-                verify: OSVersion.IsWin8);
+                verify: isWin8);
         }
 
         internal CompilationVerifier CompileAndVerify(


### PR DESCRIPTION
The tests were previously attempting to execute on non-Win8 machines, which also needs to be disabled. Compilation, however, should proceed on all platforms.