### PR TITLE
Add stack guards for expression and statement parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6307,7 +6307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             return ParseWithStackGuard(
                 ParseStatementCore,
-                () => SyntaxFactory.EmptyStatement(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+                () => SyntaxFactory.EmptyStatement(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken)));
         }
 
         private StatementSyntax ParseStatementCore()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -221,11 +221,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private void ParseInterpolationStart(out SyntaxToken openBraceToken, out ExpressionSyntax expr, out SyntaxToken commaToken, out ExpressionSyntax alignmentExpression)
         {
             openBraceToken = this.EatToken(SyntaxKind.OpenBraceToken);
-            expr = this.ParseExpression();
+            expr = this.ParseExpressionCore();
             if (this.CurrentToken.Kind == SyntaxKind.CommaToken)
             {
                 commaToken = this.EatToken(SyntaxKind.CommaToken);
-                alignmentExpression = ConsumeUnexpectedTokens(this.ParseExpression());
+                alignmentExpression = ConsumeUnexpectedTokens(this.ParseExpressionCore());
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -4792,6 +4792,60 @@ class Program
         }
 
         [Fact]
+        public void TooDeepObjectInitializerAsExpression()
+        {
+            var builder = new StringBuilder();
+            const int depth = 5000;
+            builder.Append(@"new C {");
+
+            for (int i = 0; i < depth; i++)
+            {
+                builder.AppendLine("c = new C {");
+            }
+
+            builder.Append("c = new C(), u = 0");
+
+            for (int i = 0; i < depth - 1; i++)
+            {
+                builder.AppendLine("}, u = 0");
+            }
+
+            builder.Append(@"}");
+
+            var expr = SyntaxFactory.ParseExpression(builder.ToString());
+            var actualErrors = expr.GetDiagnostics().ToArray();
+            Assert.Equal(1, actualErrors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InsufficientStack, actualErrors[0].Code);
+        }
+
+        [Fact]
+        public void TooDeepObjectInitializerAsStatement()
+        {
+            var builder = new StringBuilder();
+            const int depth = 5000;
+            builder.Append(@"C c = new C {");
+
+            for (int i = 0; i < depth; i++)
+            {
+                builder.AppendLine("c = new C {");
+            }
+
+            builder.Append("c = new C(), u = 0");
+
+            for (int i = 0; i < depth - 1; i++)
+            {
+                builder.AppendLine("}, u = 0");
+            }
+
+            builder.Append(@"}");
+
+            var stmt = SyntaxFactory.ParseStatement(builder.ToString());
+            var actualErrors = stmt.GetDiagnostics().ToArray();
+            Assert.Equal(1, actualErrors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InsufficientStack, actualErrors[0].Code);
+        }
+
+        [Fact]
         [WorkItem(1085618, "DevDiv")]
         public void MismatchedBracesAndDelegateDeclaration()
         {

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim PrevEvaluatingConditionCompilationExpressions As Boolean = m_EvaluatingConditionCompilationExpression
             m_EvaluatingConditionCompilationExpression = True
 
-            Dim Expr = ParseExpression()
+            Dim Expr = ParseExpressionCore()
 
             m_EvaluatingConditionCompilationExpression = PrevEvaluatingConditionCompilationExpressions
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         ' File: Parser.cpp
         ' Lines: 12312 - 12312
-        ' Expression* .Parser::ParseExpressionCore( [ OperatorPrecedence PendingPrecedence ] [ _Inout_ bool& ErrorInConstruct ] [ bool AllowArrayInitExpression ] )
+        ' Expression* .Parser::ParseExpression( [ OperatorPrecedence PendingPrecedence ] [ _Inout_ bool& ErrorInConstruct ] [ bool AllowArrayInitExpression ] )
         '        //EatLeadingNewLine: Indicates that the parser should
         '        //dig through a leading EOL token when it tries
         '        //to parse the expression.

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -9,6 +9,18 @@ Imports InternalSyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.Syntax.Intern
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
     Partial Class Parser
+
+        Friend Function ParseExpression(
+            Optional pendingPrecedence As OperatorPrecedence = OperatorPrecedence.PrecedenceNone,
+            Optional bailIfFirstTokenRejected As Boolean = False
+        ) As ExpressionSyntax
+
+            Return ParseWithStackGuard(Of ExpressionSyntax)(
+                Function() ParseExpressionCore(pendingPrecedence, bailIfFirstTokenRejected),
+                Function() InternalSyntaxFactory.MissingExpression())
+
+        End Function
+
         ' /*********************************************************************
         ' *
         ' * Function:
@@ -24,14 +36,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         ' File: Parser.cpp
         ' Lines: 12312 - 12312
-        ' Expression* .Parser::ParseExpression( [ OperatorPrecedence PendingPrecedence ] [ _Inout_ bool& ErrorInConstruct ] [ bool AllowArrayInitExpression ] )
+        ' Expression* .Parser::ParseExpressionCore( [ OperatorPrecedence PendingPrecedence ] [ _Inout_ bool& ErrorInConstruct ] [ bool AllowArrayInitExpression ] )
         '        //EatLeadingNewLine: Indicates that the parser should
         '        //dig through a leading EOL token when it tries
         '        //to parse the expression.
         '
-        '    bool EatLeadingNewLine,         - we no longer support it in ParseExpression, please eat the new line yourself before calling
+        '    bool EatLeadingNewLine,         - we no longer support it in ParseExpressionCore, please eat the new line yourself before calling
         '    bool BailIfFirstTokenRejected                 // bail (return NULL) if the first token isn't a valid expression-starter, rather than reporting an error or setting ErrorInConstruct
-        Friend Function ParseExpression(
+        Private Function ParseExpressionCore(
             Optional pendingPrecedence As OperatorPrecedence = OperatorPrecedence.PrecedenceNone,
             Optional bailIfFirstTokenRejected As Boolean = False
         ) As ExpressionSyntax
@@ -71,13 +83,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         ' "-" unary minus
                         GetNextToken()
 
-                        Dim Operand As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceNegate)
+                        Dim Operand As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceNegate)
                         expression = SyntaxFactory.UnaryMinusExpression(startToken, Operand)
 
                     Case SyntaxKind.NotKeyword
                         ' NOT expr
                         GetNextToken()
-                        Dim Operand = ParseExpression(OperatorPrecedence.PrecedenceNot)
+                        Dim Operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNot)
                         expression = SyntaxFactory.NotExpression(startToken, Operand)
 
                     Case SyntaxKind.PlusToken
