### PR TITLE
update unit tests to use localized resources

### DIFF
--- a/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
@@ -383,9 +383,9 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.I.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), string.Format(EditorFeaturesResources.Implements, "Foo") });
+            testState.VerifyRoot(root, "N.I.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), string.Format(EditorFeaturesResources.ImplementsArg, "Foo") });
             testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.G.Main()" });
-            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Implements, "Foo"), new[] { "N.C.Foo()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.ImplementsArg, "Foo"), new[] { "N.C.Foo()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]

--- a/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
@@ -429,7 +429,7 @@ namespace N
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
             testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), EditorFeaturesResources.Overrides });
-            testState.VerifyResult(root, EditorFeatures.Overrides, new[] { "N.G.Foo()" });
+            testState.VerifyResult(root, EditorFeaturesResources.Overrides, new[] { "N.G.Foo()" });
         }
 
         [WorkItem(844613)]

--- a/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CallHierarchy/CallHierarchyTests.cs
@@ -90,8 +90,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.Foo()", new[] { "Calls To 'Foo'" });
-            testState.VerifyResult(root, "Calls To 'Foo'", new[] { "N.G.Main()", "N.G.Main2()" });
+            testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.G.Main()", "N.G.Main2()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -129,9 +129,9 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.Foo()", new[] { "Calls To 'Foo'", "Calls To Interface Implementation 'N.I.Foo()'" });
-            testState.VerifyResult(root, "Calls To 'Foo'", new[] { "N.G.Main2()" });
-            testState.VerifyResult(root, "Calls To Interface Implementation 'N.I.Foo()'", new[] { "N.G.Main()" });
+            testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), string.Format(EditorFeaturesResources.CallsToInterfaceImplementation, "N.I.Foo()") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.G.Main2()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsToInterfaceImplementation, "N.I.Foo()"), new[] { "N.G.Main()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -164,9 +164,9 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.Foo()", new[] { "Calls To 'Foo'", "Calls To Overrides" });
-            testState.VerifyResult(root, "Calls To 'Foo'", new[] { "N.D.Bar()" });
-            testState.VerifyResult(root, "Calls To Overrides", new[] { "N.D.Baz()" });
+            testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), EditorFeaturesResources.CallsToOverrides });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.D.Bar()" });
+            testState.VerifyResult(root, EditorFeaturesResources.CallsToOverrides, new[] { "N.D.Baz()" });
         }
 
         [Fact, WorkItem(829705), Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -199,9 +199,9 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.D.Foo()", new[] { "Calls To 'Foo'", "Calls To Base Member 'N.C.Foo()'" });
-            testState.VerifyResult(root, "Calls To 'Foo'", new[] { "N.D.Baz()" });
-            testState.VerifyResult(root, "Calls To Base Member 'N.C.Foo()'", new[] { "N.D.Bar()" });
+            testState.VerifyRoot(root, "N.D.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), string.Format(EditorFeaturesResources.CallsToBaseMember, "N.C.Foo()") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.D.Baz()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsToBaseMember, "N.C.Foo()"), new[] { "N.D.Bar()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -219,8 +219,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.Foo()", new[] { "Calls To 'Foo'" });
-            testState.VerifyResultName(root, "Calls To 'Foo'", new[] { "Initializers" });
+            testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo") });
+            testState.VerifyResultName(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { EditorFeaturesResources.Initializers });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -238,8 +238,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.foo", new[] { "References To Field 'foo'" });
-            testState.VerifyResult(root, "References To Field 'foo'", new[] { "N.C.Foo()" });
+            testState.VerifyRoot(root, "N.C.foo", new[] { string.Format(EditorFeaturesResources.ReferencesToField, "foo") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.ReferencesToField, "foo"), new[] { "N.C.Foo()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -266,8 +266,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.val.get", new[] { "Calls To 'get_val'" });
-            testState.VerifyResult(root, "Calls To 'get_val'", new[] { "N.C.foo()" });
+            testState.VerifyRoot(root, "N.C.val.get", new[] { string.Format(EditorFeaturesResources.CallsTo, "get_val") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "get_val"), new[] { "N.C.foo()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -292,8 +292,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.generic<T>(this string, ref T)", new[] { "Calls To 'generic'" });
-            testState.VerifyResult(root, "Calls To 'generic'", new[] { "N.C.foo()" });
+            testState.VerifyRoot(root, "N.C.generic<T>(this string, ref T)", new[] { string.Format(EditorFeaturesResources.CallsTo, "generic") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "generic"), new[] { "N.C.foo()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -321,8 +321,8 @@ namespace ConsoleApplication10
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "ConsoleApplication10.Extensions.BarString(this string)", new[] { "Calls To 'BarString'" });
-            testState.VerifyResult(root, "Calls To 'BarString'", new[] { "ConsoleApplication10.Program.Main(string[])" });
+            testState.VerifyRoot(root, "ConsoleApplication10.Extensions.BarString(this string)", new[] { string.Format(EditorFeaturesResources.CallsTo, "BarString") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "BarString"), new[] { "ConsoleApplication10.Program.Main(string[])" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -344,8 +344,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "System.Linq.Enumerable.Single<TSource>(this System.Collections.Generic.IEnumerable<TSource>)", new[] { "Calls To 'Single'" });
-            testState.VerifyResult(root, "Calls To 'Single'", new[] { "N.Program.Main(string[])" });
+            testState.VerifyRoot(root, "System.Linq.Enumerable.Single<TSource>(this System.Collections.Generic.IEnumerable<TSource>)", new[] { string.Format(EditorFeaturesResources.CallsTo, "Single") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Single"), new[] { "N.Program.Main(string[])" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -383,9 +383,9 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.I.Foo()", new[] { "Calls To 'Foo'", "Implements 'Foo'" });
-            testState.VerifyResult(root, "Calls To 'Foo'", new[] { "N.G.Main()" });
-            testState.VerifyResult(root, "Implements 'Foo'", new[] { "N.C.Foo()" });
+            testState.VerifyRoot(root, "N.I.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), string.Format(EditorFeaturesResources.Implements, "Foo") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.CallsTo, "Foo"), new[] { "N.G.Main()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Implements, "Foo"), new[] { "N.C.Foo()" });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
@@ -428,8 +428,8 @@ namespace N
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "N.C.Foo()", new[] { "Calls To 'Foo'", "Overrides" });
-            testState.VerifyResult(root, "Overrides", new[] { "N.G.Foo()" });
+            testState.VerifyRoot(root, "N.C.Foo()", new[] { string.Format(EditorFeaturesResources.CallsTo, "Foo"), EditorFeaturesResources.Overrides });
+            testState.VerifyResult(root, EditorFeatures.Overrides, new[] { "N.G.Foo()" });
         }
 
         [WorkItem(844613)]
@@ -453,8 +453,8 @@ class Derived : Base
 }";
             var testState = new CallHierarchyTestState(text);
             var root = testState.GetRoot();
-            testState.VerifyRoot(root, "Base.M()", new[] { "Calls To 'M'", "Overrides", "Calls To Overrides" });
-            testState.VerifyResult(root, "Overrides", new[] { "Derived.M()" });
+            testState.VerifyRoot(root, "Base.M()", new[] { string.Format(EditorFeaturesResources.CallsTo, "M"), EditorFeaturesResources.Overrides, EditorFeaturesResources.CallsToOverrides });
+            testState.VerifyResult(root, EditorFeaturesResources.Overrides, new[] { "Derived.M()" });
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.GenerateFromMembers.AddConstructorParameters;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -57,7 +54,7 @@ index: 1);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Add parameters to 'Program(bool)'",
+string.Format(FeaturesResources.AddParametersTo, "Program", "bool"),
 index: 0);
         }
 
@@ -66,7 +63,7 @@ index: 0);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Add optional parameters to 'Program(bool)'",
+string.Format(FeaturesResources.AddOptionalParametersTo, "Program", "bool"),
 index: 1);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.GenerateFromMembers.GenerateConstructor;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -148,7 +145,7 @@ index: 0);
         {
             TestSmartTagText(
 @"using System.Collections.Generic; class Program { [|bool b; HashSet<string> s;|] }",
-@"Generate constructor 'Program(bool, HashSet<string>)'");
+string.Format(FeaturesResources.GenerateConstructor, "Program", "bool, HashSet<string>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
@@ -156,7 +153,7 @@ index: 0);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Generate field assigning constructor 'Program(bool, HashSet<string>)'");
+string.Format(FeaturesResources.GenerateFieldAssigningConstructor, "Program", "bool, HashSet<string>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
@@ -164,7 +161,7 @@ index: 0);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Generate delegating constructor 'Program(bool, HashSet<string>)'",
+string.Format(FeaturesResources.GenerateDelegatingConstructor, "Program", "bool, HashSet<string>"),
 index: 1);
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
@@ -154,7 +154,7 @@ index: 1);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Generate 'Equals(object)'");
+FeaturesResources.GenerateEqualsObject);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -162,7 +162,7 @@ index: 1);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Generate 'GetHashCode()'",
+FeaturesResources.GenerateGetHashCode,
 index: 1);
         }
 
@@ -171,7 +171,7 @@ index: 1);
         {
             TestSmartTagText(
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
-@"Generate Both",
+FeaturesResources.GenerateBoth,
 index: 2);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -876,7 +876,7 @@ class Program
     }
 }";
 
-            TestExactActionSetOffered(code, new[] { "Introduce local constant for '5'" });
+            TestExactActionSetOffered(code, new[] { string.Format(FeaturesResources.IntroduceLocalConstantFor, "5") });
 
             Test(code,
 @"
@@ -916,7 +916,7 @@ class Program
 }";
 
             TestExactActionSetOffered(code,
-                new[] { "Introduce local constant for '5'", "Introduce local constant for all occurrences of '5'" });
+                new[] { string.Format(FeaturesResources.IntroduceLocalConstantFor, "5"), string.Format(FeaturesResources.IntroduceLocalConstantForAll, "5") });
         }
 
         [WorkItem(529795)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -362,7 +362,7 @@ class Class1
 }
 ";
             VerifyItemExists(markup, "obj:",
-                expectedDescriptionOrNull: "(parameter) Class1 obj = default(Class1)");
+                expectedDescriptionOrNull: $"({FeaturesResources.Parameter}) Class1 obj = default(Class1)");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -2492,7 +2492,7 @@ class C
     {
         $$";
 
-            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverload})");
+            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6299,7 +6299,7 @@ class Program
 }";
 
             var description = $@"({CSharpEditorResources.Awaitable}) Task Program.foo()
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");
@@ -6320,7 +6320,7 @@ class Program
 }";
 
             var description = $@"({CSharpEditorResources.Awaitable}) Task<int> Program.foo()
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   int x = {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6299,7 +6299,7 @@ class Program
 }";
 
             var description = $@"({CSharpEditorResources.Awaitable}) Task Program.foo()
-Usage:
+{CSharpFeaturesResources.Usage}
   {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");
@@ -6320,7 +6320,7 @@ class Program
 }";
 
             var description = $@"({CSharpEditorResources.Awaitable}) Task<int> Program.foo()
