### PR TITLE
make PreviewDialogWorkspace internal to facilitate other testing

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -4,14 +4,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Preview;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 {
     internal partial class PreviewUpdater
     {
-        private class PreviewDialogWorkspace : PreviewWorkspace
+        internal class PreviewDialogWorkspace : PreviewWorkspace
         {
             public PreviewDialogWorkspace(Solution solution) : base(solution)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 {
     internal partial class PreviewUpdater
     {
+        // internal for testing
         internal class PreviewDialogWorkspace : PreviewWorkspace
         {
             public PreviewDialogWorkspace(Solution solution) : base(solution)


### PR DESCRIPTION
Some internal stress testing work requires access to this class.  Making it internal allows us to use `typeof()` instead of using the string name and relying on reflection.