@@ -86,13 +98,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                         ' unary "+" has the same precedence as unary "-"
 
-                        Dim Operand = ParseExpression(OperatorPrecedence.PrecedenceNegate)
+                        Dim Operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNegate)
                         expression = SyntaxFactory.UnaryPlusExpression(startToken, Operand)
 
                     Case SyntaxKind.AddressOfKeyword
                         GetNextToken()
 
-                        Dim Operand = ParseExpression(OperatorPrecedence.PrecedenceNegate)
+                        Dim Operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNegate)
                         expression = SyntaxFactory.AddressOfExpression(startToken, Operand)
 
                     Case Else
@@ -146,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         'Binary.Opcode = Opcode
 
                         'Binary.Left = Expr
-                        Dim rightOperand As ExpressionSyntax = ParseExpression(precedence)
+                        Dim rightOperand As ExpressionSyntax = ParseExpressionCore(precedence)
 
                         expression = SyntaxFactory.BinaryExpression(GetBinaryOperatorHelper([operator]), expression, [operator], rightOperand)
 
@@ -667,7 +679,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim openParen As PunctuationSyntax = Nothing
             TryGetTokenAndEatNewLine(SyntaxKind.OpenParenToken, openParen, createIfMissing:=True)
 
-            Dim nameOfName = ValidateNameOfArgument(ParseExpression(), isTopLevel:=True)
+            Dim nameOfName = ValidateNameOfArgument(ParseExpressionCore(), isTopLevel:=True)
 
             Dim closeParen As PunctuationSyntax = Nothing
             TryEatNewLineAndGetToken(SyntaxKind.CloseParenToken, closeParen, createIfMissing:=True)
@@ -765,7 +777,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim openParen As PunctuationSyntax = Nothing
             TryGetTokenAndEatNewLine(SyntaxKind.OpenParenToken, openParen, createIfMissing:=True)
 
-            Dim Operand = ParseExpression()
+            Dim Operand = ParseExpressionCore()
 
             Dim closeParen As PunctuationSyntax = Nothing
             TryEatNewLineAndGetToken(SyntaxKind.CloseParenToken, closeParen, createIfMissing:=True)
@@ -917,7 +929,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' Consume 'TypeOf'.
             GetNextToken()
 
-            Dim exp As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceRelational) 'Dev10 uses ParseVariable
+            Dim exp As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceRelational) 'Dev10 uses ParseVariable
 
             If exp.ContainsDiagnostics Then
                 exp = ResyncAt(exp, SyntaxKind.IsKeyword, SyntaxKind.IsNotKeyword)
@@ -961,7 +973,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 16191 - 16191
         ' Expression* .Parser::ParseVariable( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseVariable() As ExpressionSyntax
-            Return ParseExpression(OperatorPrecedence.PrecedenceRelational)
+            Return ParseExpressionCore(OperatorPrecedence.PrecedenceRelational)
         End Function
 
         ' /*********************************************************************
@@ -1215,7 +1227,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' "(" expr ")"
             Dim openParen As PunctuationSyntax = Nothing
             TryGetTokenAndEatNewLine(SyntaxKind.OpenParenToken, openParen)
-            Dim Operand = ParseExpression()
+            Dim Operand = ParseExpressionCore()
 
             Dim closeParen As PunctuationSyntax = Nothing
             TryEatNewLineAndGetToken(SyntaxKind.CloseParenToken, closeParen, createIfMissing:=True)
@@ -1407,7 +1419,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     argumentName = ReportSyntaxError(argumentName, ERRID.ERR_ExpectedNamedArgument)
                 End If
 
-                Dim namedArgument = SyntaxFactory.SimpleArgument(SyntaxFactory.NameColonEquals(argumentName, colonEquals), ParseExpression())
+                Dim namedArgument = SyntaxFactory.SimpleArgument(SyntaxFactory.NameColonEquals(argumentName, colonEquals), ParseExpressionCore())
 
                 If CurrentToken.Kind <> SyntaxKind.CommaToken Then
                     If CurrentToken.Kind = SyntaxKind.CloseParenToken OrElse MustEndStatement(CurrentToken) Then
@@ -1443,7 +1455,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function ParseArgument(Optional RedimOrNewParent As Boolean = False) As ArgumentSyntax
             Dim argument As ArgumentSyntax
 
-            Dim value As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceNone)
+            Dim value As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
             If value.ContainsDiagnostics Then
                 value = ResyncAt(value, SyntaxKind.CommaToken, SyntaxKind.CloseParenToken)
@@ -1454,7 +1466,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Dim lowerBound As ExpressionSyntax = value
 
                 GetNextToken() ' consume tkTO
