### PR TITLE
Don't leak exceptions from AssemblyResolve handler

### DIFF
--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
@@ -150,14 +150,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// </summary>
             private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
             {
-                if (args.RequestingAssembly == null)
+                try
                 {
-                    return ResolveForUnknownRequestor(args.Name);
+                    if (args.RequestingAssembly == null)
+                    {
+                        return ResolveForUnknownRequestor(args.Name);
+                    }
+                    else
+                    {
+                        return ResolveForKnownRequestor(args.Name, args.RequestingAssembly);
+                    }
                 }
-                else
-                {
-                    return ResolveForKnownRequestor(args.Name, args.RequestingAssembly);
-                }
+                catch { }
+
+                return null;
             }
 
             /// <summary>

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
@@ -148,6 +148,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// <summary>
             /// Handles the <see cref="AppDomain.AssemblyResolve"/> event.
             /// </summary>
+            /// <remarks>
+            /// This handler catches and swallow any and all exceptions that
+            /// arise, and simply returns null when they do. Leaking an exception
+            /// from the event handler may interrupt the entire assembly
+            /// resolution process, which is undesirable.
+            /// </remarks>
             private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
             {
                 try


### PR DESCRIPTION
Leaking an exception from an `AppDomain.AssemblyResolve` event handler
may interrupt the entire assembly resolution process, which is
undesirable. Instead, we should just return null and give other handlers
and/or the CLR a chance at assembly resolution.