### PR TITLE
'this' keyword available in expression-bodied members

### DIFF
--- a/src/EditorFeatures/CSharpTest/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/ThisKeywordRecommenderTests.cs
@@ -526,5 +526,97 @@ class C
     {
         var c = new C { x = 2, y = 3, $$");
         }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void InExpressionBodiedMembersProperty()
+        {
+            VerifyKeyword(@"
+class C
+{
+    int x;
+    int M => $$
+    int p;
+}");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void InExpressionBodiedMembersMethod()
+        {
+            VerifyKeyword(@"
+class C
+{
+    int x;
+    int give() => $$");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void InExpressionBodiedMembersIndexer()
+        {
+            VerifyKeyword(@"
+class C
+{
+    int x;
+    public object this[int i] => $$");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void NotInExpressionBodiedMembers_Static()
+        {
+            VerifyAbsence(@"
+class C
+{
+    int x;
+    static int M => $$");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void NotInExpressionBodiedMembersOperator()
+        {
+            VerifyAbsence(@"
+class C
+{
+    int x;
+    public static C operator - (C c1) => $$");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void NotInExpressionBodiedMembersConversionOperator()
+        {
+            VerifyAbsence(@"
+class F
+{
+}
+
+class C
+{
+    int x;
+    public static explicit operator F(C c1) => $$");
+        }
+
+        [WorkItem(725, "https://github.com/dotnet/roslyn/issues/725")]
+        [WorkItem(1107414)]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void OutsideExpressionBodiedMember()
+        {
+            VerifyAbsence(@"
+class C
+{
+    int x;
+    int M => this.x;$$
+    int p;
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
@@ -1420,6 +1419,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             if (modifiers.Any(SyntaxKind.StaticKeyword))
             {
                 return false;
+            }
+
+            var expressionBody = containingMember.GetExpressionBody();
+            if (expressionBody != null)
+            {
+                return TextSpan.FromBounds(expressionBody.ArrowToken.Span.End, expressionBody.FullSpan.End).IntersectsWith(position);
             }
 
             // Must be a property or something method-like.

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -316,6 +316,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return null;
         }
 
+        public static ArrowExpressionClauseSyntax GetExpressionBody(this MemberDeclarationSyntax memberDeclaration)
+        {
+            switch (memberDeclaration?.Kind())
+            {
+                case SyntaxKind.PropertyDeclaration:
+                    return ((PropertyDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.MethodDeclaration:
+                    return ((MethodDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.IndexerDeclaration:
+                    return ((IndexerDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.OperatorDeclaration:
+                    return ((OperatorDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    return ((ConversionOperatorDeclarationSyntax)memberDeclaration).ExpressionBody;
+                default:
+                    return null;
+            }
+        }
+
         public static MemberDeclarationSyntax WithBody(
             this MemberDeclarationSyntax memberDeclaration,
             BlockSyntax body)


### PR DESCRIPTION
Fix #725 : 'this' keyword should be available in the completion list, in the
context of member expression body.