### PR TITLE
Show expression completion within casts

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -7898,5 +7898,25 @@ class C
 
             VerifyItemExists(markup, "x");
         }
+
+        [WorkItem(717, "https://github.com/dotnet/roslyn/issues/717")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void ExpressionContextCompletionWithinCast()
+        {
+            var markup = @"
+class Program
+{
+    void M()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var x = ($$)
+            var y = 1;
+        }
+    }
+}
+";
+            VerifyItemExists(markup, "i");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -75,8 +75,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                 // Script and interactive
                 return GetSymbolsForGlobalStatementContext(context, cancellationToken);
             }
-            else if (context.IsAnyExpressionContext || context.IsStatementContext)
+            else if (context.IsAnyExpressionContext || 
+                     context.IsStatementContext || 
+                     context.SyntaxTree.IsDefiniteCastTypeContext(context.Position, context.LeftToken, cancellationToken))
             {
+                // GitHub #717: With automatic brace completion active, typing '(i' produces "(i)", which gets parsed as
+                // as cast. The user might be trying to type a parenthesized expression, so even though a cast
+                // is a type-only context, we'll show all symbols anyway.
                 return GetSymbolsForExpressionOrStatementContext(context, filterOutOfScopeLocals, cancellationToken);
             }
             else if (context.IsTypeContext || context.IsNamespaceContext)


### PR DESCRIPTION
Automatic brace completion of "(" parses as a cast, but the user might
be trying to type a parenthesized expression.

Fixes #717 