### PR TITLE
Introduce an abstraction layer over PDB imports

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Binders\EEMethodBinder.cs" />
     <Compile Include="Binders\WithTypeArgumentsBinder.cs" />
     <Compile Include="Binders\PlaceholderLocalBinder.cs" />
+    <Compile Include="SymUnmanagedReaderExtensions.cs" />
     <Compile Include="CompilationContext.cs" />
     <Compile Include="CompilationExtensions.cs" />
     <Compile Include="CSharpLanguageInstructionDecoder.cs" />

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymUnmanagedReaderExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymUnmanagedReaderExtensions.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.SymReaderInterop;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+{
+    internal static class SymUnmanagedReaderExtensions
+    {
+        public static MethodDebugInfo GetMethodDebugInfo(
+            this ISymUnmanagedReader reader,
+            int methodToken,
+            int methodVersion)
+        {
+            ImmutableArray<string> externAliasStrings;
+            var importStringGroups = reader.GetCSharpGroupedImportStrings(methodToken, methodVersion, out externAliasStrings);
+            Debug.Assert(importStringGroups.IsDefault == externAliasStrings.IsDefault);
+
+            if (importStringGroups.IsDefault)
+            {
+                return default(MethodDebugInfo);
+            }
+
+            var importRecordGroupBuilder = ArrayBuilder<ImmutableArray<ImportRecord>>.GetInstance(importStringGroups.Length);
+            foreach (var importStringGroup in importStringGroups)
+            {
+                var groupBuilder = ArrayBuilder<ImportRecord>.GetInstance(importStringGroup.Length);
+                foreach (var importString in importStringGroup)
+                {
+                    ImportRecord record;
+                    if (NativeImportRecord.TryCreateFromCSharpImportString(importString, out record))
+                    {
+                        groupBuilder.Add(record);
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"Failed to parse import string {importString}");
+                    }
+                }
+                importRecordGroupBuilder.Add(groupBuilder.ToImmutableAndFree());
+            }
+
+            var externAliasRecordBuilder = ArrayBuilder<ExternAliasRecord>.GetInstance(externAliasStrings.Length);
+            foreach (string externAliasString in externAliasStrings)
+            {
+                string alias;
+                string externAlias;
+                string target;
+                ImportTargetKind kind;
+                if (!CustomDebugInfoReader.TryParseCSharpImportString(externAliasString, out alias, out externAlias, out target, out kind))
+                {
+                    Debug.WriteLine($"Unable to parse extern alias '{externAliasString}'");
+                    continue;
+                }
+
+                Debug.Assert(kind == ImportTargetKind.Assembly, "Programmer error: How did a non-assembly get in the extern alias list?");
+                Debug.Assert(alias != null); // Name of the extern alias.
+                Debug.Assert(externAlias == null); // Not used.
+                Debug.Assert(target != null); // Name of the target assembly.
+
+                AssemblyIdentity targetIdentity;
+                if (!AssemblyIdentity.TryParseDisplayName(target, out targetIdentity))
+                {
+                    Debug.WriteLine($"Unable to parse target of extern alias '{externAliasString}'");
+                    continue;
+                }
+
+                externAliasRecordBuilder.Add(new NativeExternAliasRecord<AssemblySymbol>(alias, targetIdentity));
+            }
+
+            return new MethodDebugInfo(
+                importRecordGroupBuilder.ToImmutableAndFree(),
+                externAliasRecordBuilder.ToImmutableAndFree(),
+                defaultNamespaceName: ""); // Unused in C#.
+        }
+
+        // TODO (acasey): overload for portable format (GH #702)
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -5832,7 +5832,7 @@ public class C
             var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
             Assert.True(result);
 
-            ISymUnmanagedReader symReader = new MockSymUnmanagedReader(ImmutableDictionary<int, MethodDebugInfo>.Empty);
+            ISymUnmanagedReader symReader = new MockSymUnmanagedReader(ImmutableDictionary<int, MethodDebugInfoBytes>.Empty);
 
             var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
             var evalContext = CreateMethodContext(runtime, "C.Main");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -274,11 +274,11 @@ namespace D
             const int methodToken3 = 0x6000540; // Has a using
             const string importString = "USystem";
 
-            ISymUnmanagedReader reader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+            ISymUnmanagedReader reader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
             {
-                { methodToken1, new MethodDebugInfo.Builder().AddForward(methodToken2).Build() },
-                { methodToken2, new MethodDebugInfo.Builder().AddForward(methodToken3).Build() },
-                { methodToken3, new MethodDebugInfo.Builder(new [] { new [] { importString } }).Build() },
+                { methodToken1, new MethodDebugInfoBytes.Builder().AddForward(methodToken2).Build() },
+                { methodToken2, new MethodDebugInfoBytes.Builder().AddForward(methodToken3).Build() },
+                { methodToken3, new MethodDebugInfoBytes.Builder(new [] { new [] { importString } }).Build() },
             }.ToImmutableDictionary());
 
             ImmutableArray<string> externAliasStrings;
@@ -301,9 +301,9 @@ namespace D
             const int methodVersion = 1;
             const int methodToken1 = 0x600057a; // Forwards to itself
 
-            ISymUnmanagedReader reader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+            ISymUnmanagedReader reader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
             {
-                { methodToken1, new MethodDebugInfo.Builder().AddForward(methodToken1).Build() },
+                { methodToken1, new MethodDebugInfoBytes.Builder().AddForward(methodToken1).Build() },
             }.ToImmutableDictionary());
 
             ImmutableArray<string> externAliasStrings;
@@ -411,9 +411,9 @@ public class C
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
                 var methodToken = metadataReader.GetToken(methodHandle);
 
-                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
                 {
-                    { methodToken, new MethodDebugInfo.Builder(new [] { new[] { "USystem", "USystem.IO" } }, suppressUsingInfo: true).AddUsingInfo(1, 1).Build() },
+                    { methodToken, new MethodDebugInfoBytes.Builder(new [] { new[] { "USystem", "USystem.IO" } }, suppressUsingInfo: true).AddUsingInfo(1, 1).Build() },
                 }.ToImmutableDictionary());
             }
 
@@ -456,9 +456,9 @@ namespace N
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
                 var methodToken = metadataReader.GetToken(methodHandle);
 
-                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
                 {
-                    { methodToken, new MethodDebugInfo.Builder(new [] { new[] { "USystem" } }, suppressUsingInfo: true).AddUsingInfo(1).Build() },
+                    { methodToken, new MethodDebugInfoBytes.Builder(new [] { new[] { "USystem" } }, suppressUsingInfo: true).AddUsingInfo(1).Build() },
                 }.ToImmutableDictionary());
             }
 
@@ -501,9 +501,9 @@ namespace N
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
                 var methodToken = metadataReader.GetToken(methodHandle);
 
-                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
                 {
-                    { methodToken, new MethodDebugInfo.Builder(new [] { new[] { "TSystem.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" } }, suppressUsingInfo: true).AddUsingInfo(1).Build() },
+                    { methodToken, new MethodDebugInfoBytes.Builder(new [] { new[] { "TSystem.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" } }, suppressUsingInfo: true).AddUsingInfo(1).Build() },
                 }.ToImmutableDictionary());
             }
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -39,6 +39,14 @@
     <Compile Include="FrameDecoder.cs" />
     <Compile Include="InstructionDecoder.cs" />
     <Compile Include="LanguageInstructionDecoder.cs" />
+    <Compile Include="PDB\ExternAliasRecord.cs" />
+    <Compile Include="PDB\MethodDebugInfo.cs" />
+    <Compile Include="PDB\ImportRecord.cs" />
+    <Compile Include="PDB\PdbHelpers.cs" />
+    <Compile Include="PDB\PortableImportRecord.cs" />
+    <Compile Include="PDB\NativeImportRecord.cs" />
+    <Compile Include="PDB\PortableExternAliasRecord.cs" />
+    <Compile Include="PDB\NativeExternAliasRecord.cs" />
     <Compile Include="ResultProperties.cs" />
     <Compile Include="ExpressionCompilerUtilities.cs" />
     <Compile Include="ExpressionEvaluatorFatalError.cs" />
@@ -54,7 +62,6 @@
     <Compile Include="MethodScope.cs" />
     <Compile Include="NamedLocalConstant.cs" />
     <Compile Include="PseudoVariableUtilities.cs" />
-    <Compile Include="PdbHelpers.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.VisualStudio.SymReaderInterop;
 
@@ -402,6 +403,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 default:
                     return false;
             }