-Usage:
+{CSharpFeaturesResources.Usage}
   int x = {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Roslyn.Test.Utilities;
@@ -2447,7 +2448,7 @@ class C
     {
         $$";
 
-            VerifyItemExists(markup, "M", expectedDescriptionOrNull: "void C.M(int i) (+ 1 overload)");
+            VerifyItemExists(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 1 {FeaturesResources.Overload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2462,7 +2463,7 @@ class C
     {
         $$";
 
-            VerifyItemExists(markup, "M", expectedDescriptionOrNull: "void C.M(int i) (+ 2 overloads)");
+            VerifyItemExists(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 2 {FeaturesResources.Overloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2476,7 +2477,7 @@ class C
     {
         $$";
 
-            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: "void C.M<T>(T i) (+ 1 generic overload)");
+            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(T i) (+ 1 {FeaturesResources.GenericOverload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2491,7 +2492,7 @@ class C
     {
         $$";
 
-            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: "void C.M<T>(int i) (+ 2 generic overloads)");
+            VerifyItemExists(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2517,7 +2518,7 @@ class C<T>
     {
         $$";
 
-            VerifyItemExists(markup, "foo", expectedDescriptionOrNull: "(parameter) T foo");
+            VerifyItemExists(markup, "foo", expectedDescriptionOrNull: $"({FeaturesResources.Parameter}) T foo");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2530,7 +2531,7 @@ class C<T>
     {
         $$";
 
-            VerifyItemExists(markup, "T", expectedDescriptionOrNull: "T in C<T>");
+            VerifyItemExists(markup, "T", expectedDescriptionOrNull: $"T {FeaturesResources.In} C<T>");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2546,10 +2547,10 @@ class C
 ";
 
             var expectedDescription =
-@"(local variable) 'a a
+$@"({FeaturesResources.LocalVariable}) 'a a
 
-Anonymous Types:
-    'a is new {  }";
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{  }}";
 
             VerifyItemExists(markup, "a", expectedDescription);
         }
@@ -6297,9 +6298,9 @@ class Program
     }
 }";
 
-            var description = @"(awaitable) Task Program.foo()
+            var description = $@"({CSharpEditorResources.Awaitable}) Task Program.foo()
 Usage:
-  await foo();";
+  {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");
         }
@@ -6318,9 +6319,9 @@ class Program
     }
 }";
 
-            var description = @"(awaitable) Task<int> Program.foo()
+            var description = $@"({CSharpEditorResources.Awaitable}) Task<int> Program.foo()
 Usage:
-  int x = await foo();";
+  int x = {CSharpFeaturesResources.Await} foo();";
 
             VerifyItemWithMscorlib45(markup, "foo", description, "C#");
         }
@@ -6339,7 +6340,7 @@ class Program
         $$
     }
 }";
-            VerifyItemExists(markup, "foo", "[deprecated] void Program.foo()");
+            VerifyItemExists(markup, "foo", $"[{CSharpFeaturesResources.Deprecated}] void Program.foo()");
         }
 
         [WorkItem(568986)]
@@ -6639,7 +6640,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyItemInLinkedFiles(markup, "x", "(field) int C.x");
+            VerifyItemInLinkedFiles(markup, "x", $"({FeaturesResources.Field}) int C.x");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -6665,7 +6666,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(field) int C.x\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.";
+            var expectedDescription = $"({FeaturesResources.Field}) int C.x\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
 
             VerifyItemInLinkedFiles(markup, "x", expectedDescription);
         }
@@ -6696,7 +6697,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(field) int C.x\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.";
+            var expectedDescription = $"({FeaturesResources.Field}) int C.x\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
 
             VerifyItemInLinkedFiles(markup, "x", expectedDescription);
         }
@@ -6730,7 +6731,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(field) int C.x\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.";
+            var expectedDescription = $"({FeaturesResources.Field}) int C.x\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
 
             VerifyItemInLinkedFiles(markup, "x", expectedDescription);
         }
@@ -6768,7 +6769,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "void G.DoGStuff()\r\n\r\n    Proj1 - Not Available\r\n    Proj2 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.";
+            var expectedDescription = $"void G.DoGStuff()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
 
             VerifyItemInLinkedFiles(markup, "DoGStuff", expectedDescription);
         }
@@ -6795,7 +6796,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(local variable) int xyz";
+            var expectedDescription = $"({FeaturesResources.LocalVariable}) int xyz";
             VerifyItemInLinkedFiles(markup, "xyz", expectedDescription);
         }
 
@@ -6823,7 +6824,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(local variable) int xyz\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.";
+            var expectedDescription = $"({FeaturesResources.LocalVariable}) int xyz\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
             VerifyItemInLinkedFiles(markup, "xyz", expectedDescription);
         }
 
@@ -6849,7 +6850,7 @@ LABEL:  int xyz;
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(label) LABEL";
+            var expectedDescription = $"({FeaturesResources.Label}) LABEL";
             VerifyItemInLinkedFiles(markup, "LABEL", expectedDescription);
         }
 
@@ -6875,7 +6876,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
-            var expectedDescription = "(range variable) ? y";
+            var expectedDescription = $"({FeaturesResources.RangeVariable}) ? y";
             VerifyItemInLinkedFiles(markup, "y", expectedDescription);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -1501,7 +1501,7 @@ index: 1);
         {
             TestSmartTagText(
 @"class C : [|Foo|]",
-"Generate class for 'Foo' in 'Global Namespace' (in new file)");
+string.Format(FeaturesResources.GenerateForInNewFile, "class", "Foo", FeaturesResources.GlobalNamespace));
         }
 
         [WorkItem(543853)]
@@ -1568,8 +1568,13 @@ class Program
 }
 ";
 
-            TestExactActionSetOffered(
-code, new[] { "Generate class for 'Foo' in 'Global Namespace' (in new file)", "Generate class for 'Foo' in 'Program'", "Generate new type..." });
+            TestExactActionSetOffered(code,
+                new[]
+                {
+                    string.Format(FeaturesResources.GenerateForInNewFile, "class", "Foo", FeaturesResources.GlobalNamespace),
+                    string.Format(FeaturesResources.GenerateForIn, "class", "Foo", "Program"),
+                    FeaturesResources.GenerateNewType
+                });
 
             Test(code,
 @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -85,7 +85,7 @@ index: 2);
         {
             TestExactActionSetOffered(
 @"class Class { void Method(int i) { [|foo|] = 1; } }",
-new[] { "Generate field 'foo' in 'Class'", "Generate property 'Class.foo'", "Generate local 'foo'" });
+new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GeneratePropertyIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -110,7 +110,7 @@ index: 1);
         {
             TestExactActionSetOffered(
 @"class Class { void Method(ref int i) { Method(ref [|foo|]); } }",
-new[] { "Generate field 'foo' in 'Class'", "Generate local 'foo'" });
+new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -126,7 +126,7 @@ new[] { "Generate field 'foo' in 'Class'", "Generate local 'foo'" });
         {
             TestExactActionSetOffered(
 @"class Class { void Method(out int i) { Method(out [|foo|]); } }",
-new[] { "Generate field 'foo' in 'Class'", "Generate local 'foo'" });
+new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -741,7 +741,7 @@ compareTokens: false);
         {
             TestExactActionSetOffered(
 @"class Program { static void Main ( ) { [|p|] ++ ; } } ",
-new[] { "Generate field 'p' in 'Program'", "Generate property 'Program.p'", "Generate local 'p'" });
+new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string.Format(FeaturesResources.GeneratePropertyIn, "p", "Program"), string.Format(FeaturesResources.GenerateLocal, "p") });
 
             Test(
 @"class Program { static void Main ( ) { [|p|] ++ ; } } ",
@@ -1838,7 +1838,7 @@ class C
 #line hidden
 }
 ";
-            TestExactActionSetOffered(code, new[] { "Generate local 'Bar'" });
+            TestExactActionSetOffered(code, new[] { string.Format(FeaturesResources.GenerateLocal, "Bar") });
 
             Test(code,
 @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -1676,7 +1676,7 @@ class C : IDisposable
 class C : [|IDisposable|]",
 $@"using System;
 class C : IDisposable
-{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{{{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
 }}
 ", index: 1, compareTokens: false);
         }
@@ -1719,7 +1719,7 @@ class C : System.IDisposable
     class IDisposable
     {{
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+{DisposePatternWithIndentation("protected virtual ", "C", "void System.IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -1769,7 +1769,8 @@ class C : IDisposable
             Test(
 @"class C : [|System.IDisposable|]",
 $@"class C : System.IDisposable
-{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+{{{DisposePatternWithIndentation("protected virtual ", "C", "void System.IDisposable.")}
+}}
 ", index: 3, compareTokens: false);
         }
 
@@ -1829,7 +1830,7 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -1857,7 +1858,7 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+{DisposePatternWithIndentation("protected virtual ", "C", "void IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -2294,7 +2295,7 @@ using System;
 
 class Program : IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "public void ")}
+{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
 }}
 ", index: 1);
         }
@@ -2317,7 +2318,7 @@ using System;
 class Program : IDisposable
 {{
     private bool DisposedValue;
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "void IDisposable.")}
+{DisposePatternWithIndentation("protected virtual ", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2396,7 +2397,7 @@ using System;
 
 sealed class Program : IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "", "Program", "void IDisposable.")}
+{DisposePatternWithIndentation("", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2521,7 +2522,7 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -2568,12 +2569,21 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+{DisposePatternWithIndentation("protected virtual ", "C", "void IDisposable.")}
 }}
 
 partial class C
 {{
 }}", index: 3, compareTokens: false);
+        }
+
+        private static string DisposePatternWithIndentation(string disposeMethodModifiers, string className, string interfaceMethodModifiers, string additionalIndentation = "    ")
+        {
+            var lines = string.Format(CSharpFeaturesResources.DisposePattern, disposeMethodModifiers, className, interfaceMethodModifiers)
+                .Split('\n')
+                .Select(line => line.TrimEnd())
+                .Select(line => line.Length > 0 ? additionalIndentation + line : line); // only indent lines with content
+            return string.Join("\r\n", lines);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementInterface
 {
@@ -1673,44 +1674,10 @@ class C : IDisposable
             Test(
 @"using System;
 class C : [|IDisposable|]",
-@"using System;
+$@"using System;
 class C : IDisposable
-{
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+}}
 ", index: 1, compareTokens: false);
         }
 
@@ -1746,48 +1713,14 @@ class C : [|System.IDisposable|]
     {
     }
 }",
-@"using System;
+$@"using System;
 class C : System.IDisposable
-{
+{{
     class IDisposable
-    {
-    }
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void System.IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}", index: 3, compareTokens: false);
+    {{
+    }}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+}}", index: 3, compareTokens: false);
         }
 
         [WorkItem(994456)]
@@ -1835,43 +1768,8 @@ class C : IDisposable
         {
             Test(
 @"class C : [|System.IDisposable|]",
-@"class C : System.IDisposable
-{
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void System.IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+$@"class C : System.IDisposable
+{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
 ", index: 3, compareTokens: false);
         }
 
@@ -1920,53 +1818,19 @@ interface I : IDisposable
 class C : [|I|]
 {
 }",
-@"using System;
+$@"using System;
 interface I : IDisposable
-{
+{{
     void F();
-}
+}}
 class C : I
-{
+{{
     public void F()
-    {
+    {{
         throw new NotImplementedException();
-    }
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}", index: 1, compareTokens: false);
+    }}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+}}", index: 1, compareTokens: false);
         }
 
         [WorkItem(951968)]
@@ -1982,53 +1846,19 @@ interface I : IDisposable
 class C : [|I|]
 {
 }",
-@"using System;
+$@"using System;
 interface I : IDisposable
-{
+{{
     void F();
-}
+}}
 class C : I
-{
+{{
     void I.F()
-    {
+    {{
         throw new NotImplementedException();
-    }
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}", index: 3, compareTokens: false);
+    }}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+}}", index: 3, compareTokens: false);
         }
 
         [WorkItem(941469)]
@@ -2459,47 +2289,13 @@ class Program : [|IDisposable|]
 {
 }
 ",
-@"
+$@"
 using System;
 
 class Program : IDisposable
-{
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~Program() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+{{
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "public void ")}
+}}
 ", index: 1);
         }
 
@@ -2515,48 +2311,14 @@ class Program : [|IDisposable|]
     private bool DisposedValue;
 }
 ",
-@"
+$@"
 using System;
 
 class Program : IDisposable
-{
+{{
     private bool DisposedValue;
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~Program() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "void IDisposable.")}
+}}
 ", index: 3);
         }
 
@@ -2629,47 +2391,13 @@ sealed class Program : [|IDisposable|]
 {
 }
 ",
-@"
+$@"
 using System;
 
 sealed class Program : IDisposable
-{
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~Program() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+{{
+{string.Format(CSharpFeaturesResources.DisposePattern, "", "Program", "void IDisposable.")}
+}}
 ", index: 3);
         }
 
