### PR TITLE
Use TriggerDiagnosticDescriptor in RenameTracking

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1601,15 +1601,6 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename Tracking.
-        /// </summary>
-        internal static string RenameTracking {
-            get {
-                return ResourceManager.GetString("RenameTracking", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Renaming anonymous type members is not yet supported..
         /// </summary>
         internal static string RenamingAnonymousTypeMemberNotSupported {
@@ -1840,15 +1831,6 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Warning {
             get {
                 return ResourceManager.GetString("Warning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  with preview....
-        /// </summary>
-        internal static string WithPreview {
-            get {
-                return ResourceManager.GetString("WithPreview", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -342,9 +342,6 @@
   <data name="DocumentIsNotCurrentlyBeingTracked" xml:space="preserve">
     <value>document is not currently being tracked</value>
   </data>
-  <data name="RenameTracking" xml:space="preserve">
-    <value>Rename Tracking</value>
-  </data>
   <data name="ComputingRenameInformation" xml:space="preserve">
     <value>Computing Rename information...</value>
   </data>
@@ -623,9 +620,6 @@
   </data>
   <data name="RenameToWithPreview" xml:space="preserve">
     <value>Rename '{0}' to '{1}' with preview...</value>
-  </data>
-  <data name="WithPreview" xml:space="preserve">
-    <value> with preview...</value>
   </data>
   <data name="PreviewChanges" xml:space="preserve">
     <value>Preview Changes</value>

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
@@ -10,20 +10,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
     internal sealed class RenameTrackingDiagnosticAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
     {
         public const string DiagnosticId = "RenameTracking";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(EditorFeaturesResources.RenameTracking), EditorFeaturesResources.ResourceManager, typeof(EditorFeaturesResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(EditorFeaturesResources.RenameTo), EditorFeaturesResources.ResourceManager, typeof(EditorFeaturesResources));
+        public static DiagnosticDescriptor DiagnosticDescriptor = new TriggerDiagnosticDescriptor(
+            DiagnosticId,
+            customTags: DiagnosticCustomTags.Microsoft.Append(WellKnownDiagnosticTags.NotConfigurable));
 
-        // TODO: Ideally we'd use a TriggerDiagnosticDescriptor here. However, this analyzer uses the message to communicate
-        // with it's fixer about what has changed. This analysis is not trivial to do for the fixer because of the temporal nature
-        // of this diagnostic. We should consider adding a field on diagnostic that is for extra data. If we have that we can
-        // turn this into a trigger diagnostic. For now, this just has the "NotConfigurable" tag to not show in the ruleset editor.
-        public static DiagnosticDescriptor DiagnosticDescriptor = new DiagnosticDescriptor(DiagnosticId,
-                                                                            s_localizableTitle,
-                                                                            s_localizableMessage,
-                                                                            "",
-                                                                            DiagnosticSeverity.Hidden,
-                                                                            isEnabledByDefault: true,
-                                                                            customTags: DiagnosticCustomTags.Microsoft.Append(WellKnownDiagnosticTags.NotConfigurable));
+        internal const string RenameFromPropertyKey = "RenameFrom";
+        internal const string RenameToPropertyKey = "RenameTo";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 {
@@ -251,10 +252,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     {
                         SnapshotSpan snapshotSpan = trackingSession.TrackingSpan.GetSpan(Buffer.CurrentSnapshot);
                         var textSpan = snapshotSpan.Span.ToTextSpan();
+
+                        var builder = ImmutableDictionary.CreateBuilder<string, string>();
+                        builder.Add(RenameTrackingDiagnosticAnalyzer.RenameFromPropertyKey, trackingSession.OriginalName);
+                        builder.Add(RenameTrackingDiagnosticAnalyzer.RenameToPropertyKey, snapshotSpan.GetText());
+                        var properties = builder.ToImmutable();
+
                         var diagnostic = Diagnostic.Create(diagnosticDescriptor,
                             tree.GetLocation(textSpan),
-                            trackingSession.OriginalName,
-                            snapshotSpan.GetText());
+                            properties);
+
                         return SpecializedCollections.SingletonEnumerable(diagnostic);
                     }
 

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -137,12 +137,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             bool showPreview)
         {
             // This can run on a background thread.
-            string message = diagnostic.GetMessage();
 
-            if (showPreview)
-            {
-                message += EditorFeaturesResources.WithPreview;
-            }
+            var renameToResourceString = showPreview ? EditorFeaturesResources.RenameToWithPreview : EditorFeaturesResources.RenameTo;
+            var message = string.Format(
+                renameToResourceString, 
+                diagnostic.Properties[RenameTrackingDiagnosticAnalyzer.RenameFromPropertyKey], 
+                diagnostic.Properties[RenameTrackingDiagnosticAnalyzer.RenameToPropertyKey]);
 
             return new RenameTrackingCodeAction(document, message, refactorNotifyServices, undoHistoryRegistry, showPreview);
         }


### PR DESCRIPTION
Fixes #466 "Use a 'TriggerDiagnosticDescriptor' for the rename tracking
diagnostic"

Updates the RenameTrackingDiagnosticAnalyzer to use a
TriggerDiagnosticDescriptor, which prevents the diagnostic title from
appearing in the preview area of the lightbulb. We now pass the
RenameFrom and RenameTo names as part of the Diagnostic's property bag
and construct the localized codefix title based on these in the codefix
itself.