+        }
+
+        internal static string GetUtf8String(this BlobHandle blobHandle, MetadataReader metadataReader)
+        {
+            return Encoding.UTF8.GetString(metadataReader.GetBlobBytes(blobHandle));
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/ExternAliasRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/ExternAliasRecord.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal abstract class ExternAliasRecord
+    {
+        public readonly string Alias;
+
+        public ExternAliasRecord(string alias)
+        {
+            Alias = alias;
+        }
+
+        /// <remarks>
+        /// <paramref name="assemblyIdentityComparer"/> is only here to make the call
+        /// pattern uniform - it's actually only used by one subtype.
+        /// </remarks>
+        public abstract int GetIndexOfTargetAssembly<TSymbol>(
+            ImmutableArray<TSymbol> assembliesAndModules, 
+            AssemblyIdentityComparer assemblyIdentityComparer)
+            where TSymbol : class, ISymbol;
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/ImportRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/ImportRecord.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.SymReaderInterop;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal abstract class ImportRecord
+    {
+        public abstract ImportTargetKind TargetKind { get; }
+        public abstract string Alias { get; }
+        public abstract string TargetString { get; }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal struct MethodDebugInfo
+    {
+        public readonly ImmutableArray<ImmutableArray<ImportRecord>> ImportRecordGroups;
+        public readonly ImmutableArray<ExternAliasRecord> ExternAliasRecords;
+        public readonly string DefaultNamespaceName;
+
+        public MethodDebugInfo(
+            ImmutableArray<ImmutableArray<ImportRecord>> importRecordGroups,
+            ImmutableArray<ExternAliasRecord> externAliasRecords,
+            string defaultNamespaceName)
+        {
+            Debug.Assert(!importRecordGroups.IsDefault);
+            Debug.Assert(!externAliasRecords.IsDefault);
+            Debug.Assert(defaultNamespaceName != null);
+
+            ImportRecordGroups = importRecordGroups;
+            ExternAliasRecords = externAliasRecords;
+            DefaultNamespaceName = defaultNamespaceName;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/NativeExternAliasRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/NativeExternAliasRecord.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class NativeExternAliasRecord<TAssemblySymbol> : ExternAliasRecord
+        where TAssemblySymbol : class, IAssemblySymbol
+    {
+        private readonly AssemblyIdentity _targetAssemblyIdentity;
+
+        public NativeExternAliasRecord(
+            string alias, 
+            AssemblyIdentity targetAssemblyIdentity)
+            : base(alias)
+        {
+            _targetAssemblyIdentity = targetAssemblyIdentity;
+        }
+
+        public override int GetIndexOfTargetAssembly<TSymbol>(
+            ImmutableArray<TSymbol> assembliesAndModules,
+            AssemblyIdentityComparer assemblyIdentityComparer)
+        {
+            for (int i = 0; i < assembliesAndModules.Length; i++)
+            {
+                var assembly = assembliesAndModules[i] as TAssemblySymbol;
+                if (assembly != null && assemblyIdentityComparer.ReferenceMatchesDefinition(_targetAssemblyIdentity, assembly.Identity))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/NativeImportRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/NativeImportRecord.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.SymReaderInterop;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class NativeImportRecord : ImportRecord
+    {
+        private readonly ImportTargetKind _targetKind;
+        private readonly string _externAlias;
+        private readonly string _alias;
+        private readonly string _targetString;
+
+        public override ImportTargetKind TargetKind => _targetKind;
+        public override string Alias => _alias;
+        public override string TargetString => _targetString;
+
+        public string ExternAlias => _externAlias;
+
+        private NativeImportRecord(
+            ImportTargetKind targetKind,
+            string externAlias,
+            string alias,
+            string targetString)
+        {
+            _targetKind = targetKind;
+            _externAlias = externAlias;
+            _alias = alias;
+            _targetString = targetString;
+        }
+
+        public static bool TryCreateFromCSharpImportString(string importString, out ImportRecord record)
+        {
+            ImportTargetKind targetKind;
+            string externAlias;
+            string alias;
+            string targetString;
+            if (CustomDebugInfoReader.TryParseCSharpImportString(importString, out alias, out externAlias, out targetString, out targetKind))
+            {
+                record = new NativeImportRecord(
+                    targetKind, 
+                    externAlias, 
+                    alias, 
+                    targetString);
+                return true;
+            }
+
+            record = default(ImportRecord);
+            return false;
+        }
+
+        public static bool TryCreateFromVisualBasicImportString(string importString, out ImportRecord record, out ImportScope scope)
+        {
+            ImportTargetKind targetKind;
+            string alias;
+            string targetString;
+            if (CustomDebugInfoReader.TryParseVisualBasicImportString(importString, out alias, out targetString, out targetKind, out scope))
+            {
+                record = new NativeImportRecord(
+                    targetKind, 
+                    externAlias: null, 
+                    alias: alias, 
+                    targetString: targetString);
+                return true;
+            }
+
+            record = default(ImportRecord);
+            return false;
+        }
+
+        public static ImportRecord CreateFromVisualBasicDteeNamespace(string namespaceName)
+        {
+            return new NativeImportRecord(
+                ImportTargetKind.Namespace,
+                externAlias: null,
+                alias: null,
+                targetString: namespaceName);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PdbHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PdbHelpers.cs
@@ -34,3 +34,4 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         }
     }
 }
+

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PortableExternAliasRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PortableExternAliasRecord.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class PortableExternAliasRecord<TModuleSymbol> : ExternAliasRecord
+        where TModuleSymbol : class, IModuleSymbol
+    {
+        private readonly TModuleSymbol _owningModule;
+        private readonly PEModule _owningPEModule;
+        private readonly AssemblyReferenceHandle _targetAssemblyHandle;
+
+        public PortableExternAliasRecord(
+            string alias,
+            TModuleSymbol owningModule,
+            PEModule owningPEModule,
+            AssemblyReferenceHandle targetAssemblyHandle)
+            : base(alias)
+        {
+            _owningModule = owningModule;
+            _owningPEModule = owningPEModule;
+            _targetAssemblyHandle = targetAssemblyHandle;
+        }
+
+        public override int GetIndexOfTargetAssembly<TSymbol>(
+            ImmutableArray<TSymbol> assembliesAndModules,
+            AssemblyIdentityComparer unused)
+        {
+            var index = _owningPEModule.GetAssemblyReferenceIndexOrThrow(_targetAssemblyHandle);
+            var referencedAssembly = _owningModule.ReferencedAssemblySymbols[index];
+            return assembliesAndModules.IndexOf((TSymbol)referencedAssembly);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PortableImportRecord.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/PortableImportRecord.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Reflection.Metadata;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.SymReaderInterop;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class PortableImportRecord : ImportRecord
+    {
+        private readonly ImportTargetKind _targetKind;
+        private readonly string _alias;
+        private readonly AssemblyReferenceHandle _targetAssemblyHandle;
+        private readonly Handle _targetTypeHandle;
+        private readonly string _targetNamespaceName;
+
+        public override ImportTargetKind TargetKind => _targetKind;
+        public override string Alias => _alias;
+        public override string TargetString => _targetNamespaceName;
+
+        private PortableImportRecord(
+            ImportTargetKind targetKind,
+            string alias,
+            AssemblyReferenceHandle targetAssemblyHandle,
+            Handle targetTypeHandle,
+            string targetNamespaceName)
+        {
+            _targetKind = targetKind;
+            _alias = alias;
+            _targetAssemblyHandle = targetAssemblyHandle;
+            _targetTypeHandle = targetTypeHandle;
+            _targetNamespaceName = targetNamespaceName;
+        }
+
+        // TODO (acasey): Uncomment when ImportDefinition is available in this branch. (GH #702)
+        //public static bool TryCreateFromImportDefinition(
+        //    ImportDefinition importDefinition,
+        //    MetadataReader metadataReader,
+        //    out PortableImportRecord record)
+        //{
+        //    record = null;
+
+        //    var targetAssemblyHandle = importDefinition.TargetAssembly;
+        //    var alias = importDefinition.Alias.GetUtf8String(metadataReader);
+
+        //    var targetHandle = importDefinition.TargetType;
+
+        //    Handle targetTypeHandle;
+        //    string targetNamespaceName;
+        //    if (targetHandle.Kind == HandleKind.Blob)
+        //    {
+        //        targetTypeHandle = default(Handle);
+        //        targetNamespaceName = ((BlobHandle)importDefinition.TargetType).GetUtf8String(metadataReader);
+        //    }
+        //    else
+        //    {
+        //        targetTypeHandle = targetHandle;
+        //        targetNamespaceName = null;
+        //    }
+
+        //    ImportTargetKind targetKind;
+        //    switch (importDefinition.Kind)
+        //    {
+        //        case ImportDefinitionKind.ImportNamespace:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias == null &&
+        //                targetNamespaceName != null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Namespace;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.AliasNamespace:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias != null &&
+        //                targetNamespaceName != null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Namespace;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.ImportAssemblyNamespace:
+        //            if (!targetAssemblyHandle.IsNil &&
+        //                alias == null &&
+        //                targetNamespaceName != null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Namespace;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.AliasAssemblyNamespace:
+        //            if (!targetAssemblyHandle.IsNil &&
+        //                alias != null &&
+        //                targetNamespaceName != null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Namespace;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.ImportType:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias == null &&
+        //                targetNamespaceName == null &&
+        //                !targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Type;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.AliasType:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias != null &&
+        //                targetNamespaceName == null &&
+        //                !targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Type;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.ImportXmlNamespace:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias != null && // Always non-null, possibly empty.
+        //                targetNamespaceName != null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.XmlNamespace;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.ImportAssemblyReferenceAlias:
+        //            if (targetAssemblyHandle.IsNil &&
+        //                alias != null &&
+        //                targetNamespaceName == null &&
+        //                targetTypeHandle.IsNil)
+        //            {
+        //                targetKind = ImportTargetKind.Assembly;
+        //                break;
+        //            }
+        //            return false;
+        //        case ImportDefinitionKind.AliasAssemblyReference:
+        //            // Should have created an ExternAliasRecord for this.
+        //        default:
+        //            throw ExceptionUtilities.UnexpectedValue(importDefinition.Kind);
+        //    }
+
+        //    record = new PortableImportRecord(
+        //        targetKind,
+        //        alias,
+        //        targetAssemblyHandle,
+        //        targetTypeHandle,
+        //        targetNamespaceName);
+        //    return true;
+        //}
+
+        public TTypeSymbol GetTargetType<TModuleSymbol, TTypeSymbol, TMethodSymbol, TFieldSymbol, TSymbol>(
+            MetadataDecoder<TModuleSymbol, TTypeSymbol, TMethodSymbol, TFieldSymbol, TSymbol> metadataDecoder)
+            where TModuleSymbol : class, IModuleSymbol
+            where TTypeSymbol : class, TSymbol, ITypeSymbol
+            where TMethodSymbol : class, TSymbol, IMethodSymbol
+            where TFieldSymbol : class, TSymbol, IFieldSymbol
+            where TSymbol : class, ISymbol
+        {
+            return _targetTypeHandle.IsNil
+                ? null
+                : metadataDecoder.GetTypeOfToken(_targetTypeHandle);
+        }
+
+        public TAssemblySymbol GetTargetAssembly<TModuleSymbol, TAssemblySymbol>(
+            TModuleSymbol module,
+            PEModule peModule)
+            where TModuleSymbol : class, IModuleSymbol
+            where TAssemblySymbol : class, IAssemblySymbol
+        {
+            if (_targetAssemblyHandle.IsNil)
+            {
+                return null;
+            }
+
+            var index = peModule.GetAssemblyReferenceIndexOrThrow(_targetAssemblyHandle);
+            var referencedAssembly = module.ReferencedAssemblySymbols[index];
+            return (TAssemblySymbol)referencedAssembly;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -341,9 +341,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, methodName));
                 var methodToken = metadataReader.GetToken(methodHandle);
 
-                return new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfo>
+                return new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
                 {
-                    { methodToken, new MethodDebugInfo.Builder(new [] { importStrings }).Build() },
+                    { methodToken, new MethodDebugInfoBytes.Builder(new [] { importStrings }).Build() },
                 }.ToImmutableDictionary());
             }
         }

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
@@ -8,20 +8,20 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal sealed class MethodDebugInfo
+    internal sealed class MethodDebugInfoBytes
     {
         public readonly ImmutableArray<byte> Bytes;
         public readonly ISymUnmanagedMethod Method;
 
-        public MethodDebugInfo(ImmutableArray<byte> bytes, ISymUnmanagedMethod method)
+        public MethodDebugInfoBytes(ImmutableArray<byte> bytes, ISymUnmanagedMethod method)
         {
             this.Bytes = bytes;
             this.Method = method;
         }
 
         /// <remarks>
-        /// This is a helper class for creating mostly-correct <see cref="MethodDebugInfo"/> objects (e.g. circular forwards, extra records, etc).
-        /// To create totally broken objects (e.g. corrupted bytes, alternate scope structures, etc), construct <see cref="MethodDebugInfo"/> objects directly.
+        /// This is a helper class for creating mostly-correct <see cref="MethodDebugInfoBytes"/> objects (e.g. circular forwards, extra records, etc).
+        /// To create totally broken objects (e.g. corrupted bytes, alternate scope structures, etc), construct <see cref="MethodDebugInfoBytes"/> objects directly.
         /// </remarks>
         internal sealed class Builder
         {
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return this;
             }
 
-            public MethodDebugInfo Build()
+            public MethodDebugInfoBytes Build()
             {
                 // Global header
                 _bytesBuilder.Insert(0, Version);
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 Assert.Equal(0, _bytesBuilder.Count % 4);
 
-                var info = new MethodDebugInfo(_bytesBuilder.ToImmutableAndFree(), _method);
+                var info = new MethodDebugInfoBytes(_bytesBuilder.ToImmutableAndFree(), _method);
                 _bytesBuilder = null; // We'll blow up if any other methods are called.
                 return info;
             }

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
@@ -11,9 +11,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
     internal sealed class MockSymUnmanagedReader : ISymUnmanagedReader
     {
-        private readonly ImmutableDictionary<int, MethodDebugInfo> _methodDebugInfoMap;
+        private readonly ImmutableDictionary<int, MethodDebugInfoBytes> _methodDebugInfoMap;
 
-        public MockSymUnmanagedReader(ImmutableDictionary<int, MethodDebugInfo> methodDebugInfoMap)
+        public MockSymUnmanagedReader(ImmutableDictionary<int, MethodDebugInfoBytes> methodDebugInfoMap)
         {
             _methodDebugInfoMap = methodDebugInfoMap;
         }
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             Assert.Equal("MD2", name);
 
-            MethodDebugInfo info;
+            MethodDebugInfoBytes info;
             if (!_methodDebugInfoMap.TryGetValue(token.GetToken(), out info))
             {
                 bytesRead = 0;
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             Assert.Equal(1, version);
 
-            MethodDebugInfo info;
+            MethodDebugInfoBytes info;
             if (!_methodDebugInfoMap.TryGetValue(methodToken.GetToken(), out info))
             {
                 retVal = null;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -74,6 +74,7 @@
     <Compile Include="CompilationContext.vb" />
     <Compile Include="CompilationExtensions.vb" />
     <Compile Include="EETypeNameDecoder.vb" />
+    <Compile Include="SymUnmanagedReaderExtensions.vb" />
     <Compile Include="InternalsVisibleTo.vb" />
     <Compile Include="EEAssemblyBuilder.vb" />
     <Compile Include="EvaluationContext.vb" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -40,7 +40,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         ''' <summary>
         ''' Create a context to compile expressions within a method scope.
-        ''' Include imports if <paramref name="importStrings"/> is set.
         ''' </summary>
         Friend Sub New(
             compilation As VisualBasicCompilation,
@@ -48,26 +47,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             currentFrame As MethodSymbol,
             locals As ImmutableArray(Of LocalSymbol),
             hoistedLocalFieldNames As ImmutableHashSet(Of String),
-            importStrings As ImmutableArray(Of String),
+            methodDebugInfo As MethodDebugInfo,
             syntax As ExecutableStatementSyntax)
 
             _syntax = syntax
             _currentFrame = currentFrame
 
             Debug.Assert(compilation.Options.RootNamespace = "") ' Default value.
-
-            Dim defaultNamespaceName As String = GetDefaultNamespaceName(importStrings)
+            Debug.Assert(methodDebugInfo.ExternAliasRecords.IsDefaultOrEmpty)
 
             Dim originalCompilation = compilation
+
             If syntax IsNot Nothing Then
                 compilation = compilation.AddSyntaxTrees(syntax.SyntaxTree)
             End If
+
+            Dim defaultNamespaceName As String = methodDebugInfo.DefaultNamespaceName
             If defaultNamespaceName IsNot Nothing Then
                 compilation = compilation.WithOptions(compilation.Options.WithRootNamespace(defaultNamespaceName))
             End If
+
             If compilation Is originalCompilation Then
                 compilation = compilation.Clone()
             End If
+
             Me.Compilation = compilation
 
             ' Each expression compile should use a unique compilation
@@ -79,8 +82,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             NamespaceBinder = CreateBinderChain(
                 Me.Compilation,
+                metadataDecoder,
                 currentFrame.ContainingNamespace,
-                importStrings)
+                methodDebugInfo.ImportRecordGroups)
 
             _voidType = Me.Compilation.GetSpecialType(SpecialType.System_Void)
 
@@ -482,16 +486,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Shared Function CreateBinderChain(
             compilation As VisualBasicCompilation,
+            metadataDecoder As MetadataDecoder,
             [namespace] As NamespaceSymbol,
-            importStrings As ImmutableArray(Of String)) As Binder
+            importRecordGroups As ImmutableArray(Of ImmutableArray(Of ImportRecord))) As Binder
 
             Dim binder = BackstopBinder
             binder = New SuppressObsoleteDiagnosticsBinder(binder)
             binder = New IgnoreAccessibilityBinder(binder)
             binder = New SourceModuleBinder(binder, DirectCast(compilation.Assembly.Modules(0), SourceModuleSymbol))
 
-            If Not importStrings.IsDefault Then
-                binder = BuildImportedSymbolsBinder(binder, importStrings, New NamespaceBinder(binder, compilation.GlobalNamespace))
+            If Not importRecordGroups.IsDefault Then
+                binder = BuildImportedSymbolsBinder(binder, New NamespaceBinder(binder, compilation.GlobalNamespace), metadataDecoder, importRecordGroups)
             End If
 
             Dim stack = ArrayBuilder(Of String).GetInstance()
@@ -573,8 +578,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Shared Function BuildImportedSymbolsBinder(
             containingBinder As Binder,
-            importStrings As ImmutableArray(Of String),
-            importBinder As Binder) As Binder
+            importBinder As Binder,
+            metadataDecoder As MetadataDecoder,
+            importRecordGroups As ImmutableArray(Of ImmutableArray(Of ImportRecord))) As Binder
 
             Dim projectLevelImportsBuilder As ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition) = Nothing
             Dim fileLevelImportsBuilder As ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition) = Nothing
@@ -585,121 +591,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim projectLevelXmlImports As Dictionary(Of String, XmlNamespaceAndImportsClausePosition) = Nothing
             Dim fileLevelXmlImports As Dictionary(Of String, XmlNamespaceAndImportsClausePosition) = Nothing
 
+            Debug.Assert(importRecordGroups.Length = 2) ' First project-level, then file-level.
+            Dim projectLevelImportRecords = importRecordGroups(0)
+            Dim fileLevelImportRecords = importRecordGroups(1)
+
             ' Use this to give the imports different positions
             Dim position = 0
-            For Each importString As String In importStrings
-                Debug.Assert(importString IsNot Nothing)
 
-                Dim [alias] As String = Nothing
-                Dim target As String = Nothing
-                Dim kind As ImportTargetKind = Nothing
-                Dim scope As ImportScope = Nothing
-                If Not CustomDebugInfoReader.TryParseVisualBasicImportString(importString, [alias], target, kind, scope) Then
-                    Debug.WriteLine("Unable to parse import string '{0}'", importString)
-                    Continue For
-                ElseIf kind = ImportTargetKind.Defunct Then
-                    Continue For
+            For Each importRecord As ImportRecord In projectLevelImportRecords
+                If AddImportForRecord(
+                    importRecord,
+                    importBinder,
+                    metadataDecoder,
+                    position,
+                    projectLevelImportsBuilder,
+                    projectLevelAliases,
+                    projectLevelXmlImports) Then
+
+                    position += 1
                 End If
+            Next
 
-                ' NB: It appears that imports of generic types are not included in the PDB, so we never have to worry about parsing them.
-                ' NB: Unlike in C# PDBs, the assembly name will not be present, so we have to just bind the string.
-                Dim targetSyntax As NameSyntax = Nothing
-                If Not String.IsNullOrEmpty(target) AndAlso ' CurrentNamespace may be an empty string.
-                    kind <> ImportTargetKind.XmlNamespace AndAlso
-                    Not TryParseDottedName(target, targetSyntax) Then
+            For Each importRecord As ImportRecord In fileLevelImportRecords
+                If AddImportForRecord(
+                    importRecord,
+                    importBinder,
+                    metadataDecoder,
+                    position,
+                    fileLevelImportsBuilder,
+                    fileLevelAliases,
+                    fileLevelXmlImports) Then
 
-                    Debug.WriteLine("Import string '{0}' has syntactically invalid target '{1}'", importString, target)
-                    Continue For
+                    position += 1
                 End If
-
-                Dim aliasSyntax As IdentifierNameSyntax = Nothing
-                If Not String.IsNullOrEmpty([alias]) Then
-                    Dim aliasNameSyntax As NameSyntax = Nothing
-                    If Not TryParseDottedName([alias], aliasNameSyntax) OrElse aliasNameSyntax.Kind <> SyntaxKind.IdentifierName Then
-                        Debug.WriteLine("Import string '{0}' has syntactically invalid alias '{1}'", importString, [alias])
-                        Continue For
-                    Else
-                        aliasSyntax = DirectCast(aliasNameSyntax, IdentifierNameSyntax)
-                    End If
-                End If
-
-                Select Case kind
-                    ' Dev12 treats the current namespace the same as any other namespace (see ProcedureContext::LoadImportsAndDefaultNamespaceNormal).
-                    ' It seems pointless to add an import for the namespace in which we are binding expressions, but the native source gives
-                    ' the impression that other namespaces may take the same form in Everett PDBs.
-                    Case ImportTargetKind.CurrentNamespace, ImportTargetKind.Namespace, ImportTargetKind.Type ' Unaliased namespace or type
-                        Debug.Assert([alias] Is Nothing) ' Aliased types and namespaces are handled by ImportTargetKind.NamespaceOrType
-                        Debug.Assert(target IsNot Nothing)
-
-                        If target = "" Then
-                            Debug.Assert(kind = ImportTargetKind.CurrentNamespace) ' The current namespace can be empty.
-                            Continue For
-                        End If
-
-                        Debug.Assert(targetSyntax IsNot Nothing)
-
-                        Dim unusedDiagnostics = DiagnosticBag.GetInstance()
-                        Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
-                        unusedDiagnostics.Free()
-
-                        Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
-
-                        If namespaceOrTypeSymbol.Kind = SymbolKind.ErrorType Then
-                            ' Type is unrecognized.  The import may have been
-                            ' valid in the original source but unnecessary.
-                            Continue For ' Don't add anything for this import.
-                        End If
-
-                        Dim selectedImportsBuilder = SelectAndInitializeCollection(scope, projectLevelImportsBuilder, fileLevelImportsBuilder, Function() ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition).GetInstance())
-
-                        ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
-                        selectedImportsBuilder.Add(New NamespaceOrTypeAndImportsClausePosition(namespaceOrTypeSymbol, position))
-                    Case ImportTargetKind.NamespaceOrType ' Unaliased namespace or type
-                        Debug.Assert([alias] IsNot Nothing)
-                        Debug.Assert(target IsNot Nothing)
-                        Debug.Assert(targetSyntax IsNot Nothing)
-
-                        Dim unusedDiagnostics = DiagnosticBag.GetInstance()
-                        Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
-                        unusedDiagnostics.Free()
-
-                        Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
-
-                        If namespaceOrTypeSymbol.Kind = SymbolKind.ErrorType Then
-                            ' Type is unrecognized.  The import may have been
-                            ' valid in the original source but unnecessary.
-                            Continue For ' Don't add anything for this import.
-                        End If
-
-                        Dim aliasSymbol As New AliasSymbol(importBinder.Compilation, importBinder.ContainingNamespaceOrType, [alias], namespaceOrTypeSymbol, NoLocation.Singleton)
-
-                        Dim selectedAliases = SelectAndInitializeCollection(scope, projectLevelAliases, fileLevelAliases, Function() New Dictionary(Of String, AliasAndImportsClausePosition))
-
-                        ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
-                        selectedAliases([alias]) = New AliasAndImportsClausePosition(aliasSymbol, position)
-                    Case ImportTargetKind.XmlNamespace
-                        Debug.Assert(target IsNot Nothing)
-
-                        Dim selectedXmlImports = SelectAndInitializeCollection(scope, projectLevelXmlImports, fileLevelXmlImports, Function() New Dictionary(Of String, XmlNamespaceAndImportsClausePosition))
-
-                        ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
-                        selectedXmlImports([alias]) = New XmlNamespaceAndImportsClausePosition(target, position)
-                    Case ImportTargetKind.DefaultNamespace
-                        ' Processed ahead of time so that it can be incorporated into the compilation before
-                        ' constructing the binder chain.
-                        Continue For
-                    Case ImportTargetKind.MethodToken ' forwarding
-                        ' One level of forwarding is pre-processed away, but invalid PDBs might contain
-                        ' chains.  Just ignore them (as in Dev12).
-                        Continue For
-                    Case ImportTargetKind.Assembly
-                        ' VB doesn't have extern aliases.
-                        Throw ExceptionUtilities.UnexpectedValue(kind)
-                    Case Else
-                        Throw ExceptionUtilities.UnexpectedValue(kind)
-                End Select
-
-                position += 1
             Next
 
             ' BinderBuilder.CreateBinderForSourceFile creates separate binders for the project- and file-level
@@ -736,6 +660,158 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
 
             Return binder
+        End Function
+
+        Private Shared Function AddImportForRecord(
+            importRecord As ImportRecord,
+            importBinder As Binder,
+            metadataDecoder As MetadataDecoder,
+            position As Integer,
+            ByRef importsBuilder As ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition),
+            ByRef aliases As Dictionary(Of String, AliasAndImportsClausePosition),
+            ByRef xmlImports As Dictionary(Of String, XmlNamespaceAndImportsClausePosition)) As Boolean
+
+            Dim targetString = importRecord.TargetString
+
+            ' NB: It appears that imports of generic types are not included in the PDB, so we never have to worry about parsing them.
+            ' NB: Unlike in C# PDBs, the assembly name will not be present, so we have to just bind the string.
+            Dim targetSyntax As NameSyntax = Nothing
+            If Not String.IsNullOrEmpty(targetString) AndAlso ' CurrentNamespace may be an empty string, new-format types may be null.
+                    importRecord.TargetKind <> ImportTargetKind.XmlNamespace AndAlso
+                    Not TryParseDottedName(targetString, targetSyntax) Then
+
+                Debug.WriteLine($"Import record '{importRecord}' has syntactically invalid target '{targetString}'")
+                Return False
+            End If
+
+            ' Check for syntactically invalid aliases.
+            Dim [alias] = importRecord.Alias
+            If Not String.IsNullOrEmpty([alias]) Then
+                Dim aliasNameSyntax As NameSyntax = Nothing
+                If Not TryParseDottedName([alias], aliasNameSyntax) OrElse aliasNameSyntax.Kind <> SyntaxKind.IdentifierName Then
+                    Debug.WriteLine($"Import record '{importRecord}' has syntactically invalid alias '{[alias]}'")
+                    Return False
+                End If
+            End If
+
+            Select Case importRecord.TargetKind
+                Case ImportTargetKind.Type
+                    Dim typeSymbol As TypeSymbol
+                    Dim portableImportRecord = TryCast(importRecord, PortableImportRecord)
+                    If portableImportRecord IsNot Nothing Then
+                        typeSymbol = portableImportRecord.GetTargetType(metadataDecoder)
+                        Debug.Assert(typeSymbol IsNot Nothing)
+                    Else
+                        Debug.Assert(importRecord.Alias Is Nothing) ' Represented as ImportTargetKind.NamespaceOrType in old-format PDBs.
+
+                        Dim unusedDiagnostics = DiagnosticBag.GetInstance()
+                        typeSymbol = importBinder.BindTypeSyntax(targetSyntax, unusedDiagnostics)
+                        unusedDiagnostics.Free()
+
+                        Debug.Assert(typeSymbol IsNot Nothing)
+
+                        If typeSymbol.Kind = SymbolKind.ErrorType Then
+                            ' Type is unrecognized.  The import may have been
+                            ' valid in the original source but unnecessary.
+                            Return False ' Don't add anything for this import.
+                        End If
+                    End If
+
+                    If [alias] IsNot Nothing Then
+                        Dim aliasSymbol As New AliasSymbol(importBinder.Compilation, importBinder.ContainingNamespaceOrType, [alias], typeSymbol, NoLocation.Singleton)
+
+                        If aliases Is Nothing Then
+                            aliases = New Dictionary(Of String, AliasAndImportsClausePosition)()
+                        End If
+
+                        ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
+                        aliases([alias]) = New AliasAndImportsClausePosition(aliasSymbol, position)
+                    Else
+                        If importsBuilder Is Nothing Then
+                            importsBuilder = ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition).GetInstance()
+                        End If
+
+                        ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
+                        importsBuilder.Add(New NamespaceOrTypeAndImportsClausePosition(typeSymbol, position))
+                    End If
+
+                ' Dev12 treats the current namespace the same as any other namespace (see ProcedureContext::LoadImportsAndDefaultNamespaceNormal).
+                ' It seems pointless to add an import for the namespace in which we are binding expressions, but the native source gives
+                ' the impression that other namespaces may take the same form in Everett PDBs.
+                Case ImportTargetKind.CurrentNamespace, ImportTargetKind.Namespace ' Unaliased namespace or type
+                    If targetString = "" Then
+                        Debug.Assert(importRecord.TargetKind = ImportTargetKind.CurrentNamespace) ' The current namespace can be empty.
+                        Return False
+                    End If
+
+                    Dim unusedDiagnostics = DiagnosticBag.GetInstance()
+                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
+                    unusedDiagnostics.Free()
+
+                    Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
+
+                    If namespaceOrTypeSymbol.Kind = SymbolKind.ErrorType Then
+                        ' Namespace is unrecognized.  The import may have been
+                        ' valid in the original source but unnecessary.
+                        Return False ' Don't add anything for this import.
+                    End If
+
+                    If importsBuilder Is Nothing Then
+                        importsBuilder = ArrayBuilder(Of NamespaceOrTypeAndImportsClausePosition).GetInstance()
+                    End If
+
+                    ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
+                    importsBuilder.Add(New NamespaceOrTypeAndImportsClausePosition(namespaceOrTypeSymbol, position))
+                Case ImportTargetKind.NamespaceOrType ' Aliased namespace or type
+                    Debug.Assert(TypeOf importRecord Is NativeImportRecord) ' Only happens when reading old-format PDBs
+
+                    Dim unusedDiagnostics = DiagnosticBag.GetInstance()
+                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
+                    unusedDiagnostics.Free()
+
+                    Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
+
+                    If namespaceOrTypeSymbol.Kind = SymbolKind.ErrorType Then
+                        ' Type is unrecognized.  The import may have been
+                        ' valid in the original source but unnecessary.
+                        Return False ' Don't add anything for this import.
+                    End If
+
+                    Debug.Assert([alias] IsNot Nothing) ' Implied by TargetKind
+
+                    Dim aliasSymbol As New AliasSymbol(importBinder.Compilation, importBinder.ContainingNamespaceOrType, [alias], namespaceOrTypeSymbol, NoLocation.Singleton)
+
+                    If aliases Is Nothing Then
+                        aliases = New Dictionary(Of String, AliasAndImportsClausePosition)()
+                    End If
+
+                    ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
+                    aliases([alias]) = New AliasAndImportsClausePosition(aliasSymbol, position)
+                Case ImportTargetKind.XmlNamespace
+                    If xmlImports Is Nothing Then
+                        xmlImports = New Dictionary(Of String, XmlNamespaceAndImportsClausePosition)()
+                    End If
+
+                    ' There's no real syntax, so there's no real position.  We'll give them separate numbers though.
+                    xmlImports(importRecord.Alias) = New XmlNamespaceAndImportsClausePosition(importRecord.TargetString, position)
+                Case ImportTargetKind.DefaultNamespace
+                    ' Processed ahead of time so that it can be incorporated into the compilation before
+                    ' constructing the binder chain.
+                    Return False
+                Case ImportTargetKind.MethodToken ' forwarding
+                    ' One level of forwarding is pre-processed away, but invalid PDBs might contain
+                    ' chains.  Just ignore them (as in Dev12).
+                    Return False
+                Case ImportTargetKind.Defunct
+                    Return False
+                Case ImportTargetKind.Assembly
+                    ' VB doesn't have extern aliases.
+                    Throw ExceptionUtilities.UnexpectedValue(importRecord.TargetKind)
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(importRecord.TargetKind)
+            End Select
+
+            Return True
         End Function
 
         Private Shared Function MergeAliases(Of T)(projectLevel As Dictionary(Of String, T), fileLevel As Dictionary(Of String, T)) As Dictionary(Of String, T)
@@ -783,7 +859,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' We don't want to use the real scanner because we want to treat keywords as identifiers.
         ''' Since the inputs are so simple, we'll just do the scanning ourselves.
         ''' </summary>
-        Private Shared Function TryParseDottedName(input As String, <Out> ByRef output As NameSyntax) As Boolean
+        Friend Shared Function TryParseDottedName(input As String, <Out> ByRef output As NameSyntax) As Boolean
             Dim pooled = PooledStringBuilder.GetInstance()
             Try
                 Dim builder = pooled.Builder
@@ -829,46 +905,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Finally
                 pooled.Free()
             End Try
-        End Function
-
-        Private Shared Function GetDefaultNamespaceName(importStrings As ImmutableArray(Of String)) As String
-            Dim defaultNamespaceName As String = Nothing
-            If Not importStrings.IsDefault Then
-                For Each importString As String In importStrings
-                    Debug.Assert(importString IsNot Nothing)
-                    If importString.Length > 0 AndAlso importString(0) = "*"c Then
-                        Dim [alias] As String = Nothing
-                        Dim target As String = Nothing
-                        Dim kind As ImportTargetKind = Nothing
-                        Dim scope As ImportScope = Nothing
-                        If Not CustomDebugInfoReader.TryParseVisualBasicImportString(importString, [alias], target, kind, scope) Then
-                            Debug.WriteLine("Unable to parse import string '{0}'", importString)
-                            Continue For
-                        ElseIf kind = ImportTargetKind.Defunct
-                            Continue For
-                        End If
-
-                        Debug.Assert([alias] Is Nothing) ' The default namespace is never aliased.
-                        Debug.Assert(target IsNot Nothing)
-                        Debug.Assert(kind = ImportTargetKind.DefaultNamespace)
-
-                        ' We only expect to see one of these, but it looks like ProcedureContext::LoadImportsAndDefaultNamespaceNormal
-                        ' implicitly uses the last one if there are multiple.
-                        Debug.Assert(defaultNamespaceName Is Nothing)
-
-                        defaultNamespaceName = target
-                    End If
-                Next
-            End If
-
-            ' Note: We don't need to try to bind this string because this is analogous to passing
-            ' a command-line argument - as long as the syntax is valid, an appropriate symbol will
-            ' be created for us.
-            If String.IsNullOrEmpty(defaultNamespaceName) OrElse Not TryParseDottedName(defaultNamespaceName, Nothing) Then
-                Return ""
-            Else
-                Return defaultNamespaceName
-            End If
         End Function
 
         Friend ReadOnly Property MessageProvider As CommonMessageProvider

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private ReadOnly _currentFrame As MethodSymbol
         Private ReadOnly _locals As ImmutableArray(Of LocalSymbol)
         Private ReadOnly _hoistedLocalFieldNames As ImmutableHashSet(Of String)
-        Private ReadOnly _importStrings As ImmutableArray(Of String)
+        Private ReadOnly _methodDebugInfo As MethodDebugInfo
 
         Private Sub New(
             metadataBlocks As ImmutableArray(Of MetadataBlock),
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             currentFrame As MethodSymbol,
             locals As ImmutableArray(Of LocalSymbol),
             hoistedLocalFieldNames As ImmutableHashSet(Of String),
-            importStrings As ImmutableArray(Of String))
+            methodDebugInfo As MethodDebugInfo)
 
             Me.MetadataBlocks = metadataBlocks
             Me.MethodScope = methodScope
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             _currentFrame = currentFrame
             _locals = locals
             _hoistedLocalFieldNames = hoistedLocalFieldNames
-            _importStrings = importStrings
+            _methodDebugInfo = methodDebugInfo
         End Sub
 
         ''' <summary>
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 currentFrame,
                 locals:=Nothing,
                 hoistedLocalFieldNames:=Nothing,
-                importStrings:=Nothing)
+                methodDebugInfo:=Nothing)
         End Function
 
         ''' <summary>
@@ -155,13 +155,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             scopes.Free()
             Dim locals = localBuilder.ToImmutableAndFree()
 
-            Dim importStrings As ImmutableArray(Of String)
+            Dim methodDebugInfo As MethodDebugInfo
             If IsDteeEntryPoint(currentFrame) Then
-                importStrings = SynthesizeImportStringsForDtee(lazyAssemblyReaders.Value)
+                methodDebugInfo = SynthesizeMethodDebugInfoForDtee(lazyAssemblyReaders.Value)
             ElseIf typedSymReader IsNot Nothing Then
-                importStrings = CustomDebugInfoReader.GetVisualBasicImportStrings(typedSymReader, methodToken, methodVersion)
+                ' TODO (acasey): Switch on the type of typedSymReader and call the appropriate helper. (GH #702)
+                methodDebugInfo = typedSymReader.GetMethodDebugInfo(methodToken, methodVersion)
             Else
-                importStrings = Nothing
+                methodDebugInfo = Nothing
             End If
 
             Return New EvaluationContext(
@@ -172,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 currentFrame,
                 locals,
                 hoistedLocalFieldNames,
-                importStrings)
+                methodDebugInfo)
         End Function
 
         Private Shared Function GetLocalNames(scopes As ArrayBuilder(Of ISymUnmanagedScope), <Out> ByRef hoistedLocalFieldNames As ImmutableHashSet(Of String)) As ImmutableArray(Of String)
