### PR TITLE
Use proper C# decimal separator '.' in TestIncrementCompilationAndOutput

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIncrementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIncrementTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Globalization;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1001,8 +998,9 @@ Zero
             Type type = typeof(T);
             Assert.True(type.IsPrimitive || type == typeof(decimal), string.Format("Type {0} is neither primitive nor decimal", type));
 
-            string source = string.Format(NUMERIC_INCREMENT_TEMPLATE, type.FullName, value, valuePlusOne);
-            string expectedOutput = string.Format(NUMERIC_OUTPUT_TEMPLATE, value, valuePlusOne);
+            // Explicitly provide InvariantCulture to use the proper C# decimal separator '.' in the source regardless of the current culture
+            string source = string.Format(CultureInfo.InvariantCulture, NUMERIC_INCREMENT_TEMPLATE, type.FullName, value, valuePlusOne);
+            string expectedOutput = string.Format(CultureInfo.InvariantCulture, NUMERIC_OUTPUT_TEMPLATE, value, valuePlusOne);
 
             CompileAndVerify(source, expectedOutput: expectedOutput);
         }


### PR DESCRIPTION
Some tests using `CodeGenIncrementTests.TestIncrementCompilationAndOutput` were failing if the current culture had a decimal separator different than `.`, because it used `ToString()` to convert floating point values to strings and insert them into a source template. This failure had nothing to do with error message localization.

This fix explicitly provides `CultureInfo.InvariantCulture` to use `.` in sources regardless of the current culture.