-                value = ParseExpression(OperatorPrecedence.PrecedenceNone)
+                value = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
                 ' Check that lower bound is equal to 0 moved to binder.
 
@@ -1492,7 +1504,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             TryGetTokenAndEatNewLine(SyntaxKind.OpenParenToken, openParen, createIfMissing:=True)
 
-            Dim exp As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceNone)
+            Dim exp As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
             If exp.ContainsDiagnostics Then
                 exp = ResyncAt(exp, SyntaxKind.CommaToken, SyntaxKind.CloseParenToken)
@@ -1654,7 +1666,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 value = SyntaxFactory.SingleLineLambdaExpression(SyntaxKind.SingleLineFunctionLambdaExpression,
                                                           header,
-                                                          ParseExpression())
+                                                          ParseExpressionCore())
                 value = AdjustTriviaForMissingTokens(value)
                 If header.Modifiers.Any(SyntaxKind.IteratorKeyword) Then
                     value = Parser.ReportSyntaxError(value, ERRID.ERR_BadIteratorExpressionLambda)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 expression = ReportSyntaxError(InternalSyntaxFactory.MissingExpression(), ERRID.ERR_ExpectedExpression)
 
             Else
-                expression = ParseExpression()
+                expression = ParseExpressionCore()
 
                 ' Scanned this as a terminator. Fix it.
                 If CurrentToken.Kind = SyntaxKind.ColonToken Then

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseQuery.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseQuery.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 nameEqualsOpt = SyntaxFactory.VariableNameEquals(varName, Nothing, Equals)
             End If
 