@@ -201,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' Logic copied from ProcedureContext::IsDteeEntryPoint.
         ''' Friend for testing.
         ''' </remarks>
-        ''' <seealso cref="SynthesizeImportStringsForDtee"/>
+        ''' <seealso cref="SynthesizeMethodDebugInfoForDtee"/>
         Friend Shared Function IsDteeEntryPoint(currentFrame As MethodSymbol) As Boolean
             Dim typeName = currentFrame.ContainingType.Name
             Dim methodName = currentFrame.Name
@@ -228,7 +229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' </remarks>
         ''' <seealso cref="IsDteeEntryPoint"/>
         ''' <seealso cref="PENamedTypeSymbol.TypeKind"/>
-        Friend Shared Function SynthesizeImportStringsForDtee(assemblyReaders As ImmutableArray(Of AssemblyReaders)) As ImmutableArray(Of String)
+        Friend Shared Function SynthesizeMethodDebugInfoForDtee(assemblyReaders As ImmutableArray(Of AssemblyReaders)) As MethodDebugInfo
             Dim [imports] = PooledHashSet(Of String).GetInstance()
 
             For Each readers In assemblyReaders
@@ -250,35 +251,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             PEModule.FindTargetAttribute(metadataReader, typeDefHandle, AttributeDescription.StandardModuleAttribute).HasValue Then
 
                             Dim namespaceName = metadataReader.GetString(typeDef.Namespace)
