### PR TITLE
update Roslyn.Services.Editor.VisualBasic.UnitTests.dll unit tests to use localized resources

### DIFF
--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security;
 using System.Threading;
-using System.Windows.Media;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -521,7 +517,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 throw new ArgumentOutOfRangeException("expectedSymbols");
             }
 
-            return "+" + NonBreakingSpace + (expectedSymbols - 1) + NonBreakingSpace + "overload";
+            return "+" + NonBreakingSpace + (expectedSymbols - 1) + NonBreakingSpace + FeaturesResources.Overload;
         }
 
         protected void VerifyItemInLinkedFiles(string xmlString, string expectedItem, string expectedDescription)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1,16 +1,8 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict Off
-Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.IntroduceVariable
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Microsoft.VisualStudio.Utilities
-Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.IntroduceVariable
     Public Class IntroduceVariableTests
@@ -74,8 +66,8 @@ index:=3)
             TestExactActionSetOffered(
                 source,
                 expectedActionSet:={
-                    "Introduce local for 'CType(2.ToString(), T)'",
-                    "Introduce local for all occurrences of 'CType(2.ToString(), T)'"})
+                    String.Format(FeaturesResources.IntroduceLocalFor, "CType(2.ToString(), T)"),
+                    String.Format(FeaturesResources.IntroduceLocalForAllOccurrences, "CType(2.ToString(), T)")})
 
             ' Verifies "Introduce field ..." is missing
         End Sub
@@ -86,8 +78,8 @@ index:=3)
             TestExactActionSetOffered(
                 source,
                 expectedActionSet:={
-                    "Introduce local for 'x.ToString()'",
-                    "Introduce local for all occurrences of 'x.ToString()'"})
+                    String.Format(FeaturesResources.IntroduceLocalFor, "x.ToString()"),
+                    String.Format(FeaturesResources.IntroduceLocalForAllOccurrences, "x.ToString()")})
 
             ' Verifies "Introduce field ..." is missing
         End Sub
@@ -207,7 +199,7 @@ End Module
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoLocalFromExpressionInField()
             Dim source = NewLines("Class Program \n Dim x = Foo([|2 + 2|]) \n End Class")
-            TestExactActionSetOffered(source, {"Introduce constant for '2 + 2'", "Introduce constant for all occurrences of '2 + 2'"})
+            TestExactActionSetOffered(source, {String.Format(FeaturesResources.IntroduceConstantFor, "2 + 2"), String.Format(FeaturesResources.IntroduceConstantForAllOccurrences, "2 + 2")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
@@ -985,8 +977,8 @@ End Class
 </File>
 
             TestExactActionSetOffered(code.NormalizedValue,
-                                      {"Introduce local constant for '5'",
-                                       "Introduce local constant for all occurrences of '5'"})
+                                      {String.Format(FeaturesResources.IntroduceLocalConstantFor, "5"),
+                                       String.Format(FeaturesResources.IntroduceLocalConstantForAll, "5")})
 
             Test(code, expected, compareTokens:=False)
         End Sub
@@ -1008,8 +1000,8 @@ End Class
 </Text>
 
             TestExactActionSetOffered(code.NormalizedValue,
-                                      {"Introduce local constant for '5'",
-                                       "Introduce local constant for all occurrences of '5'"})
+                                      {String.Format(FeaturesResources.IntroduceLocalConstantFor, "5"),
+                                       String.Format(FeaturesResources.IntroduceLocalConstantForAll, "5")})
         End Sub
 
         <WorkItem(545258)>
@@ -1043,8 +1035,8 @@ End Class
 </File>
 
             TestExactActionSetOffered(code.NormalizedValue,
-                                      {"Introduce local constant for '5'",
-                                       "Introduce local constant for all occurrences of '5'"})
+                                      {String.Format(FeaturesResources.IntroduceLocalConstantFor, "5"),
+                                       String.Format(FeaturesResources.IntroduceLocalConstantForAll, "5")})
 
             Test(code, expected, compareTokens:=False)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -1449,7 +1449,7 @@ Class SomeClass(Of T)
 End Class
                        ]]></Text>
 
-            VerifyItemExists(test.Value, "T", "T in SomeClass(Of T)")
+            VerifyItemExists(test.Value, "T", $"T {FeaturesResources.In} SomeClass(Of T)")
         End Sub
 
         <WorkItem(542225)>
@@ -2754,10 +2754,10 @@ Class C
         End Function
 End Class</Code>.Value
 
-            Dim description = <File>&lt;Awaitable&gt; Function C.Foo() As Task
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.Foo() As Task
 Doc Comment!
 Usage:
-  Await Foo()</File>.ConvertTestSourceTag()
+  <%= VBFeaturesResources.Await %> Foo()</File>.ConvertTestSourceTag()
 
             VerifyItemWithMscorlib45(code, "Foo", description, LanguageNames.VisualBasic)
         End Sub
@@ -5042,7 +5042,7 @@ end class]]>
                              </Project>
                          </Workspace>.ToString().NormalizeLineEndings()
 
-            VerifyItemInLinkedFiles(markup, "x", "(field) C.x As Integer")
+            VerifyItemInLinkedFiles(markup, "x", $"({FeaturesResources.Field}) C.x As Integer")
         End Sub
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Completion)>
@@ -5065,7 +5065,7 @@ Class C
                              </Project>
                          </Workspace>.ToString().NormalizeLineEndings()
 
-            Dim expectedDescription = "(field) C.x As Integer" + vbCrLf + vbCrLf + "    Proj1 - Available" + vbCrLf + "    Proj2 - Not Available" + vbCrLf + vbCrLf + "You can use the navigation bar to switch context."
+            Dim expectedDescription = $"({FeaturesResources.Field}) C.x As Integer" + vbCrLf + vbCrLf + String.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available) + vbCrLf + String.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable) + vbCrLf + vbCrLf + FeaturesResources.UseTheNavigationBarToSwitchContext
             VerifyItemInLinkedFiles(markup, "x", expectedDescription)
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ExitContinue/ExitContinueCodeActionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ExitContinue/ExitContinueCodeActionTests.vb
@@ -838,7 +838,7 @@ Class C
 End Class
 </File>
 
-            TestExactActionSetOffered(code.ConvertTestSourceTag(), {"Change 'Function' to 'Sub'.", "Delete the 'Exit Function' statement."})
+            TestExactActionSetOffered(code.ConvertTestSourceTag(), {String.Format(VBFeaturesResources.ChangeTo, "Function", "Sub"), String.Format(VBFeaturesResources.DeleteTheStatement, "Exit Function")})
         End Sub
 
         <WorkItem(531354)>
@@ -853,7 +853,7 @@ Class C
 End Class
 </File>
 
-            TestExactActionSetOffered(code.ConvertTestSourceTag(), {"Insert 'Sub'.", "Delete the 'Exit' statement."})
+            TestExactActionSetOffered(code.ConvertTestSourceTag(), {String.Format(VBFeaturesResources.Insert, "Sub"), String.Format(VBFeaturesResources.DeleteTheStatement, "Exit")})
         End Sub
 
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -461,7 +461,7 @@ Class Program
 End Class
 #End ExternalSource
 </text>.NormalizedValue,
-{"Generate class for 'Foo' in 'Global Namespace' (in new file)", "Generate class for 'Foo' in 'Program'", "Generate new type..."})
+{String.Format(FeaturesResources.GenerateForInNewFile, "class", "Foo", FeaturesResources.GlobalNamespace), String.Format(FeaturesResources.GenerateForIn, "class", "Foo", "Program"), FeaturesResources.GenerateNewType})
         End Sub
 
         <WorkItem(545363)>
@@ -480,7 +480,7 @@ Class Bar
 End Class
 #End ExternalSource
 </text>.NormalizedValue,
-{"Generate class for 'Foo' in 'Global Namespace' (in new file)", "Generate class for 'Foo' in 'Global Namespace'", "Generate class for 'Foo' in 'Program'", "Generate new type..."})
+{String.Format(FeaturesResources.GenerateForInNewFile, "class", "Foo", FeaturesResources.GlobalNamespace), String.Format(FeaturesResources.GenerateForIn, "class", "Foo", FeaturesResources.GlobalNamespace), String.Format(FeaturesResources.GenerateForIn, "class", "Foo", "Program"), FeaturesResources.GenerateNewType})
         End Sub
 
         <WorkItem(545363)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -179,7 +179,7 @@ NewLines("Class A \n Friend field As Integer \n End Class \n Class B \n Public S
         Public Sub TestOnlyGenerateFieldInByRefProperty()
             TestExactActionSetOffered(
 NewLines("Class A \n End Class \n Class B \n Public Sub Foo(ByRef d As Integer) \n End Sub \n Public Sub Bar() \n Dim s As New A() \n Foo(s.[|field|]) \n End Sub \n End Class"),
-{"Generate field 'field' in 'A'"})
+{String.Format(FeaturesResources.GenerateFieldIn, "field", "A")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -31,7 +31,7 @@ End Class</File>
         Dim a = new [|Fooa|].ToString()
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'Fooa' to 'Foo'.", "Change 'Fooa' to 'Boolean'.", "Change 'Fooa' to 'Global'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "Fooa", "Foo"), String.Format(VBFeaturesResources.ChangeTo, "Fooa", "Boolean"), String.Format(VBFeaturesResources.ChangeTo, "Fooa", "Global")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -41,7 +41,7 @@ End Class</File>
         Dim a as [|Foa|]
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'Foa' to 'Foo'.", "Change 'Foa' to 'Global'.", "Change 'Foa' to 'Char'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "Foa", "Foo"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Global"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Char")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -51,7 +51,7 @@ End Class</File>
         Dim a as [|Foa|]
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'Foa' to 'Foo'.", "Change 'Foa' to 'Global'.", "Change 'Foa' to 'Char'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "Foa", "Foo"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Global"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Char")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -60,7 +60,7 @@ End Class</File>
     Sub Bar(a as Func(Of [|Foa|]))
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'Foa' to 'Foo'.", "Change 'Foa' to 'Global'.", "Change 'Foa' to 'Char'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "Foa", "Foo"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Global"), String.Format(VBFeaturesResources.ChangeTo, "Foa", "Char")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -71,7 +71,7 @@ End Class</File>
         Dim y = 2 + [|zza|]
     End Sub
 End Module</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'zza' to 'zzz'.", "Change 'zza' to 'Char'.", "Change 'zza' to 'Await'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "zza", "zzz"), String.Format(VBFeaturesResources.ChangeTo, "zza", "Char"), String.Format(VBFeaturesResources.ChangeTo, "zza", "Await")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -84,7 +84,7 @@ Public Class Class1
         End If
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'blah' to 'Boolean'.", "Change 'blah' to 'Lazy'.", "Change 'blah' to 'Math'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "blah", "Boolean"), String.Format(VBFeaturesResources.ChangeTo, "blah", "Lazy"), String.Format(VBFeaturesResources.ChangeTo, "blah", "Math")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
@@ -97,7 +97,7 @@ Public Class Class1
         End If
     End Sub
 End Class</File>
