### PR TITLE
Call DkmClrValue.Close more conservatively

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
@@ -154,7 +154,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         protected override void OnClose()
         {
-            Value.Close();
+            // If we have an expansion, there's a danger that more than one data item is 
+            // referring to the same DkmClrValue (e.g. if it's an AggregateExpansion).
+            // To be safe, we'll only call Close when there's no expansion.  Since this
+            // is only an optimization (the debugger will eventually close the value
+            // anyway), a conservative approach is acceptable.
+            if (this.Expansion == null)
+            {
+                Value.Close();
+            }
         }
     }
 }


### PR DESCRIPTION
The problem arises when more than one expanion shares the same value - for
example, those parented by a common AggregateExpansion.  Since this is an
optimization anyway (the debugger would eventually close them on its own),
we'll just conservatively focus on member and array expensions, since they
always "own" the value in aggregate expansions.

Fixes #901.