-                            [imports].Add("@P:" & namespaceName)
+                            [imports].Add(namespaceName)
                         End If
                     Next
 
                     For Each methodDefHandle In metadataReader.MethodDefinitions
                         ' EnC can't change the default namespace of the assembly, so version 1 will suffice.
-                        Dim importStrings = CustomDebugInfoReader.GetVisualBasicImportStrings(
-                            symReader,
-                            metadataReader.GetToken(methodDefHandle),
-                            methodVersion:=1)
+                        Dim methodDefaultNamespaceName = symReader.GetMethodDebugInfo(metadataReader.GetToken(methodDefHandle), methodVersion:=1).DefaultNamespaceName
 
                         ' Some methods aren't decorated with import custom debug info.
-                        If importStrings.Any() Then
-                            For Each importString In importStrings
-                                Dim [alias] As String = Nothing
-                                Dim target As String = Nothing
-                                Dim kind As ImportTargetKind = Nothing
-                                Dim scope As ImportScope = Nothing
-                                If CustomDebugInfoReader.TryParseVisualBasicImportString(importString, [alias], target, kind, scope) AndAlso kind = ImportTargetKind.DefaultNamespace Then
-                                    Debug.Assert([alias] Is Nothing)
-                                    Debug.Assert(target IsNot Nothing)
+                        If Not String.IsNullOrEmpty(methodDefaultNamespaceName) Then
 
