### PR TITLE
Format hash directives inside other hash directives of complex trivia

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -299,12 +299,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             private bool OnDisabledTextTrivia(SyntaxTrivia trivia, int index)
             {
-                if (trivia.IsKind(SyntaxKind.DisabledTextTrivia))
+                if (trivia.IsKind(SyntaxKind.DisabledTextTrivia) &&
+                    SyntaxFacts.IsNewLine(trivia.ToString().Last()))
                 {
-                    if (SyntaxFacts.IsNewLine(trivia.ToString().Last()))
-                    {
-                        ResetStateAfterNewLine(index);
-                    }
+                    ResetStateAfterNewLine(index);
                 }
 
                 return false;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -1,16 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -299,10 +299,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             private bool OnDisabledTextTrivia(SyntaxTrivia trivia, int index)
             {
-                if (trivia.IsKind(SyntaxKind.DisabledTextTrivia) &&
-                    SyntaxFacts.IsNewLine(trivia.ToString().Last()))
+                if (trivia.IsKind(SyntaxKind.DisabledTextTrivia))
                 {
-                    ResetStateAfterNewLine(index);
+                    var triviaString = trivia.ToString();
+                    if (!string.IsNullOrEmpty(triviaString) && SyntaxFacts.IsNewLine(triviaString.Last()))
+                    {
+                        ResetStateAfterNewLine(index);
+                    }
                 }
 
                 return false;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -291,9 +292,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         OnComment(trivia, index) ||
                         OnSkippedTokensOrText(trivia) ||
                         OnRegion(trivia, index) ||
-                        OnPreprocessor(trivia, index))
+                        OnPreprocessor(trivia, index) ||
+                        OnDisabledTextTrivia(trivia, index))
                     {
                         return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private bool OnDisabledTextTrivia(SyntaxTrivia trivia, int index)
+            {
+                if (trivia.IsKind(SyntaxKind.DisabledTextTrivia))
+                {
+                    if (SyntaxFacts.IsNewLine(trivia.ToString().Last()))
+                    {
+                        ResetStateAfterNewLine(index);
                     }
                 }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5913,5 +5913,100 @@ class Program
 }";
             AssertFormat(expected, code);
         }
+
+        [WorkItem(285)]
+        [WorkItem(1089196)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatHashInBadDirectiveToZeroColumnAnywhereInsideIfDef()
+        {
+            const string code = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+            #
+
+#endif
+    }
+}";
+
+            const string expected = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+#
+
+#endif
+    }
+}";
+            AssertFormat(expected, code);
+        }
+
+        [WorkItem(285)]
+        [WorkItem(1089196)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatHashElseToZeroColumnAnywhereInsideIfDef()
+        {
+            const string code = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+            #else
+        Appropriate indentation should be here though #
+#endif
+    }
+}";
+
+            const string expected = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+#else
+        Appropriate indentation should be here though #
+#endif
+    }
+}";
+            AssertFormat(expected, code);
+        }
+
+        [WorkItem(285)]
+        [WorkItem(1089196)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatHashsToZeroColumnAnywhereInsideIfDef()
+        {
+            const string code = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+            #else
+        #
+
+#endif
+    }
+}";
+
+            const string expected = @"class MyClass
+{
+    static void Main(string[] args)
+    {
+#if false
+
+#else
+#
+
+#endif
+    }
+}";
+            AssertFormat(expected, code);
+        }
     }
 }


### PR DESCRIPTION
Fix #285 : Analyze DisabledTextTrivia appropriately, so that when it is followed by a hash directive, we will be able to determine if we need to format the hash directive.