### PR TITLE
Respect the ReferenceOutputAssembly flag

### DIFF
--- a/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -65,20 +65,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateProjectFileInfo(compilerInputs, executedProject);
             }
 
-            protected override IEnumerable<ProjectFileReference> GetProjectReferences(ProjectInstance executedProject)
+            protected override ProjectFileReference CreateProjectFileReference(ProjectItemInstance reference)
             {
-                return this.GetProjectReferencesCore(executedProject);
-            }
+                var filePath = reference.EvaluatedInclude;
+                var aliases = GetAliases(reference);
 
-            private IEnumerable<ProjectFileReference> GetProjectReferencesCore(ProjectInstance executedProject)
-            {
-                foreach (var projectReference in GetProjectReferenceItems(executedProject))
-                {
-                    var filePath = projectReference.EvaluatedInclude;
-                    var aliases = GetAliases(projectReference);
-
-                    yield return new ProjectFileReference(filePath, aliases);
-                }
+                return new ProjectFileReference(filePath, aliases);
             }
 
             private ProjectFileInfo CreateProjectFileInfo(CSharpCompilerInputs compilerInputs, MSB.Execution.ProjectInstance executedProject)

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -189,9 +189,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return PathUtilities.GetFileName(assemblyName);
         }
 
-        protected virtual IEnumerable<ProjectFileReference> GetProjectReferences(MSB.Execution.ProjectInstance executedProject)
+        protected virtual IEnumerable<ProjectFileReference> GetProjectReferences(ProjectInstance executedProject)
         {
-            return executedProject.GetItems("ProjectReference")
+            return GetProjectReferenceItems(executedProject)
                 .Select(reference => new ProjectFileReference(
                     path: reference.EvaluatedInclude,
                     aliases: ImmutableArray<string>.Empty));

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -189,22 +189,25 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return PathUtilities.GetFileName(assemblyName);
         }
 
-        protected virtual IEnumerable<ProjectFileReference> GetProjectReferences(ProjectInstance executedProject)
-        {
-            return GetProjectReferenceItems(executedProject)
-                .Select(reference => new ProjectFileReference(
-                    path: reference.EvaluatedInclude,
-                    aliases: ImmutableArray<string>.Empty));
-        }
-
-        protected IEnumerable<ProjectItemInstance> GetProjectReferenceItems(ProjectInstance executedProject)
+        protected IEnumerable<ProjectFileReference> GetProjectReferences(ProjectInstance executedProject)
         {
             return executedProject
                 .GetItems("ProjectReference")
                 .Where(i => !string.Equals(
                     i.GetMetadataValue("ReferenceOutputAssembly"),
                     bool.FalseString,
-                    StringComparison.OrdinalIgnoreCase));
+                    StringComparison.OrdinalIgnoreCase))
+                .Select(CreateProjectFileReference);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ProjectFileReference"/> from a ProjectReference node in the MSBuild file.
+        /// </summary>
+        protected virtual ProjectFileReference CreateProjectFileReference(ProjectItemInstance reference)
+        {
+            return new ProjectFileReference(
+                path: reference.EvaluatedInclude,
+                aliases: ImmutableArray<string>.Empty);
         }
 
         protected virtual IEnumerable<MSB.Framework.ITaskItem> GetDocumentsFromModel(MSB.Execution.ProjectInstance executedProject)

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -300,6 +300,10 @@
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\TestSolution_SolutionFolder.sln" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\VisualBasicProject_Circular_Target.vbproj" />
+    <EmbeddedResource Include="TestFiles\VisualBasicProject_Circular_Top.vbproj" />
+  </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Targets\VSL.Imports.targets" />
     <Import Project="..\..\..\build\VSL.Imports.Closed.targets" />

--- a/src/Workspaces/CoreTest/TestFiles/VisualBasicProject_Circular_Target.vbproj
+++ b/src/Workspaces/CoreTest/TestFiles/VisualBasicProject_Circular_Target.vbproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{76242A2D-2600-49DD-8C15-FEA07ECB1842}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>VisualBasic.Circular.dll</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/src/Workspaces/CoreTest/TestFiles/VisualBasicProject_Circular_Top.vbproj
+++ b/src/Workspaces/CoreTest/TestFiles/VisualBasicProject_Circular_Top.vbproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="VisualBasicProject_Circular_Target.vbproj" />
+  <PropertyGroup>
+    <ProjectGuid>{76242A2D-2600-49DD-8C15-FEA07ECB1843}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="VisualBasic_Circular_Target.vbproj">
+      <Project>{76242A2D-2600-49DD-8C15-FEA07ECB1842}</Project>
+      <Name>Target</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -397,6 +398,20 @@ class C1
 
             var project = MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj")).Result;
             Assert.NotEmpty(project.OutputFilePath);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public async Task Test_Respect_ReferenceOutputassembly_Flag()
+        {
+            const string top = @"VisualBasicProject_Circular_Top.vbproj";
+            const string target = @"VisualBasicProject_Circular_Target.vbproj";
+            var projFile = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
+            CreateFiles(GetSimpleCSharpSolutionFiles()
+                .WithFile(top, GetResourceText(top))
+                .WithFile(target, GetResourceText(target)));
+
+            var project = await MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(top)).ConfigureAwait(false);
+            Assert.Empty(project.ProjectReferences);
         }
 
         [Fact(Skip = "707107"), Trait(Traits.Feature, Traits.Features.Workspace)]


### PR DESCRIPTION
The MSBuild workspace code should respect the ReferenceOutputAssembly
flag.  Before only the C# implementation of MSBuild was doing so.  Now
all implementations will properly respect the flag.

closes #900