### PR TITLE
Backspace completion should map the caret to the subject buffer

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -113,6 +113,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return this.TextView.Caret.Position.BufferPosition;
         }
 
+        private SnapshotPoint GetCaretPointInSubjectBuffer()
+        {
+            AssertIsForeground();
+            return this.TextView.BufferGraph.MapUpOrDownToBuffer(this.TextView.Caret.Position.BufferPosition, this.SubjectBuffer).GetValueOrDefault();
+        }
+
         internal override void OnModelUpdated(Model modelOpt)
         {
             AssertIsForeground();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -30,18 +31,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             AssertIsForeground();
 
             char? deletedChar;
-            var caretPoint = GetCaretPointInViewBuffer().Position;
+            var subjectBufferCaretPoint = GetCaretPointInSubjectBuffer();
+            var viewBufferCaretPoint = GetCaretPointInViewBuffer();
             if (isDelete)
             {
-                deletedChar = GetCaretPointInViewBuffer().Position >= 0 && GetCaretPointInViewBuffer().Position < textView.TextBuffer.CurrentSnapshot.Length
-                    ? textView.TextBuffer.CurrentSnapshot[GetCaretPointInViewBuffer().Position]
+                deletedChar = viewBufferCaretPoint.Position >= 0 && viewBufferCaretPoint.Position < textView.TextBuffer.CurrentSnapshot.Length
+                    ? textView.TextBuffer.CurrentSnapshot[viewBufferCaretPoint.Position]
                     : default(char?);
             }
             else
             {
                 // backspace
-                deletedChar = caretPoint > 0
-                    ? textView.TextBuffer.CurrentSnapshot[caretPoint - 1]
+                deletedChar = viewBufferCaretPoint > 0
+                    ? textView.TextBuffer.CurrentSnapshot[viewBufferCaretPoint - 1]
                     : default(char?);
             }
 
@@ -88,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                 var model = sessionOpt.Computation.InitialUnfilteredModel;
 
-                if ((model == null && CaretHasLeftDefaultTrackingSpan(caretPoint, documentBeforeDeletion)) ||
+                if ((model == null && CaretHasLeftDefaultTrackingSpan(subjectBufferCaretPoint, documentBeforeDeletion)) ||
                     (model != null && this.IsCaretOutsideAllItemBounds(model, this.GetCaretPointInViewBuffer())) ||
                     (model != null && CreateCompletionService().DismissIfLastFilterCharacterDeleted && AllFilterTextsEmpty(model, GetCaretPointInViewBuffer())))
                 {

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -459,6 +459,162 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             End Using
         End Sub
 
+        <WorkItem(1124544)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
+        Public Sub CompletionUsesContextBufferPositions()
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>
+                                   e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.
+(1,3): error CS1001: Identifier expected
+e.
+(1,3): error CS1001: Identifier expected
+e.
+(1,3): error CS1001: Identifier expected
+e.
+(1,3): error CS1001: Identifier expected
+e.
+(1,3): error CS1001: Identifier expected
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+e.InnerException
+{"Exception of type 'System.Exception' was thrown."}
+    Data: {System.Collections.ListDictionaryInternal}
+    HResult: -2146233088
+    HelpLink: null
+    InnerException: null
+    Message: "Exception of type 'System.Exception' was thrown."
+    Source: null
+    StackTrace: null
+    TargetSite: null
+$$</Document>
+                               <Document>class Program
+{
+    static void Main(string[] args)
+    [|{|]
+
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, True)
+                state.SendTypeChars("arg")
+                Assert.Equal("arg", state.GetCurrentViewLineText())
+                state.AssertCompletionSession()
+                state.SendTab()
+                Assert.Equal("args", state.GetCurrentViewLineText())
+            End Using
+        End Sub
+
         Private Sub VerifyCompletionAndDotAfter(item As String, state As TestState)
             state.SendTypeChars(item)
             state.AssertSelectedCompletionItem(item)


### PR DESCRIPTION
Completion on backspace uses the caret position to determine if it should trigger, which involves inspecting the subject buffer. It did not map the text view caret position onto the subject buffer position. This resulted in crashes in projection scenarios when the surface buffer was longer than the subject buffer.

Fixes internal workitem 1088085.