-                                    ' NOTE: We're adding it as a project-level import, not as the default namespace
-                                    ' (because there's one for each assembly and they can't all be the default).
-                                    [imports].Add("@P:" & target)
-
-                                    Exit For
-                                End If
-                            Next
+                            ' NOTE: We're adding it as a project-level import, not as the default namespace
+                            ' (because there's one for each assembly and they can't all be the default).
+                            [imports].Add(methodDefaultNamespaceName)
 
                             ' The default namespace should be the same for all methods, so we only need to check one.
                             Exit For
@@ -291,13 +277,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End Try
             Next
 
-            ' add empty default namespace:
-            Dim added = [imports].Add("*")
-            Debug.Assert(added) ' All other imports were project-level, so a conflict should be impossible.
-
-            Dim result = ImmutableArray.CreateRange([imports])
+            Dim projectLevelImportRecords = ImmutableArray.CreateRange([imports].Select(AddressOf NativeImportRecord.CreateFromVisualBasicDteeNamespace))
             [imports].Free()
-            Return result
+            Dim fileLevelImportRecords = ImmutableArray(Of ImportRecord).Empty
+
+            Dim importRecordGroups = ImmutableArray.Create(projectLevelImportRecords, fileLevelImportRecords)
+
+            Return New MethodDebugInfo(importRecordGroups, ImmutableArray(Of ExternAliasRecord).Empty, defaultNamespaceName:="")
         End Function
 
         Friend Function CreateCompilationContext(syntax As ExecutableStatementSyntax) As CompilationContext
