### PR TITLE
Add -u (unsign) option to FakeSign.exe

### DIFF
--- a/src/Tools/Source/FakeSign/Program.cs
+++ b/src/Tools/Source/FakeSign/Program.cs
@@ -137,6 +137,7 @@ namespace FakeSign
                             goto Help;
 
                         case 'u':
+                        case 'U':
                             unSign = true;
                             break;
 
@@ -166,6 +167,7 @@ namespace FakeSign
 
         Help:
             Console.Error.WriteLine("Usage:\nFakeSign [-u] assemblyPath");
+            Console.Error.WriteLine("    -u (unsign) Clears the strong name flag (default is to set the flag).");
             return 1;
         }
     }


### PR DESCRIPTION
FakeSign breaks ngen. For performance testing we need a way to undo the effects of FakeSign (ngen allows delay-signed assemblies to be installed as long as the "skip verification" entries are added).

This change adds command line switches to FakeSign.exe
1. -u un-signs an assembly (i.e. clears the strong name signed bit)
2. -f forces a modification, even if nothing would change