-            TestExactActionSetOffered(text.NormalizedValue, {"Change 'blah' to 'Boolean'.", "Change 'blah' to 'Lazy'.", "Change 'blah' to 'Math'."})
+            TestExactActionSetOffered(text.NormalizedValue, {String.Format(VBFeaturesResources.ChangeTo, "blah", "Boolean"), String.Format(VBFeaturesResources.ChangeTo, "blah", "Lazy"), String.Format(VBFeaturesResources.ChangeTo, "blah", "Math")})
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -69,17 +69,17 @@ Class C
         [|Dim x As Integer|]
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method()
-#Disable Warning BC42024 ' Unused local variable
+#Disable Warning BC42024 ' {WRN_UnusedLocal_Title}
         Dim x As Integer
-#Enable Warning BC42024 ' Unused local variable
+#Enable Warning BC42024 ' {WRN_UnusedLocal_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -106,18 +106,18 @@ Class C
             As Integer|]
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method()
-#Disable Warning BC42024 ' Unused local variable
+#Disable Warning BC42024 ' {WRN_UnusedLocal_Title}
         Dim x _
             As Integer
-#Enable Warning BC42024 ' Unused local variable
+#Enable Warning BC42024 ' {WRN_UnusedLocal_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -147,20 +147,20 @@ Class C
         End If
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
-#Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Disable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
         If i < j.MaxValue AndAlso
             i > 0 Then
-#Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Enable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
             Console.WriteLine(i)
         End If
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -192,20 +192,20 @@ Class C
         End If
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
-#Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Disable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
         If i > 0 AndAlso
             i < j.MaxValue Then
-#Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Enable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
             Console.WriteLine(i)
         End If
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -235,18 +235,18 @@ Class C
             y As Integer
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method()
-#Disable Warning BC42024 ' Unused local variable
+#Disable Warning BC42024 ' {WRN_UnusedLocal_Title}
         Dim x As Integer,
             y As Integer
-#Enable Warning BC42024 ' Unused local variable
+#Enable Warning BC42024 ' {WRN_UnusedLocal_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -274,18 +274,18 @@ Class C
             [|y As Integer|]
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method()
-#Disable Warning BC42024 ' Unused local variable
+#Disable Warning BC42024 ' {WRN_UnusedLocal_Title}
         Dim x As Integer,
             y As Integer
-#Enable Warning BC42024 ' Unused local variable
+#Enable Warning BC42024 ' {WRN_UnusedLocal_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -314,19 +314,19 @@ Class C
                 </root>
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
-#Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Disable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
         Dim x = <root>
                     <condition value=<%= i < j.MaxValue %>/>
                 </root>
-#Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Enable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -356,19 +356,19 @@ Class C
                 Select i
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method(j As Short)
-#Disable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
-        Dim x = From i As Integer In {}
+#Disable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
+        Dim x = From i As Integer In {{}}
                 Where i < j.MaxValue
                 Select i
-#Enable Warning BC42025 ' Access of shared member, constant member, enum member or nested type through an instance
+#Enable Warning BC42025 ' {WRN_SharedMemberThroughInstance_Title}
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -398,19 +398,19 @@ Class C
         ' Trivia next line
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 Class C
     Sub Method()
-#Disable Warning BC42024 ' Unused local variable
+#Disable Warning BC42024 ' {WRN_UnusedLocal_Title}
         ' Trivia previous line
         Dim x As Integer    ' Trivia same line
-#Enable Warning BC42024 ' Unused local variable
+#Enable Warning BC42024 ' {WRN_UnusedLocal_Title}
         ' Trivia next line
     End Sub
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -442,7 +442,7 @@ Module Module1
       [|C|]
     End Sub
 End Module]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 <Obsolete>
 Class C
@@ -450,13 +450,13 @@ End Class
 
 Module Module1
     Sub Main
-#Disable Warning BC40008 ' Type or member is obsolete
+#Disable Warning BC40008 ' {WRN_UseOfObsoleteSymbol2_Title}
         C
-#Enable Warning BC40008 ' Type or member is obsolete
+#Enable Warning BC40008 ' {WRN_UseOfObsoleteSymbol2_Title}
     End Sub
-End Module]]>
+End Module"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -981,30 +981,30 @@ Imports System
         Dim x
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:Class1")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class1"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:Class1")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class1"")>
 
 [|Class Class1|]
     Sub Method()
         Dim x
     End Sub
-End Class]]>
+End Class"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1019,22 +1019,22 @@ Imports System
         End Sub
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="namespace", Target:="~N:N")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""namespace"", Target:=""~N:N"")>
+"
 
-                    Test(source.Value, expected.Value, index:=1, isAddedDocument:=True)
+                    Test(source.Value, expected, index:=1, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="namespace", Target:="~N:N")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""namespace"", Target:=""~N:N"")>
 
 [|Namespace N|]
     Class Class1
@@ -1042,9 +1042,9 @@ Imports System
             Dim x
         End Sub
     End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1061,22 +1061,22 @@ Namespace N1
         End Class
     End Namespace
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:N1.N2.Class1")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:N1.N2.Class1"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:N1.N2.Class1")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:N1.N2.Class1"")>
 
 Namespace N1
     Namespace N2
@@ -1086,9 +1086,9 @@ Namespace N1
             End Sub
         End Class
     End Namespace
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1105,22 +1105,22 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:N.Generic`1.Class1")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:N.Generic`1.Class1"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:N.Generic`1.Class1")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:N.Generic`1.Class1"")>
 
 Namespace N
     Class Generic(Of T)
@@ -1130,9 +1130,9 @@ Namespace N
             End Sub
         End Class
     End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1149,22 +1149,22 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method"")>
 
 Namespace N
     Class Generic(Of T)
@@ -1174,9 +1174,9 @@ Namespace N
             End Sub|]
         End Class
     End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1197,22 +1197,22 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method(System.Int32,System.Int32@)")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method(System.Int32,System.Int32@)"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method(System.Int32,System.Int32@)")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method(System.Int32,System.Int32@)"")>
 
 Namespace N
     Class Generic(Of T)
@@ -1226,9 +1226,9 @@ Namespace N
             End Sub
         End Class
     End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1249,22 +1249,22 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method``1(``0,System.Int32@)")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method``1(``0,System.Int32@)"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~M:N.Generic`1.Class1.Method``1(``0,System.Int32@)")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method``1(``0,System.Int32@)"")>
 
 Namespace N
     Class Generic(Of T)
@@ -1278,9 +1278,9 @@ Namespace N
             End Sub
         End Class
     End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1299,22 +1299,22 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~P:N.Generic.C.P")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~P:N.Generic.C.P"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~P:N.Generic.C.P")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~P:N.Generic.C.P"")>
 
 Namespace N
 	Class Generic
@@ -1326,9 +1326,9 @@ Namespace N
 			End Property
 		End Class
 	End Class
-End Namespace]]>
+End Namespace"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1339,28 +1339,28 @@ Imports System
 Class C
 	[|Private ReadOnly F As Integer|]
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~F:C.F")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~F:C.F"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~F:C.F")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~F:C.F"")>
 
 Class C
 	[|Private ReadOnly F As Integer|]
-End Class]]>
+End Class"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1395,22 +1395,22 @@ Class C
 		End RemoveHandler
 	End Event
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~E:C.SampleEvent")>
-]]>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~E:C.SampleEvent"")>
+"
 
-                    Test(source.Value, expected.Value, isAddedDocument:=True)
+                    Test(source.Value, expected, isAddedDocument:=True)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Imports System
 
-<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="member", Target:="~E:C.SampleEvent")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""member"", Target:=""~E:C.SampleEvent"")>
 
 Public Class SampleEventArgs
 	Public Sub New(s As String)
@@ -1438,9 +1438,9 @@ Class C
 		RemoveHandler(ByVal value As SampleEventHandler)
 		End RemoveHandler
 	End Event
-End Class]]>
+End Class"
 
-                    TestMissing(fixedSource.Value)
+                    TestMissing(fixedSource)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1469,17 +1469,17 @@ End Class]]>
                         </Project>
                     </Workspace>
 
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="Class1")>
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:Class2")>
-]]>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+"
 
-                    Test(source, expected, isLine:=False)
+                    Test(source.ToString(), expected, isLine:=False)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1506,16 +1506,16 @@ End Class
                         </Project>
                     </Workspace>
 
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:Class2")>
-]]>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+"
 
-                    Test(source, expected, isLine:=False, isAddedDocument:=True)
+                    Test(source.ToString(), expected, isLine:=False, isAddedDocument:=True)
                 End Sub
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
@@ -1551,17 +1551,17 @@ End Class
                         </Project>
                     </Workspace>
 
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 ' This file is used by Code Analysis to maintain SuppressMessage 
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="Class1")>
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="~T:Class2")>
-]]>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>
+<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+"
 
-                    Test(source, expected, isLine:=False, isAddedDocument:=False)
+                    Test(source.ToString(), expected, isLine:=False, isAddedDocument:=False)
                 End Sub
             End Class
         End Class
