### PR TITLE
PERF: Concurrent dictionaries

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -45,7 +45,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Key is implemented member (method, property, or event), value is implementing member (from the 
             // perspective of this type).  Don't allocate until someone needs it.
-            internal ConcurrentDictionary<Symbol, SymbolAndDiagnostics> implementationForInterfaceMemberMap;
+            private ConcurrentDictionary<Symbol, SymbolAndDiagnostics> _implementationForInterfaceMemberMap;
+
+            public ConcurrentDictionary<Symbol, SymbolAndDiagnostics> ImplementationForInterfaceMemberMap
+            {
+                get
+                {
+                    var map = _implementationForInterfaceMemberMap;
+                    if (map != null)
+                    {
+                        return map;
+                    }
+
+                    // PERF: Avoid over-allocation. In many cases, there's only 1 entry and we don't expect concurrent updates.
+                    map = new ConcurrentDictionary<Symbol, SymbolAndDiagnostics>(concurrencyLevel: 1, capacity: 1);
+                    return Interlocked.CompareExchange(ref _implementationForInterfaceMemberMap, map, null) ?? map;
+                }
+            }
 
             // key = interface method/property/event, value = explicitly implementing method/property/event declared on this type
             internal Dictionary<Symbol, Symbol> explicitInterfaceImplementationMap;
@@ -54,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return allInterfaces.IsDefault &&
                     interfacesAndTheirBaseInterfaces == null &&
-                    implementationForInterfaceMemberMap == null &&
+                    _implementationForInterfaceMemberMap == null &&
                     explicitInterfaceImplementationMap == null;
             }
         }
@@ -641,12 +657,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         return SymbolAndDiagnostics.Empty;
                     }
 
-                    if (info.implementationForInterfaceMemberMap == null)
-                    {
-                        Interlocked.CompareExchange(ref info.implementationForInterfaceMemberMap, new ConcurrentDictionary<Symbol, SymbolAndDiagnostics>(), null);
-                    }
-
-                    return info.implementationForInterfaceMemberMap.GetOrAdd(interfaceMember, this.ComputeImplementationAndDiagnosticsForInterfaceMember);
+                    return info.ImplementationForInterfaceMemberMap.GetOrAdd(interfaceMember, this.ComputeImplementationAndDiagnosticsForInterfaceMember);
 
                 default:
                     return SymbolAndDiagnostics.Empty;

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -478,7 +478,16 @@ Done:
                 Return Nothing
             End If
 
-            Return ImplementationForInterfaceMemberMap.GetOrAdd(interfaceMember, AddressOf Me.ComputeImplementationForInterfaceMember)
+            ' PERF: Avoid delegate allocation by splitting GetOrAdd into TryGetValue+TryAdd
+            Dim map = ImplementationForInterfaceMemberMap
+            Dim result As Symbol = Nothing
+            If map.TryGetValue(interfaceMember, result) Then
+                Return result
+            End If
+
+            result = ComputeImplementationForInterfaceMember(interfaceMember)
+            map.TryAdd(interfaceMember, result)
+            Return result
         End Function
 
         Private ReadOnly Property ImplementationForInterfaceMemberMap As ConcurrentDictionary(Of Symbol, Symbol)


### PR DESCRIPTION
This addresses the top object and object[] allocations from the Picasso build throughput test.
It's further possible we don't even need ConcurrentDictionary here and we could come up with a more frugal container.