### PR TITLE
Syntax node actions are not called for field declarations in compiler analyzer driver if the declaration defines multiple variables

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -794,8 +794,8 @@ public class B
                 context.ReportDiagnostic(diagnostic);
             }
         }
-        [Fact]
 
+        [Fact]
         private void TestNoDuplicateCallbacksForFieldDeclaration()
         {
             string source = @"
@@ -810,8 +810,28 @@ public class B
                 .VerifyAnalyzerDiagnostics(analyzers, null, null,
                      Diagnostic("MyFieldDiagnostic", @"public string field = ""field"";").WithLocation(4, 5));
         }
-        [Fact, WorkItem(1096600)]
 
+        [Fact, WorkItem(565)]
+        private void TestCallbacksForFieldDeclarationWithMultipleVariables()
+        {
+            string source = @"
+public class B
+{
+    public string field1, field2;
+    public int field3 = 0, field4 = 1;
+    public int field5, field6 = 1;
+}";
+            var analyzers = new DiagnosticAnalyzer[] { new FieldDeclarationAnalyzer() };
+
+            CreateCompilationWithMscorlib45(source)
+                .VerifyDiagnostics()
+                .VerifyAnalyzerDiagnostics(analyzers, null, null,
+                     Diagnostic("MyFieldDiagnostic", @"public string field1, field2;").WithLocation(4, 5),
+                     Diagnostic("MyFieldDiagnostic", @"public int field3 = 0, field4 = 1;").WithLocation(5, 5),
+                     Diagnostic("MyFieldDiagnostic", @"public int field5, field6 = 1;").WithLocation(6, 5));
+        }
+
+        [Fact, WorkItem(1096600)]
         private void TestDescriptorForConfigurableCompilerDiagnostics()
         {
             // Verify that all configurable compiler diagnostics, i.e. all non-error diagnostics,

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -823,15 +823,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (declInNode.DeclaredNode != declaredNode)
                 {
                     // Might be a field declaration statement with multiple fields declared.
-                    // Adjust syntax node for analysis to be just the field (except for the first field so that we don't skip nodes common to all fields).
+                    // If so, we execute syntax node analysis for entire field declaration (and its descendants)
+                    // if we processing the first field and skip syntax actions for remaining fields in the declaration.
                     if (declInNode.DeclaredSymbol == declaredSymbol)
                     {
                         if (!first)
                         {
-                            declaredNode = declInNode.DeclaredNode;
+                            return;
                         }
-
-                        continue;
+                        
+                        break;
                     }
 
                     // Compute the topmost node representing the syntax declaration for the member that needs to be skipped.

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -637,50 +637,99 @@ End Class
                 Dim sourceLoc = context.Symbol.Locations.First(Function(l) l.IsInSource)
                 context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(desc1, sourceLoc))
             End Sub
+        End Class
 
-            <Fact, WorkItem(1109126)>
-            Sub TestFieldSymbolAnalyzer_EnumField()
-                Dim analyzer = New FieldSymbolAnalyzer()
-                Dim sources = <compilation>
-                                  <file name="c.vb">
-                                      <![CDATA[
+        <Fact, WorkItem(1109126)>
+        Sub TestFieldSymbolAnalyzer_EnumField()
+            Dim analyzer = New FieldSymbolAnalyzer()
+            Dim sources = <compilation>
+                              <file name="c.vb">
+                                  <![CDATA[
 Public Enum E
     X = 0
 End Enum
 ]]>
-                                  </file>
-                              </compilation>
+                              </file>
+                          </compilation>
 
-                Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
+            Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
                     references:={SystemCoreRef, MsvbRef},
                     options:=TestOptions.ReleaseDll)
 
-                compilation.VerifyDiagnostics()
-                compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing,
+            compilation.VerifyDiagnostics()
+            compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing,
                     AnalyzerDiagnostic("FieldSymbolDiagnostic", <![CDATA[X]]>))
-            End Sub
+        End Sub
 
-            <Fact, WorkItem(1111667)>
-            Sub TestFieldSymbolAnalyzer_FieldWithoutInitializer()
-                Dim analyzer = New FieldSymbolAnalyzer()
-                Dim sources = <compilation>
-                                  <file name="c.vb">
-                                      <![CDATA[
+        <Fact, WorkItem(1111667)>
+        Sub TestFieldSymbolAnalyzer_FieldWithoutInitializer()
+            Dim analyzer = New FieldSymbolAnalyzer()
+            Dim sources = <compilation>
+                              <file name="c.vb">
+                                  <![CDATA[
 Public Class TestClass
     Public Field As System.IntPtr
 End Class
 ]]>
-                                  </file>
-                              </compilation>
+                              </file>
+                          </compilation>
 
-                Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
+            Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
                     references:={SystemCoreRef, MsvbRef},
                     options:=TestOptions.ReleaseDll)
 
-                compilation.VerifyDiagnostics()
-                compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing,
+            compilation.VerifyDiagnostics()
+            compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing,
                     AnalyzerDiagnostic("FieldSymbolDiagnostic", <![CDATA[Field]]>))
+        End Sub
+
+        Class FieldDeclarationAnalyzer
+            Inherits DiagnosticAnalyzer
+
+            Public Shared desc1 As New DiagnosticDescriptor("FieldDeclarationDiagnostic", "DummyDescription", "DummyMessage", "DummyCategory", DiagnosticSeverity.Warning, isEnabledByDefault:=True)
+
+            Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+                Get
+                    Return ImmutableArray.Create(desc1)
+                End Get
+            End Property
+
+            Public Overrides Sub Initialize(context As AnalysisContext)
+                context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, SyntaxKind.FieldDeclaration)
+            End Sub
+
+            Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
+                Dim sourceLoc = DirectCast(context.Node, FieldDeclarationSyntax).GetLocation
+                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(desc1, sourceLoc))
             End Sub
         End Class
