### PR TITLE
Make OutliningSpan Creation not assume MultiLine Comment always end with...

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/CSharpOutliningHelpers.cs
+++ b/src/EditorFeatures/CSharp/Outlining/CSharpOutliningHelpers.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
     internal static class CSharpOutliningHelpers
     {
         public const string Ellipsis = "...";
+        public const string MultiLineCommentSuffix = "*/";
         public const int MaxXmlDocCommentBannerLength = 120;
 
         private static int GetCollapsibleStart(SyntaxToken firstToken)
@@ -121,8 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
                 }
                 else
                 {
-                    int suffixLength = "*/".Length;
-                    text = text.Substring(0, text.Length - suffixLength);
+                    text = text.EndsWith(MultiLineCommentSuffix) ? text.Substring(0, text.Length - MultiLineCommentSuffix.Length) : text;
                 }
 
                 return CreateCommentBannerTextWithPrefix(text, "/*");

--- a/src/EditorFeatures/CSharpTest/Outlining/CommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/CommentTests.cs
@@ -163,5 +163,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
 
             AssertRegion(expectedRegion, actualRegion);
         }
+
+        [WorkItem(791)]
+        [WorkItem(1108049)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public void TestIncompleteMultilineCommentZeroSpace()
+        {
+            var tree = ParseLines("/*");
+
+            var multiLineCommentTrivia = tree.GetRoot().FindToken(0).LeadingTrivia;
+            var regions = CSharpOutliningHelpers.CreateCommentRegions(multiLineCommentTrivia).ToList();
+            Assert.Equal(1, regions.Count);
+
+            var actualRegion = regions[0];
+            var expectedRegion = new OutliningSpan(
+                TextSpan.FromBounds(0, 2),
+                "/*  ...",
+                autoCollapse: true);
+
+            AssertRegion(expectedRegion, actualRegion);
+        }
+
+        [WorkItem(791)]
+        [WorkItem(1108049)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public void TestIncompleteMultilineCommentSingleSpace()
+        {
+            var tree = ParseLines("/* ");
+
+            var multiLineCommentTrivia = tree.GetRoot().FindToken(0).LeadingTrivia;
+            var regions = CSharpOutliningHelpers.CreateCommentRegions(multiLineCommentTrivia).ToList();
+            Assert.Equal(1, regions.Count);
+
+            var actualRegion = regions[0];
+            var expectedRegion = new OutliningSpan(
+                TextSpan.FromBounds(0, 3),
+                "/*  ...",
+                autoCollapse: true);
+
+            AssertRegion(expectedRegion, actualRegion);
+        }
     }
 }


### PR DESCRIPTION
...'*/'

Fixes #791: The code '\*' is parsed as MultiLine Comment even with the
presence of the corresponding '*\' in some cases. Hence, OutLining Span
creator should not assume that '*\' will always be present for Multiline
Comment and handle the creation appropriately