### PR TITLE
update unit tests to use localized resources and fix product code that wasn't

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -1676,7 +1676,8 @@ class C : IDisposable
 class C : [|IDisposable|]",
 $@"using System;
 class C : IDisposable
-{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{{
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
 }}
 ", index: 1, compareTokens: false);
         }
@@ -1769,7 +1770,8 @@ class C : IDisposable
             Test(
 @"class C : [|System.IDisposable|]",
 $@"class C : System.IDisposable
-{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+{{
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
 }}
 ", index: 3, compareTokens: false);
         }

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/FunctionAggregationSignatureHelpProvider.vb
@@ -145,14 +145,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
                    Not delegateInvokeMethod.ReturnsVoid Then
 
                     Dim parts = New List(Of SymbolDisplayPart)
-                    parts.Add(Text("<expression>"))
+                    parts.Add(Text(Expression1))
                     parts.Add(Space())
                     parts.Add(Keyword(SyntaxKind.AsKeyword))
                     parts.Add(Space())
                     parts.AddRange(delegateInvokeMethod.ReturnType.ToMinimalDisplayParts(semanticModel, position))
 
                     Dim sigHelpParameter = New SignatureHelpParameter(
-                        "<expression>",
+                        Expression1,
                         parameter.IsOptional,
                         parameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                         parts)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -450,9 +450,9 @@ End Class
 
 Module Module1
     Sub Main
-#Disable Warning BC40008 ' {WRN_UseOfObsoleteSymbol2_Title}
+#Disable Warning BC40008 ' {WRN_UseOfObsoleteSymbolNoMessage1_Title}
         C
-#Enable Warning BC40008 ' {WRN_UseOfObsoleteSymbol2_Title}
+#Enable Warning BC40008 ' {WRN_UseOfObsoleteSymbolNoMessage1_Title}
     End Sub
 End Module"
 

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Using worker = SetupWorkspace("Class A(Of T)", "Class B", "Structure C(Of U)", "Sub M()", "End Sub", "End Structure", "End Class", "End Class")
                 SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item = _aggregator.GetItems("M").Single
-                VerifyNavigateToResultItem(item, "M", MatchKind.Exact, NavigateToItemKind.Method, displayName:="M()", additionalInfo:="type A(Of T).B.C(Of U)")
+                VerifyNavigateToResultItem(item, "M", MatchKind.Exact, NavigateToItemKind.Method, displayName:="M()", additionalInfo:=$"{EditorFeaturesResources.Type}A(Of T).B.C(Of U)")
             End Using
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -1374,7 +1374,7 @@ End Class
 
             Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.foo() As Task</File>.ConvertTestSourceTag()
 
-            Dim doc = StringFromLines("", WorkspacesResources.Usage, "  Await foo()")
+            Dim doc = StringFromLines("", WorkspacesResources.Usage, $"  {VBFeaturesResources.Await} foo()")
 
             TestFromXml(markup,
                  MainDescription(description), Usage(doc))
@@ -1789,7 +1789,7 @@ End Class
                          </Workspace>.ToString()
 
             Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; <%= FeaturesResources.PrefixTextForAwaitKeyword %> Class System.Threading.Tasks.Task(Of TResult)</File>.ConvertTestSourceTag()
-            TestFromXml(markup, MainDescription(description), TypeParameterMap(vbCrLf & "TResult is Integer"))
+            TestFromXml(markup, MainDescription(description), TypeParameterMap(vbCrLf & $"TResult {FeaturesResources.Is} Integer"))
         End Sub
 
         <WorkItem(756226), WorkItem(522342)>

--- a/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
@@ -187,8 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///    #region IDisposable Support
+        ///   Looks up a localized string similar to     #region IDisposable Support
         ///    private bool disposedValue = false; // To detect redundant calls
         ///
         ///    {0}void Dispose(bool disposing)
@@ -204,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///            // TODO: set large fields to null.
         ///
         ///            disposedValue = true;
-        ///       [rest of string was truncated]&quot;;.
+        ///         [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DisposePattern {
             get {

--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -256,8 +256,7 @@
     <value>&amp;Organize Usings</value>
   </data>
   <data name="DisposePattern" xml:space="preserve">
-    <value>
-    #region IDisposable Support
+    <value>    #region IDisposable Support
     private bool disposedValue = false; // To detect redundant calls
 
     {0}void Dispose(bool disposing)

--- a/src/Features/VisualBasic/Completion/KeywordRecommenders/Expressions/IfKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Completion/KeywordRecommenders/Expressions/IfKeywordRecommender.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
             If context.IsAnyExpressionContext Then
                 Return SpecializedCollections.SingletonEnumerable(
                     CreateRecommendedKeywordForIntrinsicOperator(SyntaxKind.IfKeyword,
-                                                                 "If function (+1 overload)",
+                                                                 $"{String.Format(VBFeaturesResources.Function1, "If")} (+1 {FeaturesResources.Overload})",
                                                                  Glyph.MethodPublic,
                                                                  New TernaryConditionalExpressionDocumentation()))
             End If

--- a/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
@@ -582,8 +582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 
-        '''#Region &quot;IDisposable Support&quot;
+        '''  Looks up a localized string similar to #Region &quot;IDisposable Support&quot;
         '''    Private disposedValue As Boolean &apos; To detect redundant calls
         '''
         '''    &apos; IDisposable
@@ -596,7 +595,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         '''            &apos; TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
         '''            &apos; TODO: set large fields to null.
         '''        End If
-        '''        Me.disposedValu [rest of string was truncated]&quot;;.
+        '''        Me.disposedValue  [rest of string was truncated]&quot;;.
         '''</summary>
         Friend ReadOnly Property DisposePattern() As String
             Get

--- a/src/Features/VisualBasic/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/VBFeaturesResources.resx
@@ -331,8 +331,7 @@
     <value>&amp;Remove Unnecessary Imports</value>
   </data>
   <data name="DisposePattern" xml:space="preserve">
-    <value>
-#Region "IDisposable Support"
+    <value>#Region "IDisposable Support"
     Private disposedValue As Boolean ' To detect redundant calls
 
     ' IDisposable


### PR DESCRIPTION
This also fixes a subtle localization bug around `CSharpFeaturesResources.DisposePattern` and `VBFeaturesResources.DisposePattern` where they started with a blank line that PLOC trims out.  I've updated both `DisposePattern`s to remove that initial blank line.