### PR TITLE
Improve SyntaxDiffer diffing rules

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("struct", changes[0].NewText);
         }
 
-        [Fact] //(Skip = "https://github.com/dotnet/roslyn/issues/320")]
+        [Fact]
         public void TestQualifyWithThis()
         {
             var original =  @"
@@ -283,14 +283,14 @@ class C
             // should return a single text change with 'this.' as added text.
 
             // Works as expected for last index
-            // var index = original.LastIndexOf(indexText);
-            // TestQualifyWithThisCore(root, index);
+            var index = original.LastIndexOf(indexText);
+            TestQualifyWithThisCore(root, index);
 
             // Doesn't work as expected for first index.
             // It returns 2 changes with add followed by delete, 
             // causing the 2 isolated edits of adding "this." to seem conflicting edits, even though they are not.
             // See https://github.com/dotnet/roslyn/issues/320 for details.
-            var index = original.IndexOf(indexText);
+            index = original.IndexOf(indexText);
             TestQualifyWithThisCore(root, index);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("struct", changes[0].NewText);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/320")]
+        [Fact] //(Skip = "https://github.com/dotnet/roslyn/issues/320")]
         public void TestQualifyWithThis()
         {
             var original =  @"
@@ -283,14 +283,14 @@ class C
             // should return a single text change with 'this.' as added text.
 
             // Works as expected for last index
-            var index = original.LastIndexOf(indexText);
-            TestQualifyWithThisCore(root, index);
+            // var index = original.LastIndexOf(indexText);
+            // TestQualifyWithThisCore(root, index);
 
             // Doesn't work as expected for first index.
             // It returns 2 changes with add followed by delete, 
             // causing the 2 isolated edits of adding "this." to seem conflicting edits, even though they are not.
             // See https://github.com/dotnet/roslyn/issues/320 for details.
-            index = original.IndexOf(indexText);
+            var index = original.IndexOf(indexText);
             TestQualifyWithThisCore(root, index);
         }
 


### PR DESCRIPTION
Fixes #463 

This change alters the diffing rules by no longer choosing to identify an insert action when look ahead discovers an identical matching node in the new tree if the same identical node is also found ahead in the old tree. Identical nodes generally occur due to lexer aggressive interning, but can occur due to tree edits too.