### PR TITLE
Fix a NullReferenceException in the DeclarePublicAPI analyzer

### DIFF
--- a/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -84,13 +84,13 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 AdditionalText publicApiAdditionalText = TryGetPublicApiSpec(compilationContext.Options.AdditionalFiles, compilationContext.CancellationToken);
-                var publicApiSourceText = publicApiAdditionalText.GetText(compilationContext.CancellationToken);
 
                 if (publicApiAdditionalText == null)
                 {
                     return;
                 }
 
+                SourceText publicApiSourceText = publicApiAdditionalText.GetText(compilationContext.CancellationToken);
                 HashSet<string> declaredPublicSymbols = ReadPublicSymbols(publicApiSourceText, compilationContext.CancellationToken);
                 HashSet<string> examinedPublicTypes = new HashSet<string>();
                 object lockObj = new object();


### PR DESCRIPTION
Fixes #672.

Move the existing null check to the right location.