### PR TITLE
Remove open deployment dependence on telemetry

### DIFF
--- a/src/VisualStudio/Setup/IRoslynTelemetrySetup.cs
+++ b/src/VisualStudio/Setup/IRoslynTelemetrySetup.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.ComponentModelHost;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.VisualStudio.LanguageServices.Setup
 {
+    /// <summary>
+    /// This interface allows the host to set up a telemetry service during package initialization.
+    /// </summary>
     internal interface IRoslynTelemetrySetup
     {
         void Initialize(IServiceProvider componentModel);

--- a/src/VisualStudio/Setup/RoslynPackage.cs
+++ b/src/VisualStudio/Setup/RoslynPackage.cs
@@ -59,8 +59,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             var componentModel = (IComponentModel)this.GetService(typeof(SComponentModel));
             _workspace = componentModel.GetService<VisualStudioWorkspace>();
 
-            var telemetrySetup = componentModel.GetService<IRoslynTelemetrySetup>();
-            telemetrySetup?.Initialize(this);
+            var telemetrySetupExtensions = componentModel.GetExtensions<IRoslynTelemetrySetup>();
+            foreach (var telemetrySetup in telemetrySetupExtensions)
+            {
+                telemetrySetup.Initialize(this);
+            }
                 
             // set workspace output pane
             _outputPane = new WorkspaceFailureOutputPane(this, _workspace);


### PR DESCRIPTION
Possible fix for internal TFS bug 1128536

When open-only builds of Roslyn are deployed to the RoslynDev hive,
there is no telemetry service hooked up, so we no longer assume one
exists.