@@ -2749,6 +2477,7 @@ namespace Scenarios
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDisposePatternWhenAdditionalUsingsAreIntroduced1()
         {
+            //CSharpFeaturesResources.DisposePattern
             Test(
 @"interface I<T, U> : System.IDisposable, System.IEquatable<int> where U : T
 {
@@ -2763,71 +2492,37 @@ partial class C
 partial class C : [|I<System.Exception, System.AggregateException>|], System.IDisposable
 {
 }",
-@"using System;
+$@"using System;
 using System.Collections.Generic;
 
 interface I<T, U> : System.IDisposable, System.IEquatable<int> where U : T
-{
+{{
     System.Collections.Generic.List<U> M(System.Collections.Generic.Dictionary<T, System.Collections.Generic.List<U>> a, T b, U c);
     System.Collections.Generic.List<UU> M<TT, UU>(System.Collections.Generic.Dictionary<TT, System.Collections.Generic.List<UU>> a, TT b, UU c) where UU : TT;
-}
+}}
 
 partial class C
-{
-}
+{{
+}}
 
 partial class C : I<System.Exception, System.AggregateException>, System.IDisposable
-{
+{{
     public bool Equals(int other)
-    {
+    {{
         throw new NotImplementedException();
-    }
+    }}
 
     public List<AggregateException> M(Dictionary<Exception, List<AggregateException>> a, Exception b, AggregateException c)
-    {
+    {{
         throw new NotImplementedException();
-    }
+    }}
 
     public List<UU> M<TT, UU>(Dictionary<TT, List<UU>> a, TT b, UU c) where UU : TT
-    {
+    {{
         throw new NotImplementedException();
-    }
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}", index: 1, compareTokens: false);
+    }}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+}}", index: 1, compareTokens: false);
         }
 
         [WorkItem(994328)]
@@ -2848,71 +2543,37 @@ partial class C : [|I<System.Exception, System.AggregateException>|], System.IDi
 partial class C
 {
 }",
-@"using System;
+$@"using System;
 using System.Collections.Generic;
 
 interface I<T, U> : System.IDisposable, System.IEquatable<int> where U : T
-{
+{{
     System.Collections.Generic.List<U> M(System.Collections.Generic.Dictionary<T, System.Collections.Generic.List<U>> a, T b, U c);
     System.Collections.Generic.List<UU> M<TT, UU>(System.Collections.Generic.Dictionary<TT, System.Collections.Generic.List<UU>> a, TT b, UU c) where UU : TT;
-}
+}}
 
 partial class C : I<System.Exception, System.AggregateException>, System.IDisposable
-{
+{{
     bool IEquatable<int>.Equals(int other)
-    {
+    {{
         throw new NotImplementedException();
-    }
+    }}
 
     List<AggregateException> I<Exception, AggregateException>.M(Dictionary<Exception, List<AggregateException>> a, Exception b, AggregateException c)
-    {
+    {{
         throw new NotImplementedException();
-    }
+    }}
 
     List<UU> I<Exception, AggregateException>.M<TT, UU>(Dictionary<TT, List<UU>> a, TT b, UU c)
-    {
+    {{
         throw new NotImplementedException();
-    }
-
-    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).          
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }
-    }
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
-    // ~C() {
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }
-
-    // This code added to correctly implement the disposable pattern.
-    void IDisposable.Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }
-    #endregion
-}
+    }}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+}}
 
 partial class C
-{
-}", index: 3, compareTokens: false);
+{{
+}}", index: 3, compareTokens: false);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -60,16 +60,16 @@ class Class
         [|int x = 0;|]
     }
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
-#pragma warning disable CS0219 // Variable is assigned but its value is never used
+    {{
+#pragma warning disable CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
         int x = 0;
-#pragma warning restore CS0219 // Variable is assigned but its value is never used
-    }
-}");
+#pragma warning restore CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
+    }}
+}}");
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
@@ -85,17 +85,17 @@ class Class
               + 1;|]
     }
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
-#pragma warning disable CS0219 // Variable is assigned but its value is never used
+    {{
+#pragma warning disable CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
         int x = 0
-#pragma warning restore CS0219 // Variable is assigned but its value is never used
+#pragma warning restore CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
               + 1;
-    }
-}");
+    }}
+}}");
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
@@ -112,19 +112,19 @@ class Class
         /* End comment next line */
     }
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
-#pragma warning disable CS0219 // Variable is assigned but its value is never used
+    {{
+#pragma warning disable CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
                               // Start comment previous line
                               /* Start comment same line */
         int x = 0; // End comment same line
-#pragma warning restore CS0219 // Variable is assigned but its value is never used
+#pragma warning restore CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
                               /* End comment next line */
-    }
-}");
+    }}
+}}");
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
@@ -139,16 +139,16 @@ class Class
         [|int x = 0, y = 0;|]
     }
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
-#pragma warning disable CS0219 // Variable is assigned but its value is never used
+    {{
+#pragma warning disable CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
         int x = 0, y = 0;
-#pragma warning restore CS0219 // Variable is assigned but its value is never used
-    }
-}");
+#pragma warning restore CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
+    }}
+}}");
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
@@ -164,17 +164,17 @@ class Class
         [|int x = ""0"";|]
     }
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
+    {{
         return 0;
-#pragma warning disable CS0162 // Unreachable code detected
+#pragma warning disable CS0162 // {CSharpResources.WRN_UnreachableCode}
         int x = ""0"";
-#pragma warning restore CS0162 // Unreachable code detected
-    }
-}");
+#pragma warning restore CS0162 // {CSharpResources.WRN_UnreachableCode}
+    }}
+}}");
                 }
 
                 [WorkItem(956453)]
@@ -183,9 +183,9 @@ class Class
                 {
                     Test(
         @"class Class { void Method() { [|int x = 0;|] } }",
-        @"#pragma warning disable CS0219 // Variable is assigned but its value is never used
-class Class { void Method() { int x = 0; } }
-#pragma warning restore CS0219 // Variable is assigned but its value is never used");
+        $@"#pragma warning disable CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}
+class Class {{ void Method() {{ int x = 0; }} }}
+#pragma warning restore CS0219 // {CSharpResources.WRN_UnreferencedVarAssg_Title}");
                 }
 
                 [WorkItem(970129)]
@@ -204,19 +204,19 @@ class Program
       [|Session|]
     }
 }",
-        @"
+        $@"
 using System;
 [Obsolete]
-class Session { }
+class Session {{ }}
 class Program
-{
+{{
     static void Main()
-    {
-#pragma warning disable CS0612 // Type or member is obsolete
+    {{
+#pragma warning disable CS0612 // {CSharpResources.WRN_DeprecatedSymbol_Title}
         Session
-#pragma warning restore CS0612 // Type or member is obsolete
-    }
-}");
+#pragma warning restore CS0612 // {CSharpResources.WRN_DeprecatedSymbol_Title}
+    }}
+}}");
                 }
 
                 [WorkItem(1066576)]
@@ -239,23 +239,23 @@ class Class
 
 
 }",
-        @"
+        $@"
 class Class
-{
+{{
     void Method()
-    {
+    {{
 
-#pragma warning disable CS1633 // Unrecognized #pragma directive
+#pragma warning disable CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
                               // Comment
                               // Comment
 #pragma abcde
 
-    }    // Comment   
-#pragma warning restore CS1633 // Unrecognized #pragma directive
+    }}    // Comment   
+#pragma warning restore CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 
 
 
-}");
+}}");
                 }
 
                 [WorkItem(1066576)]
@@ -264,9 +264,9 @@ class Class
                 {
                     Test(
         @"[|#pragma abcde|]",
-        @"#pragma warning disable CS1633 // Unrecognized #pragma directive
+        $@"#pragma warning disable CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 #pragma abcde
-#pragma warning restore CS1633 // Unrecognized #pragma directive");
+#pragma warning restore CS1633 // {CSharpResources.WRN_IllegalPragma_Title}");
                 }
 
                 [WorkItem(1066576)]
@@ -275,9 +275,9 @@ class Class
                 {
                     Test(
         @"  [|#pragma abcde|]  ",
-        @"#pragma warning disable CS1633 // Unrecognized #pragma directive
+        $@"#pragma warning disable CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 #pragma abcde  
-#pragma warning restore CS1633 // Unrecognized #pragma directive");
+#pragma warning restore CS1633 // {CSharpResources.WRN_IllegalPragma_Title}");
                 }
 
                 [WorkItem(1066576)]
@@ -291,12 +291,12 @@ class Class
 class C { }
 
 ",
-        @"
+        $@"
 
-#pragma warning disable CS1633 // Unrecognized #pragma directive
+#pragma warning disable CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 #pragma abc
-class C { }
-#pragma warning restore CS1633 // Unrecognized #pragma directive
+class C {{ }}
+#pragma warning restore CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 
 ");
                 }
@@ -310,12 +310,12 @@ class C { }
 [|#pragma abc|]
 class C2 { }
 class C3 { }",
-        @"class C1 { }
-#pragma warning disable CS1633 // Unrecognized #pragma directive
+        $@"class C1 {{ }}
+#pragma warning disable CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
 #pragma abc
-class C2 { }
-#pragma warning restore CS1633 // Unrecognized #pragma directive
-class C3 { }");
+class C2 {{ }}
+#pragma warning restore CS1633 // {CSharpResources.WRN_IllegalPragma_Title}
+class C3 {{ }}");
                 }
 
                 [WorkItem(1066576)]
@@ -704,13 +704,13 @@ using System;
         int x = 0;
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:Class"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class"")]
 
 ", isAddedDocument: true);
 
@@ -747,13 +747,13 @@ using System;
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""namespace"", Target = ""~N:N"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""namespace"", Target = ""~N:N"")]
 
 ", index: 1, isAddedDocument: true);
 
@@ -796,13 +796,13 @@ namespace N1
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:N1.N2.Class"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:N1.N2.Class"")]
 
 ", isAddedDocument: true);
 
@@ -848,13 +848,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:N.Generic`1.Class"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:N.Generic`1.Class"")]
 
 ", isAddedDocument: true);
 
@@ -900,13 +900,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
 
 ", isAddedDocument: true);
 
@@ -957,13 +957,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method(System.Int32,System.Char@)~System.Int32"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method(System.Int32,System.Char@)~System.Int32"")]
 
 ", isAddedDocument: true);
 
@@ -1048,13 +1048,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method``1(``0)~System.Int32"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method``1(``0)~System.Int32"")]
 
 ", isAddedDocument: true);
 
@@ -1100,13 +1100,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~P:N.Generic.Class.Property"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~P:N.Generic.Class.Property"")]
 
 ", isAddedDocument: true);
 
@@ -1143,13 +1143,13 @@ class Class
 {
     [|int field = 0;|]
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~F:Class.field"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~F:Class.field"")]
 
 ", isAddedDocument: true);
 
@@ -1177,13 +1177,13 @@ class Class
 {
     int [|field = 0|], field2 = 1;
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~F:Class.field"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~F:Class.field"")]
 
 ", isAddedDocument: true);
 
@@ -1225,13 +1225,13 @@ class Class
         remove { }
     }|]
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~E:Class.SampleEvent"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~E:Class.SampleEvent"")]
 
 ", isAddedDocument: true);
 
@@ -1287,14 +1287,14 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        @"
+                        $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:Class2"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]
 
 ";
 
@@ -1324,13 +1324,13 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        @"
+                        $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:Class2"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]
 
 ";
 
@@ -1369,14 +1369,14 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        @"
+                        $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""~T:Class2"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]
 
 ";
 
@@ -1454,19 +1454,19 @@ using System;
         int x = 0;
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 // Some trivia
 /* More Trivia */