@@ -307,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 _currentFrame,
                 _locals,
                 _hoistedLocalFieldNames,
-                _importStrings,
+                _methodDebugInfo,
                 syntax)
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymUnmanagedReaderExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymUnmanagedReaderExtensions.vb
@@ -1,0 +1,82 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.VisualStudio.SymReaderInterop
+Imports ImportScope = Microsoft.VisualStudio.SymReaderInterop.ImportScope
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+    Friend Module SymUnmanagedReaderExtensions
+        <Extension>
+        Public Function GetMethodDebugInfo(
+            reader As ISymUnmanagedReader,
+            methodToken As Integer,
+            methodVersion As Integer) As MethodDebugInfo
+
+            Dim importStrings = reader.GetVisualBasicImportStrings(methodToken, methodVersion)
+            If importStrings.IsDefault Then
+                Return Nothing
+            End If
+
+            Dim projectLevelImportRecords = ArrayBuilder(Of ImportRecord).GetInstance()
+            Dim fileLevelImportRecords = ArrayBuilder(Of ImportRecord).GetInstance()
+            Dim defaultNamespaceName As String = Nothing
+
+            For Each importString As String In importStrings
+                Debug.Assert(importString IsNot Nothing)
+                If importString.Length > 0 AndAlso importString(0) = "*"c Then
+                    Dim [alias] As String = Nothing
+                    Dim target As String = Nothing
+                    Dim kind As ImportTargetKind = Nothing
+                    Dim scope As ImportScope = Nothing
+                    If Not CustomDebugInfoReader.TryParseVisualBasicImportString(importString, [alias], target, kind, scope) Then
+                        Debug.WriteLine($"Unable to parse import string '{importString}'")
+                        Continue For
+                    ElseIf kind = ImportTargetKind.Defunct
+                        Continue For
+                    End If
+
+                    Debug.Assert([alias] Is Nothing) ' The default namespace is never aliased.
+                    Debug.Assert(target IsNot Nothing)
+                    Debug.Assert(kind = ImportTargetKind.DefaultNamespace)
+
+                    ' We only expect to see one of these, but it looks like ProcedureContext::LoadImportsAndDefaultNamespaceNormal
+                    ' implicitly uses the last one if there are multiple.
+                    Debug.Assert(defaultNamespaceName Is Nothing)
+
+                    defaultNamespaceName = target
+                Else
+                    Dim importRecord As ImportRecord = Nothing
+                    Dim scope As ImportScope = Nothing
+                    If NativeImportRecord.TryCreateFromVisualBasicImportString(importString, importRecord, scope) Then
+                        If scope = ImportScope.Project Then
+                            projectLevelImportRecords.Add(importRecord)
+                        Else
+                            Debug.Assert(scope = ImportScope.File OrElse scope = ImportScope.Unspecified)
+                            fileLevelImportRecords.Add(importRecord)
+                        End If
+                    Else
+                        Debug.WriteLine($"Failed to parse import string {importString}")
+                    End If
+                End If
+            Next
+
+            ' Note: We don't need to try to bind this string because this is analogous to passing
+            ' a command-line argument - as long as the syntax is valid, an appropriate symbol will
+            ' be created for us.
+            If String.IsNullOrEmpty(defaultNamespaceName) OrElse Not CompilationContext.TryParseDottedName(defaultNamespaceName, Nothing) Then
+                defaultNamespaceName = ""
+            End If
+
+            Dim importRecordGroups = ImmutableArray.Create(
+                projectLevelImportRecords.ToImmutableAndFree(),
+                fileLevelImportRecords.ToImmutableAndFree())
+
+            Return New MethodDebugInfo(importRecordGroups, ImmutableArray(Of ExternAliasRecord).Empty, defaultNamespaceName)
+        End Function
+
+        ' TODO (acasey): portable format overload (GH #702)
+    End Module
+End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -7,6 +7,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.VisualStudio.SymReaderInterop
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
@@ -163,8 +164,8 @@ End Class
                 compModuleInstance2,
                 MscorlibRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "@P:root1", "@P:root2", "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo, "root1", "root2")
         End Sub
 
         <Fact>
