### PR TITLE
make solution crawler to cancel all running tasks on global operation

### DIFF
--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -99,6 +99,15 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
                 }
 
+                public void RequestCancellationOnRunningTasks()
+                {
+                    lock (_gate)
+                    {
+                        // request to cancel all running works
+                        _cancellationMap.Do(p => p.Value.Cancel());
+                    }
+                }
+
                 public void Dispose()
                 {
                     lock (_gate)

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
@@ -45,6 +45,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         _globalOperationNotificationService.Stopped += OnGlobalOperationStopped;
                     }
 
+                    protected abstract void PauseOnGlobalOperation();
+
                     private void OnGlobalOperationStarted(object sender, EventArgs e)
                     {
                         Contract.ThrowIfFalse(_globalOperation == null);
@@ -54,6 +56,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         _globalOperationTask = _globalOperation.Task;
 
                         SolutionCrawlerLogger.LogGlobalOperation(this.Processor._logAggregator);
+
+                        PauseOnGlobalOperation();
                     }
 
                     private void OnGlobalOperationStopped(object sender, GlobalOperationEventArgs e)

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -75,6 +75,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
                     }
 
+                    protected override void PauseOnGlobalOperation()
+                    {
+                        _workItemQueue.RequestCancellationOnRunningTasks();
+                    }
+
                     public void Enqueue(WorkItem item)
                     {
                         this.UpdateLastAccessTime();

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -183,6 +183,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
                     }
 
+                    protected override void PauseOnGlobalOperation()
+                    {
+                        _workItemQueue.RequestCancellationOnRunningTasks();
+                    }
+
                     private void SetProjectProcessing(ProjectId currentProject)
                     {
                         if (currentProject != _currentProjectProcessing)


### PR DESCRIPTION
previously on global operation, soluton crawler will pause itself but it won't cancel already running tasks.

this change make solution crawler to even cancel running tasks and go to pause mode sooner on global operation.

cancelled tasks will re-enqueued to work queue and will run next time.