-[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
 class Class
-{
+{{
     int Method()
-    {
+    {{
         int x = 0;
-    }
-}";
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1491,20 +1491,20 @@ using System;
         int x = 0;
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 // Some trivia
 /* More Trivia */
 [System.Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification = ""<Pending>"")]
-[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
 class Class
-{
+{{
     int Method()
-    {
+    {{
         int x = 0;
-    }
-}";
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1530,21 +1530,21 @@ using System;
         int x = 0;
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 // Some trivia
 /* More Trivia */
 [System.Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification = ""<Pending>"")]
-[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
 /* Some More Trivia */
 class Class
-{
+{{
     int Method()
-    {
+    {{
         int x = 0;
-    }
-}";
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1571,23 +1571,23 @@ namespace N1
         }
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 namespace N1
-{
+{{
     namespace N2
-    {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+    {{
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
         class Class
-        {
+        {{
             int Method()
-            {
+            {{
                 int x = 0;
-            }
-        }
-    }
-}";
+            }}
+        }}
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1614,23 +1614,23 @@ namespace N
         }
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 namespace N
-{
+{{
     class Generic<T>
-    {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+    {{
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
         class Class
-        {
+        {{
             int Method()
-            {
+            {{
                 int x = 0;
-            }
-        }
-    }
-}";
+            }}
+        }}
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1657,23 +1657,23 @@ namespace N
         }
     }
 }";
-                    var expected = @"
+                    var expected = $@"
 using System;
 
 namespace N
-{
+{{
     class Generic<T>
-    {
+    {{
         class Class
-        {
-            [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"")]
+        {{
+            [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
             int Method()
-            {
+            {{
                 int x = 0;
-            }
-        }
-    }
-}";
+            }}
+        }}
+    }}
+}}";
                     Test(initial, expected);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Method").Single();
-                VerifyNavigateToResultItem(item, "Method", MatchKind.Exact, NavigateToItemKind.Method, "Method()", "type Foo.Bar.DogBed");
+                VerifyNavigateToResultItem(item, "Method", MatchKind.Exact, NavigateToItemKind.Method, "Method()", $"{EditorFeaturesResources.Type}Foo.Bar.DogBed");
             }
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Bar").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar<T>(T)", "type Foo<U>");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar<T>(T)", $"{EditorFeaturesResources.Type}Foo<U>");
             }
         }
 
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("string").Single();
-                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("this").Single();
-                VerifyNavigateToResultItem(item, "this[]", MatchKind.Exact, NavigateToItemKind.Property, displayName: "this[int]", additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "this[]", MatchKind.Exact, NavigateToItemKind.Property, displayName: "this[int]", additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupEvent, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("CEH").Single();
-                VerifyNavigateToResultItem(item, "ChangedEventHandler", MatchKind.Regular, NavigateToItemKind.Event, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "ChangedEventHandler", MatchKind.Regular, NavigateToItemKind.Event, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("B").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Property, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Property, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("DS").Single();
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", "type Foo");
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("DS").Single();
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(int, string)", "type Foo");
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(int, string)", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo(int)", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo(int)", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method && t.Name != ".ctor");
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "static Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "static Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "~Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "~Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("Bar").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", "type Foo");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
-                Assert.Equal("type Foo", itemDisplay.AdditionalInformation);
+                Assert.Equal($"{EditorFeaturesResources.Type}Foo", itemDisplay.AdditionalInformation);
                 _glyphServiceMock.Verify();
             }
         }
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("sqr").Single();
-                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, "sqr", "type Foo");
+                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, "sqr", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Method").Single();
-                VerifyNavigateToResultItem(item, "Method", MatchKind.Exact, NavigateToItemKind.Method, "Method()", "type Foo.Bar.DogBed");
+                VerifyNavigateToResultItem(item, "Method", MatchKind.Exact, NavigateToItemKind.Method, "Method()", $"{EditorFeaturesResources.Type}Foo.Bar.DogBed");
             }
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Bar").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar<T>(T)", "type Foo<U>");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar<T>(T)", $"{EditorFeaturesResources.Type}Foo<U>");
             }
         }
 
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("b").Single();
-                VerifyNavigateToResultItem(item, "bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("ba").Single();
-                VerifyNavigateToResultItem(item, "bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -224,11 +224,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("string").Single();
-                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: $"{EditorFeaturesResources.Type}Foo");
 
                 // Check searching for@string too
                 item = _aggregator.GetItems("@string").Single();
-                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName: "@string", additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("this").Single();
-                VerifyNavigateToResultItem(item, "this[]", MatchKind.Exact, NavigateToItemKind.Property, displayName: "this[int]", additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "this[]", MatchKind.Exact, NavigateToItemKind.Property, displayName: "this[int]", additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupEvent, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("CEH").Single();
-                VerifyNavigateToResultItem(item, "ChangedEventHandler", MatchKind.Regular, NavigateToItemKind.Event, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "ChangedEventHandler", MatchKind.Regular, NavigateToItemKind.Event, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("B").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Property, additionalInfo: "type Foo");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Property, additionalInfo: $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("DS").Single();
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", "type Foo");
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -317,11 +317,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("static").Single();
-                VerifyNavigateToResultItem(item, "static", MatchKind.Exact, NavigateToItemKind.Method, "@static()", "type Foo");
+                VerifyNavigateToResultItem(item, "static", MatchKind.Exact, NavigateToItemKind.Method, "@static()", $"{EditorFeaturesResources.Type}Foo");
 
                 // Verify if we search for @static too
                 item = _aggregator.GetItems("@static").Single();
-                VerifyNavigateToResultItem(item, "static", MatchKind.Exact, NavigateToItemKind.Method, "@static()", "type Foo");
+                VerifyNavigateToResultItem(item, "static", MatchKind.Exact, NavigateToItemKind.Method, "@static()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("DS").Single();
-                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(int, string)", "type Foo");
+                VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(int, string)", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo(int)", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Foo(int)", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method && t.Name != ".ctor");
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "static Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "static Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
                 var item = _aggregator.GetItems("Foo").Single(t => t.Kind == NavigateToItemKind.Method);
-                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "~Foo()", "type Foo");
+                VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "~Foo()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("Bar").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", "type Foo");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("Bar").Single();
-                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", "type Foo");
+                VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -444,7 +444,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
-                Assert.Equal("type Foo", itemDisplay.AdditionalInformation);
+                Assert.Equal($"{EditorFeaturesResources.Type}Foo", itemDisplay.AdditionalInformation);
                 _glyphServiceMock.Verify();
             }
         }
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("sqr").Single();
-                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, "sqr", "type Foo");
+                VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, "sqr", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 
@@ -489,7 +489,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("itemArray").Single();
-                VerifyNavigateToResultItem(item, "itemArray", MatchKind.Exact, NavigateToItemKind.Field, "itemArray", "type Foo");
+                VerifyNavigateToResultItem(item, "itemArray", MatchKind.Exact, NavigateToItemKind.Field, "itemArray", $"{EditorFeaturesResources.Type}Foo");
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -613,7 +613,7 @@ void M() { M$$() }";
         {
             TestInClass(@"$$List<string> l;",
                 MainDescription("class System.Collections.Generic.List<T>"),
-                TypeParameterMap("\r\nT is string"));
+                TypeParameterMap($"\r\nT {FeaturesResources.Is} string"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -627,7 +627,7 @@ public class GenericList<T> { Generic$$List<int> t; }";
             Test(markup,
                 MainDescription("class GenericList<T>"),
                 Documentation("Generic List"),
-                TypeParameterMap("\r\nT is int"));
+                TypeParameterMap($"\r\nT {FeaturesResources.Is} int"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -643,8 +643,8 @@ public class GenericList<T> { Generic$$List<int> t; }";
             TestInClass(@"$$Dictionary<int, string> d;",
                 MainDescription("class System.Collections.Generic.Dictionary<TKey, TValue>"),
                 TypeParameterMap(
-                    Lines("\r\nTKey is int",
-                          "TValue is string")));
+                    Lines($"\r\nTKey {FeaturesResources.Is} int",
+                          $"TValue {FeaturesResources.Is} string")));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -653,8 +653,8 @@ public class GenericList<T> { Generic$$List<int> t; }";
             TestWithUsings(@"class C<T, U> { $$Dictionary<T, U> d; }",
                 MainDescription("class System.Collections.Generic.Dictionary<TKey, TValue>"),
                 TypeParameterMap(
-                    Lines("\r\nTKey is T",
-                          "TValue is U")));
+                    Lines($"\r\nTKey {FeaturesResources.Is} T",
+                          $"TValue {FeaturesResources.Is} U")));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -662,7 +662,7 @@ public class GenericList<T> { Generic$$List<int> t; }";
         {
             TestInClass(@"$$IEnumerable<int> M() { yield break; }",
                 MainDescription("interface System.Collections.Generic.IEnumerable<out T>"),
-                TypeParameterMap("\r\nT is int"));
+                TypeParameterMap($"\r\nT {FeaturesResources.Is} int"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -676,7 +676,7 @@ public class GenericList<T> { Generic$$List<int> t; }";
         public void TestTypeParameter()
         {
             Test(@"class C<T> { $$T t; }",
-                MainDescription("T in C<T>"));
+                MainDescription($"T {FeaturesResources.In} C<T>"));
         }
 
         [WorkItem(538636)]
@@ -690,7 +690,7 @@ public class GenericList<T> { Generic$$List<int> t; }";
 class C<T> { $$T t; }";
 
             Test(markup,
-                MainDescription("T in C<T>"),
+                MainDescription($"T {FeaturesResources.In} C<T>"),
                 Documentation("T is Type Parameter"));
         }
 
@@ -698,28 +698,28 @@ class C<T> { $$T t; }";
         public void TestTypeParameter1_Bug931949()
         {
             Test(@"class T1<T11> { $$T11 t; }",
-                MainDescription("T11 in T1<T11>"));
+                MainDescription($"T11 {FeaturesResources.In} T1<T11>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestTypeParameter2_Bug931949()
         {
             Test(@"class T1<T11> { T$$11 t; }",
-                MainDescription("T11 in T1<T11>"));
+                MainDescription($"T11 {FeaturesResources.In} T1<T11>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestTypeParameter3_Bug931949()
         {
             Test(@"class T1<T11> { T1$$1 t; }",
-                MainDescription("T11 in T1<T11>"));
+                MainDescription($"T11 {FeaturesResources.In} T1<T11>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestTypeParameter4_Bug931949()
         {
             Test(@"class T1<T11> { T11$$ t; }",
-                MainDescription("T11 in T1<T11>"));
+                MainDescription($"T11 {FeaturesResources.In} T1<T11>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -727,70 +727,70 @@ class C<T> { $$T t; }";
         {
             TestInClass(@"$$Nullable<int> i; }",
                 MainDescription("struct System.Nullable<T> where T : struct"),
-                TypeParameterMap("\r\nT is int"));
+                TypeParameterMap($"\r\nT {FeaturesResources.Is} int"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeDeclaredOnMethod1_Bug1946()
         {
             Test(@"class C { static void Meth1<T1>($$T1 i) where T1 : struct { T1 i; } }",
-                MainDescription("T1 in C.Meth1<T1> where T1 : struct"));
+                MainDescription($"T1 {FeaturesResources.In} C.Meth1<T1> where T1 : struct"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeDeclaredOnMethod2_Bug1946()
         {
             Test(@"class C { static void Meth1<T1>(T1 i) where $$T1 : struct { T1 i; } }",
-                MainDescription("T1 in C.Meth1<T1> where T1 : struct"));
+                MainDescription($"T1 {FeaturesResources.In} C.Meth1<T1> where T1 : struct"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeDeclaredOnMethod3_Bug1946()
         {
             Test(@"class C { static void Meth1<T1>(T1 i) where T1 : struct { $$T1 i; } }",
-                MainDescription("T1 in C.Meth1<T1> where T1 : struct"));
+                MainDescription($"T1 {FeaturesResources.In} C.Meth1<T1> where T1 : struct"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeParameterConstraint_Class()
         {
             Test(@"class C<T> where $$T : class { }",
-                MainDescription("T in C<T> where T : class"));
+                MainDescription($"T {FeaturesResources.In} C<T> where T : class"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeParameterConstraint_Struct()
         {
             Test(@"struct S<T> where $$T : class { }",
-                MainDescription("T in S<T> where T : class"));
+                MainDescription($"T {FeaturesResources.In} S<T> where T : class"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeParameterConstraint_Interface()
         {
             Test(@"interface I<T> where $$T : class { }",
-                MainDescription("T in I<T> where T : class"));
+                MainDescription($"T {FeaturesResources.In} I<T> where T : class"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestGenericTypeParameterConstraint_Delegate()
         {
             Test(@"delegate void D<T>() where $$T : class;",
-                MainDescription("T in D<T> where T : class"));
+                MainDescription($"T {FeaturesResources.In} D<T> where T : class"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestMinimallyQualifiedConstraint()
         {
             Test(@"class C<T> where $$T : IEnumerable<int>",
-                MainDescription("T in C<T> where T : IEnumerable<int>"));
+                MainDescription($"T {FeaturesResources.In} C<T> where T : IEnumerable<int>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void FullyQualifiedConstraint()
         {
             Test(@"class C<T> where $$T : System.Collections.Generic.IEnumerable<int>",
-                MainDescription("T in C<T> where T : System.Collections.Generic.IEnumerable<int>"));
+                MainDescription($"T {FeaturesResources.In} C<T> where T : System.Collections.Generic.IEnumerable<int>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -825,14 +825,14 @@ void M()
 }";
 
             TestInClass(markup,
-                MainDescription("(field) int C.field"));
+                MainDescription($"({FeaturesResources.Field}) int C.field"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestFieldInMethodBuiltIn2()
         {
             TestInClass("int field; void M() { int f = field$$; }",
-                MainDescription("(field) int C.field"));
+                MainDescription($"({FeaturesResources.Field}) int C.field"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -852,14 +852,14 @@ void M()
         public void TestOperatorBuiltIn1()
         {
             TestInMethod("int x; x = x$$ + 1;",
-                MainDescription("(local variable) int x"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestOperatorBuiltIn2()
         {
             TestInMethod("int x; x = x+$$x;",
-                MainDescription("(local variable) int x"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -873,7 +873,7 @@ void M()
         public void TestOperatorBuiltIn4()
         {
             TestInMethod("int x; x = x + $$x;",
-                MainDescription("(local variable) int x"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -914,7 +914,7 @@ void M()
 }";
 
             TestInClass(markup,
-                MainDescription("(field) DateTime C.field"));
+                MainDescription($"({FeaturesResources.Field}) DateTime C.field"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -929,7 +929,7 @@ void M()
 }";
 
             TestInClass(markup,
-                MainDescription("(field) System.IO.FileInfo C.file"));
+                MainDescription($"({FeaturesResources.Field}) System.IO.FileInfo C.file"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -941,7 +941,7 @@ public static int SomeField; }
 static class Test { int a = MyStruct.Some$$Field; }";
 
             Test(markup,
-                MainDescription("(field) int MyStruct.SomeField"));
+                MainDescription($"({FeaturesResources.Field}) int MyStruct.SomeField"));
         }
 
         [WorkItem(538638)]
@@ -955,7 +955,7 @@ public static int SomeField; }
 static class Test { int a = MyStruct.Some$$Field; }";
 
             Test(markup,
-                MainDescription("(field) int MyStruct.SomeField"),
+                MainDescription($"({FeaturesResources.Field}) int MyStruct.SomeField"),
                 Documentation("My Field"));
         }
 
@@ -968,7 +968,7 @@ public static int SomeField; }
 static class Test { static void Method() { int a = MyStruct.Some$$Field; } }";
 
             Test(markup,
-                MainDescription("(field) int MyStruct.SomeField"));
+                MainDescription($"({FeaturesResources.Field}) int MyStruct.SomeField"));
         }
 
         [WorkItem(538638)]
@@ -982,7 +982,7 @@ public static int SomeField; }
 static class Test { static void Method() { int a = MyStruct.Some$$Field; } }";
 
             Test(markup,
-                MainDescription("(field) int MyStruct.SomeField"),
+                MainDescription($"({FeaturesResources.Field}) int MyStruct.SomeField"),
                 Documentation("My Field"));
         }
 
@@ -990,7 +990,7 @@ static class Test { static void Method() { int a = MyStruct.Some$$Field; } }";
         public void TestMetadataFieldMinimal()
         {
             TestInMethod(@"DateTime dt = DateTime.MaxValue$$",
-                MainDescription("(field) DateTime DateTime.MaxValue"));
+                MainDescription($"({FeaturesResources.Field}) DateTime DateTime.MaxValue"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1005,7 +1005,7 @@ static class Test { static void Method() { int a = MyStruct.Some$$Field; } }";
     }
 }";
             Test(markup,
-                MainDescription("(field) System.DateTime System.DateTime.MaxValue"));
+                MainDescription($"({FeaturesResources.Field}) System.DateTime System.DateTime.MaxValue"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1018,7 +1018,7 @@ class C {
         DateTime dt = System.DateTime.MaxValue$$
     }
 }",
-                MainDescription("(field) System.DateTime System.DateTime.MaxValue"));
+                MainDescription($"({FeaturesResources.Field}) System.DateTime System.DateTime.MaxValue"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1032,7 +1032,7 @@ class C {
         DateTime dt = System.DateTime.MaxValue$$
     }
 }",
-                MainDescription("(field) DateTime DateTime.MaxValue"));
+                MainDescription($"({FeaturesResources.Field}) DateTime DateTime.MaxValue"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1045,7 +1045,7 @@ class D {
         new C<int>().Fi$$eld.ToString();
     }
 }",
-                MainDescription("(field) int C<int>.Field"));
+                MainDescription($"({FeaturesResources.Field}) int C<int>.Field"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1059,7 +1059,7 @@ class C<T> {
         Fi$$eld.ToString();
     }
 }",
-                MainDescription("(field) T C<T>.Field"));
+                MainDescription($"({FeaturesResources.Field}) T C<T>.Field"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1096,7 +1096,7 @@ class C
         return 5;
     }
 }";
-            Test(markup, MainDescription("Awaited task returns struct System.Int32"));
+            Test(markup, MainDescription($"{FeaturesResources.PrefixTextForAwaitKeyword} struct System.Int32"));
         }
 
         [WorkItem(756226)]
@@ -1112,7 +1112,7 @@ class C
         return 5;
     }
 }";
-            Test(markup, MainDescription("Awaited task returns struct System.Int32"));
+            Test(markup, MainDescription($"{FeaturesResources.PrefixTextForAwaitKeyword} struct System.Int32"));
         }
 
         [WorkItem(756226)]
@@ -1127,7 +1127,7 @@ class C
         aw$$ait Task.Delay(100);
     }
 }";
-            Test(markup, MainDescription("Awaited task returns no value."));
+            Test(markup, MainDescription($"{FeaturesResources.PrefixTextForAwaitKeyword} {FeaturesResources.TextForSystemVoid}"));
         }
 
         [WorkItem(756226), WorkItem(756337)]
@@ -1162,8 +1162,8 @@ class AsyncExample2
         result = await lambda();
     }
 }";
-            Test(markup, MainDescription("(awaitable) Awaited task returns class System.Threading.Tasks.Task<TResult>"),
-                         TypeParameterMap("\r\nTResult is int"));
+            Test(markup, MainDescription($"({CSharpFeaturesResources.Awaitable}) {FeaturesResources.PrefixTextForAwaitKeyword} class System.Threading.Tasks.Task<TResult>"),
+                         TypeParameterMap($"\r\nTResult {FeaturesResources.Is} int"));
         }
 
         [WorkItem(756226)]
@@ -1198,7 +1198,7 @@ class AsyncExample2
         result = await lambda();
     }
 }";
-            Test(markup, MainDescription("Awaited task returns struct System.Int32"));
+            Test(markup, MainDescription($"{FeaturesResources.PrefixTextForAwaitKeyword} struct System.Int32"));
         }
 
         [WorkItem(756226), WorkItem(756337)]
@@ -1225,7 +1225,7 @@ class MyAwaiter : INotifyCompletion
     public bool IsCompleted { get { throw new NotImplementedException(); } }
     public void GetResult() { }
 }";
-            Test(markup, MainDescription("(awaitable) class C"));
+            Test(markup, MainDescription($"({CSharpFeaturesResources.Awaitable}) class C"));
         }
 
         [WorkItem(756226), WorkItem(756337)]
@@ -1240,7 +1240,7 @@ class C
         Task$$ v1;
     }
 }";
-            Test(markup, MainDescription("(awaitable) class System.Threading.Tasks.Task"));
+            Test(markup, MainDescription($"({CSharpFeaturesResources.Awaitable}) class System.Threading.Tasks.Task"));
         }
 
         [WorkItem(756226), WorkItem(756337)]
@@ -1256,8 +1256,8 @@ class C
         Task$$<int> v1;
     }
 }";
-            Test(markup, MainDescription("(awaitable) class System.Threading.Tasks.Task<TResult>"),
-                         TypeParameterMap("\r\nTResult is int"));
+            Test(markup, MainDescription($"({CSharpFeaturesResources.Awaitable}) class System.Threading.Tasks.Task<TResult>"),
+                         TypeParameterMap($"\r\nTResult {FeaturesResources.Is} int"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1279,7 +1279,7 @@ class C
         {
             TestInMethod(@"dyn$$amic dyn;",
                 MainDescription("dynamic"),
-                Documentation("Represents an object whose operations will be resolved at runtime."));
+                Documentation(FeaturesResources.RepresentsAnObjectWhoseOperations));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1290,7 +1290,7 @@ void M()
 {
     d$$yn.Foo();
 }",
-                MainDescription("(field) dynamic C.dyn"));
+                MainDescription($"({FeaturesResources.Field}) dynamic C.dyn"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1363,7 +1363,7 @@ class C<T> {
         public void ValueInProperty()
         {
             TestInClass(@"public DateTime Property {set { foo = val$$ue; } }",
-                MainDescription("(parameter) DateTime value"));
+                MainDescription($"({FeaturesResources.Parameter}) DateTime value"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1440,21 +1440,21 @@ class C
         public void Parameter_InMethod_Minimal()
         {
             TestInClass(@"void M(DateTime dt) { d$$t.ToString();",
-                MainDescription("(parameter) DateTime dt"));
+                MainDescription($"({FeaturesResources.Parameter}) DateTime dt"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Parameter_InMethod_Qualified()
         {
             TestInClass(@"void M(System.IO.FileInfo fileInfo) { file$$Info.ToString();",
-                MainDescription("(parameter) System.IO.FileInfo fileInfo"));
+                MainDescription($"({FeaturesResources.Parameter}) System.IO.FileInfo fileInfo"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Parameter_FromReferenceToNamedParameter()
         {
             TestInMethod(@"Console.WriteLine(va$$lue: ""Hi"");",
-                MainDescription("(parameter) string value"));
+                MainDescription($"({FeaturesResources.Parameter}) string value"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1463,49 +1463,49 @@ class C
             // NOTE: Dev10 doesn't show the default value, but it would be nice if we did.
             // NOTE: The "DefaultValue" property isn't implemented yet.
             TestInClass(@"void M(int param = 42) { para$$m.ToString(); }",
-                MainDescription("(parameter) int param = 42"));
+                MainDescription($"({FeaturesResources.Parameter}) int param = 42"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Parameter_Params()
         {
             TestInClass(@"void M(params DateTime[] arg) { ar$$g.ToString(); }",
-                MainDescription("(parameter) params DateTime[] arg"));
+                MainDescription($"({FeaturesResources.Parameter}) params DateTime[] arg"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Parameter_Ref()
         {
             TestInClass(@"void M(ref DateTime arg) { ar$$g.ToString(); }",
-                MainDescription("(parameter) ref DateTime arg"));
+                MainDescription($"({FeaturesResources.Parameter}) ref DateTime arg"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Parameter_Out()
         {
             TestInClass(@"void M(out DateTime arg) { ar$$g.ToString(); }",
-                MainDescription("(parameter) out DateTime arg"));
+                MainDescription($"({FeaturesResources.Parameter}) out DateTime arg"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Local_Minimal()
         {
             TestInMethod(@"DateTime dt; d$$t.ToString();",
-                MainDescription("(local variable) DateTime dt"));
+                MainDescription($"({FeaturesResources.LocalVariable}) DateTime dt"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Local_Qualified()
         {
             TestInMethod(@"System.IO.FileInfo fileInfo; file$$Info.ToString();",
-                MainDescription("(local variable) System.IO.FileInfo fileInfo"));
+                MainDescription($"({FeaturesResources.LocalVariable}) System.IO.FileInfo fileInfo"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Method_MetadataOverload()
         {
             TestInMethod("Console.Write$$Line();",
-                MainDescription("void Console.WriteLine() (+ 18 overloads)"));
+                MainDescription($"void Console.WriteLine() (+ 18 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1514,7 +1514,7 @@ class C
             TestInClass(@"
 void Method() { Met$$hod(); }
 void Method(int i) { }",
-                MainDescription("void C.Method() (+ 1 overload)"));
+                MainDescription($"void C.Method() (+ 1 {FeaturesResources.Overload})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1525,7 +1525,7 @@ void Method() { Met$$hod(null); }
 void Method(int i) { }
 void Method(DateTime dt) { }
 void Method(System.IO.FileInfo fileInfo) { }",
-                MainDescription("void C.Method(System.IO.FileInfo fileInfo) (+ 3 overloads)"));
+                MainDescription($"void C.Method(System.IO.FileInfo fileInfo) (+ 3 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1549,7 +1549,7 @@ void Method(int i = 0) { }",
         {
             TestInClass(@"
 void Foo(decimal x$$yz = 10) { }",
-                MainDescription("(parameter) decimal xyz = 10"));
+                MainDescription($"({FeaturesResources.Parameter}) decimal xyz = 10"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1631,7 +1631,7 @@ void M()
 {
     new C$$ (DateTime.MaxValue).ToString();
 }",
-                MainDescription("C.C(DateTime dt) (+ 2 overloads)"));
+                MainDescription($"C.C(DateTime dt) (+ 2 {FeaturesResources.Overloads})"));
         }
 
         /// <summary>
@@ -1641,7 +1641,7 @@ void M()
         public void Constructor_OverloadFromStringLiteral()
         {
             TestInMethod(@"new InvalidOperatio$$nException("""");",
-                MainDescription("InvalidOperationException.InvalidOperationException(string message) (+ 2 overloads)"));
+                MainDescription($"InvalidOperationException.InvalidOperationException(string message) (+ 2 {FeaturesResources.Overloads})"));
         }
 
         /// <summary>
@@ -1660,14 +1660,14 @@ void M()
         public void Constructor_OverloadFromProperty()
         {
             TestInMethod(@"new InvalidOperatio$$nException(this.GetType().Name);",
-                MainDescription("InvalidOperationException.InvalidOperationException(string message) (+ 2 overloads)"));
+                MainDescription($"InvalidOperationException.InvalidOperationException(string message) (+ 2 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void Constructor_Metadata()
         {
             TestInMethod(@"new Argument$$NullException();",
-                MainDescription("ArgumentNullException.ArgumentNullException() (+ 3 overloads)"));
+                MainDescription($"ArgumentNullException.ArgumentNullException() (+ 3 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1780,7 +1780,7 @@ class T1<T11>
     $$T11 i;
 }
 ",
-                MainDescription("T11 in T1<T11>"));
+                MainDescription($"T11 {FeaturesResources.In} T1<T11>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1792,7 +1792,7 @@ class T1<T11>
         $$T1 i;
     }
 ",
-                MainDescription("T1 in C.Meth1<T1> where T1 : struct"));
+                MainDescription($"T1 {FeaturesResources.In} C.Meth1<T1> where T1 : struct"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1802,7 +1802,7 @@ class T1<T11>
 var x = new Exception();
 var y = $$x;
 ",
-                MainDescription("(local variable) Exception x"));
+                MainDescription($"({FeaturesResources.LocalVariable}) Exception x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1812,7 +1812,7 @@ var y = $$x;
             List<int>.Enu$$merator e;
 ",
                 MainDescription("struct System.Collections.Generic.List<T>.Enumerator"),
-                TypeParameterMap("\r\nT is int"));
+                TypeParameterMap($"\r\nT {FeaturesResources.Is} int"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1833,8 +1833,8 @@ var y = $$x;
 ",
                 MainDescription("class Outer<T>.Inner<U>"),
                 TypeParameterMap(
-                    Lines("\r\nT is int",
-                          "U is string")));
+                    Lines($"\r\nT {FeaturesResources.Is} int",
+                          $"U {FeaturesResources.Is} string")));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1851,7 +1851,7 @@ var y = $$x;
         public int z;
     }
 ",
-                MainDescription("(field) int test.z"));
+                MainDescription($"({FeaturesResources.Field}) int test.z"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1887,7 +1887,7 @@ class C<T, Y>
         $$variable = new C<int, DateTime>();
     }
 }",
-                MainDescription("(local variable) C<int, DateTime> variable"));
+                MainDescription($"({FeaturesResources.LocalVariable}) C<int, DateTime> variable"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1901,7 +1901,7 @@ c$$c = 1;
 bb = bb + 21;
 }
 ",
-                MainDescription("(local variable) int cc"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int cc"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1919,7 +1919,7 @@ bb = bb + 21;
             finally
             {
             }",
-                MainDescription("(local variable) int aa"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int aa"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1938,7 +1938,7 @@ bb = bb + 21;
             {
             }
 ",
-                MainDescription("(local variable) Exception ex"));
+                MainDescription($"({FeaturesResources.LocalVariable}) Exception ex"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1957,7 +1957,7 @@ bb = bb + 21;
             {
             }
 ",
-                MainDescription("(local variable) int aa"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int aa"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1976,7 +1976,7 @@ bb = bb + 21;
                 aa = a$$a + 1;
             }
 ",
-                MainDescription("(local variable) int aa"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int aa"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -1992,7 +1992,7 @@ bb = bb + 21;
                 }
             }
 ",
-                MainDescription("(local variable) C<int, DateTime> variable"));
+                MainDescription($"({FeaturesResources.LocalVariable}) C<int, DateTime> variable"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2007,7 +2007,7 @@ class Program<T>
         var p = new Dictio$$nary<int, string>();
     }
 }",
-                MainDescription(@"Dictionary<int, string>.Dictionary() (+ 5 overloads)"));
+                MainDescription($"Dictionary<int, string>.Dictionary() (+ 5 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2027,7 +2027,7 @@ class D : X$$ { }
         {
             TestInClass(@"
 DateTime fie$$ld;",
-                MainDescription("(field) DateTime C.field"));
+                MainDescription($"({FeaturesResources.Field}) DateTime C.field"));
         }
 
         [WorkItem(538767)]
@@ -2036,7 +2036,7 @@ DateTime fie$$ld;",
         {
             TestInClass(@"
 NonExistentType<int> fi$$eld;",
-                MainDescription("(field) NonExistentType<int> C.field"));
+                MainDescription($"({FeaturesResources.Field}) NonExistentType<int> C.field"));
         }
 
         [WorkItem(538822)]
@@ -2047,8 +2047,8 @@ NonExistentType<int> fi$$eld;",
 Fun$$c<int, string> field;",
                 MainDescription("delegate TResult System.Func<in T, out TResult>(T arg)"),
                 TypeParameterMap(
-                    Lines("\r\nT is int",
-                          "TResult is string")));
+                    Lines($"\r\nT {FeaturesResources.Is} int",
+                          $"TResult {FeaturesResources.Is} string")));
         }
 
         [WorkItem(538824)]
@@ -2066,7 +2066,7 @@ class Program
     }
 }
 ",
-                MainDescription("(local variable) D1 d"));
+                MainDescription($"({FeaturesResources.LocalVariable}) D1 d"));
         }
 
         [WorkItem(539240)]
@@ -2161,7 +2161,7 @@ class C
         }
     }
 }",
-                MainDescription("(local variable) int cc"));
+                MainDescription($"({FeaturesResources.LocalVariable}) int cc"));
         }
 
         [WorkItem(540438)]
@@ -2257,7 +2257,7 @@ public static class MyExtensions
     }
 }
 ",
-                MainDescription("(extension) bool int.In<int>(IEnumerable<int> items)"));
+                MainDescription($"({CSharpFeaturesResources.Extension}) bool int.In<int>(IEnumerable<int> items)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2282,7 +2282,7 @@ public static class Ex
     public static void TestExt(this string ex, int arg) { }
 }
 ",
-                MainDescription("(extension) void string.TestExt<string>() (+ 2 overloads)"));
+                MainDescription($"({CSharpFeaturesResources.Extension}) void string.TestExt<string>() (+ 2 {FeaturesResources.Overloads})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2307,7 +2307,7 @@ public static class Ex
     public static void TestExt(this int ex, int arg) { }
 }
 ",
-                MainDescription("(extension) void string.TestExt<string>() (+ 1 overload)"));
+                MainDescription($"({CSharpFeaturesResources.Extension}) void string.TestExt<string>() (+ 1 {FeaturesResources.Overload})"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2324,7 +2324,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2341,7 +2341,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2357,7 +2357,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) ? n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) ? n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2373,7 +2373,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) ? n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) ? n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2391,7 +2391,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) object n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) object n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2409,7 +2409,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) object n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) object n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2427,7 +2427,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2445,7 +2445,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int n"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int n"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2464,7 +2464,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) List<int> x"));
+                MainDescription($"({FeaturesResources.RangeVariable}) List<int> x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2483,7 +2483,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) List<int> x"));
+                MainDescription($"({FeaturesResources.RangeVariable}) List<int> x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2502,7 +2502,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int y"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int y"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2521,7 +2521,7 @@ class C
     }
 }
 ",
-                MainDescription("(range variable) int y"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int y"));
         }
 
         [WorkItem(543205)]
@@ -2550,7 +2550,7 @@ class classAttribute : Attribute
 {
     private classAttribute x$$;
 }",
-                MainDescription("(field) classAttribute classAttribute.x"));
+                MainDescription($"({FeaturesResources.Field}) classAttribute classAttribute.x"));
         }
 
         [WorkItem(544026)]
@@ -2563,14 +2563,14 @@ class class1Attribute : Attribute
 {
     private class1Attribute x$$;
 }",
-                MainDescription("(field) class1Attribute class1Attribute.x"));
+                MainDescription($"({FeaturesResources.Field}) class1Attribute class1Attribute.x"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestLabel()
         {
             TestInClass(@"void M() { Foo: int Foo; goto Foo$$; }",
-                MainDescription("(label) Foo"));
+                MainDescription($"({FeaturesResources.Label}) Foo"));
         }
 
         [WorkItem(542613)]
@@ -2606,9 +2606,9 @@ class C
                 MainDescription(@"AnonymousType 'a"),
                 NoTypeParameterMap,
                 AnonymousTypes(
-@"
-Anonymous Types:
-    'a is new {  }"));
+$@"
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{  }}"));
         }
 
         [WorkItem(543873)]
@@ -2621,10 +2621,10 @@ Anonymous Types:
                 MainDescription(@"'b 'a.Address { get; }"),
                 NoTypeParameterMap,
                 AnonymousTypes(
-@"
-Anonymous Types:
-    'a is new { string Name, 'b Address }
-    'b is new { string Street, string Zip }"));
+$@"
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{ string Name, 'b Address }}
+    'b {FeaturesResources.Is} new {{ string Street, string Zip }}"));
 
             // verify second property
             TestInMethod(@"var x = new[] { new { Name = ""BillG"", Address = new { Street = ""1 Microsoft Way"", Zip = ""98052"" } } }; x[0].$$Name",
@@ -2659,9 +2659,9 @@ Anonymous Types:
                 MainDescription(@"int 'a.N { get; }"),
                 NoTypeParameterMap,
                 AnonymousTypes(
-@"
-Anonymous Types:
-    'a is new { int N }"));
+$@"
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{ int N }}"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2702,7 +2702,7 @@ namespace N1
     }
 }
 ",
-                MainDescription("(range variable) N1.yield yield"));
+                MainDescription($"({FeaturesResources.RangeVariable}) N1.yield yield"));
         }
 
         [WorkItem(543550)]
@@ -2737,14 +2737,14 @@ class Program
         public void TestConstantField()
         {
             Test("class C { const int $$F = 1;",
-                MainDescription("(constant) int C.F = 1"));
+                MainDescription($"({FeaturesResources.Constant}) int C.F = 1"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestMultipleConstantFields()
         {
             Test("class C { public const double X = 1.0, Y = 2.0, $$Z = 3.5;",
-                MainDescription("(constant) double C.Z = 3.5"));
+                MainDescription($"({FeaturesResources.Constant}) double C.Z = 3.5"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2759,7 +2759,7 @@ class B
 {
     public const int Z = A.Y + 1;
 }",
-                MainDescription("(constant) int A.X = B.Z + 1"));
+                MainDescription($"({FeaturesResources.Constant}) int A.X = B.Z + 1"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2773,7 +2773,7 @@ class B
 {
     public const int Z$$ = A.X + 1;
 }",
-                MainDescription("(constant) int B.Z = A.X + 1"));
+                MainDescription($"({FeaturesResources.Constant}) int B.Z = A.X + 1"));
         }
 
         [WorkItem(544620)]
@@ -2784,7 +2784,7 @@ class B
 {
     public const int Z$$ = int.MaxValue + 1;
 }",
-                MainDescription("(constant) int B.Z = int.MaxValue + 1"));
+                MainDescription($"({FeaturesResources.Constant}) int B.Z = int.MaxValue + 1"));
         }
 
         [WorkItem(544620)]
@@ -2795,7 +2795,7 @@ class B
 {
     public const int Z$$ = unchecked(int.MaxValue + 1);
 }",
-                MainDescription("(constant) int B.Z = unchecked(int.MaxValue + 1)"));
+                MainDescription($"({FeaturesResources.Constant}) int B.Z = unchecked(int.MaxValue + 1)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2809,7 +2809,7 @@ class B
         const int $$x = (int)Days.Sun;
     }
 }",
-                MainDescription("(local constant) int x = (int)Days.Sun"));
+                MainDescription($"({FeaturesResources.LocalConstant}) int x = (int)Days.Sun"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -2823,21 +2823,21 @@ class B
         const Days $$x = default(Days);
     }
 }",
-                MainDescription("(local constant) Days x = default(Days)"));
+                MainDescription($"({FeaturesResources.LocalConstant}) Days x = default(Days)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestConstantParameter()
         {
             Test("class C { void Bar(int $$b = 1); }",
-                MainDescription("(parameter) int b = 1"));
+                MainDescription($"({FeaturesResources.Parameter}) int b = 1"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestConstantLocal()
         {
             Test("class C { void Bar() { const int $$loc = 1; }",
-                MainDescription("(local constant) int loc = 1"));
+                MainDescription($"({FeaturesResources.LocalConstant}) int loc = 1"));
         }
 
         [WorkItem(544416)]
@@ -2845,7 +2845,7 @@ class B
         public void TestErrorType1()
         {
             TestInMethod("var $$v1 = new Foo();",
-                MainDescription("(local variable) Foo v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) Foo v1"));
         }
 
         [WorkItem(544416)]
@@ -2853,7 +2853,7 @@ class B
         public void TestErrorType2()
         {
             TestInMethod("var $$v1 = v1;",
-                MainDescription("(local variable) var v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) var v1"));
         }
 
         [WorkItem(544416)]
@@ -2861,7 +2861,7 @@ class B
         public void TestErrorType3()
         {
             TestInMethod("var $$v1 = new Foo<Bar>();",
-                MainDescription("(local variable) Foo<Bar> v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) Foo<Bar> v1"));
         }
 
         [WorkItem(544416)]
@@ -2869,7 +2869,7 @@ class B
         public void TestErrorType4()
         {
             TestInMethod("var $$v1 = &(x => x);",
-                MainDescription("(local variable) ?* v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) ?* v1"));
         }
 
         [WorkItem(544416)]
@@ -2877,7 +2877,7 @@ class B
         public void TestErrorType5()
         {
             TestInMethod("var $$v1 = &v1",
-                MainDescription("(local variable) var* v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) var* v1"));
         }
 
         [WorkItem(544416)]
@@ -2885,7 +2885,7 @@ class B
         public void TestErrorType6()
         {
             TestInMethod("var $$v1 = new Foo[1]",
-                MainDescription("(local variable) Foo[] v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) Foo[] v1"));
         }
 
         [WorkItem(544416)]
@@ -2893,7 +2893,7 @@ class B
         public void TestErrorType7()
         {
             TestInClass("class C { void Method() { } void Foo() { var $$v1 = MethodGroup; } }",
-                MainDescription("(local variable) ? v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) ? v1"));
         }
 
         [WorkItem(544416)]
@@ -2901,7 +2901,7 @@ class B
         public void TestErrorType8()
         {
             TestInMethod("var $$v1 = Unknown",
-                MainDescription("(local variable) ? v1"));
+                MainDescription($"({FeaturesResources.LocalVariable}) ? v1"));
         }
 
         [WorkItem(545072)]
@@ -2925,7 +2925,7 @@ class B
         public void TestLetIdentifier1()
         {
             TestInMethod("var q = from e in \"\" let $$y = 1 let a = new { y } select a;",
-                MainDescription("(range variable) int y"));
+                MainDescription($"({FeaturesResources.RangeVariable}) int y"));
         }
 
         [WorkItem(545295)]
@@ -2944,7 +2944,7 @@ class B
 @"class Program { void M1(float $$j1 = ""Hello""
         + 
         ""World"") { } }",
-                MainDescription(@"(parameter) float j1 = ""Hello"" + ""World"""));
+                MainDescription($@"({FeaturesResources.Parameter}) float j1 = ""Hello"" + ""World"""));
         }
 
         [WorkItem(545230)]
@@ -2962,7 +2962,7 @@ class B
     }
 }
 ",
-                MainDescription(@"(local constant) int MEGABYTE = 1024 * 1024 + true"));
+                MainDescription($@"({FeaturesResources.LocalConstant}) int MEGABYTE = 1024 * 1024 + true"));
         }
 
         [WorkItem(545230)]
@@ -2980,7 +2980,7 @@ class B
         Foo($$a);
     }
 }",
-                MainDescription(@"(constant) int Program.a = true - false"));
+                MainDescription($"({FeaturesResources.Constant}) int Program.a = true - false"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -3151,10 +3151,10 @@ class C
         Fo$$o();
     }
 }";
-            var description = @"(awaitable) Task C.Foo()";
+            var description = $"({CSharpFeaturesResources.Awaitable}) Task C.Foo()";
 
-            var documentation = @"
-Usage:
+            var documentation = $@"
+{CSharpFeaturesResources.Usage}
   await Foo();";
 
             VerifyWithMscorlib45(markup, new[] { MainDescription(description), Usage(documentation) });
@@ -3174,7 +3174,7 @@ class Program
         fo$$o();
     }
 }";
-            Test(markup, MainDescription("[deprecated] void Program.foo()"));
+            Test(markup, MainDescription($"[{CSharpFeaturesResources.Deprecated}] void Program.foo()"));
         }
 
         [WorkItem(751070)]
@@ -3668,7 +3668,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription("(field) int C.x"), Usage("") });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.Field}) int C.x"), Usage("") });
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -3694,7 +3694,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = Usage("\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true);
+            var expectedDescription = Usage($"\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", expectsWarningGlyph: true);
 
             VerifyWithReferenceWorker(markup, new[] { expectedDescription });
         }
@@ -3722,7 +3722,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = Usage("\r\n    Proj1 - Not Available\r\n    Proj2 - Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true);
+            var expectedDescription = Usage($"\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.Available)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", expectsWarningGlyph: true);
 
             VerifyWithReferenceWorker(markup, new[] { expectedDescription });
         }
@@ -3754,7 +3754,7 @@ class C
     </Project>
 </Workspace>";
             var expectedDescription = Usage(
-                "\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.",
+                $"\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}",
                 expectsWarningGlyph: true);
 
             VerifyWithReferenceWorker(markup, new[] { expectedDescription });
@@ -3789,7 +3789,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = Usage("\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true);
+            var expectedDescription = Usage($"\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", expectsWarningGlyph: true);
             VerifyWithReferenceWorker(markup, new[] { expectedDescription });
         }
 
@@ -3843,7 +3843,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription("(local variable) int x"), Usage("") });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.LocalVariable}) int x"), Usage("") });
         }
 
         [WorkItem(1020944)]
@@ -3872,7 +3872,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription("(local variable) int x"), Usage("\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true) });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.LocalVariable}) int x"), Usage("\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true) });
         }
 
         [WorkItem(1020944)]
@@ -3897,7 +3897,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription("(label) LABEL"), Usage("") });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.Label}) LABEL"), Usage("") });
         }
 
         [WorkItem(1020944)]
@@ -3923,7 +3923,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription("(range variable) int y"), Usage("") });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.RangeVariable}) int y"), Usage("") });
         }
 
         [WorkItem(1019766)]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -3154,7 +3154,7 @@ class C
             var description = $"({CSharpFeaturesResources.Awaitable}) Task C.Foo()";
 
             var documentation = $@"
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   await Foo();";
 
             VerifyWithMscorlib45(markup, new[] { MainDescription(description), Usage(documentation) });

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
@@ -256,7 +255,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute(Properties: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute({CSharpEditorResources.Properties}: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
 
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
         }
@@ -342,7 +341,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute(Properties: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute({CSharpEditorResources.Properties}: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -473,7 +472,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute([int foo = 0], [string bar = null], Properties: [fieldbar = string], [fieldfoo = int])", string.Empty, "FooParameter", currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute([int foo = 0], [string bar = null], {CSharpEditorResources.Properties}: [fieldbar = string], [fieldfoo = int])", string.Empty, "FooParameter", currentParameterIndex: 0));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -500,7 +499,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute([int foo = 0], [string bar = null], Properties: [fieldbar = string], [fieldfoo = int])", string.Empty, "BarParameter", currentParameterIndex: 1));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute([int foo = 0], [string bar = null], {CSharpEditorResources.Properties}: [fieldbar = string], [fieldfoo = int])", string.Empty, "BarParameter", currentParameterIndex: 1));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -527,7 +526,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute([int foo = 0], [string bar = null], Properties: [fieldbar = string], [fieldfoo = int])", string.Empty, string.Empty, currentParameterIndex: 2));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute([int foo = 0], [string bar = null], {CSharpEditorResources.Properties}: [fieldbar = string], [fieldfoo = int])", string.Empty, string.Empty, currentParameterIndex: 2));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -552,7 +551,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute([int foo = 0], Properties: [foo = int])", string.Empty, "FooParameter", currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute([int foo = 0], {CSharpEditorResources.Properties}: [foo = int])", string.Empty, "FooParameter", currentParameterIndex: 0));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -577,7 +576,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("SomethingAttribute([int foo = 0], Properties: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 1));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"SomethingAttribute([int foo = 0], {CSharpEditorResources.Properties}: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 1));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
@@ -832,7 +831,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("Secret()\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"Secret()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -868,7 +867,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("Secret()\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"Secret()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
@@ -436,7 +435,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("Secret(int secret)\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"Secret(int secret)\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -475,7 +474,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("Secret(int secret)\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"Secret(int secret)\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
@@ -703,7 +701,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("int C[int z]\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"int C[int z]\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -743,7 +741,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("int C[int z]\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"int C[int z]\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
@@ -75,7 +75,7 @@ class Program
 }
 ";
             var documentation = $@"
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   int x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
@@ -74,12 +74,12 @@ class Program
     }
 }
 ";
-            var documentation = @"
-Usage:
+            var documentation = $@"
+{CSharpFeaturesResources.Usage}
   int x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("(awaitable) Task<int> Program.Foo<T>()", documentation, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task<int> Program.Foo<T>()", documentation, string.Empty, currentParameterIndex: 0));
 
             // TODO: Enable the script case when we have support for extension methods in scripts
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false, sourceCodeKind: Microsoft.CodeAnalysis.SourceCodeKind.Regular);
@@ -259,7 +259,7 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem("void IFoo.Bar<T>()", currentParameterIndex: 0),
-                new SignatureHelpTestItem("(extension) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
+                new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
             };
 
             // Extension methods are supported in Interactive/Script (yet).

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
@@ -543,7 +543,7 @@ static class FooClass
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("(extension) void G.Foo<T>()", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void G.Foo<T>()", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Enable the script case when we have support for extension methods in scripts
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false, sourceCodeKind: Microsoft.CodeAnalysis.SourceCodeKind.Regular);
@@ -655,7 +655,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("D<T>\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"D<T>\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -691,7 +691,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("D<T>\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"D<T>\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
@@ -317,7 +317,7 @@ public static class MyExtension
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("(extension) int string.ExtensionMethod(int x)", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) int string.ExtensionMethod(int x)", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Once we do the work to allow extension methods in nested types, we should change this.
             Test(markup, expectedOrderedItems, sourceCodeKind: SourceCodeKind.Regular);
@@ -514,17 +514,17 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem(
-@"void List<'a>.Add('a item)
+$@"void List<'a>.Add('a item)
 
-Anonymous Types:
-    'a is new { string Name, int Age }",
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{ string Name, int Age }}",
                     methodDocumentation: string.Empty,
                     parameterDocumentation: string.Empty,
                     currentParameterIndex: 0,
-                    description: @"
+                    description: $@"
 
-Anonymous Types:
-    'a is new { string Name, int Age }")
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{ string Name, int Age }}")
             };
 
             Test(markup, expectedOrderedItems);
@@ -1504,12 +1504,12 @@ class C
     }
 }";
 
-            var description = @"
-Usage:
+            var description = $@"
+{CSharpFeaturesResources.Usage}
   await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("(awaitable) Task C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
 
             TestSignatureHelpWithMscorlib45(markup, expectedOrderedItems, "C#");
         }
@@ -1527,12 +1527,12 @@ class C
     }
 }";
 
