### PR TITLE
Add testing for the MSBuildTask.

### DIFF
--- a/Src/Compilers/Core/VBCSCompilerTests/MockEngine.cs
+++ b/Src/Compilers/Core/VBCSCompilerTests/MockEngine.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+{
+    internal class MockEngine : IBuildEngine
+    {
+        public int ColumnNumberOfTaskNode
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool ContinueOnError
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int LineNumberOfTaskNode
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string ProjectFileOfTaskNode
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
+        {
+            throw new NotImplementedException();
+        }
+
+        private StringBuilder _messages = new StringBuilder();
+        private StringBuilder _errors = new StringBuilder();
+        private StringBuilder _warnings = new StringBuilder();
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogErrorEvent(BuildErrorEventArgs e) => _errors.AppendLine(e.Message);
+
+        public void LogMessageEvent(BuildMessageEventArgs e) => _messages.AppendLine(e.Message);
+
+        public void LogWarningEvent(BuildWarningEventArgs e) => _warnings.AppendLine(e.Message);
+
+        public string Messages => _messages.ToString();
+        public string Errors => _errors.ToString();
+        public string Warnings => _warnings.ToString();
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/CanonicalError.cs
+++ b/src/Compilers/Core/MSBuildTask/CanonicalError.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// Functions for dealing with the specially formatted errors returned by

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// CommandLineBuilder derived class for specialized logic specific to MSBuild tasks

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -5,7 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.Hosting;
 using Microsoft.Build.Utilities;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// This class defines the "Csc" XMake task, which enables building assemblies from C#

--- a/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.CodeAnalysis.BuildTask {
+namespace Microsoft.CodeAnalysis.BuildTasks {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.BuildTask {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.BuildTask.ErrorString", typeof(ErrorString).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.BuildTasks.ErrorString", typeof(ErrorString).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -11,7 +11,7 @@
     <ProjectGuid>{D874349C-8BB3-4BDC-8535-2D52CCCA1198}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.CodeAnalysis.BuildTask</RootNamespace>
+    <RootNamespace>Microsoft.CodeAnalysis.BuildTasks</RootNamespace>
     <AssemblyName>Microsoft.Build.Tasks.Roslyn</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -18,7 +18,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// This class defines all of the common stuff that is shared between the Vbc and Csc tasks.
@@ -191,8 +191,6 @@ namespace Microsoft.CodeAnalysis.BuildTask
             get { return (ITaskItem[])_store["ResponseFiles"]; }
         }
 
-
-
         public ITaskItem[] Sources
         {
             set
@@ -278,6 +276,18 @@ namespace Microsoft.CodeAnalysis.BuildTask
         }
 
         #endregion
+
+        /// <summary>
+        /// Returns the command line switch used by the tool executable to specify the response file
+        /// Will only be called if the task returned a non empty string from GetResponseFileCommands
+        /// Called after ValidateParameters, SkipTaskExecution and GetResponseFileCommands
+        /// </summary>
+        override protected string GenerateResponseFileCommands()
+        {
+            CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension();
+            AddResponseFileCommands(commandLineBuilder);
+            return commandLineBuilder.ToString();
+        }
 
         protected override string GenerateCommandLineCommands()
         {

--- a/src/Compilers/Core/MSBuildTask/PropertyDictionary.cs
+++ b/src/Compilers/Core/MSBuildTask/PropertyDictionary.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     internal class PropertyDictionary : Dictionary<string, object>
     {
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.BuildTask
                 return this.TryGetValue(name, out value)
                     ? value : null;
             }
-            set { this[name] = value; }
+            set { base[name] = value; }
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Security;
 using Microsoft.Build.Framework;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// General utilities.

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Tasks.Hosting;
 
-namespace Microsoft.CodeAnalysis.BuildTask
+namespace Microsoft.CodeAnalysis.BuildTasks
 {
     /// <summary>
     /// This class defines the "Vbc" XMake task, which enables building assemblies from VB

--- a/src/Compilers/Core/VBCSCompilerTests/BuildProtocolTest.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/BuildProtocolTest.cs
@@ -1,10 +1,6 @@
 ﻿using Roslyn.Test.Utilities;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -3,23 +3,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CompilerServer;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.Win32;
 using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 using System.IO.Pipes;
 
-namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class CompilerServerApiTest : TestBase
     {

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -15,16 +15,17 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using ProprietaryTestResources = Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using System.Xml;
-using System.Xml.XPath;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.BuildTasks;
 
-namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class CompilerServerUnitTests : TestBase
     {
         private const string CompilerServerExeName = "VBCSCompiler.exe";
         private const string CSharpClientExeName = "csc2.exe";
         private const string BasicClientExeName = "vbc2.exe";
+        private const string BuildTaskDllName = "Microsoft.Build.Tasks.Roslyn.dll";
 
         private static string s_msbuildDirectory;
         private static string MSBuildDirectory
@@ -74,20 +75,48 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             }
         }
 
-        private static string s_compilerServerExecutableSrc = ResolveAssemblyPath(CompilerServerExeName);
-        private static string s_buildTaskDllSrc = ResolveAssemblyPath("Roslyn.Compilers.BuildTasks.dll");
-        private static string s_CSharpCompilerExecutableSrc = ResolveAssemblyPath("csc.exe");
-        private static string s_basicCompilerExecutableSrc = ResolveAssemblyPath("vbc.exe");
-        private static string s_microsoftCodeAnalysisDllSrc = ResolveAssemblyPath("Microsoft.CodeAnalysis.dll");
-        private static string s_systemCollectionsImmutableDllSrc = ResolveAssemblyPath("System.Collections.Immutable.dll");
+        private static readonly string s_compilerServerExecutableSrc = ResolveAssemblyPath(CompilerServerExeName);
+        private static readonly string s_buildTaskDllSrc = ResolveAssemblyPath(BuildTaskDllName);
+        private static readonly string s_CSharpCompilerExecutableSrc = ResolveAssemblyPath("csc.exe");
+        private static readonly string s_basicCompilerExecutableSrc = ResolveAssemblyPath("vbc.exe");
+        private static readonly string s_microsoftCodeAnalysisDllSrc = ResolveAssemblyPath("Microsoft.CodeAnalysis.dll");
+        private static readonly string s_systemCollectionsImmutableDllSrc = ResolveAssemblyPath("System.Collections.Immutable.dll");
 
         // The native client executables can't be loaded via Assembly.Load, so we just use the
         // compiler server resolved path
-        private static string s_clientExecutableBasePath = Path.GetDirectoryName(s_compilerServerExecutableSrc);
-        private static string s_CSharpCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, CSharpClientExeName);
-        private static string s_basicCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, BasicClientExeName);
+        private static readonly string s_clientExecutableBasePath = Path.GetDirectoryName(s_compilerServerExecutableSrc);
+        private static readonly string s_CSharpCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, CSharpClientExeName);
+        private static readonly string s_basicCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, BasicClientExeName);
 
-        private static string[] s_allCompilerFiles =
+        private static readonly KeyValuePair<string, string>[] s_helloWorldSrcCs =
+        {
+            new KeyValuePair<string, string>("hello.cs",
+@"using System;
+using System.Diagnostics;
+class Hello 
+{
+    static void Main()
+    { 
+        var obj = new Process();
+        Console.WriteLine(""Hello, world.""); 
+    }
+}")
+        };
+
+        private static readonly KeyValuePair<string, string>[] s_helloWorldSrcVb = 
+        {
+            new KeyValuePair<string, string>("hello.vb",
+@"Imports System.Diagnostics
+
+Module Module1
+    Sub Main()
+        Dim p As New Process()
+        Console.WriteLine(""Hello from VB"")
+    End Sub
+End Module")
+        };
+
+        private static readonly string[] s_allCompilerFiles =
         {
             s_CSharpCompilerExecutableSrc,
             s_basicCompilerExecutableSrc,
@@ -96,6 +125,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             s_CSharpCompilerClientSrcPath,
             s_basicCompilerClientSrcPath,
             s_systemCollectionsImmutableDllSrc,
+            s_buildTaskDllSrc,
             ResolveAssemblyPath("System.Reflection.Metadata.dll"),
             ResolveAssemblyPath("Microsoft.CodeAnalysis.Desktop.dll"),
             ResolveAssemblyPath("Microsoft.CodeAnalysis.CSharp.dll"),
@@ -107,14 +137,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Path.Combine(s_clientExecutableBasePath, "vbc.rsp")
         };
 
-        #region Helpers
-
         private readonly TempDirectory _tempDirectory;
         private readonly string _compilerDirectory;
 
-        private readonly string _CSharpCompilerClientExecutable;
+        private readonly string _csharpCompilerClientExecutable;
         private readonly string _basicCompilerClientExecutable;
         private readonly string _compilerServerExecutable;
+        private readonly string _buildTaskDll;
 
         public CompilerServerUnitTests()
         {
@@ -128,9 +157,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 File.Copy(path, Path.Combine(_compilerDirectory, filename));
             }
 
-            _CSharpCompilerClientExecutable = Path.Combine(_compilerDirectory, CSharpClientExeName);
+            _csharpCompilerClientExecutable = Path.Combine(_compilerDirectory, CSharpClientExeName);
             _basicCompilerClientExecutable = Path.Combine(_compilerDirectory, BasicClientExeName);
             _compilerServerExecutable = Path.Combine(_compilerDirectory, CompilerServerExeName);
+            _buildTaskDll = Path.Combine(_compilerDirectory, BuildTaskDllName);
         }
 
         public override void Dispose()
@@ -140,14 +170,20 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             base.Dispose();
         }
 
-        private Dictionary<string, string> AddForLoggingEnvironmentVars(Dictionary<string, string> vars)
+        #region Helpers
+
+        private IEnumerable<KeyValuePair<string, string>> AddForLoggingEnvironmentVars(IEnumerable<KeyValuePair<string, string>> vars)
         {
-            var dict = vars == null ? new Dictionary<string, string>() : vars;
-            if (!dict.ContainsKey("RoslynCommandLineLogFile"))
+            vars = vars ?? new KeyValuePair<string, string>[] { };
+            if (!vars.Where(kvp => kvp.Key == "RoslynCommandLineLogFile").Any())
             {
-                dict.Add("RoslynCommandLineLogFile", typeof(CompilerServerUnitTests).Assembly.Location + ".client-server.log");
+                var list = vars.ToList();
+                list.Add(new KeyValuePair<string, string>(
+                    "RoslynCommandLineLogFile",
+                    typeof(CompilerServerUnitTests).Assembly.Location + ".client-server.log"));
+                return list;
             }
-            return dict;
+            return vars;
         }
 
         private List<Process> GetProcessesByFullPath(string path)
@@ -234,12 +270,25 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             KillProcess(_compilerServerExecutable);
         }
 
-        private ProcessResult RunCommandLineCompiler(string compilerPath, string arguments, string currentDirectory, Dictionary<string, string> additionalEnvironmentVars = null)
+        private ProcessResult RunCommandLineCompiler(
+            string compilerPath,
+            string arguments,
+            string currentDirectory,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVars = null)
         {
-            return ProcessLauncher.Run(compilerPath, arguments, currentDirectory, additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
+            return ProcessLauncher.Run(
+                compilerPath,
+                arguments,
+                currentDirectory,
+                additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
         }
 
-        private ProcessResult RunCommandLineCompiler(string compilerPath, string arguments, TempDirectory currentDirectory, Dictionary<string, string> filesInDirectory, Dictionary<string, string> additionalEnvironmentVars = null)
+        private ProcessResult RunCommandLineCompiler(
+            string compilerPath,
+            string arguments,
+            TempDirectory currentDirectory,
+            IEnumerable<KeyValuePair<string, string>> filesInDirectory,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVars = null)
         {
             foreach (var pair in filesInDirectory)
             {
@@ -247,7 +296,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 file.WriteAllText(pair.Value);
             }
 
-            return RunCommandLineCompiler(compilerPath, arguments, currentDirectory.Path, additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
+            return RunCommandLineCompiler(
+                compilerPath,
+                arguments,
+                currentDirectory.Path,
+                additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
         }
 
         private DisposableFile GetResultFile(TempDirectory directory, string resultFileName)
@@ -283,20 +336,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [Fact]
         public void FallbackToCsc()
         {
-            var files = new Dictionary<string, string> { { "hello.cs",
-@"using System;
-using System.Diagnostics;
-class Hello 
-{
-    static void Main()
-    { 
-        var obj = new Process();
-        Console.WriteLine(""Hello, world.""); 
-    }
-}"}};
             // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
         }
 
@@ -307,7 +349,7 @@ class Hello
 
             // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, files);
             Assert.Equal(result.ExitCode, 1);
             Assert.True(result.ContainsErrors);
             Assert.Equal("hello.cs(1,1): error CS1056: Unexpected character '?'", result.Output.Trim());
@@ -324,7 +366,7 @@ class Hello
 
             var result = ProcessLauncher.Run("cmd",
                 string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
-                _CSharpCompilerClientExecutable,
+                _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
             Assert.Equal("", result.Output.Trim());
@@ -379,18 +421,9 @@ class Hello
         [Fact]
         public void FallbackToVbc()
         {
-            var files = new Dictionary<string, string> { { "hello.vb",
-@"Imports System.Diagnostics
-
-Module Module1
-    Sub Main()
-        Dim p As New Process()
-        Console.WriteLine(""Hello from VB"")
-    End Sub
-End Module"}};
             // Delete VBCSCompiler.exe so vbc2 is forced to fall back to vbc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo hello.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo hello.vb", _tempDirectory, s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
         }
 
@@ -398,19 +431,7 @@ End Module"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void HelloWorldCS()
         {
-            var files = new Dictionary<string, string> { { "hello.cs",
-@"using System;
-using System.Diagnostics;
-class Hello 
-{
-    static void Main()
-    { 
-        var obj = new Process();
-        Console.WriteLine(""Hello, world.""); 
-    }
-}"}};
-
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
         }
 
@@ -434,7 +455,7 @@ class Hello
         public void Platformx86MscorlibCsc()
         {
             var files = new Dictionary<string, string> { { "c.cs", "class C {}" } };
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable,
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
                                                 "/nologo /t:library /platform:x86 c.cs",
                                                 _tempDirectory,
                                                 files);
@@ -457,17 +478,10 @@ class Hello
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void ExtraMSCorLibCS()
         {
-            Dictionary<string, string> files =
-                                   new Dictionary<string, string> {
-                                           { "hello.cs",
-@"using System;
-class Hello 
-{
-    static void Main()
-    { Console.WriteLine(""Hello, world.""); }
-}"}};
-
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo /r:mscorlib.dll hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
+                                                "/nologo /r:mscorlib.dll hello.cs",
+                                                _tempDirectory,
+                                                s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
         }
 
@@ -475,19 +489,10 @@ class Hello
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void HelloWorldVB()
         {
-            Dictionary<string, string> files =
-                                   new Dictionary<string, string> {
-                                           { "hello.vb",
-@"Imports System.Diagnostics
-
-Module Module1
-    Sub Main()
-        Dim p As New Process()
-        Console.WriteLine(""Hello from VB"")
-    End Sub
-End Module"}};
-
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo /r:Microsoft.VisualBasic.dll hello.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
+                                                "/nologo /r:Microsoft.VisualBasic.dll hello.vb",
+                                                _tempDirectory,
+                                                s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
         }
 
@@ -495,18 +500,10 @@ End Module"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void ExtraMSCorLibVB()
         {
-            Dictionary<string, string> files =
-                                   new Dictionary<string, string> {
-                                           { "hello.vb",
-@"Imports System
-
-Module Module1
-    Sub Main()
-        Console.WriteLine(""Hello from VB"")
-    End Sub
-End Module"}};
-
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
+                "/nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb",
+                _tempDirectory,
+                s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
         }
 
@@ -524,7 +521,7 @@ class Hello
     { Console.WriteLine(""Hello, world."") }
 }"}};
 
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello.cs", _tempDirectory, files);
 
             // Should output errors, but not create output file.                  
             Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
@@ -564,7 +561,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void MissingFileErrorCS()
         {
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "missingfile.cs", _tempDirectory, new Dictionary<string, string>());
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "missingfile.cs", _tempDirectory, new Dictionary<string, string>());
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -578,19 +575,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void MissingReferenceErrorCS()
         {
-            Dictionary<string, string> files =
-                                   new Dictionary<string, string> {
-                                           { "hello.cs",
-@"using System;
-class Hello 
-{
-    static void Main()
-    { 
-        Console.WriteLine(""Hello, world.""); 
-    }
-}"}};
-
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/r:missing.dll hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -611,7 +596,7 @@ class Hello
                                                { "app.cs", "class Test { static void Main() {} }"},
                                            };
 
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/r:Lib.cs app.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/r:Lib.cs app.cs", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -826,7 +811,7 @@ public class Library
     { return ""library1""; }
 }"}};
 
-                var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "src1.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
+                var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src1.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
                 Assert.Equal("", result.Output);
                 Assert.Equal("", result.Errors);
                 Assert.Equal(0, result.ExitCode);
@@ -842,7 +827,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-                    result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
+                    result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
                     Assert.Equal("", result.Output);
                     Assert.Equal("", result.Errors);
                     Assert.Equal(0, result.ExitCode);
@@ -864,7 +849,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello2 from {0}"", Library.GetString()); }
 }"}};
-                        result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "hello2.cs /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
+                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello2.cs /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -887,7 +872,7 @@ public class Library
     { return ""library3""; }
 }"}};
 
-                        result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "src2.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
+                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src2.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -903,7 +888,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello3 from {0}"", Library.GetString2()); }
 }"}};
-                            result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "hello3.cs /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
+                            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello3.cs /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
                             Assert.Equal("", result.Output);
                             Assert.Equal("", result.Errors);
                             Assert.Equal(0, result.ExitCode);
@@ -951,7 +936,7 @@ End Module", i));
         // Run compiler in directory set up by SetupDirectory
         private Process RunCompilerCS(TempDirectory dir, int i)
         {
-            return ProcessLauncher.StartProcess(_CSharpCompilerClientExecutable, string.Format("/nologo hello{0}.cs /out:hellocs{0}.exe", i), dir.Path);
+            return ProcessLauncher.StartProcess(_csharpCompilerClientExecutable, string.Format("/nologo hello{0}.cs /out:hellocs{0}.exe", i), dir.Path);
         }
 
         // Run compiler in directory set up by SetupDirectory
@@ -1020,6 +1005,314 @@ End Module", i));
             Assert.Equal(string.Empty, process.StandardOutput.ReadToEnd());
             Assert.Equal(string.Empty, process.StandardError.ReadToEnd());
         }
+
+        // A dictionary with name and contents of all the files we want to create for the SimpleMSBuild test.
+        private Dictionary<string, string> SimpleMsBuildFiles => new Dictionary<string, string> {
+{ "HelloSolution.sln",
+@"
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""HelloProj"", ""HelloProj.csproj"", ""{7F4CCBA2-1184-468A-BF3D-30792E4E8003}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""HelloLib"", ""HelloLib.csproj"", ""{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}""
+EndProject
+Project(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"") = ""VBLib"", ""VBLib.vbproj"", ""{F21C894B-28E5-4212-8AF7-C8E0E5455737}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Debug|x86.ActiveCfg = Debug|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Debug|x86.Build.0 = Debug|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Release|Any CPU.ActiveCfg = Release|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Release|Mixed Platforms.Build.0 = Release|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Release|x86.ActiveCfg = Release|x86
+		{7F4CCBA2-1184-468A-BF3D-30792E4E8003}.Release|x86.Build.0 = Release|x86
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}.Release|x86.ActiveCfg = Release|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F21C894B-28E5-4212-8AF7-C8E0E5455737}.Release|x86.ActiveCfg = Release|Any CPU	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+"},
+
+{ "HelloProj.csproj",
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <UsingTask TaskName=""Microsoft.CodeAnalysis.BuildTasks.Csc"" AssemblyFile=""" + _buildTaskDll + @""" />
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F4CCBA2-1184-468A-BF3D-30792E4E8003}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloProj</RootNamespace>
+    <AssemblyName>HelloProj</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|x86' "">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|x86' "">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Core"" />
+    <Reference Include=""System.Xml.Linq"" />
+    <Reference Include=""System.Xml"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""Program.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""HelloLib.csproj"">
+      <Project>{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}</Project>
+      <Name>HelloLib</Name>
+    </ProjectReference>
+    <ProjectReference Include=""VBLib.vbproj"">
+      <Project>{F21C894B-28E5-4212-8AF7-C8E0E5455737}</Project>
+      <Name>VBLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include=""Properties\"" />
+  </ItemGroup>
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+</Project>"},
+
+{ "Program.cs",
+@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using HelloLib;
+using VBLib;
+
+namespace HelloProj
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            HelloLibClass.SayHello();
+            VBLibClass.SayThere();
+            Console.WriteLine(""World"");
+        }
+    }
+}
+"},
+
+{ "HelloLib.csproj",
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <UsingTask TaskName=""Microsoft.CodeAnalysis.BuildTasks.Csc"" AssemblyFile=""" + _buildTaskDll + @""" />
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C1170A4A-80CF-4B4F-AA58-2FAEA9158D31}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloLib</RootNamespace>
+    <AssemblyName>HelloLib</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Core"" />
+    <Reference Include=""System.Xml.Linq"" />
+    <Reference Include=""System.Xml"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""HelloLib.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include=""Properties\"" />
+  </ItemGroup>
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+</Project>"},
+
+{ "HelloLib.cs",
+@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HelloLib
+{
+    public class HelloLibClass
+    {
+        public static void SayHello()
+        {
+            Console.WriteLine(""Hello"");
+        }
+    }
+}
+"},
+
+ { "VBLib.vbproj",
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <UsingTask TaskName=""Microsoft.CodeAnalysis.BuildTasks.Vbc"" AssemblyFile=""" + _buildTaskDll + @""" />
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>
+    </SchemaVersion>
+    <ProjectGuid>{F21C894B-28E5-4212-8AF7-C8E0E5455737}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>VBLib</RootNamespace>
+    <AssemblyName>VBLib</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <MyType>Windows</MyType>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DocumentationFile>VBLib.xml</DocumentationFile>
+    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugType>pdbonly</DebugType>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DocumentationFile>VBLib.xml</DocumentationFile>
+    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionExplicit>On</OptionExplicit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionCompare>Binary</OptionCompare>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionStrict>Off</OptionStrict>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Import Include=""Microsoft.VisualBasic"" />
+    <Import Include=""System"" />
+    <Import Include=""System.Collections.Generic"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""VBLib.vb"" />
+  </ItemGroup>
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  -->
+</Project>"},
+
+ { "VBLib.vb",
+@"
+Public Class VBLibClass
+    Public Shared Sub SayThere()
+        Console.WriteLine(""there"")
+    End Sub
+End Class
+"}
+            };
+
+        [Fact()]
+        public void SimpleMSBuild()
+        {
+            string arguments = string.Format(@"/m /nr:false /t:Rebuild /p:UseRoslyn=1 HelloSolution.sln");
+            var result = RunCommandLineCompiler(MSBuildExecutable, arguments, _tempDirectory, SimpleMsBuildFiles);
+
+            using (var resultFile = GetResultFile(_tempDirectory, @"bin\debug\helloproj.exe"))
+            {
+                // once we stop issuing BC40998 (NYI), we can start making stronger assertions
+                // about our ouptut in the general case
+                if (result.ExitCode != 0)
+                {
+                    Assert.Equal("", result.Output);
+                    Assert.Equal("", result.Errors);
+                }
+                Assert.Equal(0, result.ExitCode);
+                var runningResult = RunCompilerOutput(resultFile);
+                Assert.Equal("Hello\r\nthere\r\nWorld\r\n", runningResult.Output);
+            }
+        }
+
+
 
         private Dictionary<string, string> GetMultiFileMSBuildFiles()
         {
@@ -1275,7 +1568,7 @@ public class Library
     { return ""library1""; }
 }"}};
 
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable,
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
                                                 "src1.cs /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
                                                 _tempDirectory, files);
 
@@ -1294,7 +1587,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-            result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
+            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
                                             additionalEnvironmentVars: new Dictionary<string, string>() { { "LIB", libDirectory.Path } });
 
             Assert.Equal("", result.Output);
@@ -1363,7 +1656,7 @@ End Module
 
             var result = ProcessLauncher.Run("cmd",
                 string.Format("/C {0} /nologo /t:library {1} > {2}",
-                _CSharpCompilerClientExecutable,
+                _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
             Assert.Equal("", result.Output.Trim());
@@ -1403,7 +1696,7 @@ End Module
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
             var result = ProcessLauncher.Run("cmd", string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
-                _CSharpCompilerClientExecutable,
+                _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
             Assert.Equal("", result.Output.Trim());
@@ -1455,7 +1748,7 @@ End Module
 }
 "}};
 
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable,
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
                                                 "ref_mscorlib2.cs /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
                                                 _tempDirectory, files);
 
@@ -1479,7 +1772,7 @@ class Program
     }
 }
 "}};
-            result = RunCommandLineCompiler(_CSharpCompilerClientExecutable,
+            result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
                                             "main.cs /nologo /nostdlib /noconfig /r:mscorlib40.dll /r:ref_mscorlib2.dll",
                                             _tempDirectory, files);
 
@@ -1607,8 +1900,8 @@ class Hello
             };
 
             // Run a build using the analyzer
-            var firstBuildResultTask = Task.Run(() => RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo hello.cs /a:bin\\Debug\\MyAnalyzer.dll", directory.Path, environmentVars));
-            WaitForProcess(firstBuildResultTask, timeout, string.Format("Compiler server {0} timed out after {1} seconds", _CSharpCompilerClientExecutable, timeout.TotalSeconds), _CSharpCompilerClientExecutable);
+            var firstBuildResultTask = Task.Run(() => RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs /a:bin\\Debug\\MyAnalyzer.dll", directory.Path, environmentVars));
+            WaitForProcess(firstBuildResultTask, timeout, string.Format("Compiler server {0} timed out after {1} seconds", _csharpCompilerClientExecutable, timeout.TotalSeconds), _csharpCompilerClientExecutable);
             var firstBuildResult = firstBuildResultTask.Result;
 
             // Change the analyzer to cause it to be reloaded
@@ -1620,8 +1913,8 @@ class Hello
                     GetProcessesByFullPath(_compilerServerExecutable).Count));
 
             // Run another build using the analyzer
-            var secondBuildResultTask = Task.Run(() => RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/nologo hello.cs /a:bin\\Debug\\MyAnalyzer.dll", directory.Path, environmentVars));
-            WaitForProcess(secondBuildResultTask, timeout, string.Format("Compiler server {0} timed out after {1} seconds", _CSharpCompilerClientExecutable, timeout.TotalSeconds), _CSharpCompilerClientExecutable);
+            var secondBuildResultTask = Task.Run(() => RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs /a:bin\\Debug\\MyAnalyzer.dll", directory.Path, environmentVars));
+            WaitForProcess(secondBuildResultTask, timeout, string.Format("Compiler server {0} timed out after {1} seconds", _csharpCompilerClientExecutable, timeout.TotalSeconds), _csharpCompilerClientExecutable);
             var secondBuildResult = secondBuildResultTask.Result;
 
             var firstBuildOutput = firstBuildResult.Output;
@@ -1699,7 +1992,7 @@ class Hello
             var result = ProcessLauncher.Run("cmd",
                 string.Format(
                     "/C {0} /noconfig @{1} > {2}",
-                    _CSharpCompilerClientExecutable,
+                    _csharpCompilerClientExecutable,
                     rspFile,
                     tempOut));
 
@@ -1761,7 +2054,7 @@ class Hello
         [Fact]
         public void BadKeepAlive1()
         {
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/keepalive", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1772,7 +2065,7 @@ class Hello
         [Fact]
         public void BadKeepAlive2()
         {
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/keepalive:foo", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:foo", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1783,7 +2076,7 @@ class Hello
         [Fact]
         public void BadKeepAlive3()
         {
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/keepalive:-100", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:-100", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1794,7 +2087,7 @@ class Hello
         [Fact]
         public void BadKeepAlive4()
         {
-            var result = RunCommandLineCompiler(_CSharpCompilerClientExecutable, "/keepalive:9999999999", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:9999999999", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1812,7 +2105,7 @@ class Hello
 
             var result = ProcessLauncher.Run("cmd",
                 string.Format("/C \"SET TMP={2} && {0} /nologo /t:library {1}\"",
-                _CSharpCompilerClientExecutable,
+                _csharpCompilerClientExecutable,
                 srcFile, tmp));
 
             Assert.Equal(0, result.ExitCode);
@@ -1821,7 +2114,7 @@ class Hello
 
             result = ProcessLauncher.Run("cmd",
                 string.Format("/C {0} /nologo /t:library {1}",
-                _CSharpCompilerClientExecutable,
+                _csharpCompilerClientExecutable,
                 srcFile));
 
             Assert.Equal("", result.Output.Trim());
@@ -1852,6 +2145,60 @@ class Hello
 
             Assert.Equal("", result.Output.Trim());
             Assert.Equal(0, result.ExitCode);
+        }
+
+        [Fact]
+        public void ExecuteCscBuildTask()
+        {
+            var csc = new Csc();
+            csc.ToolPath = _compilerDirectory;
+            var srcFile = _tempDirectory.CreateFile(s_helloWorldSrcCs[0].Key).WriteAllText(s_helloWorldSrcCs[0].Value).Path;
+            var exeFile = Path.Combine(_tempDirectory.Path, "hello.exe");
+
+            var engine = new MockEngine();
+            csc.BuildEngine = engine;
+            csc.Sources = new[] { new Build.Utilities.TaskItem(srcFile) };
+            csc.NoLogo = true;
+            csc.OutputAssembly = new Build.Utilities.TaskItem(exeFile);
+
+            csc.Execute();
+
+            Assert.Equal(0, csc.ExitCode);
+            Assert.Equal(string.Empty, engine.Warnings);
+            Assert.Equal(string.Empty, engine.Errors);
+
+            Assert.True(File.Exists(exeFile));
+
+            var result = ProcessLauncher.Run(exeFile, "");
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("Hello, world.", result.Output.Trim());
+        }
+
+        [Fact]
+        public void ExecuteVbcBuildTask()
+        {
+            var vbc = new Vbc();
+            vbc.ToolPath = _compilerDirectory;
+            var srcFile = _tempDirectory.CreateFile(s_helloWorldSrcVb[0].Key).WriteAllText(s_helloWorldSrcVb[0].Value).Path;
+            var exeFile = Path.Combine(_tempDirectory.Path, "hello.exe");
+
+            var engine = new MockEngine();
+            vbc.BuildEngine = engine;
+            vbc.Sources = new[] { new Build.Utilities.TaskItem(srcFile) };
+            vbc.NoLogo = true;
+            vbc.OutputAssembly = new Build.Utilities.TaskItem(exeFile);
+
+            vbc.Execute();
+
+            Assert.Equal(0, vbc.ExitCode);
+            Assert.Equal(string.Empty, engine.Warnings);
+            Assert.Equal(string.Empty, engine.Errors);
+
+            Assert.True(File.Exists(exeFile));
+
+            var result = ProcessLauncher.Run(exeFile, "");
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("Hello from VB", result.Output.Trim());
         }
     }
 }

--- a/src/Compilers/Core/VBCSCompilerTests/RunKeepAliveTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/RunKeepAliveTests.cs
@@ -3,7 +3,7 @@
 using System;
 using Roslyn.Test.Utilities;
 
-namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     internal class RunKeepAliveTests : ExecutionCondition
     {

--- a/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -54,6 +54,10 @@
       <Project>{63d0f073-f0b3-42cd-829f-e48b977b48ba}</Project>
       <Name>csc2</Name>
     </ProjectReference>
+    <ProjectReference Include="..\MSBuildTask\MSBuildTask.csproj">
+      <Project>{d874349c-8bb3-4bdc-8535-2d52ccca1198}</Project>
+      <Name>MSBuildTask</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Portable\CodeAnalysis.csproj">
       <Project>{1ee8cad3-55f9-4d91-96b2-084641da9a6c}</Project>
       <Name>CodeAnalysis</Name>
@@ -67,6 +71,13 @@
     <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
+    <Reference Include="Microsoft.Build.Framework">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\MSBuild\v14.0\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\MSBuild\v14.0\Microsoft.Build.Utilities.Core.dll</HintPath>
+    </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
@@ -115,6 +126,7 @@
     <Compile Include="BuildProtocolTest.cs" />
     <Compile Include="CompilerServerApiTest.cs" />
     <Compile Include="CompilerServerTests.cs" />
+    <Compile Include="MockEngine.cs" />
     <Compile Include="RunKeepAliveTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Roslyn.sln
+++ b/src/Roslyn.sln
@@ -13,6 +13,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBCSCompiler", "Compilers\Core\VBCSCompiler\VBCSCompiler.csproj", "{9508F118-F62E-4C16-A6F4-7C3B56E166AD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBCSCompilerTests", "Compilers\Core\VBCSCompilerTests\VBCSCompilerTests.csproj", "{F5CE416E-B906-41D2-80B9-0078E887A3F6}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198} = {D874349C-8BB3-4BDC-8535-2D52CCCA1198}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{A41D1B99-F489-4C43-BBDF-96D61B19A6B9}"
 EndProject

--- a/src/Test/Utilities/ProcessLauncher.cs
+++ b/src/Test/Utilities/ProcessLauncher.cs
@@ -12,7 +12,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <summary>
         /// Launch a process, wait for it to complete, and return output, error, and exit code.
         /// </summary>
-        public static ProcessResult Run(string fileName, string arguments, string workingDirectory = null, Dictionary<string, string> additionalEnvironmentVars = null)
+        public static ProcessResult Run(
+            string fileName,
+            string arguments,
+            string workingDirectory = null,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVars = null)
         {
             if (fileName == null) throw new ArgumentNullException("fileName");
 
@@ -29,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (additionalEnvironmentVars != null)
             {
-                foreach (KeyValuePair<string, string> entry in additionalEnvironmentVars)
+                foreach (var entry in additionalEnvironmentVars)
                 {
                     startInfo.EnvironmentVariables[entry.Key] = entry.Value;
                 }


### PR DESCRIPTION
This change brings back the SimpleMSBuild test, which sets
up a "hello world" C#+VB solution and builds it using msbuild using
the build task.

Two build-task-specific tests have also been added, which directly
load and call execute on the Csc and Vbc tasks.

@AlekseyTs @VSadov @VladimirReshetnikov @gafter @jaredpar