@@ -218,8 +219,8 @@ End Namespace
                 MscorlibRef.ToModuleInstance(Nothing, Nothing),
                 MsvbRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "@P:N1", "@P:N2.N3", "@P:N5.N6", "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo, "N1", "N2.N3", "N5.N6")
         End Sub
 
         <Fact>
@@ -234,8 +235,8 @@ End Namespace
 
             ' Since there are no methods in the assembly, there is no import custom debug info, so we
             ' have no way to find the root namespace.
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo)
         End Sub
 
         <Fact>
@@ -265,8 +266,8 @@ End Namespace
                 MscorlibRef.ToModuleInstance(Nothing, Nothing),
                 MsvbRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "@P:N2", "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo, "N2")
         End Sub
 
         <Fact>
@@ -317,8 +318,8 @@ End Namespace
                 MscorlibRef.ToModuleInstance(Nothing, Nothing),
                 MsvbRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo)
         End Sub
 
         <Fact>
@@ -350,8 +351,8 @@ End Namespace
                 MscorlibRef.ToModuleInstance(Nothing, Nothing),
                 MsvbRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo)
         End Sub
 
         <Fact>
@@ -382,8 +383,8 @@ End Namespace
                 MscorlibRef.ToModuleInstance(Nothing, Nothing),
                 MsvbRef.ToModuleInstance(Nothing, Nothing)))
 
-            Dim [imports] = EvaluationContext.SynthesizeImportStringsForDtee(MakeAssemblyReaders(runtimeInstance))
-            AssertEx.SetEqual([imports], "*")
+            Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
+            CheckDteeMethodDebugInfo(methodDebugInfo)
         End Sub
 
         <Fact>
@@ -493,5 +494,22 @@ End Namespace
             Dim compRef = AssemblyMetadata.CreateFromImage(peBytes).GetReference()
             Return compRef.ToModuleInstance(peBytes.ToArray(), New SymReader(pdbBytes.ToArray()))
         End Function
+
+        Private Shared Sub CheckDteeMethodDebugInfo(methodDebugInfo As MethodDebugInfo, ParamArray namespaceNames As String())
+            Assert.Equal("", methodDebugInfo.DefaultNamespaceName)
+
+            Dim importRecordGroups = methodDebugInfo.ImportRecordGroups
+            Assert.Equal(2, importRecordGroups.Length)
+            Dim projectLevelImportRecords As ImmutableArray(Of ImportRecord) = importRecordGroups(0)
+            Dim fileLevelImportRecords As ImmutableArray(Of ImportRecord) = importRecordGroups(1)
+
+            Assert.Empty(fileLevelImportRecords)
+
+            AssertEx.All(projectLevelImportRecords, Function(record) TypeOf record Is NativeImportRecord)
+            AssertEx.All(projectLevelImportRecords, Function(record) DirectCast(record, NativeImportRecord).ExternAlias Is Nothing)
+            AssertEx.All(projectLevelImportRecords, Function(record) record.TargetKind = ImportTargetKind.Namespace)
+            AssertEx.All(projectLevelImportRecords, Function(record) record.Alias Is Nothing)
+            AssertEx.SetEqual(projectLevelImportRecords.Select(Function(record) record.TargetString), namespaceNames)
+        End Sub
     End Class
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -3704,7 +3704,7 @@ End Class
             Dim result = comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
             Assert.True(result)
 
-            Dim symReader As ISymUnmanagedReader = New MockSymUnmanagedReader(ImmutableDictionary(Of Integer, MethodDebugInfo).Empty)
+            Dim symReader As ISymUnmanagedReader = New MockSymUnmanagedReader(ImmutableDictionary(Of Integer, MethodDebugInfoBytes).Empty)
 
             Dim runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader)
             Dim evalContext = CreateMethodContext(runtime, "C.Main")

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -8,7 +8,6 @@ Imports System.Reflection.Metadata.Ecma335
 Imports System.Reflection.PortableExecutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -150,11 +149,11 @@ End Namespace
             Const importString = "@F:System"
 
             Dim reader As ISymUnmanagedReader = New MockSymUnmanagedReader(
-                            New Dictionary(Of Integer, MethodDebugInfo)() From
+                            New Dictionary(Of Integer, MethodDebugInfoBytes)() From
                             {
-                                {methodToken1, New MethodDebugInfo.Builder({({"@" & methodToken2})}).Build()},
-                                {methodToken2, New MethodDebugInfo.Builder({({"@" & methodToken3})}).Build()},
-                                {methodToken3, New MethodDebugInfo.Builder({({importString})}).Build()}
+                                {methodToken1, New MethodDebugInfoBytes.Builder({({"@" & methodToken2})}).Build()},
+                                {methodToken2, New MethodDebugInfoBytes.Builder({({"@" & methodToken3})}).Build()},
+                                {methodToken3, New MethodDebugInfoBytes.Builder({({importString})}).Build()}
                             }.ToImmutableDictionary())
 
             Dim importStrings = reader.GetVisualBasicImportStrings(methodToken1, methodVersion)
@@ -173,9 +172,9 @@ End Namespace
             Const methodToken1 = &H600057A ' Forwards to itself
 
             Dim reader As ISymUnmanagedReader = New MockSymUnmanagedReader(
-                            New Dictionary(Of Integer, MethodDebugInfo)() From
+                            New Dictionary(Of Integer, MethodDebugInfoBytes)() From
                             {
-                                {methodToken1, New MethodDebugInfo.Builder({({"@" & methodToken1})}).Build()}
+                                {methodToken1, New MethodDebugInfoBytes.Builder({({"@" & methodToken1})}).Build()}
                             }.ToImmutableDictionary())
 
             Dim importStrings = reader.GetVisualBasicImportStrings(methodToken1, methodVersion)
@@ -269,9 +268,9 @@ End Class
             Const importString = "&MyPia"
 
             Dim reader As ISymUnmanagedReader = New MockSymUnmanagedReader(
-                            New Dictionary(Of Integer, MethodDebugInfo)() From
+                            New Dictionary(Of Integer, MethodDebugInfoBytes)() From
                             {
-                                {methodToken, New MethodDebugInfo.Builder({({importString})}).Build()}
+                                {methodToken, New MethodDebugInfoBytes.Builder({({importString})}).Build()}
                             }.ToImmutableDictionary())
 
             Dim importStrings = reader.GetVisualBasicImportStrings(methodToken, methodVersion)
@@ -286,9 +285,9 @@ End Class
             Const importString2 = "$NotSureWhatGoesHere"
 
             Dim reader As ISymUnmanagedReader = New MockSymUnmanagedReader(
-                            New Dictionary(Of Integer, MethodDebugInfo)() From
+                            New Dictionary(Of Integer, MethodDebugInfoBytes)() From
                             {
-                                {methodToken, New MethodDebugInfo.Builder({({importString1, importString2})}).Build()}
+                                {methodToken, New MethodDebugInfoBytes.Builder({({importString1, importString2})}).Build()}
                             }.ToImmutableDictionary())
 
             Dim importStrings = reader.GetVisualBasicImportStrings(methodToken, methodVersion)

