### PR TITLE
Make locals case-insensitive in the VB EE

### DIFF
--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' CONSIDER: It would be nice to capture this behavior with a test.
         ''' </remarks>
         Private Shared Function BuildNameToSymbolMap(parameters As ImmutableArray(Of ParameterSymbol), locals As ImmutableArray(Of LocalSymbol)) As Dictionary(Of String, Symbol)
-            Dim nameToSymbolMap As New Dictionary(Of String, Symbol)()
+            Dim nameToSymbolMap As New Dictionary(Of String, Symbol)(CaseInsensitiveComparison.Comparer)
 
             For Each parameter In parameters
                 nameToSymbolMap(parameter.Name) = parameter

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
@@ -28,7 +28,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             _inspectionContext = inspectionContext
             _typeNameDecoder = typeNameDecoder
             _containingMethod = containingMethod
-            _implicitDeclarations = If(allowImplicitDeclarations, New Dictionary(Of String, LocalSymbol), Nothing)
+            ' TODO (acasey): pass comparer (GH #878).  Until then, there is no need for a comparer,
+            ' since we're going to canonicalize all names.
+            _implicitDeclarations = If(allowImplicitDeclarations, New Dictionary(Of String, LocalSymbol)(), Nothing)
         End Sub
 
         Friend Overrides Sub LookupInSingleBinder(
@@ -43,13 +45,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Return
             End If
 
+            ' TODO (acasey): use name (GH #878)
+            Dim canonicalName = Canonicalize(name)
+
             Dim local As LocalSymbol = Nothing
             If _implicitDeclarations IsNot Nothing Then
-                _implicitDeclarations.TryGetValue(name, local)
+                _implicitDeclarations.TryGetValue(canonicalName, local)
             End If
 
             If local Is Nothing Then
-                local = LookupPlaceholder(name)
+                local = LookupPlaceholder(canonicalName)
                 If local Is Nothing Then
                     Return
                 End If
@@ -71,13 +76,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim typeChar As String = Nothing
             Dim specialType = GetSpecialTypeForTypeCharacter(identifier.GetTypeCharacter(), typeChar)
             Dim type = Compilation.GetSpecialType(If(specialType = SpecialType.None, SpecialType.System_Object, specialType))
+            ' NOTE: Don't create the local with the canonical name since we want it to have the user's text in diagnostic messages.
             Dim local = LocalSymbol.Create(
                 _containingMethod,
                 Me,
                 identifier,
                 LocalDeclarationKind.ImplicitVariable,
                 type)
-            _implicitDeclarations.Add(local.Name, local)
+            _implicitDeclarations.Add(Canonicalize(local.Name), local)
             If local.Name.StartsWith("$", StringComparison.Ordinal) Then
                 diagnostics.Add(ERRID.ERR_IllegalChar, identifier.GetLocation())
             End If
@@ -88,13 +94,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Throw New NotImplementedException()
         End Sub
 
-        Private Function LookupPlaceholder(name As String) As PlaceholderLocalSymbol
+        Private Function LookupPlaceholder(canonicalName As String) As PlaceholderLocalSymbol
+            Debug.Assert(canonicalName = Canonicalize(canonicalName))
+
             Dim kind = PseudoVariableKind.None
             Dim id As String = Nothing
             Dim index = 0
-            If Not PseudoVariableUtilities.TryParseVariableName(name, caseSensitive:=False, kind:=kind, id:=id, index:=index) Then
+            If Not PseudoVariableUtilities.TryParseVariableName(canonicalName, caseSensitive:=False, kind:=kind, id:=id, index:=index) Then
                 Return Nothing
             End If
+
+            Debug.Assert(id = Canonicalize(id)) ' Since we started from a canonical name.
 
             Dim typeName = PseudoVariableUtilities.GetTypeName(_inspectionContext, kind, id, index)
             If typeName Is Nothing Then
@@ -120,6 +130,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(kind)
             End Select
+        End Function
+
+        Friend Shared Function Canonicalize(name As String) As String
+            Return CaseInsensitiveComparison.ToLower(name)
         End Function
 
     End Class

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' CreateVariable(type As Type, name As String)
             Dim method = PlaceholderLocalSymbol.GetIntrinsicMethod(compilation, ExpressionCompilerConstants.CreateVariableMethodName)
             Dim type = New BoundGetType(syntax, New BoundTypeExpression(syntax, local.Type), typeType)
-            Dim name = New BoundLiteral(syntax, ConstantValue.Create(local.Name), stringType)
+            Dim name = New BoundLiteral(syntax, ConstantValue.Create(PlaceholderLocalBinder.Canonicalize(local.Name)), stringType)
             Dim expr = New BoundCall(
                 syntax,
                 method,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -2309,6 +2309,52 @@ End Class"
             locals.Free()
         End Sub
 
+        <WorkItem(1115044, "DevDiv")>
+        <Fact>
+        Public Sub CaseSensitivity()
+            Const source = "
+Class C
+    Shared Sub M(p As Integer)
+        Dim s As String
+    End Sub
+End Class
+"
+            Dim comp = CreateCompilationWithMscorlib({source}, compOptions:=TestOptions.DebugDll)
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(
+                runtime,
+                methodName:="C.M")
+
+            Dim errorMessage As String = Nothing
+            Dim testData As CompilationTestData
+
+            testData = New CompilationTestData()
+            context.CompileExpression("P", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (String V_0) //s
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}
+")
+
+            testData = New CompilationTestData()
+            context.CompileExpression("S", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (String V_0) //s
+  IL_0000:  ldloc.0
+  IL_0001:  ret
+}
+")
+        End Sub
+
         Private Shared Sub GetLocals(runtime As RuntimeInstance, methodName As String, argumentsOnly As Boolean, locals As ArrayBuilder(Of LocalAndMethod), count As Integer, ByRef typeName As String, ByRef testData As CompilationTestData)
             Dim context = CreateMethodContext(runtime, methodName)
             testData = New CompilationTestData()

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
@@ -36,7 +36,7 @@ End Class
             Next
 
             Assert.Equal(DkmEvaluationResultCategory.Method, GetResultProperties(context, "M()").Category)
-            Assert.Equal(DkmEvaluationResultCategory.Property, GetResultProperties(context, "P").Category)
+            Assert.Equal(DkmEvaluationResultCategory.Property, GetResultProperties(context, "Me.P").Category)
         End Sub
 
         <Fact>


### PR DESCRIPTION
1) Pass StringComparer.OrdinalIgnoreCase to the dictionary of (real)
locals.
2) Canonicalize (i.e. lowercase) the names of pseudo-variables and
locals declared in the Immediate window (because the debugger APIs
we call are case-sensitive).