### PR TITLE
Improve exception filter parsing error recovery

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7176,9 +7176,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             CatchFilterClauseSyntax filter = null;
 
-            if (this.CurrentToken.ContextualKind == SyntaxKind.WhenKeyword)
+            var keywordKind = this.CurrentToken.ContextualKind;
+            if (keywordKind == SyntaxKind.WhenKeyword || keywordKind == SyntaxKind.IfKeyword)
             {
                 var whenKeyword = this.EatContextualToken(SyntaxKind.WhenKeyword);
+                if (keywordKind == SyntaxKind.IfKeyword)
+                {
+                    // The initial design of C# exception filters called for the use of the
+                    // "if" keyword in this position.  We've since changed to "when", but 
+                    // the error recovery experience for early adopters (and for old source
+                    // stored in the symbol server) will be better if we consume "if" as
+                    // though it were "when".
+                    whenKeyword = AddTrailingSkippedSyntax(whenKeyword, EatToken());
+                }
                 whenKeyword = CheckFeatureAvailability(whenKeyword, MessageID.IDS_FeatureExceptionFilter);
                 _termState |= TerminatorState.IsEndOfilterClause;
                 var openParen = this.EatToken(SyntaxKind.OpenParenToken);


### PR DESCRIPTION
When we originally introduced exception filters to C#, we used the if
keyword in the filter clause.  To avoid confusion with regular if
statements, we switched to using the when (contextual) keyword.

Unfortunately, the if syntax was around long enough that code with that
syntax was stored in the source server database.  Now, when you try to
debug such files, they parse very badly.  In particular, there is a file
in the debugger in which thousands of lines of text become skipped text
trivia and the resulting syntax tree results in an
InsufficientExcecutionStackException whenever that file is displayed.
This makes it very difficult to inspect older dumps.

A simple solution is to allow the if keyword and replace it with a when
keyword with an error attached.

With this change applied, the debugger crash is resolved.