### PR TITLE
Indent appropriately on Enter inside InterpolatedVerbatimString

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -136,8 +136,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 Contract.ThrowIfTrue(token.Kind() == SyntaxKind.None);
 
                 // special cases
-                // if token belongs to verbatim token literal
-                if (token.IsVerbatimStringLiteral())
+                // case 1: token belongs to verbatim token literal
+                // case 2: $@"$${0}"
+                // case 3: $@"Comment$$ inbetween{0}"
+                // case 4: $@"{0}$$"
+                if (token.IsVerbatimStringLiteral() ||
+                    token.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken) ||
+                    token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
+                    (token.IsKind(SyntaxKind.CloseBraceToken) && token.Parent.IsKind(SyntaxKind.Interpolation)))
                 {
                     return IndentFromStartOfLine(0);
                 }

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             }
 
             var lineOperation = FormattingOperations.GetAdjustNewLinesOperation(formattingRules, previousToken, token, optionSet);
-            if (lineOperation != null)
+            if (lineOperation != null && lineOperation.Option != AdjustNewLinesOption.ForceLinesIfOnSingleLine)
             {
                 return true;
             }
@@ -109,7 +109,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                 if (node is BaseParameterListSyntax ||
                     node is TypeArgumentListSyntax ||
-                    node is TypeParameterListSyntax)
+                    node is TypeParameterListSyntax ||
+                    node.IsKind(SyntaxKind.Interpolation))
                 {
                     AddIndentBlockOperations(list, node);
                     return;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -978,6 +978,280 @@ class What
                 expectedIndentation: 8);
         }
 
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationString_1()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""
+{Program.number}"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationString_2()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""Comment
+{Program.number}"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationString_3()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""Comment{Program.number}
+"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationString_4()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""Comment{Program.number}Comment here
+"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void OutsideInterpolationString()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""Comment{Program.number}Comment here""
+;
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_1()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""{
+Program.number}"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_2()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""{
+            Program
+.number}"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 6,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_3()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = $@""{
+}"";
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_4()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($@""PPP{ 
+((Func<int, int>)((int s) => { return number; })).Invoke(3):(408) ###-####}"");
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_5()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($@""PPP{ ((Func<int, int>)((int s) 
+=> { return number; })).Invoke(3):(408) ###-####}"");
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_6()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($@""PPP{ ((Func<int, int>)((int s) => { return number; }))
+.Invoke(3):(408) ###-####}"");
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void InsideInterpolationSyntax_7()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($@""PPP{ ((Func<int, int>)((int s) => 
+{ return number; })).Invoke(3):(408) ###-####}"");
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 8);
+        }
+
+        [Fact]
+        [WorkItem(872)]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void IndentLambdaBodyOneIndentationToFirstTokenOfTheStatement()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(((Func<int, int>)((int s) => 
+{ return number; })).Invoke(3));
+    }
+
+    static int number;
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 8);
+        }
+
         private void AssertIndentUsingSmartTokenFormatter(
             string code,
             char ch,


### PR DESCRIPTION
Fix #872 : Indent appropriately on Enter inside InterpolatedVerbatimString

If the Return is issued in the context of the InterpolatedString, the next line is placed at the column 0

If the Return is issued inside the Interpolated syntax of the InterpolatedVerbatimString then place the next line accordingly to the indentation rule