@@ -1642,22 +1642,22 @@ Imports System
     End Sub
 End Class
 ]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 ' Some Trivia
-<Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
 Class C
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1676,23 +1676,23 @@ Imports System
     End Sub
 End Class
 ]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 ' Some Trivia
-<Diagnostics.CodeAnalysis.SuppressMessage("SomeOtherDiagnostic", "SomeOtherDiagnostic:Title", Justification:="<Pending>")>
-<Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification:=""<Pending>"")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
 Class C
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1713,25 +1713,25 @@ Imports System
     End Sub
 End Class
 ]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 ' Some Trivia
 ''' <summary>
 ''' My custom type
 ''' </summary>
-<Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
 Class C
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1753,26 +1753,26 @@ Imports System
     End Sub
 End Class
 ]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 ' Some Trivia
 ''' <summary>
 ''' My custom type
 ''' </summary>
-<Diagnostics.CodeAnalysis.SuppressMessage("SomeOtherDiagnostic", "SomeOtherDiagnostic:Title", Justification:="<Pending>")>
-<Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification:=""<Pending>"")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
 Class C
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1790,23 +1790,23 @@ Namespace N
         End Sub
     End Class
 End Namespace]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 Namespace N
     ' Some Trivia
-    <Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+    <Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
     Class C
         Sub Method()
             Dim x
         End Sub
     End Class
-End Namespace]]>
+End Namespace"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1824,23 +1824,23 @@ Class Generic(Of T)
         End Sub
     End Class
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 Class Generic(Of T)
     ' Some Trivia
-    <Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+    <Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
     Class C
         Sub Method()
             Dim x
         End Sub
     End Class
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Class C", "[|Class C|]")
+                    Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
 
                     TestMissing(fixedSource)
                 End Sub
@@ -1858,23 +1858,23 @@ Class Generic(Of T)
         End Sub|]
     End Class
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Imports System
 
 Class Generic(Of T)
     Class C
         ' Some Trivia
-        <Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>")>
+        <Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"")>
         Sub Method()
             Dim x
         End Sub
     End Class
-End Class]]>
+End Class"
 
-                    Test(source.Value, expected.Value)
+                    Test(source.Value, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
-                    Dim fixedSource = expected.Value.Replace("Sub Method()", "[|Sub Method()|]")
+                    Dim fixedSource = expected.Replace("Sub Method()", "[|Sub Method()|]")
 
                     TestMissing(fixedSource)
                 End Sub

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
@@ -1,14 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Microsoft.VisualStudio.Text
-Imports Roslyn.Test.EditorUtilities
-Imports Roslyn.Test.Utilities
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGeneration
     Public Class MethodBlockTests
         <Fact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
@@ -56,10 +47,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
                         "Class c1",
                         "    Sub New()",
                         "",
-                        "        ' This call is required by the designer.",
+                       $"        ' {ThisCallIsRequiredByTheDesigner}",
                         "        InitializeComponent()",
                         "",
-                        "        ' Add any initialization after the InitializeComponent() call.",
+                       $"        ' {AddAnyInitializationAfter}",
                         "",
                         "    End Sub",
                         "",

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Alpha", "Class Beta", "Class Gamma", "Sub DoSomething()", "End Sub", "End Class", "End Class", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", "type Alpha.Beta.Gamma")
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Alpha.Beta.Gamma")
             End Using
         End Sub
 
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo(Of M As IComparable)", "Public Sub Bar(Of T As IComparable)()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Of T)()", "type Foo(Of M)")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Of T)()", $"{EditorFeaturesResources.Type}Foo(Of M)")
             End Using
         End Sub
 
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Bar As Integer", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Ba").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Bar As Integer", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("ba").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -183,10 +183,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private [string] As String", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("string").Single()
-                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName:="[string]", additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName:="[string]", additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
 
                 item = _aggregator.GetItems("[string]").Single()
