### PR TITLE
Show 'else' within Ifs within Elses

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/ElseKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/ElseKeywordRecommenderTests.vb
@@ -266,5 +266,19 @@ Else
 End If
 </MethodBody>, "Else")
         End Sub
+
+        <Fact>
+<Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub ElseNotWithinDo()
+            VerifyRecommendationsMissing(
+<MethodBody>
+If True Then
+Do While True
+    |
+End While
+End If
+</MethodBody>, "Else")
+        End Sub
     End Class
+
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/ElseKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/ElseKeywordRecommenderTests.vb
@@ -235,5 +235,36 @@ Select Case x
     Case 1
 </MethodBody>, "Else")
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub ElseWithinIfWithinElse()
+            VerifyRecommendationsContain(
+<MethodBody>
+If True Then
+
+Else
+    If False Then
+    |
+    End If
+End If
+</MethodBody>, "Else")
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub ElseWithinElseIfWithinElse()
+            VerifyRecommendationsContain(
+<MethodBody>
+If True Then
+
+Else
+    If False Then
+    ElseIf True
+        |
+    End If
+End If
+</MethodBody>, "Else")
+        End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Completion/KeywordRecommenders/Statements/ElseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Completion/KeywordRecommenders/Statements/ElseKeywordRecommender.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Stat
 
             If context.IsSingleLineStatementContext AndAlso
                context.IsInStatementBlockOfKind(SyntaxKind.MultiLineIfBlock, SyntaxKind.ElseIfBlock) AndAlso
-               Not context.IsInStatementBlockOfKind(SyntaxKind.ElseBlock) Then
+               IsNotDirectlyInElseBlock(context) Then
 
                 Return SpecializedCollections.SingletonEnumerable(New RecommendedKeyword("Else", VBFeaturesResources.ElseKeywordToolTip))
             End If
@@ -44,6 +44,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Stat
             End If
 
             Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
+        End Function
+
+        Private Function IsNotDirectlyInElseBlock(context As VisualBasicSyntaxContext) As Boolean
+            Dim parent = context.TargetToken.Parent
+            Do While parent IsNot Nothing
+                If parent.IsKind(SyntaxKind.MultiLineIfBlock, SyntaxKind.ElseIfBlock) Then
+                    Return True
+                End If
+
+                If parent.IsKind(SyntaxKind.ElseBlock) Then
+                    Return False
+                End If
+
+                parent = parent.Parent
+            Loop
+
+            ' We already know we're inside a Multiline If or ElseIf
+            Throw ExceptionUtilities.Unreachable
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
When recommending "Else" we walk all the way up the tree to determine
if the position is nested inside an Else block. This means we don't
recommend "Else" inside an If block nested within an Else block. When
walking up the tree, we should stop at the If/ElseIf block.

Fixes #719.