### PR TITLE
Support Introduce Variable refactoring in expression bodied members

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -1790,5 +1790,52 @@ class B
 
             Test(code, expected, index: 0, compareTokens: false);
         }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestInExpressionBodiedMethodLikeMember()
+        {
+            var code =
+    @"using System;
+class T
+{
+    int m;
+    int M1() => [|1|] + 2 + 3 + m;
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    private const int {|Rename:V|} = 1;
+    int m;
+    int M1() => V + 2 + 3 + m;
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestInExpressionBodiedPropertyLikeMember()
+        {
+            var code =
+    @"using System;
+class T
+{
+    int M1 => [|1|] + 2;
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    private const int {|Rename:V|} = 1;
+
+    int M1 => V + 2;
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -1791,7 +1791,7 @@ class B
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethod()
         {
@@ -1818,7 +1818,7 @@ class T
             Test(code, expected, index: 2, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedMethod()
         {
@@ -1842,7 +1842,7 @@ class T
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedOperator()
         {
@@ -1879,7 +1879,7 @@ class Complex
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedOperator()
         {
@@ -1913,7 +1913,7 @@ class Complex
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedConversionOperator()
         {
@@ -1951,7 +1951,7 @@ public struct DBBool
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedProperty()
         {
@@ -1974,7 +1974,7 @@ class T
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedProperty()
         {
@@ -2002,7 +2002,7 @@ class T
             Test(code, expected, index: 2, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedIndexer()
         {
@@ -2026,7 +2026,7 @@ class SampleCollection<T>
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedIndexer()
         {
@@ -2056,7 +2056,7 @@ class SampleCollection<T>
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestTrailingTriviaOnExpressionBodiedMethodRewrites()
         {
@@ -2082,6 +2082,243 @@ class T
 
     // rewrite should preserve newline above this.
     void Cat() { }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestLeadingTriviaOnExpressionBodiedMethodRewrites()
+        {
+            var code =
+    @"using System;
+class T
+{
+    /*not moved*/
+    int M1() => 1 + 2 + /*not moved*/ [|3|];
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    /*not moved*/
+    int M1()
+    {
+        const int {|Rename:V|} = 3;
+        return 1 + 2 + /*not moved*/ V;
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestTriviaAroundArrowTokenInExpressionBodiedMemberSyntax()
+        {
+            var code =
+    @"using System;
+class T
+{
+    // comment
+    int M1() /*c1*/ => /*c2*/ 1 + 2 + /*c3*/ [|3|];
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    // comment
+    int M1() /*c1*/  /*c2*/
+    {
+        const int {|Rename:V|} = 3;
+        return 1 + 2 + /*c3*/ V;
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact(Skip = "http://github.com/dotnet/roslyn/issues/971"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x)
+    {
+        return [|9|];
+    };
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x)
+    {
+        const int {|Rename:V|} = 9;
+        return V;
+    };
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact(Skip = "http://github.com/dotnet/roslyn/issues/971"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithSingleLineBlockBodiedAnonymousMethodExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x) { return [|9|]; };
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x) { const int {|Rename:V|} = 9; return V; };
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact(Skip = "http://github.com/dotnet/roslyn/issues/971"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedSimpleLambdaExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => f =>
+    {
+        return f * [|9|];
+    };
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => f =>
+    {
+        const int {|Rename:V|} = 9;
+        return f * V;
+    };
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithExpressionBodiedSimpleLambdaExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => f => f * [|9|];
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y()
+    {
+        const int {|Rename:V|} = 9;
+        return f => f * V;
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact(Skip = "http://github.com/dotnet/roslyn/issues/971"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedParenthesizedLambdaExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => (f) =>
+    {
+        return f * [|9|];
+    };
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => (f) =>
+    {
+        const int {|Rename:V|} = 9;
+        return f * V;
+    };
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithExpressionBodiedParenthesizedLambdaExpression()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y() => (f) => f * [|9|];
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    Func<int, int> Y()
+    {
+        const int {|Rename:V|} = 9;
+        return (f) => f * V;
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
+        [Fact(Skip = "http://github.com/dotnet/roslyn/issues/971"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpressionInMethodArgs()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    public int Prop => Method1(delegate()
+    {
+        return [|8|];
+    });
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    public int Prop => Method1(delegate()
+    {
+        const int {|Rename:V|} = 8;
+        return V;
+    });
 }";
 
             Test(code, expected, index: 2, compareTokens: false);

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -1793,7 +1793,34 @@ class B
 
         [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
-        public void TestInExpressionBodiedMethodLikeMember()
+        public void TestIntroduceLocalInExpressionBodiedMethod()
+        {
+            var code =
+    @"using System;
+class T
+{
+    int m;
+    int M1() => [|1|] + 2 + 3 + m;
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    int m;
+    int M1()
+    {
+        const int {|Rename:V|} = 1;
+        return V + 2 + 3 + m;
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceFieldInExpressionBodiedMethod()
         {
             var code =
     @"using System;
@@ -1817,7 +1844,116 @@ class T
 
         [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
-        public void TestInExpressionBodiedPropertyLikeMember()
+        public void TestIntroduceLocalInExpressionBodiedOperator()
+        {
+            var code =
+    @"using System;
+class Complex
+{
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b) => a.Add([|b.real + 1|]);
+
+    private Complex Add(int b)
+    {
+        throw new NotImplementedException();
+    }
+}";
+
+            var expected =
+    @"using System;
+class Complex
+{
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b)
+    {
+        var {|Rename:v|} = b.real + 1;
+        return a.Add(v);
+    }
+
+    private Complex Add(int b)
+    {
+        throw new NotImplementedException();
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceFieldInExpressionBodiedOperator()
+        {
+            var code =
+    @"using System;
+class Complex
+{
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b) => a.Add(b.real + [|1|]);
+
+    private Complex Add(int b)
+    {
+        throw new NotImplementedException();
+    }
+}";
+
+            var expected =
+    @"using System;
+class Complex
+{
+    private const int {|Rename:V|} = 1;
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b) => a.Add(b.real + V);
+
+    private Complex Add(int b)
+    {
+        throw new NotImplementedException();
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceFieldInExpressionBodiedConversionOperator()
+        {
+            var code =
+    @"using System;
+public struct DBBool
+{
+    public static readonly DBBool dbFalse = new DBBool(-1);
+    int value;
+
+    DBBool(int value)
+    {
+        this.value = value;
+    }
+
+    public static implicit operator DBBool(bool x) => x ? new DBBool([|1|]) : dbFalse;
+}";
+
+            var expected =
+    @"using System;
+public struct DBBool
+{
+    private const int {|Rename:V|} = 1;
+    public static readonly DBBool dbFalse = new DBBool(-1);
+    int value;
+
+    DBBool(int value)
+    {
+        this.value = value;
+    }
+
+    public static implicit operator DBBool(bool x) => x ? new DBBool(V) : dbFalse;
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceFieldInExpressionBodiedProperty()
         {
             var code =
     @"using System;
@@ -1836,6 +1972,119 @@ class T
 }";
 
             Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedProperty()
+        {
+            var code =
+    @"using System;
+class T
+{
+    int M1 => [|1|] + 2;
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    int M1
+    {
+        get
+        {
+            const int {|Rename:V|} = 1;
+            return V + 2;
+        }
+    }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceFieldInExpressionBodiedIndexer()
+        {
+            var code =
+    @"using System;
+class SampleCollection<T>
+{
+    private T[] arr = new T[100];
+    public T this[int i] => i > [|0|] ? arr[i + 1] : arr[i + 2];
+}";
+
+            var expected =
+    @"using System;
+class SampleCollection<T>
+{
+    private const int {|Rename:V|} = 0;
+    private T[] arr = new T[100];
+    public T this[int i] => i > V ? arr[i + 1] : arr[i + 2];
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestIntroduceLocalInExpressionBodiedIndexer()
+        {
+            var code =
+    @"using System;
+class SampleCollection<T>
+{
+    private T[] arr = new T[100];
+    public T this[int i] => i > 0 ? arr[[|i + 1|]] : arr[i + 2];
+}";
+
+            var expected =
+    @"using System;
+class SampleCollection<T>
+{
+    private T[] arr = new T[100];
+    public T this[int i]
+    {
+        get
+        {
+            var {|Rename:v|} = i + 1;
+            return i > 0 ? arr[v] : arr[i + 2];
+        }
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(528, "github.com/dotnet/roslyn/issues/528")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestTrailingTriviaOnExpressionBodiedMethodRewrites()
+        {
+            var code =
+    @"using System;
+class T
+{
+    int M1() => 1 + 2 + [|3|] /*not moved*/; /*moved to end of block*/
+
+    // rewrite should preserve newline above this.
+    void Cat() { }
+}";
+
+            var expected =
+    @"using System;
+class T
+{
+    int M1()
+    {
+        const int {|Rename:V|} = 3;
+        return 1 + 2 + V /*not moved*/;
+    } /*moved to end of block*/
+
+    // rewrite should preserve newline above this.
+    void Cat() { }
+}";
+
+            Test(code, expected, index: 2, compareTokens: false);
         }
     }
 }

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -51,6 +51,11 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             return expression.GetAncestorOrThis<ConstructorInitializerSyntax>() != null;
         }
 
+        protected override bool IsInExpressionBodiedMember(ExpressionSyntax expression)
+        {
+            return expression.GetAncestorOrThis<ArrowExpressionClauseSyntax>() != null;
+        }
+
         protected override bool IsInAttributeArgumentInitializer(ExpressionSyntax expression)
         {
             // Don't call the base here.  We want to let the user extract a constant if they've

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -53,7 +53,22 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
 
         protected override bool IsInExpressionBodiedMember(ExpressionSyntax expression)
         {
-            return expression.GetAncestorOrThis<ArrowExpressionClauseSyntax>() != null;
+            // walk up until we find a nearest enclosing block or arrow expression.
+            for (SyntaxNode node = expression; node != null; node = node.GetParent())
+            {
+                // If we are in an expression bodied member and if the expression has a block body, then,
+                // act as if we're in a block context and not in an expression body context at all.
+                if (node.IsKind(SyntaxKind.Block))
+                {
+                    return false;
+                }
+                else if (node.IsKind(SyntaxKind.ArrowExpressionClause))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         protected override bool IsInAttributeArgumentInitializer(ExpressionSyntax expression)

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -202,7 +202,6 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                                        .WithTrailingTrivia(oldBody.GetTrailingTrivia())
                                        .WithAdditionalAnnotations(Formatter.Annotation);
 
-            // TODO: What happens to surrounding directives - do we make if def'd out code active with this rewrite?
             SyntaxNode newParentingNode = null;
             if (oldParentingNode is BasePropertyDeclarationSyntax)
             {

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -195,10 +195,12 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
         {
             var oldBody = expression.GetAncestorOrThis<ArrowExpressionClauseSyntax>();
             var oldParentingNode = oldBody.Parent;
+            var leadingTrivia = oldBody.GetLeadingTrivia()
+                                       .AddRange(oldBody.ArrowToken.TrailingTrivia);
 
             var newStatement = Rewrite(document, expression, newLocalName, document, oldBody.Expression, allOccurrences, cancellationToken);
             var newBody = SyntaxFactory.Block(declarationStatement, SyntaxFactory.ReturnStatement(newStatement))
-                                       .WithLeadingTrivia(oldBody.GetLeadingTrivia())
+                                       .WithLeadingTrivia(leadingTrivia)
                                        .WithTrailingTrivia(oldBody.GetTrailingTrivia())
                                        .WithAdditionalAnnotations(Formatter.Annotation);
 
@@ -206,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             if (oldParentingNode is BasePropertyDeclarationSyntax)
             {
                 var getAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, newBody);
-                var accessorList = SyntaxFactory.AccessorList(SyntaxFactory.List(new AccessorDeclarationSyntax[] { getAccessor }));
+                var accessorList = SyntaxFactory.AccessorList(SyntaxFactory.List(new[] { getAccessor }));
 
                 newParentingNode = ((BasePropertyDeclarationSyntax)oldParentingNode).RemoveNode(oldBody, SyntaxRemoveOptions.KeepNoTrivia);
 

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             public bool InFieldContext { get; private set; }
             public bool InParameterContext { get; private set; }
             public bool InQueryContext { get; private set; }
+            public bool InExpressionBodiedMemberContext { get; private set; }
 
             public bool IsConstant { get; private set; }
 
@@ -122,6 +123,17 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     if (IsInBlockContext(cancellationToken))
                     {
                         this.InBlockContext = true;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                if (_service.IsInExpressionBodiedMember(this.Expression))
+                {
+                    if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))
+                    {
+                        this.InExpressionBodiedMemberContext = true;
                         return true;
                     }
 

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -129,6 +129,8 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     return false;
                 }
 
+                // TODO: This may have to move to a partial class with its own method
+                // IsInSomething*Context* to deal with query variables etc.
                 if (_service.IsInExpressionBodiedMember(this.Expression))
                 {
                     if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -129,6 +129,11 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     return false;
                 }
 
+                // The ordering of checks is important here. If we are inside a block within an Expression 
+                // bodied member, we should treat it as if we are in block context.
+                // For example, in such a scenario we should generate inside the block, instead of rewriting
+                // a concise expression bodied member to its equivalent that has a body with a block.
+                // For this reason, block should precede expression bodied member check.
                 if (_service.IsInExpressionBodiedMember(this.Expression))
                 {
                     if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -129,8 +129,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     return false;
                 }
 
-                // TODO: This may have to move to a partial class with its own method
-                // IsInSomething*Context* to deal with query variables etc.
                 if (_service.IsInExpressionBodiedMember(this.Expression))
                 {
                     if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -119,9 +119,9 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             }
             else if (state.InExpressionBodiedMemberContext)
             {
-                // TODO: for now, from an expression bodied member, we can generate only fields.
-                // Offer generate local, and if the user chooses this, rewrite expression bodied member to a regular one.
                 await CreateConstantFieldActionsAsync(state, actions, cancellationToken).ConfigureAwait(false);
+                actions.Add(CreateAction(state, allOccurrences: false, isConstant: state.IsConstant, isLocal: true, isQueryLocal: false));
+                actions.Add(CreateAction(state, allOccurrences: true, isConstant: state.IsConstant, isLocal: true, isQueryLocal: false));
             }
 
             return actions;

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
         protected abstract bool IsInParameterInitializer(TExpressionSyntax expression);
         protected abstract bool IsInConstructorInitializer(TExpressionSyntax expression);
         protected abstract bool IsInAttributeArgumentInitializer(TExpressionSyntax expression);
+        protected abstract bool IsInExpressionBodiedMember(TExpressionSyntax expression);
 
         protected abstract IEnumerable<SyntaxNode> GetContainingExecutableBlocks(TExpressionSyntax expression);
         protected abstract IList<bool> GetInsertionIndices(TTypeDeclarationSyntax destination, CancellationToken cancellationToken);
@@ -101,25 +102,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             }
             else if (state.InBlockContext)
             {
-                if (state.IsConstant &&
-                    !state.GetSemanticMap(cancellationToken).AllReferencedSymbols.OfType<ILocalSymbol>().Any() &&
-                    !state.GetSemanticMap(cancellationToken).AllReferencedSymbols.OfType<IParameterSymbol>().Any())
-                {
-                    // If something is a constant, and it doesn't access any other locals constants,
-                    // then we prefer to offer to generate a constant field instead of a constant
-                    // local.
-                    var action1 = CreateAction(state, allOccurrences: false, isConstant: true, isLocal: false, isQueryLocal: false);
-                    if (await CanGenerateIntoContainerAsync(state, action1, cancellationToken).ConfigureAwait(false))
-                    {
-                        actions.Add(action1);
-                    }
-
-                    var action2 = CreateAction(state, allOccurrences: true, isConstant: true, isLocal: false, isQueryLocal: false);
-                    if (await CanGenerateIntoContainerAsync(state, action2, cancellationToken).ConfigureAwait(false))
-                    {
-                        actions.Add(action2);
-                    }
-                }
+                await CreateConstantFieldActionsAsync(state, actions, cancellationToken).ConfigureAwait(false);
 
                 var blocks = this.GetContainingExecutableBlocks(state.Expression);
                 var block = blocks.FirstOrDefault();
@@ -134,8 +117,37 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     }
                 }
             }
+            else if (state.InExpressionBodiedMemberContext)
+            {
+                // TODO: for now, from an expression bodied member, we can generate only fields.
+                // Offer generate local, and if the user chooses this, rewrite expression bodied member to a regular one.
+                await CreateConstantFieldActionsAsync(state, actions, cancellationToken).ConfigureAwait(false);
+            }
 
             return actions;
+        }
+
+        private async Task CreateConstantFieldActionsAsync(State state, List<CodeAction> actions, CancellationToken cancellationToken)
+        {
+            if (state.IsConstant &&
+                !state.GetSemanticMap(cancellationToken).AllReferencedSymbols.OfType<ILocalSymbol>().Any() &&
+                !state.GetSemanticMap(cancellationToken).AllReferencedSymbols.OfType<IParameterSymbol>().Any())
+            {
+                // If something is a constant, and it doesn't access any other locals constants,
+                // then we prefer to offer to generate a constant field instead of a constant
+                // local.
+                var action1 = CreateAction(state, allOccurrences: false, isConstant: true, isLocal: false, isQueryLocal: false);
+                if (await CanGenerateIntoContainerAsync(state, action1, cancellationToken).ConfigureAwait(false))
+                {
+                    actions.Add(action1);
+                }
+
+                var action2 = CreateAction(state, allOccurrences: true, isConstant: true, isLocal: false, isQueryLocal: false);
+                if (await CanGenerateIntoContainerAsync(state, action2, cancellationToken).ConfigureAwait(false))
+                {
+                    actions.Add(action2);
+                }
+            }
         }
 
         private async Task<bool> CanGenerateIntoContainerAsync(State state, CodeAction action, CancellationToken cancellationToken)

--- a/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
+++ b/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
@@ -112,6 +112,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
             Return expression.GetAncestorOrThis(Of EqualsValueSyntax)().IsParentKind(SyntaxKind.Parameter)
         End Function
 
+        Protected Overrides Function IsInExpressionBodiedMember(expression As ExpressionSyntax) As Boolean
+            Return False
+        End Function
+
         Protected Overrides Function CanReplace(expression As ExpressionSyntax) As Boolean
             If expression.CheckParent(Of RangeArgumentSyntax)(Function(n) n.LowerBound Is expression) Then
                 Return False


### PR DESCRIPTION
This PR implements support for Introduce Variable refactoring in Expression Bodied Members in C#. Added unit tests for the same. 

Associated with #528. Will address Extract Method in a separate PR.