--- a/src/Test/PdbUtilities/Pdb/PdbToXml.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbToXml.cs
@@ -198,7 +198,7 @@ namespace Roslyn.Test.PdbUtilities
         {
             int token = metadataReader.GetToken(methodHandle);
 
-            byte[] cdi = pdbReader.SymbolReader.GetCustomDebugInfo(token, methodVersion: 0);
+            byte[] cdi = pdbReader.SymbolReader.GetCustomDebugInfoBytes(token, methodVersion: 0);
             ISymUnmanagedMethod method = pdbReader.SymbolReader.GetMethod(token);
             if (cdi == null && method == null)
             {
@@ -818,18 +818,19 @@ namespace Roslyn.Test.PdbUtilities
                     }
                     break;
                 case ImportTargetKind.Assembly:
-                    Debug.Assert(alias == null);
+                    Debug.Assert(alias != null);
+                    Debug.Assert(externAlias == null);
                     Debug.Assert(scope == ImportScope.Unspecified);
                     if (target == null)
                     {
                         writer.WriteStartElement("extern");
-                        writer.WriteAttributeString("alias", externAlias);
+                        writer.WriteAttributeString("alias", alias);
                         writer.WriteEndElement(); // </extern>
                     }
                     else
                     {
                         writer.WriteStartElement("externinfo");
-                        writer.WriteAttributeString("alias", externAlias);
+                        writer.WriteAttributeString("alias", alias);
                         writer.WriteAttributeString("assembly", target);
                         writer.WriteEndElement(); // </externinfo>
                     }

--- a/src/Test/PdbUtilities/Shared/CustomDebugInfoReader.cs
+++ b/src/Test/PdbUtilities/Shared/CustomDebugInfoReader.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using CDI = Microsoft.Cci.CustomDebugInfoConstants;
 
+#pragma warning disable RS0010 // Avoid using cref tags with a prefix
+
 namespace Microsoft.VisualStudio.SymReaderInterop
 {
     /// <summary>
@@ -58,6 +60,9 @@ namespace Microsoft.VisualStudio.SymReaderInterop
             return default(ImmutableArray<byte>);
         }
 
+        /// <remarks>
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
+        /// </remarks>
         /// <exception cref="InvalidOperationException"></exception>
         public static IEnumerable<CustomDebugInfoRecord> GetCustomDebugInfoRecords(byte[] customDebugInfo)
         {
@@ -106,6 +111,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// </summary>
         /// <remarks>
         /// There's always at least one entry (for the global namespace).
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
         /// </remarks>
         public static ImmutableArray<short> DecodeUsingRecord(ImmutableArray<byte> bytes)
         {
@@ -127,6 +133,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// </summary>
         /// <remarks>
         /// Appears when multiple method would otherwise have identical using records (see <see cref="DecodeUsingRecord"/>).
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
         /// </remarks>
         public static int DecodeForwardRecord(ImmutableArray<byte> bytes)
         {
@@ -140,6 +147,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// </summary>
         /// <remarks>
         /// Appears when there are extern aliases and edit-and-continue is disabled.
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
         /// </remarks>
         public static int DecodeForwardToModuleRecord(ImmutableArray<byte> bytes)
         {
@@ -150,6 +158,9 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// <summary>
         /// Scopes of state machine hoisted local variables.
         /// </summary>
+        /// <remarks>
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
+        /// </remarks>
         public static ImmutableArray<StateMachineHoistedLocalScope> DecodeStateMachineHoistedLocalScopesRecord(ImmutableArray<byte> bytes)
         {
             int offset = 0;
@@ -173,6 +184,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// </summary>
         /// <remarks>
         /// Appears when are iterator methods.
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
         /// </remarks>
         public static string DecodeForwardIteratorRecord(ImmutableArray<byte> bytes)
         {
@@ -200,6 +212,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// </summary>
         /// <remarks>
         /// Appears when there are dynamic locals.
+        /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Bad data.</exception>
         public static ImmutableArray<DynamicLocalBucket> DecodeDynamicLocalsRecord(ImmutableArray<byte> bytes)
@@ -285,7 +298,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
             bool seenForward = false;
 
         RETRY:
-            byte[] bytes = reader.GetCustomDebugInfo(methodToken, methodVersion);
+            byte[] bytes = reader.GetCustomDebugInfoBytes(methodToken, methodVersion);
             if (bytes == null)
             {
                 return default(ImmutableArray<ImmutableArray<string>>);
@@ -451,6 +464,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
             return importStrings;
         }
 
+        // TODO (acasey): caller should depend on abstraction (GH #702)
         public static ImmutableSortedSet<int> GetCSharpInScopeHoistedLocalIndices(byte[] customDebugInfo, int methodToken, int methodVersion, int ilOffset)
         {
             var record = TryGetCustomDebugInfoRecord(customDebugInfo, CustomDebugInfoKind.StateMachineHoistedLocalScopes);
@@ -478,6 +492,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
             return result;
         }
 
+        // TODO (acasey): caller should depend on abstraction (GH #702)
         /// <exception cref="InvalidOperationException">Bad data.</exception>
         public static void GetCSharpDynamicLocalInfo(
             byte[] customDebugInfo,
@@ -581,7 +596,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
             return bytes[i];
         }
 
-        public static bool IsCSharpExternAliasInfo(string import)
+        private static bool IsCSharpExternAliasInfo(string import)
         {
             return import.Length > 0 && import[0] == 'Z';
         }
@@ -676,19 +691,20 @@ namespace Microsoft.VisualStudio.SymReaderInterop
                     }
 
                 case 'X': // C# extern alias (in file)
-                    externAlias = import.Substring(1);
-                    alias = null;
+                    externAlias = null;
+                    alias = import.Substring(1); // For consistency with the portable format, store it in alias, rather than externAlias.
                     target = null;
                     kind = ImportTargetKind.Assembly;
                     return true;
 
                 case 'Z': // C# extern alias (module-level)
-                    if (!TrySplit(import, 1, ' ', out externAlias, out target))
+                    // For consistency with the portable format, store it in alias, rather than externAlias.
+                    if (!TrySplit(import, 1, ' ', out alias, out target))
                     {
                         return false;
                     }
 
-                    alias = null;
+                    externAlias = null;
                     kind = ImportTargetKind.Assembly;
                     return true;
 
@@ -875,6 +891,9 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         }
     }
 
+    /// <remarks>
+    /// Exposed for <see cref="T:Roslyn.Test.PdbUtilities.PdbToXmlConverter"/>.
+    /// </remarks>
     internal struct CustomDebugInfoRecord
     {
         public readonly CustomDebugInfoKind Kind;
@@ -989,3 +1008,4 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         EditAndContinueLambdaMap = CDI.CdiKindEditAndContinueLambdaMap,
     }
 }
+#pragma warning restore RS0010 // Avoid using cref tags with a prefix

--- a/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
+++ b/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.SymReaderInterop
         /// Get the blob of binary custom debug info for a given method.
         /// TODO: consume <paramref name="methodVersion"/> (DevDiv #1068138).
         /// </summary>
-        public static byte[] GetCustomDebugInfo(this ISymUnmanagedReader reader, int methodToken, int methodVersion)
+        public static byte[] GetCustomDebugInfoBytes(this ISymUnmanagedReader reader, int methodToken, int methodVersion)
         {
             return GetItems(reader, new SymbolToken(methodToken), CdiAttributeName,
                 (ISymUnmanagedReader a, SymbolToken b, string c, int d, out int e, byte[] f) => a.GetSymAttribute(b, c, d, out e, f));

--- a/src/Test/Utilities/PdbTestUtilities.cs
+++ b/src/Test/Utilities/PdbTestUtilities.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Test.Utilities
     {
         public static EditAndContinueMethodDebugInformation GetEncMethodDebugInfo(this ISymUnmanagedReader symReader, MethodDefinitionHandle handle)
         {
-            var cdi = symReader.GetCustomDebugInfo(MetadataTokens.GetToken(handle), methodVersion: 0);
+            var cdi = symReader.GetCustomDebugInfoBytes(MetadataTokens.GetToken(handle), methodVersion: 0);
             if (cdi == null)
             {
                 return default(EditAndContinueMethodDebugInformation);

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -1072,7 +1072,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 }
             }
 
-            byte[] debugInfo = _pdbReader.GetCustomDebugInfo(MetadataTokens.GetToken(methodHandle), methodVersion: 0);
+            byte[] debugInfo = _pdbReader.GetCustomDebugInfoBytes(MetadataTokens.GetToken(methodHandle), methodVersion: 0);
             if (debugInfo != null)
             {
                 try


### PR DESCRIPTION
In the dev12 PDB format, usings and imports were encoded as strings in
PDB files.  The strings were structured, but required a certain amount of
guesswork (for example, you might not know whether you were importing a
type or a namespace until after binding).  In the new PDB format, usings
and imports are represented as structured blobs and tokens are used
wherever possible.

This change introduces two new class hierarchies, ImportRecord and
ExternAliasRecord, that the expression compiler can pass around instead
of raw strings.  Unfortunately, there is still switching logic in two
places - both when these types are instantiated and when they are
consumed.  The instantiation switch is very simple - we just check for
the appropriate version of ISymUnmanagedReaderX.  The consumption logic
is more complex, because the new and old representations differ
substantially.

TODO: Presently, there is very little code for consuming the new PDB
format, since the APIs are not yet available.