-            var description = @"
-Usage:
+            var description = $@"
+{CSharpFeaturesResources.Usage}
   Task<int> x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem("(awaitable) Task<Task<int>> C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task<Task<int>> C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
 
             TestSignatureHelpWithMscorlib45(markup, expectedOrderedItems, "C#");
         }
@@ -1621,7 +1621,7 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem("void IFoo.Bar<T>()", currentParameterIndex: 0),
-                new SignatureHelpTestItem("(extension) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
+                new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
             };
 
             // Extension methods are supported in Interactive/Script (yet).
@@ -1676,7 +1676,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("void C.bar()\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"void C.bar()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -1712,7 +1712,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("void C.bar()\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"void C.bar()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -1505,7 +1505,7 @@ class C
 }";
 
             var description = $@"
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
@@ -1528,7 +1528,7 @@ class C
 }";
 
             var description = $@"
-{CSharpFeaturesResources.Usage}
+{WorkspacesResources.Usage}
   Task<int> x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
 using Roslyn.Test.Utilities;
@@ -497,7 +496,7 @@ class C
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
     </Project>
 </Workspace>";
-            var expectedDescription = new SignatureHelpTestItem("D()\r\n\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"D()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 
@@ -533,7 +532,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = new SignatureHelpTestItem("D()\r\n\r\n    Proj1 - Available\r\n    Proj3 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", currentParameterIndex: 0);
+            var expectedDescription = new SignatureHelpTestItem($"D()\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj3", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", currentParameterIndex: 0);
             VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2795,7 +2795,7 @@ Class SomeClass
     End Sub
 End Class</Code>.Value
 
-            VerifyItemExists(code, "Foo", "(Deprecated) Sub SomeClass.Foo()")
+            VerifyItemExists(code, "Foo", $"({VBFeaturesResources.Deprecated}) Sub SomeClass.Foo()")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2756,7 +2756,7 @@ End Class</Code>.Value
 
             Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.Foo() As Task
 Doc Comment!
-Usage:
+<%= WorkspacesResources.Usage %>
   <%= VBFeaturesResources.Await %> Foo()</File>.ConvertTestSourceTag()
 
             VerifyItemWithMscorlib45(code, "Foo", description, LanguageNames.VisualBasic)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2754,10 +2754,11 @@ Class C
         End Function
 End Class</Code>.Value
 
-            Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.Foo() As Task
+            Dim description =
+$"<{VBFeaturesResources.Awaitable}> Function C.Foo() As Task
 Doc Comment!
-<%= WorkspacesResources.Usage %>
-  <%= VBFeaturesResources.Await %> Foo()</File>.ConvertTestSourceTag()
+{WorkspacesResources.Usage}
+  {VBFeaturesResources.Await} Foo()"
 
             VerifyItemWithMscorlib45(code, "Foo", description, LanguageNames.VisualBasic)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -1526,44 +1526,13 @@ Class Program
 
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
+$"Imports System
 Class Program
     Implements IDisposable
-
-#Region "IDisposable Support"
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ")}
 
 End Class
-</Text>.Value.Replace(vbLf, vbCrLf),
+",
 index:=1,
 compareTokens:=False)
         End Sub
@@ -1628,44 +1597,13 @@ Public NotInheritable Class Program
 
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
+$"Imports System
 Public NotInheritable Class Program
     Implements IDisposable
-
-#Region "IDisposable Support"
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("")}
 
 End Class
