### PR TITLE
Fix KeyNotFoundException

### DIFF
--- a/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
@@ -54,26 +54,28 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         private void ContextChangedWorker(UIContextChangedEventArgs e, string operation)
         {
-            if (_notificationService != null)
+            if (_notificationService == null)
             {
-                TryCancelPendingNotification(operation);
-                
-                if (e.Activated)
-                {
-                    _operations[operation] = _notificationService.Start(operation);
-                }
+                return;
+            }
+
+            TryCancelPendingNotification(operation);
+
+            if (e.Activated)
+            {
+                _operations[operation] = _notificationService.Start(operation);
             }
         }
 
         private void TryCancelPendingNotification(string operation)
         {
-            if (_operations.ContainsKey(operation))
+            GlobalOperationRegistration globalOperation;
+            if (_operations.TryGetValue(operation, out globalOperation))
             {
-                var globalOperation = _operations[operation];
                 globalOperation.Done();
                 globalOperation.Dispose();
             }
         }
-       
+
     }
 }

--- a/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
@@ -56,24 +56,24 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             if (_notificationService != null)
             {
-                var globalOperation = _operations[operation];
+                TryCancelPendingNotification(operation);
+                
                 if (e.Activated)
                 {
-                    if (globalOperation != null)
-                    {
-                        globalOperation.Dispose();
-                    }
-
                     _operations[operation] = _notificationService.Start(operation);
-
-                }
-                else if (globalOperation != null)
-                {
-                    globalOperation.Done();
-                    globalOperation.Dispose();
-                    globalOperation = null;
                 }
             }
         }
+
+        private void TryCancelPendingNotification(string operation)
+        {
+            if (_operations.ContainsKey(operation))
+            {
+                var globalOperation = _operations[operation];
+                globalOperation.Done();
+                globalOperation.Dispose();
+            }
+        }
+       
     }
 }


### PR DESCRIPTION
Ensure a an operation is a key in the dictionary of operations before
attempting to look it up.