### PR TITLE
Metadata definition navigation in Find References

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_FindReferences.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_FindReferences.cs
@@ -86,7 +86,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             if (!location.IsInSource)
             {
                 return referencedSymbol.Locations.Any()
-                    ? new MetadataDefinitionTreeItem(referencedSymbol.Definition, glyph.GetGlyphIndex())
+                    ? new MetadataDefinitionTreeItem(
+                        solution.Workspace, 
+                        referencedSymbol.Definition, 
+                        referencedSymbol.Locations.First().Document.Project.Id,
+                        glyph.GetGlyphIndex())
                     : null;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/ObjectList.cs
@@ -28,10 +28,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                     return true;
 
                 case VSOBJGOTOSRCTYPE.GS_DEFINITION:
-                    return item.GlyphIndex != Glyph.Reference.GetGlyphIndex() && item.CanGoToSource;
+                    return item.GlyphIndex != Glyph.Reference.GetGlyphIndex();
 
                 case VSOBJGOTOSRCTYPE.GS_REFERENCE:
-                    return item.GlyphIndex == Glyph.Reference.GetGlyphIndex() && item.CanGoToSource;
+                    return item.GlyphIndex == Glyph.Reference.GetGlyphIndex();
             }
 
             return false;

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
@@ -24,14 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             }
         }
 
-        public virtual bool CanGoToSource
-        {
-            get
-            {
-                return true;
-            }
-        }
-
         protected static readonly SymbolDisplayFormat definitionDisplayFormat =
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Navigation;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindResults
 {
@@ -9,14 +10,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
     {
         private readonly string _assemblyName;
         private readonly string _symbolDefinition;
-
-        public override bool CanGoToSource
-        {
-            get
-            {
-                return false;
-            }
-        }
+        private readonly SymbolKey _symbolKey;
+        private readonly Workspace _workspace;
+        private readonly ProjectId _referencingProjectId;
 
         public override bool UseGrayText
         {
@@ -26,9 +22,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             }
         }
 
-        public MetadataDefinitionTreeItem(ISymbol definition, ushort glyphIndex)
+        public MetadataDefinitionTreeItem(Workspace workspace, ISymbol definition, ProjectId referencingProjectId, ushort glyphIndex)
             : base(glyphIndex)
         {
+            _workspace = workspace;
+            _referencingProjectId = referencingProjectId;
+            _symbolKey = definition.GetSymbolKey();
             _assemblyName = definition.ContainingAssembly.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             _symbolDefinition = definition.ToDisplayString(definitionDisplayFormat);
             this.DisplayText = $"[{_assemblyName}] {_symbolDefinition}";
@@ -36,7 +35,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         public override int GoToSource()
         {
-            return VSConstants.E_NOTIMPL;
+            var resolution = _symbolKey.Resolve(_workspace.CurrentSolution.GetCompilationAsync(_referencingProjectId, CancellationToken.None).Result);
+            var referencingProject = _workspace.CurrentSolution.GetProject(_referencingProjectId);
+            if (resolution.Symbol != null && referencingProject != null)
+            {
+                var navigationService = _workspace.Services.GetService<ISymbolNavigationService>();
+                return navigationService.TryNavigateToSymbol(resolution.Symbol, referencingProject) 
+                    ? VSConstants.S_OK
+                    : VSConstants.E_FAIL;
+            }
+
+            return VSConstants.E_FAIL;
         }
 
         public void SetReferenceCount(int referenceCount)


### PR DESCRIPTION
Allow navigation to metadata definitions in the Find Symbol Results
window.