-</Text>.Value.Replace(vbLf, vbCrLf),
+",
 index:=1,
 compareTokens:=False)
         End Sub
@@ -1792,40 +1730,9 @@ End Class
             Test(
 "Imports System
 Class C : Implements [|IDisposable|]",
-"Imports System
+$"Imports System
 Class C : Implements IDisposable
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ")}
 End Class
 ", index:=1, compareTokens:=False)
         End Sub
@@ -1873,42 +1780,11 @@ Class C : Implements [|System.IDisposable|]
     Class IDisposable
     End Class
 End Class",
-"Imports System
+$"Imports System
 Class C : Implements System.IDisposable
     Class IDisposable
     End Class
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements System.IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ", simplifySystem:=False)}
 End Class", index:=1, compareTokens:=False)
         End Sub
 
@@ -1918,39 +1794,8 @@ End Class", index:=1, compareTokens:=False)
             Test(
 "Class C : Implements [|System.IDisposable|]
 ",
-"Class C : Implements System.IDisposable
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements System.IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+$"Class C : Implements System.IDisposable
+{DisposePattern("Overridable ", simplifySystem:=False)}
 End Class
 ", index:=1, compareTokens:=False)
         End Sub
@@ -1991,7 +1836,7 @@ Interface I : Inherits IDisposable
 End Interface
 Class C : Implements [|I|]
 End Class",
-"Imports System
+$"Imports System
 Interface I : Inherits IDisposable
     Sub F()
 End Interface
@@ -2000,38 +1845,7 @@ Class C : Implements I
     Public Sub F() Implements I.F
         Throw New NotImplementedException()
     End Sub
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ")}
 End Class", index:=1, compareTokens:=False)
         End Sub
 
@@ -2092,7 +1906,7 @@ End Class
 Partial Class C
     Implements IDisposable
 End Class",
-"Imports System
+$"Imports System
 Imports System.Collections.Generic
 
 Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of Integer)
@@ -2115,38 +1929,7 @@ Class _
     Public Function M(Of TT, UU As TT)(a As Dictionary(Of TT, List(Of UU)), b As TT, c As UU) As List(Of UU) Implements I(Of Exception, AggregateException).M
         Throw New NotImplementedException()
     End Function
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ")}
 End Class
 
 Partial Class C
@@ -2170,7 +1953,7 @@ Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of In
     Function M(a As System.Collections.Generic.Dictionary(Of T, System.Collections.Generic.List(Of U)), b As T, c As U) As System.Collections.Generic.List(Of U)
     Function M(Of TT, UU As TT)(a As System.Collections.Generic.Dictionary(Of TT, System.Collections.Generic.List(Of UU)), b As TT, c As UU) As System.Collections.Generic.List(Of UU)
 End Interface",
-"Imports System
+$"Imports System
 Imports System.Collections.Generic
 
 Class C
@@ -2191,38 +1974,7 @@ Partial Class C
     Public Function M(Of TT, UU As TT)(a As Dictionary(Of TT, List(Of UU)), b As TT, c As UU) As List(Of UU) Implements I(Of Exception, AggregateException).M
         Throw New NotImplementedException()
     End Function
-
-#Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(disposing As Boolean)
-        If Not disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region
+{DisposePattern("Overridable ")}
 End Class
 
 Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of Integer)