-                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName:="[string]", additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName:="[string]", additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Const bar As String = ""bar""", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupConstant, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("bar").Single()
-                VerifyNavigateToResultItem(item, "bar", MatchKind.Exact, NavigateToItemKind.Constant, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "bar", MatchKind.Exact, NavigateToItemKind.Constant, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -208,7 +208,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
                                        "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Item").Single()
-                VerifyNavigateToResultItem(item, "Item", MatchKind.Exact, NavigateToItemKind.Property, "Item(Integer)", "type Foo")
+                VerifyNavigateToResultItem(item, "Item", MatchKind.Exact, NavigateToItemKind.Property, "Item(Integer)", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -217,7 +217,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Public Event Bar as EventHandler", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupEvent, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Event, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Event, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -228,7 +228,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
                                           "Set(value As String)", "End Set", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Name").Single()
-                VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -237,7 +237,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Property Name As String", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Name").Single()
-                VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -246,7 +246,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Sub DoSomething()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", "type Foo")
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -255,10 +255,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Sub [Sub]()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("sub").Single()
-                VerifyNavigateToResultItem(item, "Sub", MatchKind.Exact, NavigateToItemKind.Method, "[Sub]()", "type Foo")
+                VerifyNavigateToResultItem(item, "Sub", MatchKind.Exact, NavigateToItemKind.Method, "[Sub]()", $"{EditorFeaturesResources.Type}Foo")
 
                 item = _aggregator.GetItems("[sub]").Single()
-                VerifyNavigateToResultItem(item, "Sub", MatchKind.Exact, NavigateToItemKind.Method, "[Sub]()", "type Foo")
+                VerifyNavigateToResultItem(item, "Sub", MatchKind.Exact, NavigateToItemKind.Method, "[Sub]()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -267,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private Sub DoSomething(ByVal i As Integer, s As String)", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(Integer, String)", "type Foo")
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(Integer, String)", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -276,7 +276,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Sub New()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single(Function(i) i.Kind = NavigateToItemKind.Method)
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "New()", "type Foo")
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "New()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -285,7 +285,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Shared Sub New()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single(Function(i) i.Kind = NavigateToItemKind.Method)
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Shared New()", "type Foo")
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Shared New()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -296,11 +296,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
                                        "Protected Overrides Sub Finalize()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemProtected)
                 Dim item As NavigateToItem = _aggregator.GetItems("Finalize").Single()
-                VerifyNavigateToResultItem(item, "Finalize", MatchKind.Exact, NavigateToItemKind.Method, "Finalize()", "type Foo")
+                VerifyNavigateToResultItem(item, "Finalize", MatchKind.Exact, NavigateToItemKind.Method, "Finalize()", $"{EditorFeaturesResources.Type}Foo")
 
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 item = _aggregator.GetItems("Dispose").Single()
-                VerifyNavigateToResultItem(item, "Dispose", MatchKind.Exact, NavigateToItemKind.Method, "Dispose()", "type Foo")
+                VerifyNavigateToResultItem(item, "Dispose", MatchKind.Exact, NavigateToItemKind.Method, "Dispose()", $"{EditorFeaturesResources.Type}Foo")
 
             End Using
         End Sub
@@ -328,7 +328,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Partial Class Foo", "Partial Private Sub Bar()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", "type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -337,7 +337,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Partial Class Foo", "Private Sub Bar()", "End Sub", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", "type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -474,7 +474,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Dim sqr As Func(Of Integer, Integer) = Function(x) x*x", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("sqr").Single()
-                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -492,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Public Sub Bar(x as Integer,", "y as Integer)", "End Sub")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Integer, Integer)", "type Foo")
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Integer, Integer)", $"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 
@@ -501,7 +501,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class Foo", "Private itemArray as object()", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("itemArray").Single
-                VerifyNavigateToResultItem(item, "itemArray", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:="type Foo")
+                VerifyNavigateToResultItem(item, "itemArray", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
             End Using
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -168,12 +168,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                WhiteSpace(" "),
                TypeParameter("T"),
                Punctuation.CloseParen)),
-             TypeParameterMap(vbCrLf & "T is String",
+             TypeParameterMap(vbCrLf & $"T {FeaturesResources.Is} String",
               ExpectedClassifications(
                   WhiteSpace(vbCrLf),
                TypeParameter("T"),
                WhiteSpace(" "),
-               Text("is"),
+               Text(FeaturesResources.Is),
                WhiteSpace(" "),
                Keyword("String"))))
         End Sub
@@ -242,8 +242,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                 </Text>.NormalizedValue,
              MainDescription("Class System.Collections.Generic.Dictionary(Of TKey, TValue)"),
              TypeParameterMap(
-              Lines(vbCrLf & "TKey is Integer",
-                 "TValue is String")))
+              Lines(vbCrLf & $"TKey {FeaturesResources.Is} Integer",
+                 $"TValue {FeaturesResources.Is} String")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -255,15 +255,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                 </Text>.NormalizedValue,
              MainDescription("Class System.Collections.Generic.Dictionary(Of TKey, TValue)"),
              TypeParameterMap(
-              Lines(vbCrLf & "TKey is T",
-                 "TValue is U")))
+              Lines(vbCrLf & $"TKey {FeaturesResources.Is} T",
+                 $"TValue {FeaturesResources.Is} U")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestIEnumerableOfInteger()
             TestInClass("Dim ie As $$IEnumerable(Of Integer)",
              MainDescription("Interface System.Collections.Generic.IEnumerable(Of Out T)"),
-             TypeParameterMap(vbCrLf & "T is Integer"))
+             TypeParameterMap(vbCrLf & $"T {FeaturesResources.Is} Integer"))
         End Sub
 
         <WorkItem(542157)>
@@ -318,14 +318,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
             Test(StringFromLines("Class C(Of T)",
                   "    Dim t As $$T",
                   "End Class"),
-             MainDescription("T in C(Of T)"))
+             MainDescription($"T {FeaturesResources.In} C(Of T)"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestNullableOfInteger()
             TestInClass("Dim n As $$Nullable(Of Integer)",
              MainDescription("Structure System.Nullable(Of T As Structure)"),
-             TypeParameterMap(vbCrLf & "T is Integer"))
+             TypeParameterMap(vbCrLf & $"T {FeaturesResources.Is} Integer"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -337,7 +337,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                         End Sub
                     End Class
                 </Text>.NormalizedValue,
-             MainDescription("T1 in C.Meth1(Of T1)"))
+             MainDescription($"T1 {FeaturesResources.In} C.Meth1(Of T1)"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -349,7 +349,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                         End Sub
                     End Class
                 </Text>.NormalizedValue,
-             MainDescription("T1 in C.Meth1(Of T1 As Class)"))
+             MainDescription($"T1 {FeaturesResources.In} C.Meth1(Of T1 As Class)"))
         End Sub
 
         <WorkItem(538732)>
@@ -362,7 +362,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                         End Sub
                     End Class
                 </Text>.NormalizedValue,
-             MainDescription("Sub Console.Write(value As Integer) (+ 17 overloads)",
+             MainDescription($"Sub Console.Write(value As Integer) (+ 17 {FeaturesResources.Overloads})",
               ExpectedClassifications(
                Keyword("Sub"),
                WhiteSpace(" "),
@@ -382,14 +382,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                WhiteSpace(" "),
                Text("17"),
                WhiteSpace(" "),
-               Text("overloads"),
+               Text(FeaturesResources.Overloads),
                Punctuation.CloseParen)))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestOnFieldDeclaration()
             TestInClass("Dim $$i As Int32",
-             MainDescription("(field) C.i As Integer"))
+             MainDescription($"({FeaturesResources.Field}) C.i As Integer"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -400,7 +400,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                      Dim p as New Li$$st(Of string)
                      End Class
                  </Text>.NormalizedValue,
-              MainDescription("Sub List(Of String).New() (+ 2 overloads)"))
+              MainDescription($"Sub List(Of String).New() (+ 2 {FeaturesResources.Overloads})"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -441,8 +441,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                  </Text>.NormalizedValue,
               MainDescription("Delegate Function System.Func(Of In T, Out TResult)(arg As T) As TResult"),
               TypeParameterMap(
-               Lines(vbCrLf & "T is Integer",
-                  "TResult is String")))
+               Lines(vbCrLf & $"T {FeaturesResources.Is} Integer",
+                  $"TResult {FeaturesResources.Is} String")))
         End Sub
 
         <WorkItem(538824)>
@@ -456,7 +456,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                             $$d()
                         end sub
                     end class</Text>.NormalizedValue,
-            MainDescription("(local variable) d As D1"))
+            MainDescription($"({FeaturesResources.LocalVariable}) d As D1"))
         End Sub
 
         <WorkItem(538786)>
@@ -481,7 +481,7 @@ Class Test
     End Sub
 End Class
 </Text>.NormalizedValue,
-            MainDescription("Sub C.M() (+ 2 overloads)"))
+            MainDescription($"Sub C.M() (+ 2 {FeaturesResources.Overloads})"))
         End Sub
 
         <WorkItem(538786)>
@@ -531,7 +531,7 @@ Class C
     End Sub
 End Class
 </Text>.NormalizedValue,
-            MainDescription("Sub B.G() (+ 1 overload)"))
+            MainDescription($"Sub B.G() (+ 1 {FeaturesResources.Overload})"))
         End Sub
 
         <WorkItem(538918)>
@@ -724,7 +724,7 @@ Module MyExtensions
         Return True
     End Function
 End Module]]></Text>.NormalizedValue,
-            MainDescription("<Extension> Function Integer.Count(items As IEnumerable(Of Integer)) As Boolean"))
+            MainDescription($"<{VBFeaturesResources.Extension}> Function Integer.Count(items As IEnumerable(Of Integer)) As Boolean"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -748,7 +748,7 @@ Module Ex
     Public Sub TestExt(ex As String, arg As Integer)
     End Sub
 End Module]]></Text>.NormalizedValue,
-            MainDescription("<Extension> Sub String.TestExt() (+ 2 overloads)"))
+            MainDescription($"<{VBFeaturesResources.Extension}> Sub String.TestExt() (+ 2 {FeaturesResources.Overloads})"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -772,7 +772,7 @@ Module Ex
     Public Sub TestExt(ex As Integer, arg As Integer)
     End Sub
 End Module]]></Text>.NormalizedValue,
-            MainDescription("<Extension> Sub String.TestExt() (+ 1 overload)"))
+            MainDescription($"<{VBFeaturesResources.Extension}> Sub String.TestExt() (+ 1 {FeaturesResources.Overload})"))
         End Sub
 
         <WorkItem(541960)>
@@ -785,7 +785,7 @@ Class _Attribute
 
     Dim x$$ As _Attribute
 End Class]]></Text>.NormalizedValue,
-            MainDescription("(field) _Attribute.x As _Attribute"))
+            MainDescription($"({FeaturesResources.Field}) _Attribute.x As _Attribute"))
         End Sub
 
         <WorkItem(541960)>
@@ -798,7 +798,7 @@ Class ClassAttribute
 
     Dim x$$ As ClassAttribute
 End Class]]></Text>.NormalizedValue,
-            MainDescription("(field) ClassAttribute.x As ClassAttribute"))
+            MainDescription($"({FeaturesResources.Field}) ClassAttribute.x As ClassAttribute"))
         End Sub
 
         <WorkItem(541960)>
@@ -811,7 +811,7 @@ Class Class1Attribute
 
     Dim x$$ As Class1Attribute
 End Class]]></Text>.NormalizedValue,
-            MainDescription("(field) Class1Attribute.x As Class1Attribute"))
+            MainDescription($"({FeaturesResources.Field}) Class1Attribute.x As Class1Attribute"))
         End Sub
 
         <WorkItem(542613)>
@@ -840,7 +840,7 @@ Class C
 End Class]]></Text>.NormalizedValue,
             MainDescription("AnonymousType 'a"),
             NoTypeParameterMap,
-            AnonymousTypes(vbCrLf & "Anonymous Types:" & vbCrLf & "    'a is New With { Key .Name As String, Key .Price As Integer }"))
+            AnonymousTypes(vbCrLf & FeaturesResources.AnonymousTypes & vbCrLf & $"    'a {FeaturesResources.Is} New With {{ Key .Name As String, Key .Price As Integer }}"))
         End Sub
 
         <WorkItem(543226)>
@@ -858,7 +858,7 @@ Module Program
 End Module]]></Text>.NormalizedValue,
             MainDescription("ReadOnly Property 'a.Name As String"),
             NoTypeParameterMap,
-            AnonymousTypes(vbCrLf & "Anonymous Types:" & vbCrLf & "    'a is New With { Key .Name As String, Key .Price As Integer }"))
+            AnonymousTypes(vbCrLf & FeaturesResources.AnonymousTypes & vbCrLf & $"    'a {FeaturesResources.Is} New With {{ Key .Name As String, Key .Price As Integer }}"))
         End Sub
 
         <WorkItem(543223)>
@@ -873,7 +873,7 @@ End Class
 ]]></Text>.NormalizedValue,
             MainDescription("AnonymousType 'a"),
             NoTypeParameterMap,
-            AnonymousTypes(vbCrLf & "Anonymous Types:" & vbCrLf & "    'a is New With { Key .Foo As ? }"))
+            AnonymousTypes(vbCrLf & FeaturesResources.AnonymousTypes & vbCrLf & $"    'a {FeaturesResources.Is} New With {{ Key .Foo As ? }}"))
         End Sub
 
         <WorkItem(543242)>
@@ -903,7 +903,7 @@ Module Program
     End Sub
 End Module
 ]]></Text>.NormalizedValue,
-            MainDescription("(local variable) a As <Sub()>"))
+            MainDescription($"({FeaturesResources.LocalVariable}) a As <Sub()>"))
         End Sub
 
         <WorkItem(543624)>
@@ -919,7 +919,7 @@ Module Program
     End Sub
 End Module
 ]]></Text>.NormalizedValue,
-            MainDescription("(local variable) a As <Function() As Integer>"))
+            MainDescription($"({FeaturesResources.LocalVariable}) a As <Function() As Integer>"))
         End Sub
 
         <WorkItem(543624)>
@@ -934,9 +934,9 @@ Module Program
     End Sub
 End Module
 ]]></Text>.NormalizedValue,
-            MainDescription("(local variable) a As <Function() As 'a>"),
-            AnonymousTypes(vbCrLf & "Anonymous Types:" & vbCrLf &
-                           "    'a is New With { .Foo As String }"))
+            MainDescription($"({FeaturesResources.LocalVariable}) a As <Function() As 'a>"),
+            AnonymousTypes(vbCrLf & FeaturesResources.AnonymousTypes & vbCrLf &
+                           $"    'a {FeaturesResources.Is} New With {{ .Foo As String }}"))
         End Sub
 
         <WorkItem(543624)>
@@ -952,9 +952,9 @@ Module Program
     End Sub
 End Module
 ]]></Text>.NormalizedValue,
-            MainDescription("(local variable) a As <Function(i As Integer) As 'a>"),
-            AnonymousTypes(vbCrLf & "Anonymous Types:" & vbCrLf &
-                           "    'a is New With { .Sq As Integer, .M As <Function(j As Integer) As Integer> }"))
+            MainDescription($"({FeaturesResources.LocalVariable}) a As <Function(i As Integer) As 'a>"),
+            AnonymousTypes(vbCrLf & FeaturesResources.AnonymousTypes & vbCrLf &
+                           $"    'a {FeaturesResources.Is} New With {{ .Sq As Integer, .M As <Function(j As Integer) As Integer> }}"))
         End Sub
 
         <WorkItem(543389)>
@@ -1013,23 +1013,23 @@ End Module
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub BinaryConditionalExpression()
             TestInMethod("Dim x = If$$(True, False)",
-                MainDescription("If(<expression>, <expressionIfNothing>) As Boolean"),
-                Documentation("If <expression> evaluates to a reference or Nullable value that is not Nothing, the function returns that value. Otherwise, it calculates and returns <expressionIfNothing>."))
+                MainDescription($"If({Expression1}, {ExpressionIfNothing}) As Boolean"),
+                Documentation(ExpressionEvalReturns))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TernaryConditionalExpression()
             TestInMethod("Dim x = If$$(True, ""Foo"", ""Bar"")",
-                MainDescription("If(<condition> As Boolean, <expressionIfTrue>, <expressionIfFalse>) As String"),
-                Documentation("If <condition> returns True, the function calculates and returns <expressionIfTrue>. Otherwise, it returns <expressionIfFalse>."))
+                MainDescription($"If({Condition} As Boolean, {ExpressionIfTrue}, {ExpressionIfFalse}) As String"),
+                Documentation(IfConditionReturnsResults))
         End Sub
 
         <WorkItem(957082)>
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub AddHandlerStatement()
             TestInMethod("$$AddHandler foo, bar",
-                MainDescription("AddHandler <event>, <handler>"),
-                Documentation("Associates an event with an event handler, delegate or lambda expression at run time."),
+                MainDescription($"AddHandler {Event1}, {Handler}"),
+                Documentation(AssociatesAnEvent),
                 SymbolGlyph(Glyph.Keyword))
         End Sub
 
@@ -1037,8 +1037,8 @@ End Module
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub RemoveHandlerStatement()
             TestInMethod("$$RemoveHandler foo, bar",
-                MainDescription("RemoveHandler <event>, <handler>"),
-                Documentation("Removes the association between an event and an event handler or delegate at run time."),
+                MainDescription($"RemoveHandler {Event1}, {Handler}"),
+                Documentation(RemovesEventAssociation),
                 SymbolGlyph(Glyph.Keyword))
         End Sub
 
@@ -1046,7 +1046,7 @@ End Module
         Public Sub GetTypeExpression()
             TestInMethod("Dim x = GetType$$(String)",
                 MainDescription("GetType(String) As Type"),
-                Documentation("Returns a System.Type object for the specified type name."))
+                Documentation(ReturnsSystemTypeObject))
         End Sub
 
         <WorkItem(544140)>
@@ -1061,167 +1061,167 @@ class C
 end class
                 </text>.NormalizedValue,
                 {GetType(System.Xml.XmlAttribute).Assembly.Location, GetType(System.Xml.Linq.XAttribute).Assembly.Location},
-                MainDescription("GetXmlNamespace([<xmlNamespacePrefix>]) As Xml.Linq.XNamespace"),
-                Documentation("Returns the System.Xml.Linq.XNamespace object corresponding to the specified XML namespace prefix."))
+                MainDescription($"GetXmlNamespace([{XmlNamespacePrefix}]) As Xml.Linq.XNamespace"),
+                Documentation(ReturnsXNamespaceObject))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TryCastExpression()
             TestInMethod("Dim x = TryCast$$(a, String)",
-                MainDescription("TryCast(<expression>, String) As String"),
-                Documentation("Introduces a type conversion operation that does not throw an exception. If an attempted conversion fails, TryCast returns Nothing, which your program can test for."))
+                MainDescription($"TryCast({Expression1}, String) As String"),
+                Documentation(IntroducesSafeTypeConversion))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub DirectCastExpression()
             TestInMethod("Dim x = DirectCast$$(a, String)",
-                MainDescription("DirectCast(<expression>, String) As String"),
-                Documentation("Introduces a type conversion operation similar to CType. The difference is that CType succeeds as long as there is a valid conversion, whereas DirectCast requires that one type inherit from or implement the other type."))
+                MainDescription($"DirectCast({Expression1}, String) As String"),
+                Documentation(IntroducesTypeConversion))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CTypeCastExpression()
             TestInMethod("Dim x = CType$$(a, String)",
-                MainDescription("CType(<expression>, String) As String"),
-                Documentation("Returns the result of explicitly converting an expression to a specified data type."))
+                MainDescription($"CType({Expression1}, String) As String"),
+                Documentation(ReturnsConvertResult))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CBoolExpression()
             TestInMethod("Dim x = CBool$$(a)",
-                MainDescription("CBool(<expression>) As Boolean"),
-                Documentation("Converts an expression to the Boolean data type."))
+                MainDescription($"CBool({Expression1}) As Boolean"),
+                Documentation(String.Format(ConvertsToDataType, "Boolean")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CByteExpression()
             TestInMethod("Dim x = CByte$$(a)",
-                MainDescription("CByte(<expression>) As Byte"),
-                Documentation("Converts an expression to the Byte data type."))
+                MainDescription($"CByte({Expression1}) As Byte"),
+                Documentation(String.Format(ConvertsToDataType, "Byte")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CCharExpression()
             TestInMethod("Dim x = CChar$$(a)",
-                MainDescription("CChar(<expression>) As Char"),
-                Documentation("Converts an expression to the Char data type."))
+                MainDescription($"CChar({Expression1}) As Char"),
+                Documentation(String.Format(ConvertsToDataType, "Char")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CDateExpression()
             TestInMethod("Dim x = CDate$$(a)",
-                MainDescription("CDate(<expression>) As Date"),
-                Documentation("Converts an expression to the Date data type."))
+                MainDescription($"CDate({Expression1}) As Date"),
+                Documentation(String.Format(ConvertsToDataType, "Date")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CDblExpression()
             TestInMethod("Dim x = CDbl$$(a)",
-                MainDescription("CDbl(<expression>) As Double"),
-                Documentation("Converts an expression to the Double data type."))
+                MainDescription($"CDbl({Expression1}) As Double"),
+                Documentation(String.Format(ConvertsToDataType, "Double")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CDecExpression()
             TestInMethod("Dim x = CDec$$(a)",
-                MainDescription("CDec(<expression>) As Decimal"),
-                Documentation("Converts an expression to the Decimal data type."))
+                MainDescription($"CDec({Expression1}) As Decimal"),
+                Documentation(String.Format(ConvertsToDataType, "Decimal")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CIntExpression()
             TestInMethod("Dim x = CInt$$(a)",
-                MainDescription("CInt(<expression>) As Integer"),
-                Documentation("Converts an expression to the Integer data type."))
+                MainDescription($"CInt({Expression1}) As Integer"),
+                Documentation(String.Format(ConvertsToDataType, "Integer")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CLngExpression()
             TestInMethod("Dim x = CLng$$(a)",
-                MainDescription("CLng(<expression>) As Long"),
-                Documentation("Converts an expression to the Long data type."))
+                MainDescription($"CLng({Expression1}) As Long"),
+                Documentation(String.Format(ConvertsToDataType, "Long")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CObjExpression()
             TestInMethod("Dim x = CObj$$(a)",
-                MainDescription("CObj(<expression>) As Object"),
-                Documentation("Converts an expression to the Object data type."))
+                MainDescription($"CObj({Expression1}) As Object"),
+                Documentation(String.Format(ConvertsToDataType, "Object")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CSByteExpression()
             TestInMethod("Dim x = CSByte$$(a)",
-                MainDescription("CSByte(<expression>) As SByte"),
-                Documentation("Converts an expression to the SByte data type."))
+                MainDescription($"CSByte({Expression1}) As SByte"),
+                Documentation(String.Format(ConvertsToDataType, "SByte")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CShortExpression()
             TestInMethod("Dim x = CShort$$(a)",
-                MainDescription("CShort(<expression>) As Short"),
-                Documentation("Converts an expression to the Short data type."))
+                MainDescription($"CShort({Expression1}) As Short"),
+                Documentation(String.Format(ConvertsToDataType, "Short")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CSngExpression()
             TestInMethod("Dim x = CSng$$(a)",
-                MainDescription("CSng(<expression>) As Single"),
-                Documentation("Converts an expression to the Single data type."))
+                MainDescription($"CSng({Expression1}) As Single"),
+                Documentation(String.Format(ConvertsToDataType, "Single")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CStrExpression()
             TestInMethod("Dim x = CStr$$(a)",
-                MainDescription("CStr(<expression>) As String"),
-                Documentation("Converts an expression to the String data type."))
+                MainDescription($"CStr({Expression1}) As String"),
+                Documentation(String.Format(ConvertsToDataType, "String")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CUIntExpression()
             TestInMethod("Dim x = CUInt$$(a)",
-                MainDescription("CUInt(<expression>) As UInteger"),
-                Documentation("Converts an expression to the UInteger data type."))
+                MainDescription($"CUInt({Expression1}) As UInteger"),
+                Documentation(String.Format(ConvertsToDataType, "UInteger")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CULngExpression()
             TestInMethod("Dim x = CULng$$(a)",
-                MainDescription("CULng(<expression>) As ULong"),
-                Documentation("Converts an expression to the ULong data type."))
+                MainDescription($"CULng({Expression1}) As ULong"),
+                Documentation(String.Format(ConvertsToDataType, "ULong")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub CUShortExpression()
             TestInMethod("Dim x = CUShort$$(a)",
-                MainDescription("CUShort(<expression>) As UShort"),
-                Documentation("Converts an expression to the UShort data type."))
+                MainDescription($"CUShort({Expression1}) As UShort"),
+                Documentation(String.Format(ConvertsToDataType, "UShort")))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub MidAssignmentStatement1()
             TestInMethod("$$Mid(""foo"", 0) = ""bar""",