-            Dim expr As ExpressionSyntax = ParseExpression()
+            Dim expr As ExpressionSyntax = ParseExpressionCore()
 
             Return SyntaxFactory.ExpressionRangeVariable(
                 nameEqualsOpt,
@@ -108,7 +108,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Dim arg As ExpressionSyntax = Nothing
                 If CurrentToken.Kind <> SyntaxKind.CloseParenToken Then
-                    arg = ParseExpression()
+                    arg = ParseExpressionCore()
                 End If
 
                 Dim rParen As PunctuationSyntax = Nothing
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             'TODO: this is very different from original implementation.
             ' originally we would try to parse the whole thing as an expression and see if we
             ' will not consume more than "syntax". It seems that "syntax" is always a term
-            ' so the only way ParseExpression could consume more is if there is a binary operator.
+            ' so the only way ParseExpressionCore could consume more is if there is a binary operator.
             ' Hopefully checking for binary operator is enough...
             If Not CurrentToken.IsBinaryOperator AndAlso
                 CurrentToken.Kind <> SyntaxKind.DotToken Then
@@ -363,7 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     If Not TokenFollowingAsWasIn Then
                         TryEatNewLine() ' // enable implicit LC after 'In' or '=' But not if somebody did from x as IN 
                     End If
-                    source = ParseExpression()
+                    source = ParseExpressionCore()
                 End If
 
                 ' // try to recover
@@ -482,7 +482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     If Not TokenFollowingAsWasIn Then
                         TryEatNewLine() ' // enable implicit LC after 'In' or '=' But not if somebody did from x as IN 
                     End If
-                    source = ParseExpression()
+                    source = ParseExpressionCore()
                 End If
 
                 ' // try to recover
@@ -828,7 +828,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim source As ExpressionSyntax = Nothing
             If TryEatNewLineAndGetToken(SyntaxKind.InKeyword, [In], createIfMissing:=True) Then
                 TryEatNewLine() ' // dev10_500708 allow line continuation after 'IN' 
-                source = ParseExpression()
+                source = ParseExpressionCore()
             End If
 
             ' // try to recover
@@ -864,7 +864,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Dim element As JoinConditionSyntax = Nothing
 
                 If CurrentToken.Kind <> SyntaxKind.StatementTerminatorToken Then
-                    Dim Left = ParseExpression(OperatorPrecedence.PrecedenceRelational)
+                    Dim Left = ParseExpressionCore(OperatorPrecedence.PrecedenceRelational)
 
                     ' // try to recover
                     If Left.ContainsDiagnostics Then
@@ -879,7 +879,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Dim eqKw As KeywordSyntax = Nothing
                     Dim Right As ExpressionSyntax = Nothing
                     If TryGetContextualKeywordAndEatNewLine(SyntaxKind.EqualsKeyword, eqKw, createIfMissing:=True) Then
-                        Right = ParseExpression(OperatorPrecedence.PrecedenceRelational)
+                        Right = ParseExpressionCore(OperatorPrecedence.PrecedenceRelational)
                     Else
                         Right = InternalSyntaxFactory.MissingExpression
                     End If
@@ -970,7 +970,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim exprs = Me._pool.AllocateSeparated(Of OrderingSyntax)()
 
             Do
-                Dim OrderExpression = ParseExpression()
+                Dim OrderExpression = ParseExpressionCore()
 
                 ' // try to recover
                 If OrderExpression.ContainsDiagnostics Then
@@ -1082,7 +1082,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Case SyntaxKind.WhereKeyword
                             GetNextToken() ' get off where
                             TryEatNewLine()
-                            Return InternalSyntaxFactory.WhereClause(kw, ParseExpression())
+                            Return InternalSyntaxFactory.WhereClause(kw, ParseExpressionCore())
 
                         Case SyntaxKind.SkipKeyword
                             GetNextToken() ' get off Skip
@@ -1092,10 +1092,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                 Dim whileKw = DirectCast(CurrentToken, KeywordSyntax)
                                 GetNextToken() ' get off While
                                 TryEatNewLine()
-                                Return InternalSyntaxFactory.SkipWhileClause(kw, whileKw, ParseExpression())
+                                Return InternalSyntaxFactory.SkipWhileClause(kw, whileKw, ParseExpressionCore())
                             Else
                                 TryEatNewLineIfNotFollowedBy(SyntaxKind.WhileKeyword) ' // when Skip ends the line, allow a implicit line continuation
-                                Return InternalSyntaxFactory.SkipClause(kw, ParseExpression())
+                                Return InternalSyntaxFactory.SkipClause(kw, ParseExpressionCore())
                             End If
 
                         Case SyntaxKind.TakeKeyword
@@ -1106,10 +1106,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                 Dim whileKw = DirectCast(CurrentToken, KeywordSyntax)
                                 GetNextToken() ' get off While
                                 TryEatNewLine()
-                                Return InternalSyntaxFactory.TakeWhileClause(kw, whileKw, ParseExpression())
+                                Return InternalSyntaxFactory.TakeWhileClause(kw, whileKw, ParseExpressionCore())
                             Else
                                 TryEatNewLineIfNotFollowedBy(SyntaxKind.WhileKeyword) ' // when Skip ends the line, allow a implicit line continuation
-                                Return InternalSyntaxFactory.TakeClause(kw, ParseExpression())
+                                Return InternalSyntaxFactory.TakeClause(kw, ParseExpressionCore())
                             End If
 
                         Case SyntaxKind.GroupKeyword

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
@@ -272,7 +272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                             GetNextToken() ' get off relational operator
                             TryEatNewLine() ' dev10_503248
 
-                            Dim CaseExpr As ExpressionSyntax = ParseExpression()
+                            Dim CaseExpr As ExpressionSyntax = ParseExpressionCore()
 
                             If CaseExpr.ContainsDiagnostics Then
                                 CaseExpr = ResyncAt(CaseExpr)
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Else
 
-                        Dim value As ExpressionSyntax = ParseExpression()
+                        Dim value As ExpressionSyntax = ParseExpressionCore()
 
                         If value.ContainsDiagnostics Then
                             value = ResyncAt(value, SyntaxKind.ToKeyword)
@@ -300,7 +300,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Dim toKeyword As KeywordSyntax = Nothing
                         If TryGetToken(SyntaxKind.ToKeyword, toKeyword) Then
 
-                            Dim upperBound As ExpressionSyntax = ParseExpression()
+                            Dim upperBound As ExpressionSyntax = ParseExpressionCore()
 
                             If upperBound.ContainsDiagnostics Then
                                 upperBound = ResyncAt(upperBound)
@@ -380,7 +380,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim optionalCaseKeyword As KeywordSyntax = Nothing
             TryGetToken(SyntaxKind.CaseKeyword, optionalCaseKeyword)
 
-            Dim value As ExpressionSyntax = ParseExpression()
+            Dim value As ExpressionSyntax = ParseExpressionCore()
 
             If value.ContainsDiagnostics Then
                 value = ResyncAt(value)
@@ -410,7 +410,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim ifKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
 
-            Dim condition = ParseExpression(OperatorPrecedence.PrecedenceNone)
+            Dim condition = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
             If condition.ContainsDiagnostics Then
                 condition = ResyncAt(condition, SyntaxKind.ThenKeyword)
@@ -468,7 +468,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 elseIfKeyword = New KeywordSyntax(SyntaxKind.ElseIfKeyword, MergeTokenText(elseKeyword, ifKeyword), elseKeyword.GetLeadingTrivia(), ifKeyword.GetTrailingTrivia())
             End If
 
-            Dim condition = ParseExpression(OperatorPrecedence.PrecedenceNone)
+            Dim condition = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
             If condition.ContainsDiagnostics Then
                 condition = ResyncAt(condition, SyntaxKind.ThenKeyword)
@@ -609,7 +609,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim inKeyword As KeywordSyntax = Nothing
             If TryGetTokenAndEatNewLine(SyntaxKind.InKeyword, inKeyword) Then
 
-                expression = ParseExpression()
+                expression = ParseExpressionCore()
 
                 If expression.ContainsDiagnostics Then
                     expression = ResyncAt(expression)
@@ -649,7 +649,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ' Dev10_545918 - Allow implicit line continuation after '=' 
 
-                fromValue = ParseExpression()
+                fromValue = ParseExpressionCore()
 
                 If fromValue.ContainsDiagnostics Then
                     fromValue = ResyncAt(fromValue, SyntaxKind.ToKeyword)
@@ -668,7 +668,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             If TryGetToken(SyntaxKind.ToKeyword, toKeyword) Then
 
                 'TODO - davidsch - Why is newline allowed after '=' but not after 'to'?
-                toValue = ParseExpression()
+                toValue = ParseExpressionCore()
 
                 If toValue.ContainsDiagnostics Then
                     toValue = ResyncAt(toValue, SyntaxKind.StepKeyword)
@@ -688,7 +688,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             If TryGetToken(SyntaxKind.StepKeyword, stepKeyword) Then
 
-                stepValue = ParseExpression()
+                stepValue = ParseExpressionCore()
 
                 If stepValue.ContainsDiagnostics Then
                     stepValue = ResyncAt(stepValue)
@@ -1098,7 +1098,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 TryEatNewLine()
 
-                Dim source = ParseExpression()
+                Dim source = ParseExpressionCore()
 
                 If source.ContainsDiagnostics Then
                     ' Sync to avoid other errors
@@ -1344,7 +1344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim kind = If(keyword.Kind = SyntaxKind.AddHandlerKeyword, SyntaxKind.AddHandlerStatement, SyntaxKind.RemoveHandlerStatement)
             GetNextToken()
 
-            Dim eventExpression = ParseExpression()
+            Dim eventExpression = ParseExpressionCore()
 
             If eventExpression.ContainsDiagnostics Then
                 eventExpression = ResyncAt(eventExpression, SyntaxKind.CommaToken)
@@ -1353,7 +1353,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim commaToken As PunctuationSyntax = Nothing
             TryGetTokenAndEatNewLine(SyntaxKind.CommaToken, commaToken, createIfMissing:=True)
 
-            Dim DelegateExpression = ParseExpression()
+            Dim DelegateExpression = ParseExpressionCore()
 
             If DelegateExpression.ContainsDiagnostics Then
                 DelegateExpression = ResyncAt(DelegateExpression)
@@ -1384,7 +1384,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             GetNextToken()
 
-            Dim operand = ParseExpression(OperatorPrecedence.PrecedenceNone)
+            Dim operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNone)
 
             If operand.ContainsDiagnostics Then
                 operand = ResyncAt(operand)
