### PR TITLE
Add explicit null checks during module lookup

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal static PENamedTypeSymbol GetType(this CSharpCompilation compilation, Guid moduleVersionId, int typeToken, out MetadataDecoder metadataDecoder)
         {
             var module = compilation.GetModule(moduleVersionId);
+            CheckModule(module, moduleVersionId);
             var reader = module.Module.MetadataReader;
             var typeHandle = (TypeDefinitionHandle)MetadataTokens.Handle(typeToken);
             var type = GetType(module, typeHandle);
@@ -62,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal static PEMethodSymbol GetMethod(this CSharpCompilation compilation, Guid moduleVersionId, MethodDefinitionHandle methodHandle)
         {
             var module = compilation.GetModule(moduleVersionId);
+            CheckModule(module, moduleVersionId);
             var reader = module.Module.MetadataReader;
             var typeHandle = reader.GetMethodDefinition(methodHandle).GetDeclaringType();
             var type = GetType(module, typeHandle);
@@ -86,6 +88,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
 
             return null;
+        }
+
+        private static void CheckModule(PEModuleSymbol module, Guid moduleVersionId)
+        {
+            if ((object)module == null)
+            {
+                throw new ArgumentException($"No module found with MVID '{moduleVersionId}'", nameof(moduleVersionId));
+            }
         }
 
         internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataBlock> metadataBlocks)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -20,6 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         <Extension>
         Friend Function [GetType](compilation As VisualBasicCompilation, moduleVersionId As Guid, typeToken As Integer, <Out> ByRef metadataDecoder As MetadataDecoder) As PENamedTypeSymbol
             Dim [module] = compilation.GetModule(moduleVersionId)
+            CheckModule([module], moduleVersionId)
             Dim reader = [module].Module.MetadataReader
             Dim typeHandle = CType(MetadataTokens.Handle(typeToken), TypeDefinitionHandle)
             Dim type = [GetType]([module], typeHandle)
@@ -57,6 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         <Extension>
         Friend Function GetMethod(compilation As VisualBasicCompilation, moduleVersionId As Guid, methodHandle As MethodDefinitionHandle) As PEMethodSymbol
             Dim [module] = compilation.GetModule(moduleVersionId)
+            CheckModule([module], moduleVersionId)
             Dim reader = [module].Module.MetadataReader
             Dim typeHandle = reader.GetMethodDefinition(methodHandle).GetDeclaringType()
             Dim type = [GetType]([module], typeHandle)
@@ -79,6 +81,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Return Nothing
         End Function
+
+        Private Sub CheckModule([module] As PEModuleSymbol, moduleVersionId As Guid)
+            If [module] Is Nothing Then
+                Throw New ArgumentException($"No module found with MVID '{moduleVersionId}'", NameOf(moduleVersionId))
+            End If
+        End Sub
 
         <Extension>
         Friend Function ToCompilation(metadataBlocks As ImmutableArray(Of MetadataBlock)) As VisualBasicCompilation


### PR DESCRIPTION
We got a release-build dump with a NRE in a location that didn't make sense.  Based on our best guess of what happened (something that should be impossible) add some explicit checks so that we'll get a clearer stack trace if it happens again.

No tests since we still believe this is impossible.