-                MainDescription("Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>"),
-                Documentation("Replaces a specified number of characters in a String variable with characters from another string."))
+                MainDescription($"Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}"),
+                Documentation(ReplacesChars))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub MidAssignmentStatement2()
             TestInMethod("$$Mid(""foo"", 0, 0) = ""bar""",
-                MainDescription("Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>"),
-                Documentation("Replaces a specified number of characters in a String variable with characters from another string."))
+                MainDescription($"Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}"),
+                Documentation(ReplacesChars))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestConstantField()
             TestInClass("const $$F = 1",
-                MainDescription("(constant) C.F As Integer = 1"))
+                MainDescription($"({FeaturesResources.Constant}) C.F As Integer = 1"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestMultipleConstantFields()
             TestInClass("Public Const X As Double = 1.0, Y As Double = 2.0, $$Z As Double = 3.5",
-                MainDescription("(constant) C.Z As Double = 3.5"))
+                MainDescription($"({FeaturesResources.Constant}) C.Z As Double = 3.5"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -1237,7 +1237,7 @@ Class B
     Public Const Z As Integer = A.Y + 1
 End Class
 ]]></Text>.NormalizedValue,
-                MainDescription("(constant) A.X As Integer = B.Z + 1"))
+                MainDescription($"({FeaturesResources.Constant}) A.X As Integer = B.Z + 1"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -1252,14 +1252,14 @@ Class B
     Public Const Z As Integer = A.X + 1
 End Class
 ]]></Text>.NormalizedValue,
