### PR TITLE
Prototype: Ask for bytes of not-yet-loaded winmd

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -550,6 +550,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         }
                     }
                     break;
+                case ErrorCode.ERR_DottedTypeNameNotFoundInNS:
+                    if (arguments.Count == 2)
+                    {
+                        var namespaceName = arguments[0] as string;
+                        var containingNamespace = arguments[1] as NamespaceSymbol;
+                        if (namespaceName != null && (object)containingNamespace != null &&
+                            containingNamespace.ConstituentNamespaces.Select(n => n.ContainingAssembly.Identity).Any(MetadataUtilities.IsWindowsAssemblyIdentity))
+                        {
+                            var identity = new AssemblyIdentity($"{containingNamespace.ToDisplayString()}.{namespaceName}", contentType: System.Reflection.AssemblyContentType.WindowsRuntime);
+                            return ImmutableArray.Create(identity);
+                        }
+                    }
+                    break;
                 case ErrorCode.ERR_DynamicAttributeMissing:
                 case ErrorCode.ERR_DynamicRequiredTypesMissing:
                 // MSDN says these might come from System.Dynamic.Runtime

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -194,6 +194,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return assemblyName.Equals("windows", StringComparison.OrdinalIgnoreCase);
         }
 
+        internal static bool IsWindowsAssemblyIdentity(AssemblyIdentity assemblyIdentity)
+        {
+            return IsWindowsAssemblyName(assemblyIdentity.Name) && 
+                assemblyIdentity.ContentType == System.Reflection.AssemblyContentType.WindowsRuntime;
+        }
+
         internal static LocalInfo<TTypeSymbol> GetLocalInfo<TModuleSymbol, TTypeSymbol, TMethodSymbol, TFieldSymbol, TSymbol>(
             this MetadataDecoder<TModuleSymbol, TTypeSymbol, TMethodSymbol, TFieldSymbol, TSymbol> metadataDecoder,
                 byte[] signature)


### PR DESCRIPTION
When we try to bind something that is from a not-yet-loaded winmd, we
generally see ErrorCode.ERR_DottedTypeNameNotFoundInNS because the
namespace Windows.X is only provided by Windows.X.winmd.  When this
occurs, heuristically ask the debugger for an assembly with name Windows.X
and content type AssemblyContentType.WindowsRuntime.

Caveat: I tried this with Windows.Storage.winmd, which exists on my box,
but the debugger didn't return bytes.  Either this approach isn't sound,
or debugger work is required.