@@ -2230,5 +1982,18 @@ Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of In
     Function M(Of TT, UU As TT)(a As System.Collections.Generic.Dictionary(Of TT, System.Collections.Generic.List(Of UU)), b As TT, c As UU) As System.Collections.Generic.List(Of UU)
 End Interface", index:=1, compareTokens:=False)
         End Sub
+
+        Private Shared Function DisposePattern(disposeMethodModifiers As String, Optional simplifySystem As Boolean = True) As String
+            ' the simplifier removes the "Me." prefix
+            Dim code = String.Format(VBFeaturesResources.DisposePattern, disposeMethodModifiers).
+                Replace("Me.disposedValue", "disposedValue")
+
+            ' some tests count on "System." being simplified out
+            If simplifySystem Then
+                code = code.Replace("System.IDisposable.Dispose", "IDisposable.Dispose")
+            End If
+
+            Return code
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -1374,7 +1374,7 @@ End Class
 
             Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.foo() As Task</File>.ConvertTestSourceTag()
 
-            Dim doc = StringFromLines("", VBFeaturesResources.Usage, "  Await foo()")
+            Dim doc = StringFromLines("", WorkspacesResources.Usage, "  Await foo()")
 
             TestFromXml(markup,
                  MainDescription(description), Usage(doc))

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -743,7 +743,7 @@ Class C
 End Class
 ]]></a>.Value
 
