### PR TITLE
Disable the severity menu items when a selected diagnostic is not configurable

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
@@ -20,9 +20,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private IVsMonitorSelection _vsMonitorSelection = null;
         private uint _selectionEventsCookie = 0;
 
-        public event EventHandler SelectedHierarchyChanged;
         public event EventHandler SelectedDiagnosticItemsChanged;
-        public event EventHandler SelectedItemIdChanged;
+        public event EventHandler SelectedHierarchyItemChanged;
 
         [ImportingConstructor]
         public AnalyzerItemsTracker(SVsServiceProvider serviceProvider)
@@ -94,14 +93,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                                            .Select(b => b.DiagnosticItem)
                                            .ToImmutableArray();
 
-            if (!object.ReferenceEquals(oldSelectedHierarchy, this.SelectedHierarchy))
+            if (!object.ReferenceEquals(oldSelectedHierarchy, this.SelectedHierarchy) ||
+                oldSelectedItemId != this.SelectedItemId)
             {
-                this.SelectedHierarchyChanged?.Invoke(this, EventArgs.Empty);
-            }
-
-            if (oldSelectedItemId != this.SelectedItemId)
-            {
-                this.SelectedItemIdChanged?.Invoke(this, EventArgs.Empty);
+                this.SelectedHierarchyItemChanged?.Invoke(this, EventArgs.Empty);
             }
 
             if (oldSelectedDiagnosticItems != this.SelectedDiagnosticItems)

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -86,9 +86,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
                 if (_tracker != null)
                 {
-                    _tracker.SelectedHierarchyChanged += SelectedHierarchyChangedHandler;
+                    _tracker.SelectedHierarchyItemChanged += SelectedHierarchyItemChangedHandler;
                     _tracker.SelectedDiagnosticItemsChanged += SelectedDiagnosticItemsChangedHandler;
-                    _tracker.SelectedItemIdChanged += SelectedItemIdChangedHandler;
                 }
 
                 var buildManager = (IVsSolutionBuildManager)_serviceProvider.GetService(typeof(SVsSolutionBuildManager));
@@ -132,12 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
         }
 
-        private void SelectedHierarchyChangedHandler(object sender, EventArgs e)
-        {
-            UpdateMenuItemVisibility();
-        }
-
-        private void SelectedItemIdChangedHandler(object sender, EventArgs e)
+        private void SelectedHierarchyItemChangedHandler(object sender, EventArgs e)
         {
             UpdateMenuItemVisibility();
         }
@@ -169,6 +163,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _setSeverityNoneMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Suppress);
         }
 
+        private bool AnyDiagnosticsWithSeverity(ReportDiagnostic severity)
+        {
+            return _selectedDiagnosticItems.Any(item => item.EffectiveSeverity == severity);
+        }
+
         private void UpdateSeverityMenuItemsEnabled()
         {
             bool configurable = !_selectedDiagnosticItems.Any(item => item.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable));
@@ -178,11 +177,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _setSeverityInfoMenuItem.Enabled = configurable;
             _setSeverityHiddenMenuItem.Enabled = configurable;
             _setSeverityNoneMenuItem.Enabled = configurable;
-        }
-
-        private bool AnyDiagnosticsWithSeverity(ReportDiagnostic severity)
-        {
-            return _selectedDiagnosticItems.Any(item => item.EffectiveSeverity == severity);
         }
 
         private bool SelectedProjectSupportsAnalyzers()

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 _openHelpLinkMenuItem = AddCommandHandler(menuCommandService, ID.RoslynCommands.OpenDiagnosticHelpLink, OpenDiagnosticHelpLinkHandler);
 
                 UpdateMenuItemVisibility();
-                UpdateMenuItemsChecked();
+                UpdateSeverityMenuItemsChecked();
 
                 if (_tracker != null)
                 {
@@ -120,14 +120,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 item.PropertyChanged += DiagnosticItemPropertyChangedHandler;
             }
 
-            UpdateMenuItemsChecked();
+            UpdateSeverityMenuItemsChecked();
+            UpdateSeverityMenuItemsEnabled();
         }
 
         private void DiagnosticItemPropertyChangedHandler(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(DiagnosticItem.EffectiveSeverity))
             {
-                UpdateMenuItemsChecked();
+                UpdateSeverityMenuItemsChecked();
             }
         }
 
@@ -159,13 +160,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                                                 Path.GetExtension(itemName).Equals(".ruleset", StringComparison.OrdinalIgnoreCase);
         }
 
-        private void UpdateMenuItemsChecked()
+        private void UpdateSeverityMenuItemsChecked()
         {
             _setSeverityErrorMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Error);
             _setSeverityWarningMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Warn);
             _setSeverityInfoMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Info);
             _setSeverityHiddenMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Hidden);
             _setSeverityNoneMenuItem.Checked = AnyDiagnosticsWithSeverity(ReportDiagnostic.Suppress);
+        }
+
+        private void UpdateSeverityMenuItemsEnabled()
+        {
+            bool configurable = !_selectedDiagnosticItems.Any(item => item.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable));
+
+            _setSeverityErrorMenuItem.Enabled = configurable;
+            _setSeverityWarningMenuItem.Enabled = configurable;
+            _setSeverityInfoMenuItem.Enabled = configurable;
+            _setSeverityHiddenMenuItem.Enabled = configurable;
+            _setSeverityNoneMenuItem.Enabled = configurable;
         }
 
         private bool AnyDiagnosticsWithSeverity(ReportDiagnostic severity)


### PR DESCRIPTION
If a diagnostic is tagged with "NotConfigurable" we don't allow changing its severity. The rule set editor already respects this tag, but the Solution Explorer does not. Now, if any of the selected diagnostics are tagged we disable the menu items for changing the effective severity.

Fixes #465.