@@ -1483,7 +1483,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim whenKeyword As KeywordSyntax = Nothing
             Dim filter As ExpressionSyntax = Nothing
             If TryGetToken(SyntaxKind.WhenKeyword, whenKeyword) Then
-                filter = ParseExpression()
+                filter = ParseExpressionCore()
 
                 optionalWhenClause = SyntaxFactory.CatchFilterClause(whenKeyword, filter)
             End If
@@ -1514,7 +1514,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim throwKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
 
-            Dim value = ParseExpression(bailIfFirstTokenRejected:=True)
+            Dim value = ParseExpressionCore(bailIfFirstTokenRejected:=True)
             If value IsNot Nothing Then
                 If value.ContainsDiagnostics Then
                     value = ResyncAt(value)
@@ -1532,7 +1532,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim errorKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
 
-            Dim value = ParseExpression()
+            Dim value = ParseExpressionCore()
 
             If value.ContainsDiagnostics Then
                 value = ResyncAt(value)
@@ -1649,7 +1649,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim equals As PunctuationSyntax = Nothing
             VerifyExpectedToken(SyntaxKind.EqualsToken, equals)
 
-            Dim source As ExpressionSyntax = ParseExpression()
+            Dim source As ExpressionSyntax = ParseExpressionCore()
 
             If source.ContainsDiagnostics() Then
                 source = ResyncAt(source)
@@ -1682,7 +1682,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     GetNextToken()
 
-                    Dim condition = ParseExpression()
+                    Dim condition = ParseExpressionCore()
                     If condition.ContainsDiagnostics Then
                         condition = ResyncAt(condition)
                     End If
@@ -1737,10 +1737,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             ' We will try to parse the expression, but the final "true" argument means
             ' "Bail if the first token isn't a valid way to start an expression; in this case just return NULL"
-            Dim operand = ParseExpression(OperatorPrecedence.PrecedenceNone, True)
+            Dim operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNone, True)
 
             ' Note: Orcas behavior had been to bail immediately if IsValidStatementTerminator(CurrentToken).
-            ' Well, all such tokens are invalid as ways to start an expression, so the above call to ParseExpression
+            ' Well, all such tokens are invalid as ways to start an expression, so the above call to ParseExpressionCore
             ' will bail correctly for them. I've put in this assert to show that it's safe to skip the check for IsValidStatementTerminator.
 
             Debug.Assert(operand Is Nothing OrElse Not IsValidStatementTerminator(startToken), "Unexpected: we should have bailed on the token after this return statement")
@@ -1753,7 +1753,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 ' token cannot possibly come after the statement, so we'll report on it now:
                 If Not CanFollowStatement(CurrentToken) Then
                     ' This time don't let it bail:
-                    operand = ParseExpression(OperatorPrecedence.PrecedenceNone, False)
+                    operand = ParseExpressionCore(OperatorPrecedence.PrecedenceNone, False)
                 End If
 
             ElseIf operand.ContainsDiagnostics Then
@@ -1802,7 +1802,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 variables = ParseVariableDeclaration(allowAsNewWith:=True)
             Else
-                optionalExpression = ParseExpression()
+                optionalExpression = ParseExpressionCore()
             End If
 
             'TODO - not resynching here may cause errors to differ from Dev10.
@@ -1847,7 +1847,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             yieldKeyword = CheckFeatureAvailability(Feature.Iterators, yieldKeyword)
             GetNextToken()
 
-            Dim expression As ExpressionSyntax = ParseExpression()
+            Dim expression As ExpressionSyntax = ParseExpressionCore()
             Dim result = SyntaxFactory.YieldStatement(yieldKeyword, expression)
 
             Return result
@@ -1858,7 +1858,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim questionToken = DirectCast(CurrentToken, PunctuationSyntax)
             GetNextToken()
 
-            Dim expression As ExpressionSyntax = ParseExpression()
+            Dim expression As ExpressionSyntax = ParseExpressionCore()
             Dim result = SyntaxFactory.PrintStatement(questionToken, expression)
 
             ' skip possible statement terminator

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
@@ -2009,7 +2009,7 @@ TryResync:
             beginXmlEmbedded = TransitionFromXmlToVB(beginXmlEmbedded)
             TryEatNewLine(ScannerState.VB)
 