-                MainDescription("(constant) A.X As Integer = B.Z + 1"))
+                MainDescription($"({FeaturesResources.Constant}) A.X As Integer = B.Z + 1"))
         End Sub
 
         <WorkItem(544620)>
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestConstantOverflow()
             TestInClass("Public Const $$Z As Integer = Integer.MaxValue + 1",
-                MainDescription("(constant) C.Z As Integer = Integer.MaxValue + 1"))
+                MainDescription($"({FeaturesResources.Constant}) C.Z As Integer = Integer.MaxValue + 1"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -1280,7 +1280,7 @@ Public Class EnumTest
     End Sub
 End Class
 ]]></Text>.NormalizedValue,
-                MainDescription("(local constant) x As Integer = CInt(Days.Sun)"))
+                MainDescription($"({FeaturesResources.LocalConstant}) x As Integer = CInt(Days.Sun)"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -1301,37 +1301,37 @@ Public Class EnumTest
     End Sub
 End Class
 ]]></Text>.NormalizedValue,
-                MainDescription("(local constant) x As Days = Days.Sun"))
+                MainDescription($"({FeaturesResources.LocalConstant}) x As Days = Days.Sun"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestConstantParameter()
             TestInClass("Sub Bar(optional $$b as Integer = 1)",
-                MainDescription("(parameter) b As Integer = 1"))
+                MainDescription($"({FeaturesResources.Parameter}) b As Integer = 1"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestConstantLocal()
             TestInMethod("const $$loc = 1",
-                MainDescription("(local constant) loc As Integer = 1"))
+                MainDescription($"({FeaturesResources.LocalConstant}) loc As Integer = 1"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestEnumValue1()
             TestInMethod("Const $$sunday = DayOfWeek.Sunday",
-                MainDescription("(local constant) sunday As DayOfWeek = DayOfWeek.Sunday"))
+                MainDescription($"({FeaturesResources.LocalConstant}) sunday As DayOfWeek = DayOfWeek.Sunday"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestEnumValue2()
             TestInMethod("Const $$v = AttributeTargets.Constructor or AttributeTargets.Class",
-                MainDescription("(local constant) v As AttributeTargets = AttributeTargets.Constructor or AttributeTargets.Class"))
+                MainDescription($"({FeaturesResources.LocalConstant}) v As AttributeTargets = AttributeTargets.Constructor or AttributeTargets.Class"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestComplexConstantParameter()
             TestInClass("Sub Bar(optional $$b as Integer = 1 + True)",
-                MainDescription("(parameter) b As Integer = 1 + True"))
+                MainDescription($"({FeaturesResources.Parameter}) b As Integer = 1 + True"))
         End Sub
 
         <WorkItem(546849)>
@@ -1372,9 +1372,9 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>&lt;Awaitable&gt; Function C.foo() As Task</File>.ConvertTestSourceTag()
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.foo() As Task</File>.ConvertTestSourceTag()
 
-            Dim doc = StringFromLines("", "Usage:", "  Await foo()")
+            Dim doc = StringFromLines("", VBFeaturesResources.Usage, "  Await foo()")
 
             TestFromXml(markup,
                  MainDescription(description), Usage(doc))
@@ -1392,7 +1392,7 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue,
-                MainDescription("(Deprecated) Sub C.Foo()"))
+                MainDescription($"({VBFeaturesResources.Deprecated}) Sub C.Foo()"))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
@@ -1706,7 +1706,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>Awaited task returns no value.</File>.ConvertTestSourceTag()
+            Dim description = <File><%= FeaturesResources.PrefixTextForAwaitKeyword %><%= " " %><%= FeaturesResources.TextForSystemVoid %></File>.ConvertTestSourceTag()
 
             TestFromXml(markup, MainDescription(description))
         End Sub
@@ -1729,7 +1729,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>Awaited task returns Structure System.Int32</File>.ConvertTestSourceTag()
+            Dim description = <File><%= FeaturesResources.PrefixTextForAwaitKeyword %> Structure System.Int32</File>.ConvertTestSourceTag()
 
             TestFromXml(markup, MainDescription(description))
         End Sub
@@ -1751,7 +1751,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>Awaited task returns no value.</File>.ConvertTestSourceTag()
+            Dim description = <File><%= FeaturesResources.PrefixTextForAwaitKeyword %><%= " " %><%= FeaturesResources.TextForSystemVoid %></File>.ConvertTestSourceTag()
 
             TestFromXml(markup, MainDescription(description))
         End Sub
@@ -1788,7 +1788,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>&lt;Awaitable&gt; Awaited task returns Class System.Threading.Tasks.Task(Of TResult)</File>.ConvertTestSourceTag()
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; <%= FeaturesResources.PrefixTextForAwaitKeyword %> Class System.Threading.Tasks.Task(Of TResult)</File>.ConvertTestSourceTag()
             TestFromXml(markup, MainDescription(description), TypeParameterMap(vbCrLf & "TResult is Integer"))
         End Sub
 
@@ -1824,7 +1824,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>Awaited task returns Structure System.Int32</File>.ConvertTestSourceTag()
+            Dim description = <File><%= FeaturesResources.PrefixTextForAwaitKeyword %> Structure System.Int32</File>.ConvertTestSourceTag()
             TestFromXml(markup, MainDescription(description))
         End Sub
 
@@ -1846,7 +1846,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>&lt;Awaitable&gt; Class System.Threading.Tasks.Task</File>.ConvertTestSourceTag()
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Class System.Threading.Tasks.Task</File>.ConvertTestSourceTag()
             TestFromXml(markup, MainDescription(description))
         End Sub
 
@@ -1868,8 +1868,8 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>&lt;Awaitable&gt; Class System.Threading.Tasks.Task(Of TResult)</File>.ConvertTestSourceTag()
-            TestFromXml(markup, MainDescription(description), TypeParameterMap(vbCrLf & "TResult is Integer"))
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Class System.Threading.Tasks.Task(Of TResult)</File>.ConvertTestSourceTag()
+            TestFromXml(markup, MainDescription(description), TypeParameterMap(vbCrLf & $"TResult {FeaturesResources.Is} Integer"))
         End Sub
 
         <WorkItem(756226), WorkItem(756337), WorkItem(522342)>
@@ -1911,7 +1911,7 @@ End Class
                              </Project>
                          </Workspace>.ToString()
 
-            Dim description = <File>&lt;Awaitable&gt; Class C</File>.ConvertTestSourceTag()
+            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Class C</File>.ConvertTestSourceTag()
             TestFromXml(markup, MainDescription(description))
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/EventHandling/AddHandlerKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/EventHandling/AddHandlerKeywordRecommenderTests.vb
@@ -1,22 +1,14 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.EventHandling
     Public Class AddHandlerKeywordRecommenderTests
         <Fact>
         <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub AddHandlerHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>|</MethodBody>, "AddHandler",
-                                                  <Text><![CDATA[
-AddHandler statement
-Associates an event with an event handler, delegate or lambda expression at run time.
-AddHandler <event>, <handler>]]></Text>)
+$"{VBFeaturesResources.AddhandlerStatement}
+{AssociatesAnEvent}
+AddHandler {Event1}, {Handler}")
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/EventHandling/RemoveHandlerKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/EventHandling/RemoveHandlerKeywordRecommenderTests.vb
@@ -1,22 +1,14 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.EventHandling
     Public Class RemoveHandlerKeywordRecommenderTests
         <Fact>
         <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub RemoveHandlerHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>|</MethodBody>, "RemoveHandler",
-                                                  <Text><![CDATA[
-RemoveHandler statement
-Removes the association between an event and an event handler or delegate at run time.
-RemoveHandler <event>, <handler>]]></Text>)
+$"{VBFeaturesResources.RemovehandlerStatement}
+{RemovesEventAssociation}
+RemoveHandler {Event1}, {Handler}")
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/CastOperatorsKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/CastOperatorsKeywordRecommenderTests.vb
@@ -19,37 +19,33 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Ex
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub DirectCastHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "DirectCast",
-                                                  <Text><![CDATA[
-DirectCast function
-Introduces a type conversion operation similar to CType. The difference is that CType succeeds as long as there is a valid conversion, whereas DirectCast requires that one type inherit from or implement the other type.
-DirectCast(<expression>, <typeName>) As <result>]]></Text>)
+$"{VBFeaturesResources.DirectcastFunction}
+{IntroducesTypeConversion}
+DirectCast({Expression1}, {VBWorkspaceResources.Typename}) As {Result}")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub TryCastHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "TryCast",
-                                                  <Text><![CDATA[
-TryCast function
-Introduces a type conversion operation that does not throw an exception. If an attempted conversion fails, TryCast returns Nothing, which your program can test for.
-TryCast(<expression>, <typeName>) As <result>]]></Text>)
+$"{VBFeaturesResources.TrycastFunction}
+{IntroducesSafeTypeConversion}
+TryCast({Expression1}, {VBWorkspaceResources.Typename}) As {Result}")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub CTypeHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "CType",
-                                                  <Text><![CDATA[
-CType function
-Returns the result of explicitly converting an expression to a specified data type.
-CType(<expression>, <typeName>) As <result>]]></Text>)
+$"{VBFeaturesResources.CtypeFunction}
+{ReturnsConvertResult}
+CType({Expression1}, {VBWorkspaceResources.Typename}) As {Result}")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub CBoolHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "CBool",
-                                                  <Text><![CDATA[
-CBool function
-Converts an expression to the Boolean data type.
-CBool(<expression>) As Boolean]]></Text>)
+$"{String.Format(VBFeaturesResources.Function1, "CBool")}
+{String.Format(ConvertsToDataType, "Boolean")}
+CBool({Expression1}) As Boolean")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/GetTypeKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/GetTypeKeywordRecommenderTests.vb
@@ -1,17 +1,13 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Roslyn.Test.Utilities
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Expressions
     Public Class GetTypeKeywordRecommenderTests
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub GetTypeHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "GetType",
-                                                  <Text><![CDATA[
-GetType function
-Returns a System.Type object for the specified type name.
-GetType(<typeName>) As Type]]></Text>)
+$"{VBFeaturesResources.GettypeFunction}
+{ReturnsSystemTypeObject}
+GetType({VBWorkspaceResources.Typename}) As Type")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/GetXmlNamespaceKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/GetXmlNamespaceKeywordRecommenderTests.vb
@@ -1,17 +1,13 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Roslyn.Test.Utilities
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Expressions
     Public Class GetXmlNamespaceKeywordRecommenderTests
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub GetXmlNamespaceHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "GetXmlNamespace",
-                                                  <Text><![CDATA[
-GetXmlNamespace function
-Returns the System.Xml.Linq.XNamespace object corresponding to the specified XML namespace prefix.
-GetXmlNamespace([<xmlNamespacePrefix>]) As System.Xml.Linq.XNamespace]]></Text>)
+$"{VBFeaturesResources.GetxmlnamespaceFunction}
+{ReturnsXNamespaceObject}
+GetXmlNamespace([{XmlNamespacePrefix}]) As System.Xml.Linq.XNamespace")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/IfKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/IfKeywordRecommenderTests.vb
@@ -1,18 +1,13 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Roslyn.Test.Utilities
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Expressions
     Public Class IfKeywordRecommenderTests
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub IfHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>Return |</MethodBody>, "If",
-                                                  <Text><![CDATA[
-If function (+1 overload)
-If <condition> returns True, the function calculates and returns <expressionIfTrue>. Otherwise, it returns <expressionIfFalse>.
-If(<condition> As Boolean, <expressionIfTrue>, <expressionIfFalse>) As <result>
-                                                  ]]></Text>)
+$"{String.Format(VBFeaturesResources.Function1, "If")} (+1 {FeaturesResources.Overload})
+{IfConditionReturnsResults}
+If({Condition} As Boolean, {ExpressionIfTrue}, {ExpressionIfFalse}) As {Result}")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
@@ -42,10 +42,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Assert.Equal(recommendations.OrderBy(Function(recommendation) recommendation).ToArray(), recommendedKeywords)
         End Sub
 