+
+        <Fact, WorkItem(565)>
+        Sub TestFieldDeclarationAnalyzer()
+            Dim analyzer = New FieldDeclarationAnalyzer()
+            Dim sources = <compilation>
+                              <file name="c.vb">
+                                  <![CDATA[
+Public Class C
+    Dim x, y As Integer
+    Dim z As Integer
+    Dim x2 = 0, y2 = 0
+    Dim z2 = 0
+End Class
+]]>
+                              </file>
+                          </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
+                    references:={SystemCoreRef, MsvbRef},
+                    options:=TestOptions.ReleaseDll)
+
+            compilation.VerifyDiagnostics()
+            compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing,
+                    AnalyzerDiagnostic("FieldDeclarationDiagnostic", <![CDATA[Dim x, y As Integer]]>),
+                    AnalyzerDiagnostic("FieldDeclarationDiagnostic", <![CDATA[Dim z As Integer]]>),
+                    AnalyzerDiagnostic("FieldDeclarationDiagnostic", <![CDATA[Dim x2 = 0, y2 = 0]]>),
+                    AnalyzerDiagnostic("FieldDeclarationDiagnostic", <![CDATA[Dim z2 = 0]]>))
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -809,6 +809,72 @@ End Class
             End Sub
         End Class
 
+        <Fact, WorkItem(565)>
+        Sub TestFieldDeclarationAnalyzer()
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>
+public class B
+{
+    public string field0;
+    public string field1, field2;
+    public int field3 = 0, field4 = 1;
+    public int field5, field6 = 1;
+}
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspaceFactory.CreateWorkspace(test)
+                Dim project = workspace.CurrentSolution.Projects.Single()
+                Dim analyzer = New FieldDeclarationAnalyzer()
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+
+                Dim diagnosticService = New DiagnosticAnalyzerService()
+
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Assert.Equal(1, descriptorsMap.Count)
+
+                Dim document = project.Documents.Single()
+                Dim fullSpan = document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan
+
+                Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
+                Dim diagnostics = diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan, CancellationToken.None).
+                    WaitAndGetResult(CancellationToken.None).
+                    OrderBy(Function(d) d.TextSpan.Start).
+                    ToArray()
+                Assert.Equal(4, diagnostics.Length)
+                Assert.Equal(4, diagnostics.Where(Function(d) d.Id = FieldDeclarationAnalyzer.Desriptor1.Id).Count)
+
+                Assert.Equal("public string field0;", diagnostics(0).Message)
+                Assert.Equal("public string field1, field2;", diagnostics(1).Message)
+                Assert.Equal("public int field3 = 0, field4 = 1;", diagnostics(2).Message)
+                Assert.Equal("public int field5, field6 = 1;", diagnostics(3).Message)
+            End Using
+        End Sub
+
+        Class FieldDeclarationAnalyzer
+            Inherits DiagnosticAnalyzer
+
+            Public Shared Desriptor1 As New DiagnosticDescriptor("FieldDeclarationDiagnostic", "DummyDescription", "{0}", "DummyCategory", DiagnosticSeverity.Warning, isEnabledByDefault:=True)
+
+            Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+                Get
+                    Return ImmutableArray.Create(Desriptor1)
+                End Get
+            End Property
+
+            Public Overrides Sub Initialize(context As AnalysisContext)
+                context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, CodeAnalysis.CSharp.SyntaxKind.FieldDeclaration)
+            End Sub
+
+            Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
+                Dim fieldDecl = DirectCast(context.Node, CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax)
+                context.ReportDiagnostic(Diagnostic.Create(Desriptor1, fieldDecl.GetLocation, fieldDecl.ToString()))
+            End Sub
+        End Class
+
         <DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
         Private Class WorkspaceDiagnosticAnalyzer
             Inherits AbstractDiagnosticAnalyzer


### PR DESCRIPTION
Fix for #565: Syntax node actions are not called for field declarations in compiler analyzer driver if the declaration defines multiple variables

Simplify logic for execution of syntax node actions for field declarations: If there are multiple decls, execute syntax node actions for entire field decl (and its descendants) when processing symbol declared event for first field within it, and skip syntax node actions for rest of fields defined within that declaration.
Current logic is unnecessarily complex in that it tries to execute syntax node actions for individual variable declarators when processing corresponding field symbol declared event, and executes the node actions for shared nodes (e.g. defining type syntax node) when processing first field symbol, and caused this bug to sneak through.

Added regression tests for compiler driver (VB and C#) and IDE driver.

@JohnHamby @srivatsn please take a look.