-            Dim value = ParseExpression()
+            Dim value = ParseExpressionCore()
 
             Dim endXmlEmbedded As PunctuationSyntax = Nothing
             If Not TryEatNewLineAndGetToken(SyntaxKind.PercentGreaterThanToken, endXmlEmbedded, createIfMissing:=False, state:=enclosingState) Then

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -432,75 +432,89 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 1125 - 1125
         ' HRESULT .Parser::ParseDecls( [ _In_ Scanner* InputStream ] [ ErrorTable* Errors ] [ SourceFile* InputFile ] [  ParseTree::FileBlockStatement** Result ] [ _Inout_ NorlsAllocator* ConditionalCompilationSymbolsStorage ] [ BCSYM_Container* ProjectLevelCondCompScope ] [ _Out_opt_ BCSYM_Container** ConditionalCompilationConstants ] [ _In_ LineMarkerTable* LineMarkerTableForConditionals ] )
         Friend Function ParseCompilationUnit() As CompilationUnitSyntax
+            Return ParseWithStackGuard(Of CompilationUnitSyntax)(
+                AddressOf Me.ParseCompilationUnitCore,
+                Function() SyntaxFactory.CompilationUnit(
+                    New SyntaxList(Of VisualBasicSyntaxNode)(),
+                    New SyntaxList(Of VisualBasicSyntaxNode)(),
+                    New SyntaxList(Of VisualBasicSyntaxNode)(),
+                    New SyntaxList(Of VisualBasicSyntaxNode)(),
+                    Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxFactory.EndOfFileToken()))
+        End Function
 
-            Dim restorePoint = _scanner.CreateRestorePoint()
-            Try
-                Debug.Assert(_context IsNot Nothing)
-                Dim programContext As CompilationUnitContext = DirectCast(_context, CompilationUnitContext)
+        Friend Function ParseCompilationUnitCore() As CompilationUnitSyntax
+            Debug.Assert(_context IsNot Nothing)
+            Dim programContext As CompilationUnitContext = DirectCast(_context, CompilationUnitContext)
 
-                GetNextToken()
+            GetNextToken()
 
-                While True
-                    Dim curSyntaxNode As VisualBasicSyntaxNode = Nothing
-                    Dim incrementalContext = GetCurrentSyntaxNodeIfApplicable(curSyntaxNode)
+            While True
+                Dim curSyntaxNode As VisualBasicSyntaxNode = Nothing
+                Dim incrementalContext = GetCurrentSyntaxNodeIfApplicable(curSyntaxNode)
 
-                    If incrementalContext IsNot Nothing Then
-                        _context = incrementalContext
-                        Dim lastTrivia = curSyntaxNode.LastTriviaIfAny()
-                        If lastTrivia IsNot Nothing Then
-                            If lastTrivia.Kind = SyntaxKind.EndOfLineTrivia Then
-                                ConsumedStatementTerminator(allowLeadingMultilineTrivia:=True)
-                                ResetCurrentToken(ScannerState.VBAllowLeadingMultilineTrivia)
-                            ElseIf lastTrivia.Kind = SyntaxKind.ColonTrivia Then
-                                Debug.Assert(Not _context.IsSingleLine) ' Not handling single-line statements.
-                                ConsumedStatementTerminator(
-                                allowLeadingMultilineTrivia:=True,
-                                possibleFirstStatementOnLine:=PossibleFirstStatementKind.IfPrecededByLineBreak)
-                                ResetCurrentToken(If(_allowLeadingMultilineTrivia, ScannerState.VBAllowLeadingMultilineTrivia, ScannerState.VB))
-                            End If
-                        Else
-                            ' If we reuse a label statement, note that it may end with a colon.
-                            Dim curNodeLabel As LabelStatementSyntax = TryCast(curSyntaxNode, LabelStatementSyntax)
-                            If curNodeLabel IsNot Nothing AndAlso curNodeLabel.ColonToken.Kind = SyntaxKind.ColonToken Then
-                                ConsumedStatementTerminator(
-                                allowLeadingMultilineTrivia:=True,
-                                possibleFirstStatementOnLine:=PossibleFirstStatementKind.IfPrecededByLineBreak)
-                            End If
+                If incrementalContext IsNot Nothing Then
+                    _context = incrementalContext
+                    Dim lastTrivia = curSyntaxNode.LastTriviaIfAny()
+                    If lastTrivia IsNot Nothing Then
+                        If lastTrivia.Kind = SyntaxKind.EndOfLineTrivia Then
+                            ConsumedStatementTerminator(allowLeadingMultilineTrivia:=True)
+                            ResetCurrentToken(ScannerState.VBAllowLeadingMultilineTrivia)
+                        ElseIf lastTrivia.Kind = SyntaxKind.ColonTrivia Then
+                            Debug.Assert(Not _context.IsSingleLine) ' Not handling single-line statements.
+                            ConsumedStatementTerminator(
+                            allowLeadingMultilineTrivia:=True,
+                            possibleFirstStatementOnLine:=PossibleFirstStatementKind.IfPrecededByLineBreak)
+                            ResetCurrentToken(If(_allowLeadingMultilineTrivia, ScannerState.VBAllowLeadingMultilineTrivia, ScannerState.VB))
                         End If
                     Else
-                        ResetCurrentToken(If(_allowLeadingMultilineTrivia, ScannerState.VBAllowLeadingMultilineTrivia, ScannerState.VB))
-
-                        If CurrentToken.IsEndOfParse Then
-                            _context.RecoverFromMissingEnd(programContext)
-                            Exit While
+                        ' If we reuse a label statement, note that it may end with a colon.
+                        Dim curNodeLabel As LabelStatementSyntax = TryCast(curSyntaxNode, LabelStatementSyntax)
+                        If curNodeLabel IsNot Nothing AndAlso curNodeLabel.ColonToken.Kind = SyntaxKind.ColonToken Then
+                            ConsumedStatementTerminator(
+                            allowLeadingMultilineTrivia:=True,
+                            possibleFirstStatementOnLine:=PossibleFirstStatementKind.IfPrecededByLineBreak)
                         End If
