### PR TITLE
Fixes #540: Better handle dismissed rename tracking sessions

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1718,6 +1718,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The rename tracking session was cancelled and is no longer available..
+        /// </summary>
+        internal static string TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable {
+            get {
+                return ResourceManager.GetString("TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The token is not contained in the workspace..
         /// </summary>
         internal static string TheTokenIsNotContainedInWorkspace {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -727,4 +727,7 @@ Do you want to proceed?</value>
   <data name="CannotApplyOperationWhileRenameSessionIsActive" xml:space="preserve">
     <value>Cannot apply operation while a rename session is active.</value>
   </data>
+  <data name="TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable" xml:space="preserve">
+    <value>The rename tracking session was cancelled and is no longer available.</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
@@ -37,11 +37,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             var document = context.Document;
             var diagnostic = context.Diagnostics.Single();
 
-            var action1 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: false);
-            context.RegisterCodeFix(action1, diagnostic);
+            // Ensure rename can still be invoked in this document. We reanalyze the document for
+            // diagnostics when rename tracking is manually dismissed, but the existence of our
+            // diagnostic may still be cached, so we have to double check before actually providing
+            // any fixes.
+            if (RenameTrackingTaggerProvider.CanInvokeRename(document))
+            {
+                var action1 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: false);
+                context.RegisterCodeFix(action1, diagnostic);
 
-            var action2 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: true);
-            context.RegisterCodeFix(action2, diagnostic);
+                var action2 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: true);
+                context.RegisterCodeFix(action2, diagnostic);
+            }
 
             return SpecializedTasks.EmptyTask;
         }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 {
@@ -35,12 +36,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
         private readonly IWaitIndicator _waitIndicator;
         private readonly IInlineRenameService _inlineRenameService;
         private readonly IEnumerable<IRefactorNotifyService> _refactorNotifyServices;
+        private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
 
         [ImportingConstructor]
         public RenameTrackingTaggerProvider(
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IWaitIndicator waitIndicator,
             IInlineRenameService inlineRenameService,
+            IDiagnosticAnalyzerService diagnosticAnalyzerService,
             [ImportMany] IEnumerable<IRefactorNotifyService> refactorNotifyServices,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
@@ -48,12 +51,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             _waitIndicator = waitIndicator;
             _inlineRenameService = inlineRenameService;
             _refactorNotifyServices = refactorNotifyServices;
+            _diagnosticAnalyzerService = diagnosticAnalyzerService;
             _asyncListener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.RenameTracking);
         }
 
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
         {
-            var stateMachine = buffer.Properties.GetOrCreateSingletonProperty(() => new StateMachine(buffer, _inlineRenameService, _asyncListener));
+            var stateMachine = buffer.Properties.GetOrCreateSingletonProperty(() => new StateMachine(buffer, _inlineRenameService, _asyncListener, _diagnosticAnalyzerService));
             return new Tagger(stateMachine, _undoHistoryRegistry, _waitIndicator, _refactorNotifyServices) as ITagger<T>;
         }
 
@@ -126,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             {
                 throw ExceptionUtilities.Unreachable;
             }
-            }
+        }
 
         internal static CodeAction CreateCodeAction(
             Document document,
@@ -179,6 +183,24 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 // isRenamableIdentifierTask was cancelled, we'll get an AggregateException
                 return false;
             }
+        }
+
+        internal static bool CanInvokeRename(Document document)
+        {
+            SourceText text;
+            StateMachine stateMachine;
+            ITextBuffer textBuffer;
+            TrackingSession unused;
+
+            if (document == null || !document.TryGetText(out text))
+            {
+                return false;
             }
+
+            textBuffer = text.Container.TryGetTextBuffer();
+            return textBuffer != null &&
+                textBuffer.Properties.TryGetProperty(typeof(StateMachine), out stateMachine) && 
+                stateMachine.CanInvokeRename(out unused);
         }
     }
+}

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 {
@@ -77,6 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
                 _historyRegistry,
                 Workspace.ExportProvider.GetExport<Host.IWaitIndicator>().Value,
                 Workspace.ExportProvider.GetExport<IInlineRenameService>().Value,
+                Workspace.ExportProvider.GetExport<IDiagnosticAnalyzerService>().Value,
                 SpecializedCollections.SingletonEnumerable(_mockRefactorNotifyService),
                 Workspace.ExportProvider.GetExports<IAsynchronousOperationListener, FeatureMetadata>());
 

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -15,6 +15,7 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 Imports Microsoft.VisualStudio.Composition
+Imports Microsoft.CodeAnalysis.Diagnostics
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Module RenameTestHelpers
@@ -108,6 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 workspace.ExportProvider.GetExport(Of ITextUndoHistoryRegistry)().Value,
                 workspace.ExportProvider.GetExport(Of IWaitIndicator)().Value,
                 workspace.ExportProvider.GetExport(Of IInlineRenameService)().Value,
+                workspace.ExportProvider.GetExport(Of IDiagnosticAnalyzerService)().Value,
                 SpecializedCollections.SingletonEnumerable(New MockRefactorNotifyService()),
                 DirectCast(workspace.ExportProvider.GetExports(Of IAsynchronousOperationListener, FeatureMetadata), IEnumerable(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata))))
 


### PR DESCRIPTION
Fixes #540 "Stale rename entries in the lightbulb menu"

Prior to this change, dismissed rename tracking sessions continued to
provide codefixes which would silently fail when invoked, without
completing the rename operation.

With this change, we now do the following when rename tracking is
manually dismissed:

- Trigger the diagnostic service to reanalyze the document, thus
removing the rename tracking diagnostic.
- Stop providing a codefix when requested
- Show a dialog if a cached codefix is invoked explaining that the
rename was not performed.

Here are the there user scenarios:

1. The user dismisses rename tracking
    - The lightbulb will continue to show in the margin, regardless of
whether any codefix/refactoring is actually still available.

2. The user expands the lightbulb without it ever having been expanded
before.
     - In this case, we are queried for fixes and will not return any, so
either the lightbulb will disappear or it will contain other relevant
codefixes/refactorings at that position, excluding rename.

3. The user expands the lightbulb after it was previously expanded.
    - Our fix was already cached, so we can only give a reasonable message
when it is invoked.

If we introduce a way to trigger lightbulb reanalysis, then these
problems go away.