### PR TITLE
Add docs for ISymbol and its derived interfaces that say that they shoul...

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/IAliasSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAliasSymbol.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a using alias (Imports alias in Visual Basic).
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IAliasSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IArrayTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IArrayTypeSymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents an array.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IArrayTypeSymbol : ITypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a .NET assembly, consisting of one or more modules.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IAssemblySymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IDynamicTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IDynamicTypeSymbol.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents the 'dynamic' type in C#.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IDynamicTypeSymbol : ITypeSymbol
     {
     }

--- a/src/Compilers/Core/Portable/Symbols/IErrorTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IErrorTypeSymbol.cs
@@ -11,6 +11,10 @@ namespace Microsoft.CodeAnalysis
     /// of an error. For example, if a field is declared "Foo x;", and the type "Foo" cannot be
     /// found, an IErrorTypeSymbol is returned when asking the field "x" what it's type is.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IErrorTypeSymbol : INamedTypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents an event.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IEventSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a field in a class, struct or enum.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IFieldSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/ILabelSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ILabelSymbol.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a label in method body
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILabelSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/ILocalSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ILocalSymbol.cs
@@ -5,6 +5,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a local variable in method body.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILocalSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
     /// Represents a method or method-like symbol (including constructor,
     /// destructor, operator, or property/event accessor).
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IMethodSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a module within an assembly. Every assembly contains one or more modules.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IModuleSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a type other than an array, a pointer, a type parameter.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface INamedTypeSymbol : ITypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/INamespaceOrTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamespaceOrTypeSymbol.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents either a namespace or a type.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface INamespaceOrTypeSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/INamespaceSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamespaceSymbol.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a namespace.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface INamespaceSymbol : INamespaceOrTypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a parameter of a method or property.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IParameterSymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IPointerTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IPointerTypeSymbol.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
     /// Represents a pointer type such as "int *". Pointer types
     /// are used only in unsafe code.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPointerTypeSymbol : ITypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IPreprocessingSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IPreprocessingSymbol.cs
@@ -5,6 +5,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a preprocessing conditional compilation symbol.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPreprocessingSymbol : ISymbol
     {
     }

--- a/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a property or indexer.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPropertySymbol : ISymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/IRangeVariableSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IRangeVariableSymbol.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a range variable in a query expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IRangeVariableSymbol : ISymbol
     {
     }

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -13,6 +13,10 @@ namespace Microsoft.CodeAnalysis
     /// Represents a symbol (namespace, class, method, parameter, etc.)
     /// exposed by the compiler.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     [InternalImplementationOnly]
     public interface ISymbol : IEquatable<ISymbol>
     {

--- a/src/Compilers/Core/Portable/Symbols/ISynthesizedMethodBodyImplementationSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISynthesizedMethodBodyImplementationSymbol.cs
@@ -5,6 +5,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Synthesized symbol that implements a method body feature (iterator, async, lambda, etc.)
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     internal interface ISynthesizedMethodBodyImplementationSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a type parameter in a generic type or generic method.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITypeParameterSymbol : ITypeSymbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -4,6 +4,13 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis
 {
+    /// <summary>
+    /// Represents a type.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITypeSymbol : INamespaceOrTypeSymbol
     {
         /// <summary>


### PR DESCRIPTION
...d not be implemented outside Roslyn.

Fixes #632.