-
-                        Dim statement = _context.Parse()
-                        Dim adjustedStatement = AdjustTriviaForMissingTokens(statement)
-                        _context = _context.LinkSyntax(adjustedStatement)
-                        _context = _context.ResyncAndProcessStatementTerminator(adjustedStatement, lambdaContext:=Nothing)
-
                     End If
-                End While
+                Else
+                    ResetCurrentToken(If(_allowLeadingMultilineTrivia, ScannerState.VBAllowLeadingMultilineTrivia, ScannerState.VB))
 
-                ' Create program
-                Dim terminator = DirectCast(CurrentToken, PunctuationSyntax)
-                Debug.Assert(terminator.Kind = SyntaxKind.EndOfFileToken)
+                    If CurrentToken.IsEndOfParse Then
+                        _context.RecoverFromMissingEnd(programContext)
+                        Exit While
+                    End If
 
-                Dim notClosedIfDirectives As ArrayBuilder(Of IfDirectiveTriviaSyntax) = Nothing
-                Dim notClosedRegionDirectives As ArrayBuilder(Of RegionDirectiveTriviaSyntax) = Nothing
-                Dim notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax = Nothing
-                terminator = _scanner.RecoverFromMissingConditionalEnds(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
-                Return programContext.CreateCompilationUnit(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
+                    Dim statement = _context.Parse()
+                    Dim adjustedStatement = AdjustTriviaForMissingTokens(statement)
+                    _context = _context.LinkSyntax(adjustedStatement)
+                    _context = _context.ResyncAndProcessStatementTerminator(adjustedStatement, lambdaContext:=Nothing)
 
+                End If
+            End While
+
+            ' Create program
+            Dim terminator = DirectCast(CurrentToken, PunctuationSyntax)
+            Debug.Assert(terminator.Kind = SyntaxKind.EndOfFileToken)
+
+            Dim notClosedIfDirectives As ArrayBuilder(Of IfDirectiveTriviaSyntax) = Nothing
+            Dim notClosedRegionDirectives As ArrayBuilder(Of RegionDirectiveTriviaSyntax) = Nothing
+            Dim notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax = Nothing
+            terminator = _scanner.RecoverFromMissingConditionalEnds(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
+            Return programContext.CreateCompilationUnit(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
+        End Function
+
+        Private Function ParseWithStackGuard(Of TNode As VisualBasicSyntaxNode)(parseFunc As Func(Of TNode), defaultFunc As Func(Of TNode)) As TNode
+            Debug.Assert(_recursionDepth = 0)
+            Dim restorePoint = _scanner.CreateRestorePoint()
+            Try
+                Return parseFunc()
                 ' TODO (DevDiv workitem 966425): Replace exception name test with a type test once the type 
                 ' Is available in the PCL
             Catch ex As Exception When ex.GetType().Name = "InsufficientExecutionStackException"
-                Return CreateForInsufficientStack(restorePoint)
+                Return CreateForInsufficientStack(restorePoint, defaultFunc())
             End Try
         End Function
 
-        Function CreateForInsufficientStack(ByRef restorePoint As Scanner.RestorePoint) As CompilationUnitSyntax
+        Private Function CreateForInsufficientStack(Of TNode As VisualBasicSyntaxNode)(ByRef restorePoint As Scanner.RestorePoint, result As TNode) As TNode
             restorePoint.Restore()
             GetNextToken()
 
@@ -510,17 +524,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 GetNextToken()
             End While
 
-            Dim result = _syntaxFactory.CompilationUnit(
-                New SyntaxList(Of VisualBasicSyntaxNode)(),
-                New SyntaxList(Of VisualBasicSyntaxNode)(),
-                New SyntaxList(Of VisualBasicSyntaxNode)(),
-                New SyntaxList(Of VisualBasicSyntaxNode)(),
-                DirectCast(CurrentToken, PunctuationSyntax))
-
             Return result.AddLeadingSyntax(builder.ToList(Of SyntaxToken)(), ERRID.ERR_TooLongOrComplexExpression)
         End Function
 
         Friend Function ParseExecutableStatement() As StatementSyntax
+            Return ParseWithStackGuard(Of StatementSyntax)(
+                AddressOf Me.ParseExecutableStatementCore,
+                Function() InternalSyntaxFactory.EmptyStatement())
+        End Function
+
+        Private Function ParseExecutableStatementCore() As StatementSyntax
             Dim outerContext As New CompilationUnitContext(Me)
             Dim fakeBegin = SyntaxFactory.SubStatement(Nothing, Nothing, InternalSyntaxFactory.MissingKeyword(SyntaxKind.SubKeyword),
                                                   InternalSyntaxFactory.MissingIdentifier(), Nothing, Nothing, Nothing, Nothing, Nothing)
@@ -1475,7 +1488,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             If TryGetTokenAndEatNewLine(SyntaxKind.EqualsToken, optionalEquals) Then
 
-                expr = ParseExpression()
+                expr = ParseExpressionCore()
 
                 If expr.ContainsDiagnostics Then
                     ' Resync at EOS so we don't get any more errors.
@@ -2240,7 +2253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     ' Make the initializer expression a deferred expression
                     ' Allow expression initializer
                     ' Disallow assignment initializer
-                    Dim value As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceNone) 'Dev10 was ParseInitializer
+                    Dim value As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceNone) 'Dev10 was ParseInitializer
 
                     Debug.Assert(Equals IsNot Nothing)
                     optionalInitializer = SyntaxFactory.EqualsValue(Equals, value)
@@ -2343,7 +2356,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Do
                     'This used to call ParseInitializer
-                    Dim Initializer As ExpressionSyntax = ParseExpression(OperatorPrecedence.PrecedenceNone) 'Dev 10 was ParseInitializer
+                    Dim Initializer As ExpressionSyntax = ParseExpressionCore(OperatorPrecedence.PrecedenceNone) 'Dev 10 was ParseInitializer
 
                     If Initializer.ContainsDiagnostics Then
                         Initializer = ResyncAt(Initializer, SyntaxKind.CommaToken, SyntaxKind.CloseBraceToken)
@@ -2556,7 +2569,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 End If
 
             ElseIf anonymousTypeInitializer Then
-                expression = ParseExpression() 'Dev10 was ParseInitializer()
+                expression = ParseExpressionCore() 'Dev10 was ParseInitializer()
 
                 Dim propertyName As SyntaxToken
                 Dim isNameDictionaryAccess As Boolean = False
@@ -2613,7 +2626,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             ' allow expression initializer
             ' disallow assignment initializer
-            expression = ParseExpression() 'Dev10 was ParseInitializer()
+            expression = ParseExpressionCore() 'Dev10 was ParseInitializer()
 
             Return SyntaxFactory.NamedFieldInitializer(optionalKey, dot, SyntaxFactory.IdentifierName(id), equals, expression)
         End Function
@@ -3215,7 +3228,7 @@ checkNullable:
             Do
                 Dim lowerBound As ExpressionSyntax = Nothing
                 Dim toKeyword As KeywordSyntax = Nothing
-                Dim upperBound As ExpressionSyntax = ParseExpression()
+                Dim upperBound As ExpressionSyntax = ParseExpressionCore()
 
                 If upperBound.ContainsDiagnostics Then
                     upperBound = ResyncAt(upperBound, SyntaxKind.CommaToken, SyntaxKind.CloseParenToken, SyntaxKind.AsKeyword)
@@ -3228,7 +3241,7 @@ checkNullable:
 
                     GetNextToken() ' consume To keyword
 
-                    upperBound = ParseExpression()
+                    upperBound = ParseExpressionCore()
                 End If
 
                 If upperBound.ContainsDiagnostics OrElse (toKeyword IsNot Nothing AndAlso lowerBound.ContainsDiagnostics) Then
@@ -4538,12 +4551,12 @@ checkNullable:
                     equals = ReportSyntaxError(equals, ERRID.ERR_DefaultValueForNonOptionalParam)
                 End If
 
-                value = ParseExpression()
+                value = ParseExpressionCore()
 
             ElseIf modifiers.Any AndAlso modifiers.Any(SyntaxKind.OptionalKeyword) Then
 
                 equals = ReportSyntaxError(InternalSyntaxFactory.MissingPunctuation(SyntaxKind.EqualsToken), ERRID.ERR_ObsoleteOptionalWithoutValue)
-                value = ParseExpression()
+                value = ParseExpressionCore()
 
             End If
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -2734,4 +2734,46 @@ End Module]]>.Value)
         Assert.Equal(CInt(ERRID.ERR_TooLongOrComplexExpression), diagnostic.Code)
     End Sub
 