-        Friend Sub VerifyRecommendationDescriptionTextIs(testSource As XElement, keyword As String, text As XElement)
+        Friend Sub VerifyRecommendationDescriptionTextIs(testSource As XElement, keyword As String, text As String)
             Dim source = ConvertTestSourceTag(testSource)
             Dim recommendedKeyword = GetRecommendedKeywords(source.Replace("|", ""), source.IndexOf("|")).Single(Function(r) r.Keyword = keyword)
-            Dim expectedText = text.Value.Replace(vbLf, vbCrLf).Trim()
+            Dim expectedText = text.Trim()
             Assert.Equal(expectedText, recommendedKeyword.DescriptionFactory(CancellationToken.None).GetFullText())
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/MidKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/MidKeywordRecommenderTests.vb
@@ -1,18 +1,14 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Roslyn.Test.Utilities
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Statements
     Public Class MidKeywordRecommenderTests
         <Fact>
         <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub MidHelpText()
             VerifyRecommendationDescriptionTextIs(<MethodBody>|</MethodBody>, "Mid",
-                                      <Text><![CDATA[
-Mid statement
-Replaces a specified number of characters in a String variable with characters from another string.
-Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>]]></Text>)
+$"{VBFeaturesResources.MidStatement}
+{ReplacesChars}
+Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}")
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AddRemoveHandlerSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AddRemoveHandlerSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "AddHandler <event>, <handler>",
-                                     "Associates an event with an event handler, delegate or lambda expression at run time.",
-                                     "The event to associate an event handler, delegate or lambda expression with.",
+                                     $"AddHandler {Event1}, {Handler}",
+                                     AssociatesAnEvent,
+                                     EventToAssociate,
                                      currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
@@ -44,9 +43,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "AddHandler <event>, <handler>",
-                                     "Associates an event with an event handler, delegate or lambda expression at run time.",
-                                     "The event handler to associate with the event. This may take the form of { AddressOf <eventHandler> | <delegate> | <lambdaExpression> }.",
+                                     $"AddHandler {Event1}, {Handler}",
+                                     AssociatesAnEvent,
+                                     EventHandlerToAssociate,
                                      currentParameterIndex:=1))
 
             Test(markup, expectedOrderedItems)
@@ -66,9 +65,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "RemoveHandler <event>, <handler>",
-                                     "Removes the association between an event and an event handler or delegate at run time.",
-                                     "The event to disassociate an event handler or delegate from.",
+                                     $"RemoveHandler {Event1}, {Handler}",
+                                     RemovesEventAssociation,
+                                     EventToDisassociate,
                                      currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
@@ -86,9 +85,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "RemoveHandler <event>, <handler>",
-                                     "Removes the association between an event and an event handler or delegate at run time.",
-                                     "The event handler to disassociate from the event. This may take the form of { AddressOf <eventHandler> | <delegate> }.",
+                                     $"RemoveHandler {Event1}, {Handler}",
+                                     RemovesEventAssociation,
+                                     EventHandlerToDisassociate,
                                      currentParameterIndex:=1))
 
             Test(markup, expectedOrderedItems)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/CastExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/CastExpressionSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "CType(<expression>, <typeName>) As <result>",
-                                     "Returns the result of explicitly converting an expression to a specified data type.",
-                                     "The expression to be evaluated and converted.",
+                                     $"CType({Expression1}, {VBWorkspaceResources.Typename}) As {Result}",
+                                     ReturnsConvertResult,
+                                     ExpressionToConvert,
                                      currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
@@ -44,9 +43,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "CType(<expression>, <typeName>) As <result>",
-                                     "Returns the result of explicitly converting an expression to a specified data type.",
-                                     "The name of the data type to which the value of expression will be converted.",
+                                     $"CType({Expression1}, {VBWorkspaceResources.Typename}) As {Result}",
+                                     ReturnsConvertResult,
+                                     NameOfTypeToConvert,
                                      currentParameterIndex:=1))
 
             Test(markup, expectedOrderedItems)
@@ -65,9 +64,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "DirectCast(<expression>, <typeName>) As <result>",
-                                     "Introduces a type conversion operation similar to CType. The difference is that CType succeeds as long as there is a valid conversion, whereas DirectCast requires that one type inherit from or implement the other type.",
-                                     "The expression to be evaluated and converted.",
+                                     $"DirectCast({Expression1}, {VBWorkspaceResources.Typename}) As {Result}",
+                                     IntroducesTypeConversion,
+                                     ExpressionToConvert,
                                      currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
@@ -86,9 +85,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "TryCast(<expression>, <typeName>) As <result>",
-                                     "Introduces a type conversion operation that does not throw an exception. If an attempted conversion fails, TryCast returns Nothing, which your program can test for.",
-                                     "The expression to be evaluated and converted.",
+                                     $"TryCast({Expression1}, {VBWorkspaceResources.Typename}) As {Result}",
+                                     IntroducesSafeTypeConversion,
+                                     ExpressionToConvert,
                                      currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/ConditionalExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/ConditionalExpressionSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,14 +23,14 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "If(<expression>, <expressionIfNothing>) As <result>",
-                                     "If <expression> evaluates to a reference or Nullable value that is not Nothing, the function returns that value. Otherwise, it calculates and returns <expressionIfNothing>.",
-                                     "Returned if it evaluates to a reference or nullable type that is not Nothing.",
+                                     $"If({Expression1}, {ExpressionIfNothing}) As {Result}",
+                                     ExpressionEvalReturns,
+                                     ReturnedIfINotNothing,
                                      currentParameterIndex:=0))
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "If(<condition> As Boolean, <expressionIfTrue>, <expressionIfFalse>) As <result>",
-                                     "If <condition> returns True, the function calculates and returns <expressionIfTrue>. Otherwise, it returns <expressionIfFalse>.",
-                                     "The expression to evaluate.",
+                                     $"If({Condition} As Boolean, {ExpressionIfTrue}, {ExpressionIfFalse}) As {Result}",
+                                     IfConditionReturnsResults,
+                                     ExpressionToEvaluate,
                                      currentParameterIndex:=0))
             Test(markup, expectedOrderedItems)
         End Sub
@@ -48,14 +47,14 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "If(<expression>, <expressionIfNothing>) As <result>",
-                                     "If <expression> evaluates to a reference or Nullable value that is not Nothing, the function returns that value. Otherwise, it calculates and returns <expressionIfNothing>.",
-                                     "Evaluated and returned if <expression> evaluates to Nothing.",
+                                     $"If({Expression1}, {ExpressionIfNothing}) As {Result}",
+                                     ExpressionEvalReturns,
+                                     ReturnedIfNothing,
                                      currentParameterIndex:=1))
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "If(<condition> As Boolean, <expressionIfTrue>, <expressionIfFalse>) As <result>",
-                                     "If <condition> returns True, the function calculates and returns <expressionIfTrue>. Otherwise, it returns <expressionIfFalse>.",
-                                     "Evaluated and returned if <condition> evaluates to True.",
+                                     $"If({Condition} As Boolean, {ExpressionIfTrue}, {ExpressionIfFalse}) As {Result}",
+                                     IfConditionReturnsResults,
+                                     EvaluatedAndReturnedIfTrue,
                                      currentParameterIndex:=1))
             Test(markup, expectedOrderedItems)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/FunctionAggregationSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/FunctionAggregationSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -26,8 +25,8 @@ End Module
 ]]></Text>.Value
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> Count() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> Count(<expression> As Boolean) As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> Count() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> Count({Expression1} As Boolean) As Integer", String.Empty, Nothing, currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
         End Sub
