### PR TITLE
fix a case where we subscribe to an event while global operation is alre...

### DIFF
--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
@@ -62,7 +62,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     private void OnGlobalOperationStopped(object sender, GlobalOperationEventArgs e)
                     {
-                        Contract.ThrowIfFalse(_globalOperation != null);
+                        if (_globalOperation == null)
+                        {
+                            // we subscribed to the event while it is already running.
+                            return;
+                        }
 
                         // events are serialized. no lock is needed
                         _globalOperation.SetResult(null);


### PR DESCRIPTION
...ady running.

one of tests found a case where we subscribe to an event while global operation is running. and we crash when stop event is fired.