-            Dim documentation = StringFromLines("", "Usage:", "  Await Foo()")
+            Dim documentation = StringFromLines("", WorkspacesResources.Usage, "  Await Foo()")
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)() From {
                 New SignatureHelpTestItem("C.Foo() As Task", currentParameterIndex:=0, methodDocumentation:=documentation)
@@ -767,7 +767,7 @@ Class C
 End Class
 ]]></a>.Value
 
-            Dim documentation = StringFromLines("", "Usage:", "  Dim r as Integer = Await Foo()")
+            Dim documentation = StringFromLines("", WorkspacesResources.Usage, "  Dim r as Integer = Await Foo()")
 
             Dim expectedOrderedItems = New List(Of SignatureHelpTestItem)() From {
                 New SignatureHelpTestItem("C.Foo() As Task(Of Integer)", currentParameterIndex:=0, methodDocumentation:=documentation)

--- a/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///    {{
         ///        if (disposing)
         ///        {{
-        ///            // TODO: dispose managed state (managed objects).          
+        ///            // TODO: dispose managed state (managed objects).
         ///        }}
         /// 
         ///        // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///    }}
         ///}}
         ///
-        /// // TODO: override a finalizer o [rest of string was truncated]&quot;;.
+        ///// TODO: override a finalizer only if Disp [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DisposePattern {
             get {

--- a/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
@@ -585,15 +585,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Usage:.
-        /// </summary>
-        internal static string Usage {
-            get {
-                return ResourceManager.GetString("Usage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Warning: Declaration changes scope and may change meaning..
         /// </summary>
         internal static string WarningDeclarationChangesScope {

--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -237,9 +237,6 @@
   <data name="AwaitableExtension" xml:space="preserve">
     <value>awaitable, extension</value>
   </data>
-  <data name="Usage" xml:space="preserve">
-    <value>Usage:</value>
-  </data>
   <data name="Await" xml:space="preserve">
     <value>await</value>
   </data>

--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -266,7 +266,7 @@ private bool disposedValue = false; // To detect redundant calls
     {{
         if (disposing)
         {{
-            // TODO: dispose managed state (managed objects).          
+            // TODO: dispose managed state (managed objects).
         }}
  
         // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
@@ -276,7 +276,7 @@ private bool disposedValue = false; // To detect redundant calls
     }}
 }}
 
- // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
+// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
 // ~{1}() {{
 //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 //   Dispose(false);

--- a/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
@@ -2640,15 +2640,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Usage:.
-        '''</summary>
-        Friend ReadOnly Property Usage() As String
-            Get
-                Return ResourceManager.GetString("Usage", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to A Using block does three things: it creates and initializes variables in the resource list, it runs the code in the block, and it disposes of the variables before exiting. Resources used in the Using block must implement System.IDisposable.
         '''Using &lt;resource1&gt;[, &lt;resource2&gt;]...End Using.
         '''</summary>

--- a/src/Features/VisualBasic/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/VBFeaturesResources.resx
@@ -309,9 +309,6 @@
   <data name="AwaitableExtension" xml:space="preserve">
     <value>Awaitable, Extension</value>
   </data>
-  <data name="Usage" xml:space="preserve">
-    <value>Usage:</value>
-  </data>
   <data name="Await" xml:space="preserve">
     <value>Await</value>
   </data>

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -960,7 +960,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var spacePart = new SymbolDisplayPart(SymbolDisplayPartKind.Space, null, " ");
             var parts = new List<SymbolDisplayPart>();
 
-            parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, "\r\nUsage:\r\n  "));
+            parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, $"\r\n{WorkspacesResources.Usage}\r\n  "));
 
             var returnType = symbol.InferAwaitableReturnType(semanticModel, position);
             returnType = returnType != null && returnType.SpecialType != SpecialType.System_Void ? returnType : null;

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -1043,6 +1043,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Usage:.
+        /// </summary>
+        internal static string Usage {
+            get {
+                return ResourceManager.GetString("Usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value too large to be represented as a 30 bit unsigned integer..
         /// </summary>
         internal static string ValueTooLargeToBeRepresented {

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -453,4 +453,7 @@
   <data name="OpenDocumentNotSupported" xml:space="preserve">
     <value>This workspace does not support opening and closing documents.</value>
   </data>
+  <data name="Usage" xml:space="preserve">
+    <value>Usage:</value>
+  </data>
 </root>


### PR DESCRIPTION
Also fixes some stray whitespace in a C# resource (`CSharpFeaturesResources.DisposePattern`) and moves duplicated resources from `CSharpFeaturesResources` and `VBFeaturesResources` to `WorkspacesResources.Usage` and updates the product code to actually use this resource in `ISymbolExtensions.cs` (it was hard-coded English before.)

Fixes #821.