### PR TITLE
Add common Boxes to Microsoft.CodeAnalysis

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -23,6 +23,7 @@
     </Compile>
     <Compile Include="AnalyzerFileReferenceTests.cs" />
     <Compile Include="AsyncQueueTests.cs" />
+    <Compile Include="Collections\BoxesTest.cs" />
     <Compile Include="Diagnostics\DiagnosticLocalizationTests.cs" />
     <Compile Include="Emit\EmitOptionsTests.cs" />
     <Compile Include="Emit\CustomDebugInfoReaderTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/BoxesTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/BoxesTest.cs
@@ -1,0 +1,75 @@
+﻿using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class BoxesTest
+    {
+        [Fact]
+        public void AllBoxesTest()
+        {
+            // Boolean
+            Assert.Same(Boxes.Box(true), Boxes.Box(true));
+            Assert.Same(Boxes.Box(false), Boxes.Box(false));
+            Assert.NotSame(Boxes.Box(true), Boxes.Box(false));
+
+            // Byte
+            Assert.Same(Boxes.Box((byte)0), Boxes.Box((byte)0));
+            Assert.NotSame(Boxes.Box((byte)3), Boxes.Box((byte)3));
+
+            // SByte
+            Assert.Same(Boxes.Box((sbyte)0), Boxes.Box((sbyte)0));
+            Assert.NotSame(Boxes.Box((sbyte)3), Boxes.Box((sbyte)3));
+
+            // Int16
+            Assert.Same(Boxes.Box((short)0), Boxes.Box((short)0));
+            Assert.NotSame(Boxes.Box((short)3), Boxes.Box((short)3));
+
+            // UInt16
+            Assert.Same(Boxes.Box((ushort)0), Boxes.Box((ushort)0));
+            Assert.NotSame(Boxes.Box((ushort)3), Boxes.Box((ushort)3));
+
+            // Int32
+            Assert.Same(Boxes.Box(0), Boxes.Box(0));
+            Assert.Same(Boxes.Box(1), Boxes.Box(1));
+            Assert.Same(Boxes.BoxedInt32Zero, Boxes.Box(0));
+            Assert.Same(Boxes.BoxedInt32One, Boxes.Box(1));
+            Assert.NotSame(Boxes.Box(3), Boxes.Box(3));
+            
+            // UInt32
+            Assert.Same(Boxes.Box(0u), Boxes.Box(0u));
+            Assert.NotSame(Boxes.Box(3u), Boxes.Box(3u));
+
+            // Int64
+            Assert.Same(Boxes.Box(0L), Boxes.Box(0L));
+            Assert.NotSame(Boxes.Box(3L), Boxes.Box(3L));
+
+            // UInt64
+            Assert.Same(Boxes.Box(0UL), Boxes.Box(0UL));
+            Assert.NotSame(Boxes.Box(3UL), Boxes.Box(3UL));
+
+            // Single
+            Assert.Same(Boxes.Box(0.0f), Boxes.Box(0.0f));
+            Assert.NotSame(Boxes.Box(0.0f), Boxes.Box(-0.0f));
+            Assert.NotSame(Boxes.Box(1.0f), Boxes.Box(1.0f));
+
+            // Double
+            Assert.Same(Boxes.Box(0.0), Boxes.Box(0.0));
+            Assert.NotSame(Boxes.Box(0.0), Boxes.Box(-0.0));
+            Assert.NotSame(Boxes.Box(1.0), Boxes.Box(1.0));
+
+            // Decimal
+            Assert.Same(Boxes.Box(decimal.Zero), Boxes.Box(0m));
+            Assert.NotSame(Boxes.Box(0m), Boxes.Box(decimal.Negate(0m)));
+            decimal strangeDecimalZero = new decimal(0, 0, 0, false, 10);
+            Assert.Equal(decimal.Zero, strangeDecimalZero);
+            Assert.NotSame(Boxes.Box(decimal.Zero), Boxes.Box(strangeDecimalZero));
+
+            // Char
+            Assert.Same(Boxes.Box('\0'), Boxes.Box('\0'));
+            Assert.Same(Boxes.Box('*'), Boxes.Box('*'));
+            Assert.Same(Boxes.Box('0'), Boxes.Box('0'));
+            Assert.NotSame(Boxes.Box('\u1234'), Boxes.Box('\u1234')); // non ASCII
+        }
+
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Collections\ArrayBuilderExtensions.cs" />
     <Compile Include="Collections\ArrayElement.cs" />
     <Compile Include="Collections\BitArray.cs" />
+    <Compile Include="Collections\Boxes.cs" />
     <Compile Include="Collections\ByteSequenceComparer.cs" />
     <Compile Include="Collections\CachingDictionary.cs" />
     <Compile Include="Collections\CachingFactory.cs" />

--- a/src/Compilers/Core/Portable/Collections/Boxes.cs
+++ b/src/Compilers/Core/Portable/Collections/Boxes.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    internal static class Boxes
+    {
+        public static readonly object BoxedTrue = true;
+        public static readonly object BoxedFalse = false;
+        public static readonly object BoxedInt16Zero = (short)0;
+        public static readonly object BoxedInt32Zero = 0;
+        public static readonly object BoxedInt64Zero = 0L;
+
+        public static object Box(bool b)
+        {
+            return b ? BoxedTrue : BoxedFalse;
+        }
+
+        public static object Box(short s)
+        {
+            return s == 0 ? BoxedInt16Zero : s;
+        }
+
+        public static object Box(int i)
+        {
+            return i == 0 ? BoxedInt32Zero : i;
+        }
+
+        public static object Box(long l)
+        {
+            return l == 0 ? BoxedInt64Zero : l;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/Boxes.cs
+++ b/src/Compilers/Core/Portable/Collections/Boxes.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Collections
         public static readonly object BoxedInt16Zero = (short)0;
         public static readonly object BoxedUInt16Zero = (ushort)0;
         public static readonly object BoxedInt32Zero = 0;
+        public static readonly object BoxedInt32One = 1;
         public static readonly object BoxedUInt32Zero = 0U;
         public static readonly object BoxedInt64Zero = 0L;
         public static readonly object BoxedUInt64Zero = 0UL;
@@ -42,7 +43,13 @@ namespace Microsoft.CodeAnalysis.Collections
 
         public static object Box(int i)
         {
-            return i == 0 ? BoxedInt32Zero : i;
+            switch(i)
+            {
+                case 0: return BoxedInt32Zero;
+                case 1: return BoxedInt32One;
+                default:
+                    return i;
+            }
         }
 
         public static object Box(uint u)

--- a/src/Compilers/Core/Portable/Collections/Boxes.cs
+++ b/src/Compilers/Core/Portable/Collections/Boxes.cs
@@ -6,13 +6,28 @@ namespace Microsoft.CodeAnalysis.Collections
     {
         public static readonly object BoxedTrue = true;
         public static readonly object BoxedFalse = false;
+        public static readonly object BoxedByteZero = (byte)0;
+        public static readonly object BoxedSByteZero = (sbyte)0;
         public static readonly object BoxedInt16Zero = (short)0;
+        public static readonly object BoxedUInt16Zero = (ushort)0;
         public static readonly object BoxedInt32Zero = 0;
+        public static readonly object BoxedUInt32Zero = 0U;
         public static readonly object BoxedInt64Zero = 0L;
+        public static readonly object BoxedUInt64Zero = 0UL;
 
         public static object Box(bool b)
         {
             return b ? BoxedTrue : BoxedFalse;
+        }
+
+        public static object Box(byte b)
+        {
+            return b == 0 ? BoxedByteZero : b;
+        }
+
+        public static object Box(sbyte sb)
+        {
+            return sb == 0 ? BoxedSByteZero : sb;
         }
 
         public static object Box(short s)
@@ -20,14 +35,29 @@ namespace Microsoft.CodeAnalysis.Collections
             return s == 0 ? BoxedInt16Zero : s;
         }
 
+        public static object Box(ushort us)
+        {
+            return us == 0 ? BoxedUInt16Zero : us;
+        }
+
         public static object Box(int i)
         {
             return i == 0 ? BoxedInt32Zero : i;
         }
 
+        public static object Box(uint u)
+        {
+            return u == 0 ? BoxedUInt32Zero : u;
+        }
+
         public static object Box(long l)
         {
             return l == 0 ? BoxedInt64Zero : l;
+        }
+
+        public static object Box(ulong ul)
+        {
+            return ul == 0 ? BoxedUInt64Zero : ul;
         }
     }
 }

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Collections;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -446,11 +444,11 @@ namespace Microsoft.CodeAnalysis
                     case ConstantValueTypeDiscriminator.UInt32: return Boxes.Box(UInt32Value);
                     case ConstantValueTypeDiscriminator.Int64: return Boxes.Box(Int64Value);
                     case ConstantValueTypeDiscriminator.UInt64: return Boxes.Box(UInt64Value);
-                    case ConstantValueTypeDiscriminator.Char: return CharValue;
+                    case ConstantValueTypeDiscriminator.Char: return Boxes.Box(CharValue);
                     case ConstantValueTypeDiscriminator.Boolean: return Boxes.Box(BooleanValue);
-                    case ConstantValueTypeDiscriminator.Single: return SingleValue;
-                    case ConstantValueTypeDiscriminator.Double: return DoubleValue;
-                    case ConstantValueTypeDiscriminator.Decimal: return DecimalValue;
+                    case ConstantValueTypeDiscriminator.Single: return Boxes.Box(SingleValue);
+                    case ConstantValueTypeDiscriminator.Double: return Boxes.Box(DoubleValue);
+                    case ConstantValueTypeDiscriminator.Decimal: return Boxes.Box(DecimalValue);
                     case ConstantValueTypeDiscriminator.DateTime: return DateTimeValue;
                     case ConstantValueTypeDiscriminator.String: return StringValue;
                     default: throw ExceptionUtilities.UnexpectedValue(this.Discriminator);

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -437,16 +438,16 @@ namespace Microsoft.CodeAnalysis
                 {
                     case ConstantValueTypeDiscriminator.Bad: return null;
                     case ConstantValueTypeDiscriminator.Null: return null;
-                    case ConstantValueTypeDiscriminator.SByte: return SByteValue;
-                    case ConstantValueTypeDiscriminator.Byte: return ByteValue;
-                    case ConstantValueTypeDiscriminator.Int16: return Int16Value;
-                    case ConstantValueTypeDiscriminator.UInt16: return UInt16Value;
-                    case ConstantValueTypeDiscriminator.Int32: return Int32Value;
-                    case ConstantValueTypeDiscriminator.UInt32: return UInt32Value;
-                    case ConstantValueTypeDiscriminator.Int64: return Int64Value;
-                    case ConstantValueTypeDiscriminator.UInt64: return UInt64Value;
+                    case ConstantValueTypeDiscriminator.SByte: return Boxes.Box(SByteValue);
+                    case ConstantValueTypeDiscriminator.Byte: return Boxes.Box(ByteValue);
+                    case ConstantValueTypeDiscriminator.Int16: return Boxes.Box(Int16Value);
+                    case ConstantValueTypeDiscriminator.UInt16: return Boxes.Box(UInt16Value);
+                    case ConstantValueTypeDiscriminator.Int32: return Boxes.Box(Int32Value);
+                    case ConstantValueTypeDiscriminator.UInt32: return Boxes.Box(UInt32Value);
+                    case ConstantValueTypeDiscriminator.Int64: return Boxes.Box(Int64Value);
+                    case ConstantValueTypeDiscriminator.UInt64: return Boxes.Box(UInt64Value);
                     case ConstantValueTypeDiscriminator.Char: return CharValue;
-                    case ConstantValueTypeDiscriminator.Boolean: return BooleanValue;
+                    case ConstantValueTypeDiscriminator.Boolean: return Boxes.Box(BooleanValue);
                     case ConstantValueTypeDiscriminator.Single: return SingleValue;
                     case ConstantValueTypeDiscriminator.Double: return DoubleValue;
                     case ConstantValueTypeDiscriminator.Decimal: return DecimalValue;

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -1936,12 +1937,9 @@ namespace Microsoft.CodeAnalysis
             return new TypedConstant(type, kind, value);
         }
 
-        private readonly static object s_boxedTrue = true;
-        private readonly static object s_boxedFalse = false;
-
         private TypedConstant CreateTypedConstant(TypeSymbol type, TypedConstantKind kind, bool value)
         {
-            return CreateTypedConstant(type, kind, value ? s_boxedTrue : s_boxedFalse);
+            return CreateTypedConstant(type, kind, Boxes.Box(value));
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
-using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -4,7 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Roslyn.Utilities
 {
@@ -181,10 +182,6 @@ namespace Roslyn.Utilities
             }
         }
 
-        private static readonly object s_int32Zero = 0;
-        private static readonly object s_booleanTrue = true;
-        private static readonly object s_booleanFalse = false;
-
         /// <summary>
         /// Read a value from the stream. The value must have been written using ObjectWriter.WriteValue.
         /// </summary>
@@ -196,9 +193,9 @@ namespace Roslyn.Utilities
                 case DataKind.Null:
                     return null;
                 case DataKind.Boolean_T:
-                    return s_booleanTrue;
+                    return Boxes.BoxedTrue;
                 case DataKind.Boolean_F:
-                    return s_booleanFalse;
+                    return Boxes.BoxedFalse;
                 case DataKind.Int8:
                     return _reader.ReadSByte();
                 case DataKind.UInt8:
@@ -214,7 +211,7 @@ namespace Roslyn.Utilities
                 case DataKind.Int32_S:
                     return (int)_reader.ReadUInt16();
                 case DataKind.Int32_Z:
-                    return s_int32Zero;
+                    return Boxes.BoxedInt32Zero;
                 case DataKind.UInt32:
                     return _reader.ReadUInt32();
                 case DataKind.Int64:

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -3,6 +3,7 @@
 Imports System.Collections.ObjectModel
 Imports System.Text
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -520,18 +521,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
     Partial Class KeywordSyntax
 
-        Private Shared ReadOnly BoxedTrue As Object = True
-        Private Shared ReadOnly BoxedFalse As Object = False
-
         Friend NotOverridable Overrides ReadOnly Property ObjectValue As Object
             Get
                 Select Case MyBase.Kind
                     Case SyntaxKind.NothingKeyword
                         Return Nothing
                     Case SyntaxKind.TrueKeyword
-                        Return BoxedTrue
+                        Return Boxes.BoxedTrue
                     Case SyntaxKind.FalseKeyword
-                        Return BoxedFalse
+                        Return Boxes.BoxedFalse
                     Case Else
                         Return Me.Text
                 End Select
@@ -545,4 +543,3 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Property
     End Class
 End Namespace
-

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -3,7 +3,6 @@
 Imports System.Collections.ObjectModel
 Imports System.Text
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -48,6 +48,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="Linked Files">
+    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\Boxes.cs">
+      <Link>InternalUtilities\Boxes.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\Collections\ImmutableArrayExtensions.cs">
       <Link>InternalUtilities\ImmutableArrayExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
From duplicate object memory analysis of C# compilation, I found hundreds of boxed Boolean, Int32 and Int64 values.
These were coming from ConstantValue.get_Value
I introduced a "Boxes" static class in the compiler and wired up ConstantValue.Value to use it for the Boolean and integral types.