+    <Fact>
+    Public Sub TooDeepLambdaDeclarationsAsExpression()
+        Dim depth = 5000
+        Dim builder As New StringBuilder()
+        builder.AppendLine("Sub()")
+        For i = 0 To depth
+            Dim line = String.Format("Dim x{0} = Sub()", i)
+            builder.AppendLine(line)
+        Next
+
+        For i = 0 To depth
+            builder.AppendLine("End Sub")
+        Next
+
+        builder.AppendLine("End Sub")
+
+        Dim expr = SyntaxFactory.ParseExpression(builder.ToString())
+        Dim diagnostic = expr.GetDiagnostics().Single()
+        Assert.Equal(CInt(ERRID.ERR_TooLongOrComplexExpression), diagnostic.Code)
+    End Sub
+
+    <Fact>
+    Public Sub TooDeepLambdaDeclarationsAsStatement()
+        Dim depth = 5000
+        Dim builder As New StringBuilder()
+        builder.AppendLine("Dim c = Sub()")
+        For i = 0 To depth
+            Dim line = String.Format("Dim x{0} = Sub()", i)
+            builder.AppendLine(line)
+        Next
+
+        For i = 0 To depth
+            builder.AppendLine("End Sub")
+        Next
+
+        builder.AppendLine("End Sub")
+
+        Dim stmt = SyntaxFactory.ParseExecutableStatement(builder.ToString())
+        Dim diagnostic = stmt.GetDiagnostics().Single()
+        Assert.Equal(CInt(ERRID.ERR_TooLongOrComplexExpression), diagnostic.Code)
+    End Sub
+
 End Class


### PR DESCRIPTION
The C# and VB compilers were previously hardened against stack overflows when parsing files / trees.  This hardening missed the entry points of parsing an expression or statement individually.  This meant excessively deep code would have resulted in a consumable error when parsed as part of a file but not if it was parsed directly as an expression or statement.

The debugger is one of our bigger consumers of parsing expression / statements directly.  This left them open to crashes when debugging files which could be processed fine by the IDE (see #832 for an example). 

This change extends the stack guards to cover these two cases.  

closes #839