### PR TITLE
Format on Typing Colon For Switch Case Default and Labels

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -142,7 +142,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         private static bool TokenShouldNotFormatOnTypeChar(SyntaxToken token)
         {
-            return token.IsKind(SyntaxKind.CloseParenToken) && !token.Parent.IsKind(SyntaxKind.UsingStatement);
+            return token.IsKind(SyntaxKind.CloseParenToken) && !token.Parent.IsKind(SyntaxKind.UsingStatement) ||
+                token.IsKind(SyntaxKind.ColonToken) && !(token.Parent.IsKind(SyntaxKind.LabeledStatement) || token.Parent.IsKind(SyntaxKind.CaseSwitchLabel) || token.Parent.IsKind(SyntaxKind.DefaultSwitchLabel));
         }
 
         public async Task<IList<TextChange>> GetFormattingChangesAsync(Document document, char typedChar, int caretPosition, CancellationToken cancellationToken)

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -142,8 +142,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         private static bool TokenShouldNotFormatOnTypeChar(SyntaxToken token)
         {
-            return token.IsKind(SyntaxKind.CloseParenToken) && !token.Parent.IsKind(SyntaxKind.UsingStatement) ||
-                token.IsKind(SyntaxKind.ColonToken) && !(token.Parent.IsKind(SyntaxKind.LabeledStatement) || token.Parent.IsKind(SyntaxKind.CaseSwitchLabel) || token.Parent.IsKind(SyntaxKind.DefaultSwitchLabel));
+            return (token.IsKind(SyntaxKind.CloseParenToken) && !token.Parent.IsKind(SyntaxKind.UsingStatement)) ||
+                (token.IsKind(SyntaxKind.ColonToken) && !(token.Parent.IsKind(SyntaxKind.LabeledStatement) || token.Parent.IsKind(SyntaxKind.CaseSwitchLabel) || token.Parent.IsKind(SyntaxKind.DefaultSwitchLabel)));
         }
 
         public async Task<IList<TextChange>> GetFormattingChangesAsync(Document document, char typedChar, int caretPosition, CancellationToken cancellationToken)
@@ -166,7 +166,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                 return null;
             }
 
-            // Check to see if the token is ')' and also the parent is a using statement. If not, bail
+            // Check to see if any of the below. If not, bail.
+            // case 1: The token is ')' and the parent is an using statement.
+            // case 2: The token is ':' and the parent is either labelled statement or case switch or default switch
             if (TokenShouldNotFormatOnTypeChar(token))
             {
                 return null;

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -839,6 +839,227 @@ class Program
             AssertFormatAfterTypeChar(code, expected);
         }
 
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ColonInSwitchCase()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int f = 0;
+        switch(f)
+        {
+                 case     1     :$$    break;
+        }
+    }
+}";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int f = 0;
+        switch(f)
+        {
+            case 1:    break;
+        }
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ColonInDefaultSwitchCase()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int f = 0;
+        switch(f)
+        {
+            case 1:    break;
+                    default    :$$     break;
+        }
+    }
+}";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int f = 0;
+        switch(f)
+        {
+            case 1:    break;
+            default:     break;
+        }
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ColonInLabeledStatement()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+            label1   :$$   int s = 0;
+    }
+}";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+            label1:   int s = 0;
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInTargetAttribute()
+        {
+            var code = @"using System;
+[method    :$$    C]
+class C : Attribute
+{
+}";
+
+            var expected = @"using System;
+[method    :    C]
+class C : Attribute
+{
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInBaseList()
+        {
+            var code = @"class C   :$$   Attribute
+{
+}";
+
+            var expected = @"class C   :   Attribute
+{
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInThisConstructor()
+        {
+            var code = @"class Foo
+{
+    Foo(int s)   :$$   this()
+    {
+    }
+
+    Foo()
+    {
+    }
+}";
+
+            var expected = @"class Foo
+{
+    Foo(int s)   :   this()
+    {
+    }
+
+    Foo()
+    {
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInConditionalOperator()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var vari = foo()     ?    true  :$$  false;
+    }
+}";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var vari = foo()     ?    true  :  false;
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInArgument()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Main(args  :$$  args);
+    }
+}";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Main(args  :  args);
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [WorkItem(464)]
+        [WorkItem(908729)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatColonInTyepPararmeter()
+        {
+            var code = @"class Program<T>
+{
+    class C1<U>
+        where   T  :$$  U
+    {
+
+    }
+}";
+
+            var expected = @"class Program<T>
+{
+    class C1<U>
+        where   T  :  U
+    {
+
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
         private static void AssertFormatAfterTypeChar(string code, string expected)
         {
             using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(code))


### PR DESCRIPTION
Fixes #464 : Formatting should be triggered on typing colon only in the context of Switch cases, switch default and labelled statement