### PR TITLE
Fix to VB pretty-listing of line continuation characters in interpolations

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
@@ -833,12 +833,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return True
 
                 ' After an open parenthesis (() or before a closing parenthesis ()).
-                ' After an open curly brace ({) or before a closing curly brace (}).
                 ' After an open embedded expression (<%=) or before the close of an embedded expression (%>) within an XML literal.
                 Case SyntaxKind.OpenParenToken,
-                     SyntaxKind.OpenBraceToken,
                      SyntaxKind.LessThanPercentEqualsToken,
                      SyntaxKind.PercentGreaterThanToken
+
+                    Return True
+
+                ' After an open curly brace ({) or before a closing curly brace (})
+                ' However, a line-continuation character is required following the open curly brace of a string interpolation.
+                Case SyntaxKind.OpenBraceToken
+
+                    If parentKind = SyntaxKind.Interpolation Then
+                        Return False
+                    End If
 
                     Return True
 
@@ -892,12 +900,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Order By, Select, Skip, Skip While, Take, Take While, Where, In, Into, On, Ascending, and Descending). 
                 ' After the From keyword in a collection initializer.
                 Case SyntaxKind.AggregateKeyword,
-                        SyntaxKind.ByKeyword,
-                        SyntaxKind.EqualsKeyword,
-                        SyntaxKind.FromKeyword,
-                        SyntaxKind.IntoKeyword,
-                        SyntaxKind.JoinKeyword,
-                        SyntaxKind.WhereKeyword
+                     SyntaxKind.ByKeyword,
+                     SyntaxKind.EqualsKeyword,
+                     SyntaxKind.FromKeyword,
+                     SyntaxKind.IntoKeyword,
+                     SyntaxKind.JoinKeyword,
+                     SyntaxKind.WhereKeyword
 
                     Return True
 
@@ -932,27 +940,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Keywords that may appear outside of query clauses
                 Case SyntaxKind.OnKeyword,
-                        SyntaxKind.LetKeyword,
-                        SyntaxKind.SelectKeyword,
-                        SyntaxKind.WhileKeyword
+                     SyntaxKind.LetKeyword,
+                     SyntaxKind.SelectKeyword,
+                     SyntaxKind.WhileKeyword
 
                     Return TypeOf token.Parent Is QueryClauseSyntax
 
                 ' XML Literals
                 Case SyntaxKind.BeginCDataToken,
-                        SyntaxKind.DoubleQuoteToken,
-                        SyntaxKind.LessThanExclamationMinusMinusToken,
-                        SyntaxKind.LessThanQuestionToken,
-                        SyntaxKind.XmlKeyword,
-                        SyntaxKind.XmlNameToken,
-                        SyntaxKind.XmlTextLiteralToken
+                     SyntaxKind.DoubleQuoteToken,
+                     SyntaxKind.LessThanExclamationMinusMinusToken,
+                     SyntaxKind.LessThanQuestionToken,
+                     SyntaxKind.XmlKeyword,
+                     SyntaxKind.XmlNameToken,
+                     SyntaxKind.XmlTextLiteralToken
 
                     Return True
 
                 Case SyntaxKind.EndCDataToken,
-                        SyntaxKind.MinusMinusGreaterThanToken,
-                        SyntaxKind.QuestionGreaterThanToken,
-                        SyntaxKind.SlashGreaterThanToken
+                     SyntaxKind.MinusMinusGreaterThanToken,
+                     SyntaxKind.QuestionGreaterThanToken,
+                     SyntaxKind.SlashGreaterThanToken
 
                     ' An implicit line continuation is allowed only if the token is not the end of
                     ' the xml literal. Walk up the parent chain and see if there is a parent node
@@ -1042,11 +1050,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return parentKind = SyntaxKind.AttributeList
 
                 ' After an open parenthesis (() or before a closing parenthesis ()).
-                ' After an open curly brace ({) or before a closing curly brace (}).
                 ' After an open embedded expression (<%=) or before the close of an embedded expression (%>) within an XML literal.
                 Case SyntaxKind.CloseParenToken,
-                     SyntaxKind.CloseBraceToken,
                      SyntaxKind.PercentGreaterThanToken
+
+                    Return True
+                    Return True
+
+                ' After an open curly brace ({) or before a closing curly brace (})
+                ' However, a line-continuation character is required before the closing curly brace of a string interpolation.
+                Case SyntaxKind.CloseBraceToken
+
+                    If parentKind = SyntaxKind.Interpolation Then
+                        Return False
+                    End If
 
                     Return True
 

--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -1307,6 +1307,75 @@ End Module
             Verify(code, expected);
         }
 
+        [Fact]
+        [WorkItem(710, "#710")]
+        [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
+        public void DontRemoveLineContinuationInStringInterpolation1()
+        {
+            var code = @"[|
+Module Program
+    Dim x = $""{ _
+            1}""
+End Module
+|]";
+
+            var expected = @"
+Module Program
+    Dim x = $""{ _
+            1}""
+End Module
+";
+            Verify(code, expected);
+        }
+
+        [Fact]
+        [WorkItem(710, "#710")]
+        [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
+        public void DontRemoveLineContinuationInStringInterpolation2()
+        {
+            var code = @"[|
+Module Program
+    Dim x = $""{1 _
+               }""
+End Module
+|]";
+
+            var expected = @"
+Module Program
+    Dim x = $""{1 _
+               }""
+End Module
+";
+            Verify(code, expected);
+        }
+
+        [Fact]
+        [WorkItem(710, "#710")]
+        [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
+        public void DontRemoveLineContinuationInStringInterpolation3()
+        {
+            var code = @"[|
+Module Program
+    Dim x = $""{ _
+
+1 _
+
+}""
+End Module
+|]";
+
+            var expected = @"
+Module Program
+    Dim x = $""{ _
+
+1 _
+
+}""
+End Module
+";
+            Verify(code, expected);
+        }
+
         private string CreateMethod(string body)
         {
             return @"Imports System

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
@@ -106,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                 End If
 
                 ' check context
-                If token1.IsLastTokenOfStatement() Then
+                If token1.IsLastTokenOfStatement() AndAlso Not token1.IsMissing Then
                     ' check trivia
                     If Not GetTrailingTrivia(token1).Any(SyntaxKind.LineContinuationTrivia) AndAlso
                        Not GetLeadingTrivia(token2).Any(SyntaxKind.LineContinuationTrivia) Then


### PR DESCRIPTION
The VB pretty-lister shouldn't remove line continuation characters after
the opening brace or before the closing brace of an interpolated string.
In addition, I found that the pretty-lister was greedily removing line
continuation characters in error conditions where a missing token was
inserted by the compiler to represent the list token of a statement.

Fixes Issue #710.