### PR TITLE
fix resource string that was causing an invalid xml doc comment to be generated

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -1676,7 +1676,7 @@ class C : IDisposable
 class C : [|IDisposable|]",
 $@"using System;
 class C : IDisposable
-{{{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
+{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
 }}
 ", index: 1, compareTokens: false);
         }
@@ -1719,7 +1719,7 @@ class C : System.IDisposable
     class IDisposable
     {{
     }}
-{DisposePatternWithIndentation("protected virtual ", "C", "void System.IDisposable.")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -1769,7 +1769,7 @@ class C : IDisposable
             Test(
 @"class C : [|System.IDisposable|]",
 $@"class C : System.IDisposable
-{{{DisposePatternWithIndentation("protected virtual ", "C", "void System.IDisposable.")}
+{{{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
 }}
 ", index: 3, compareTokens: false);
         }
@@ -1830,7 +1830,7 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -1858,7 +1858,7 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{DisposePatternWithIndentation("protected virtual ", "C", "void IDisposable.")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -2295,7 +2295,7 @@ using System;
 
 class Program : IDisposable
 {{
-{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
 }}
 ", index: 1);
         }
@@ -2318,7 +2318,7 @@ using System;
 class Program : IDisposable
 {{
     private bool DisposedValue;
-{DisposePatternWithIndentation("protected virtual ", "Program", "void IDisposable.")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2397,7 +2397,7 @@ using System;
 
 sealed class Program : IDisposable
 {{
-{DisposePatternWithIndentation("", "Program", "void IDisposable.")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2522,7 +2522,7 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{DisposePatternWithIndentation("protected virtual ", "C", "public void ")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -2569,21 +2569,12 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{DisposePatternWithIndentation("protected virtual ", "C", "void IDisposable.")}
+{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
 }}
 
 partial class C
 {{
 }}", index: 3, compareTokens: false);
-        }
-
-        private static string DisposePatternWithIndentation(string disposeMethodModifiers, string className, string interfaceMethodModifiers, string additionalIndentation = "    ")
-        {
-            var lines = string.Format(CSharpFeaturesResources.DisposePattern, disposeMethodModifiers, className, interfaceMethodModifiers)
-                .Split('\n')
-                .Select(line => line.TrimEnd())
-                .Select(line => line.Length > 0 ? additionalIndentation + line : line); // only indent lines with content
-            return string.Join("\r\n", lines);
         }
     }
 }

--- a/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
@@ -188,26 +188,23 @@ namespace Microsoft.CodeAnalysis.CSharp {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///#region IDisposable Support
-        ///private bool disposedValue = false; // To detect redundant calls
+        ///    #region IDisposable Support
+        ///    private bool disposedValue = false; // To detect redundant calls
         ///
-        ///{0}void Dispose(bool disposing)
-        ///{{
-        ///    if (!disposedValue)
+        ///    {0}void Dispose(bool disposing)
         ///    {{
-        ///        if (disposing)
+        ///        if (!disposedValue)
         ///        {{
-        ///            // TODO: dispose managed state (managed objects).
-        ///        }}
-        /// 
-        ///        // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-        ///        // TODO: set large fields to null.
-        /// 
-        ///        disposedValue = true;
-        ///    }}
-        ///}}
+        ///            if (disposing)
+        ///            {{
+        ///                // TODO: dispose managed state (managed objects).
+        ///            }}
         ///
-        ///// TODO: override a finalizer only if Disp [rest of string was truncated]&quot;;.
+        ///            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+        ///            // TODO: set large fields to null.
+        ///
+        ///            disposedValue = true;
+        ///       [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DisposePattern {
             get {

--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -257,40 +257,40 @@
   </data>
   <data name="DisposePattern" xml:space="preserve">
     <value>
-#region IDisposable Support
-private bool disposedValue = false; // To detect redundant calls
+    #region IDisposable Support
+    private bool disposedValue = false; // To detect redundant calls
 
-{0}void Dispose(bool disposing)
-{{
-    if (!disposedValue)
+    {0}void Dispose(bool disposing)
     {{
-        if (disposing)
+        if (!disposedValue)
         {{
-            // TODO: dispose managed state (managed objects).
-        }}
- 
-        // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-        // TODO: set large fields to null.
- 
-        disposedValue = true;
-    }}
-}}
+            if (disposing)
+            {{
+                // TODO: dispose managed state (managed objects).
+            }}
 
-// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-// ~{1}() {{
-//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-//   Dispose(false);
-// }}
- 
-// This code added to correctly implement the disposable pattern.
-{2}Dispose()
-{{
-    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    Dispose(true);
-    // TODO: uncomment the following line if the finalizer is overridden above.
-    // GC.SuppressFinalize(this);
-}}
-#endregion</value>
+            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+            // TODO: set large fields to null.
+
+            disposedValue = true;
+        }}
+    }}
+
+    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+    // ~{1}() {{
+    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+    //   Dispose(false);
+    // }}
+
+    // This code added to correctly implement the disposable pattern.
+    {2}Dispose()
+    {{
+        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        Dispose(true);
+        // TODO: uncomment the following line if the finalizer is overridden above.
+        // GC.SuppressFinalize(this);
+    }}
+    #endregion</value>
   </data>
   <data name="AutoselectDisabledDueToPotentialImplicitArray" xml:space="preserve">
     <value>Autoselect disabled due to potential implicit array creation.</value>


### PR DESCRIPTION
this fixes the build warning from CSharpFeaturesResources.Designer.cs.