### PR TITLE
Run csc.exe from the MSBuild directory

### DIFF
--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -2,16 +2,34 @@
 
 Imports System.IO
 Imports System.Text
-Imports System.Threading
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
+Imports Microsoft.Win32
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
     Public Class AnalyzerDependencyCheckerTests
         Inherits TestBase
 
-        Shared CSharpCompilerExecutable As String = Path.Combine(Path.GetDirectoryName(GetType(AnalyzerDependencyCheckerTests).Assembly.Location), "csc.exe")
+        Private Shared s_msbuildDirectory As String
+        Private Shared ReadOnly Property MSBuildDirectory As String
+            Get
+                If s_msbuildDirectory Is Nothing Then
+                    Dim key = Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0", False)
+
+                    If key IsNot Nothing Then
+                        Dim toolsPath = key.GetValue("MSBuildToolsPath")
+                        If toolsPath IsNot Nothing Then
+                            s_msbuildDirectory = toolsPath.ToString()
+                        End If
+                    End If
+                End If
+
+                Return s_msbuildDirectory
+            End Get
+        End Property
+
+        Private Shared CSharpCompilerExecutable As String = Path.Combine(MSBuildDirectory, "csc.exe")
 
         <Fact, WorkItem(1064914)>
         Public Sub Test1()


### PR DESCRIPTION
The AnalyzerDependencyCheckerTests currently build a bunch of assemblies
for testing purposes. It assumes it will find csc.exe next to the
assembly contain the unit tests. This is true on systems that have built
Roslyn from source (local dev boxes and Jenkins check-in systems, for
example) but is not true for "standalone" test runs that just use
binaries built elsewhere.

Since these tests compile very simple assemblies and do not depend on
any bleeding-edge language features, we can simply uses the csc.exe from
the MSBuild directory; that one should always be available.

Fixes #695.