@@ -62,7 +61,7 @@ Public Module Foo
 End Module
 ]]></Text>.Value
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
 
             TestSignatureHelpInEditorBrowsableContexts(markup:=markup,
                                                 referencedCode:=referencedCode,
@@ -101,7 +100,7 @@ Public Module Foo
 End Module
 ]]></Text>.Value
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
 
             TestSignatureHelpInEditorBrowsableContexts(markup:=markup,
                                                 referencedCode:=referencedCode,
@@ -140,7 +139,7 @@ Public Module Foo
 End Module
 ]]></Text>.Value
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
 
             TestSignatureHelpInEditorBrowsableContexts(markup:=markup,
                                                 referencedCode:=referencedCode,
@@ -194,11 +193,11 @@ Public Module Foo
 End Module
 ]]></Text>.Value
             Dim expectedOrderedItemsMetadataOnly = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItemsMetadataOnly.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItemsMetadataOnly.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
 
             Dim expectedOrderedItemsSameSolution = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItemsSameSolution.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
-            expectedOrderedItemsSameSolution.Add(New SignatureHelpTestItem("<Extension> GetRandomNumber(<expression> As Double) As Integer", String.Empty, String.Empty, currentParameterIndex:=0))
+            expectedOrderedItemsSameSolution.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber() As Integer", String.Empty, Nothing, currentParameterIndex:=0))
+            expectedOrderedItemsSameSolution.Add(New SignatureHelpTestItem($"<{Extension}> GetRandomNumber({Expression1} As Double) As Integer", String.Empty, String.Empty, currentParameterIndex:=0))
 
             TestSignatureHelpInEditorBrowsableContexts(markup:=markup,
                                                 referencedCode:=referencedCode,

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GenericNameSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GenericNameSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -569,7 +568,7 @@ End Class
 ]]></a>.Value
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> D.Foo(Of S, T)(objS As S, objT As T) As S", String.Empty, String.Empty, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> D.Foo(Of S, T)(objS As S, objT As T) As S", String.Empty, String.Empty, currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetTypeExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetTypeExpressionSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "GetType(<typeName>) As System.Type",
-                                     "Returns a System.Type object for the specified type name.",
-                                     "The type name to return a System.Type object for.",
+                                     $"GetType({VBWorkspaceResources.Typename}) As System.Type",
+                                     ReturnsSystemTypeObject,
+                                     TypeToReturnObjectFor,
                                      currentParameterIndex:=0))
             Test(markup, expectedOrderedItems)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetXmlNamespaceExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetXmlNamespaceExpressionSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "GetXmlNamespace([<xmlNamespacePrefix>]) As System.Xml.Linq.XNamespace",
-                                     "Returns the System.Xml.Linq.XNamespace object corresponding to the specified XML namespace prefix.",
-                                     "The XML namespace prefix to return a System.Xml.Linq.XNamespace object for. If this is omitted, the object for the default XML namespace is returned.",
+                                     $"GetXmlNamespace([{XmlNamespacePrefix}]) As System.Xml.Linq.XNamespace",
+                                     ReturnsXNamespaceObject,
+                                     XMLNSToReturnObjectFor,
                                      currentParameterIndex:=0))
             Test(markup, expectedOrderedItems)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -2,7 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
-Imports Microsoft.VisualStudio.Composition
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class InvocationExpressionSignatureHelpProviderTests
@@ -551,7 +550,7 @@ End Module
 ]]></a>.Value
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
-            expectedOrderedItems.Add(New SignatureHelpTestItem("<Extension> MyExtension.ExtensionMethod(x As Integer) As Integer", String.Empty, String.Empty, currentParameterIndex:=0))
+            expectedOrderedItems.Add(New SignatureHelpTestItem($"<{Extension}> MyExtension.ExtensionMethod(x As Integer) As Integer", String.Empty, String.Empty, currentParameterIndex:=0))
 
             Test(markup, expectedOrderedItems)
         End Sub
@@ -595,7 +594,7 @@ End Module
 ]]></a>.Value
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)() From {
-                New SignatureHelpTestItem("<Extension> SomeModule.ExtensionMethod()", String.Empty, Nothing, currentParameterIndex:=0)
+                New SignatureHelpTestItem($"<{Extension}> SomeModule.ExtensionMethod()", String.Empty, Nothing, currentParameterIndex:=0)
             }
 
             Test(markup, expectedOrderedItems)
@@ -618,17 +617,17 @@ End Module]]></a>.Value
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-<d>List(Of 'a).Add(item As 'a)
+$"List(Of 'a).Add(item As 'a)
 
-Anonymous Types:
-    'a is New With { .A As Integer, .B As Integer }</d>.Value.Replace(vbLf, vbCrLf),
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} New With {{ .A As Integer, .B As Integer }}",
                                      String.Empty,
                                      String.Empty,
                                      currentParameterIndex:=0,
-                                     description:=<d>
+                                     description:=$"
 
-Anonymous Types:
-    'a is New With { .A As Integer, .B As Integer }</d>.Value.Replace(vbLf, vbCrLf)))
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} New With {{ .A As Integer, .B As Integer }}"))
 
             Test(markup, expectedOrderedItems)
         End Sub
@@ -1707,7 +1706,7 @@ end class
                                  <Document IsLinkFile="true" LinkAssemblyName="Proj1" LinkFilePath="SourceDocument"/>
                              </Project>
                          </Workspace>]]></text>.Value.NormalizeLineEndings()
-            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + vbCrLf + vbCrLf + "    Proj1 - Available" + vbCrLf + "    Proj2 - Not Available" + vbCrLf + vbCrLf + "You can use the navigation bar to switch context.", currentParameterIndex:=0)
+            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + vbCrLf + vbCrLf + String.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available) + vbCrLf + String.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable) + vbCrLf + vbCrLf + FeaturesResources.UseTheNavigationBarToSwitchContext, currentParameterIndex:=0)
             VerifyItemWithReferenceWorker(markup, {expectedDescription}, False)
         End Sub
 
@@ -1737,7 +1736,7 @@ class C
                              </Project>
                          </Workspace>]]></text>.Value.NormalizeLineEndings()
 
-            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + "\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.".Replace("\r\n", vbCrLf), currentParameterIndex:=0)
+            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + $"\r\n\r\n{String.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{String.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}".Replace("\r\n", vbCrLf), currentParameterIndex:=0)
             VerifyItemWithReferenceWorker(markup, {expectedDescription}, False)
         End Sub
     End Class

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/MidAssignmentSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/MidAssignmentSignatureHelpProviderTests.vb
@@ -2,7 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
-Imports Microsoft.VisualStudio.Composition
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class MidAssignmentSignatureHelpProviderTests
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>",
-                                     "Replaces a specified number of characters in a String variable with characters from another string.",
-                                     "The name of the string variable to modify.",
+                                     $"Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}",
+                                     ReplacesChars,
+                                     NameOfStringVariable,
                                      currentParameterIndex:=0))
             Test(markup, expectedOrderedItems)
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger:=True)
@@ -44,9 +43,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>",
-                                     "Replaces a specified number of characters in a String variable with characters from another string.",
-                                     "The one-based character position in the string where the replacement of text begins.",
+                                     $"Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}",
+                                     ReplacesChars,
+                                     OneBasedStartPos,
                                      currentParameterIndex:=1))
             Test(markup, expectedOrderedItems)
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger:=True)
@@ -64,9 +63,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "Mid(<stringName>, <startIndex>, [<length>]) = <stringExpression>",
-                                     "Replaces a specified number of characters in a String variable with characters from another string.",
-                                     "The number of characters to replace. If omitted, the length of <stringExpression> is used.",
+                                     $"Mid({StringName}, {StartIndex}, [{Length}]) = {StringExpression}",
+                                     ReplacesChars,
+                                     NumberOfCharsToReplace,
                                      currentParameterIndex:=2))
             Test(markup, expectedOrderedItems)
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger:=True)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/PredefinedCastExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/PredefinedCastExpressionSignatureHelpProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
 
@@ -24,9 +23,9 @@ End Class
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)()
             expectedOrderedItems.Add(New SignatureHelpTestItem(
-                                     "CBool(<expression>) As Boolean",
-                                     "Converts an expression to the Boolean data type.",
-                                     "The expression to be evaluated and converted.",
+                                     $"CBool({Expression1}) As Boolean",
+                                     String.Format(ConvertsToDataType, "Boolean"),
+                                     ExpressionToConvert,
                                      currentParameterIndex:=0))
             Test(markup, expectedOrderedItems)
         End Sub

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractIntrinsicOperatorDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractIntrinsicOperatorDocumentation.vb
@@ -2,9 +2,6 @@
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
@@ -62,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                     Return suffixParts
                 End If
 
-                suffixParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, "<result>"))
+                suffixParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, Result))
             End If
 
             Return suffixParts

--- a/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.Designer.vb
+++ b/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.Designer.vb
@@ -359,6 +359,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &lt;result&gt;.
+        '''</summary>
+        Friend ReadOnly Property Result() As String
+            Get
+                Return ResourceManager.GetString("Result", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Returned if it evaluates to a reference or nullable type that is not Nothing..
         '''</summary>
         Friend ReadOnly Property ReturnedIfINotNothing() As String

--- a/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.resx
+++ b/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.resx
@@ -261,4 +261,7 @@
   <data name="NameOfDocumentation" xml:space="preserve">
     <value>Produces a string for the name of the specified type or member.</value>
   </data>
+  <data name="Result" xml:space="preserve">
+    <value>&lt;result&gt;</value>
+  </data>
 </root>


### PR DESCRIPTION
This also includes adding a resource for the string '&lt;result&gt;' that wasn't localized but should have been.