### PR TITLE
Fix for #271: Compiler crashes if it cannot locate resources for analyzer

### DIFF
--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
@@ -247,6 +247,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     string directoryPath = Path.GetDirectoryName(requestingAssemblyFullPath);
                     string assemblyFullPath = Path.Combine(directoryPath, assemblyIdentity.Name + ".dll");
+                    if (!File.Exists(assemblyFullPath))
+                    {
+                        return null;
+                    }
 
                     assembly = LoadCore(assemblyFullPath);
 


### PR DESCRIPTION
CLR calls us back to search for presence of satellite resource assembly with ".resources" suffix, before attempting to go back to the main assembly as a fallback for resources. However, during this callback we were trying to load the satellite assembly without checking if the file exists on disk, causing an unhandled FileIOException.

Adding the NeutralResourcesLanguageAttribute in PR #831 caused the CLR to directly go to the Main assembly for resources, without making the satellite assembly callback.

I removed this attribute locally from our analyzer assemblies, and with the added File.Exists check, we correctly return null for satellite assembly callbacks and CLR eventually falls back to the Main assembly for resources and we are able to find resources.

@tmeschter @srivatsn @jmarolf @JohnHamby can you please take a look?