### PR TITLE
Assert only an exception type, not its localizable message

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
@@ -1,12 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -21,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         ' Test that BC30157 is generated for a member access off With when there is no containing With.
         <Fact>
         Public Sub MemberAccessNoContainingWith()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="MemberAccessNoContainingWith">
     <file name="a.vb">
 Imports System        
@@ -34,7 +30,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30157: Leading '.' or '!' can only appear inside a 'With' statement.
         x = .foo
@@ -109,7 +105,7 @@ End Module
         ' Test access to a local variable, parameter, type parameter, namespace with arity.
         <Fact>
         Public Sub LocalVariableWrongArity()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="LocalVariable1">
     <file name="a.vb">
 Imports System        
@@ -137,7 +133,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC32045: 'x' has no type parameters and so cannot have type arguments.
         y = x(Of Integer)
@@ -179,7 +175,7 @@ End Module
         ' Test access to a local variable and assignment of them..
         <Fact>
         Public Sub ArrayAssignmentError1()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="ArrayAssignmentError1">
     <file name="a.vb">
 Imports System        
@@ -194,7 +190,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30106: Number of indices exceeds the number of dimensions of the indexed array.
         z(1,1) = "world"
@@ -232,7 +228,7 @@ End Module
         ' Test access to a local variable and assignment of them..
         <Fact()>
         Public Sub ArrayAssignmentError2()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="ArrayAssignmentErrors2">
     <file name="a.vb">
 Option strict on     
@@ -249,7 +245,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30512: Option Strict On disallows implicit conversions from 'UInteger' to 'Integer'.
         z(i) = "world"
@@ -361,7 +357,7 @@ End Module
         ' Test access to simple identifier that isn't found anywhere.
         <Fact>
         Public Sub SimpleNameNotFound()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="SimpleNameNotFound">
     <file name="a.vb">
 Imports System        
@@ -375,7 +371,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30451: 'foo' is not declared. It may be inaccessible due to its protection level.
         x = foo
@@ -386,7 +382,7 @@ BC30451: 'foo' is not declared. It may be inaccessible due to its protection lev
         <WorkItem(538871, "DevDiv")>
         <Fact>
         Public Sub QualifiedNameBeforeDotNotFound()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="QualifiedNameBeforeDotNotFound">
     <file name="a.vb">
 Imports System
@@ -403,7 +399,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30451: 'Rdim123' is not declared. It may be inaccessible due to its protection level.
         Rdim123.Rdim456()
@@ -417,7 +413,7 @@ BC30456: 'B' is not a member of 'MainModule.A'.
         ' Test access to qualified identifier not found, in various scopes
         <Fact>
         Public Sub QualifiedNameNotFound()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="QualifiedNameNotFound">
     <file name="a.vb">
 Imports System        
@@ -443,7 +439,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30456: 'foo' is not a member of 'N'.
         x = N.foo
@@ -463,7 +459,7 @@ BC30456: 'foo' is not a member of 'M1'.
         ' Test access qualified identifier off of type parameter
         <Fact>
         Public Sub TypeParamCantQualify()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim compilation = CreateCompilationWithMscorlib(
 <compilation name="TypeParamCantQualify">
     <file name="a.vb">
 Imports System        
@@ -478,7 +474,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC32098: Type parameters cannot be used as qualifiers.
         x = T.foo
@@ -489,7 +485,7 @@ BC32098: Type parameters cannot be used as qualifiers.
         ' Test access to simple identifier that can be found, but has an error.
         <Fact>
         Public Sub BadSimpleName()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="BadSimpleName">
     <file name="a.vb">
 Imports System
@@ -507,7 +503,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC32042: Too few type arguments to 'Foo(Of T)'.
         y = Foo.x
@@ -518,7 +514,7 @@ BC32042: Too few type arguments to 'Foo(Of T)'.
         ' Test access to qualified identifier that can be found, but has an error.
         <Fact>
         Public Sub BadQualifiedName()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="BadQualifiedName">
     <file name="a.vb">
 Imports System
@@ -549,7 +545,7 @@ End Module
 </compilation>)
 
             ' Note that we produce different (but I think better) error messages than Dev10.
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC32042: Too few type arguments to 'Foo(Of T)'.
         y = N.Foo.x
@@ -569,7 +565,7 @@ BC42025: Access of shared member, constant member, enum member or nested type th
         ' Test access to instance member in various ways to get various errors.
         <Fact>
         Public Sub AccessInstanceFromStatic()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim compilation = CreateCompilationWithMscorlib(
 <compilation name="AccessInstanceFromStatic">
     <file name="a.vb">
 Class K
@@ -604,7 +600,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30469: Reference to a non-shared member requires an object reference.
             y()
@@ -630,7 +626,7 @@ BC30469: Reference to a non-shared member requires an object reference.
         ' Test access to static member in various ways to get various errors.
         <Fact>
         Public Sub AccessStaticViaInstance()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim compilation = CreateCompilationWithMscorlib(
 <compilation name="AccessStaticViaInstance">
     <file name="a.vb">
 Class K
@@ -665,7 +661,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC42025: Access of shared member, constant member, enum member or nested type through an instance; qualifying expression will not be evaluated.
             zInstance.yy()
@@ -694,7 +690,7 @@ End Class
     </file>
 </compilation>
 
-            Dim c1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source).VerifyDiagnostics(
+            Dim c1 = CreateCompilationWithMscorlibAndVBRuntime(source).VerifyDiagnostics(
                 Diagnostic(ERRID.WRN_SharedMemberThroughInstance, "j.MaxValue"),
                 Diagnostic(ERRID.WRN_SharedMemberThroughInstance, "i.MaxValue"))
 
@@ -702,7 +698,7 @@ End Class
 
         <Fact>
         Public Sub ConstantFields1()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="VBConstantFields1">
     <file name="a.vb">
 Module Module1
@@ -807,9 +803,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30068: Expression is a value and therefore cannot be the target of an assignment.
     Foo(1) = Nothing
@@ -867,7 +863,7 @@ End Class
     </file>
 </compilation>
 
-            compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
+            compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
 
             CompileAndVerify(compilation, <![CDATA[
 Nothing
@@ -899,9 +895,9 @@ End Module
     </file>
 </compilation>
 
-            compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC42105: Function 'Foo' doesn't return a value on all code paths. A null reference exception could occur at run time when the result is used.
   End Function
@@ -953,9 +949,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30491: Expression does not produce a value.
     Main().ToString
@@ -986,7 +982,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
 
             CompileAndVerify(compilation, <![CDATA[
 123
@@ -1008,9 +1004,9 @@ End Module
     </file>
 </compilation>
 
-            compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
+            compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseExe)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30455: Argument not specified for parameter 'x' of 'Public Function Foo(x As Integer) As Integer'.
     System.Console.WriteLine(Foo.ToString)
@@ -1060,9 +1056,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30108: 'S' is a type and cannot be used as an expression.
             S()
@@ -1090,9 +1086,9 @@ BC30108: 'S' is a type and cannot be used as an expression.
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
         End Sub
 
         <WorkItem(537219, "DevDiv")>
@@ -1112,9 +1108,9 @@ BC30108: 'S' is a type and cannot be used as an expression.
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
                                                <errors>
  BC32059: Array lower bounds can be only '0'.
     	    Dim x1(0! To 5) as Single
@@ -1148,9 +1144,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
                                                <errors>
 BC42024: Unused local variable: 'foo'.
         Dim foo As Integer
@@ -1263,9 +1259,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
         End Sub
 
@@ -1292,9 +1288,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
                                                <errors>
 BC30369: Cannot refer to an instance member of a class from within a shared method or shared member initializer without an explicit instance of the class.
         Dim x As Integer = Q.Zip 'this should be an error
@@ -1343,9 +1339,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation, <expected>
+            AssertTheseDiagnostics(compilation, <expected>
 BC30455: Argument not specified for parameter 'x' of 'Public ReadOnly Property color(x As Integer) As Color'.
         dim a = color.G(1)          ' error, missing parameter to color property
                 ~~~~~
@@ -1396,9 +1392,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
         End Sub
 
@@ -1451,9 +1447,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="evaluated").
                 VerifyIL("Module1.Test.DefaultColor",
@@ -1521,9 +1517,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="evaluated").
                 VerifyIL("Module1.Test.DefaultColor",
@@ -1593,10 +1589,10 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
                                                <errors>
 BC30455: Argument not specified for parameter 'x' of 'Public ReadOnly Property Color(x As Integer) As Module1.Color'.
             c1 = Color.G(1)          ' missing parameter x
@@ -1656,10 +1652,10 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
 
-            CompilationUtils.AssertNoDiagnostics(compilation)
+            AssertNoDiagnostics(compilation)
         End Sub
 
 
@@ -1717,9 +1713,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="evaluated").
                 VerifyIL("Module1.Test.DefaultColor",
@@ -1793,9 +1789,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="evaluated").
                 VerifyIL("Module1.Test.DefaultColor",
@@ -1890,9 +1886,9 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoErrors(compilation)
+            AssertNoErrors(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="evaluated").
                 VerifyIL("Module1.Test.DefaultColor",
@@ -1950,9 +1946,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertNoDiagnostics(compilation)
+            AssertNoDiagnostics(compilation)
 
             CompileAndVerify(compilationDef, expectedOutput:="48").
                 VerifyIL("Foo.M",
@@ -2006,9 +2002,9 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation, <expected>
+            AssertTheseDiagnostics(compilation, <expected>
 BC30369: Cannot refer to an instance member of a class from within a shared method or shared member initializer without an explicit instance of the class.
         Return Bar2.c
                ~~~~
@@ -2036,8 +2032,8 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(text)
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(text)
+            AssertTheseDiagnostics(compilation,
                                                <errors>
 BC42024: Unused local variable: 'y'.
         Dim y As System.Collections.Generic.List(Of M)
@@ -2075,8 +2071,8 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(text)
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(text)
+            AssertTheseDiagnostics(compilation,
 <errors>
 BC30182: Type expected.
     Dim x = GetType(NS)
@@ -2105,8 +2101,8 @@ End Namespace
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(text)
-            CompilationUtils.AssertNoErrors(compilation)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(text)
+            AssertNoErrors(compilation)
 
         End Sub
 
@@ -2129,14 +2125,14 @@ Imports Con = System.Console
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(text)
-            CompilationUtils.AssertNoErrors(compilation)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(text)
+            AssertNoErrors(compilation)
 
         End Sub
 
         <Fact>
         Public Sub Bug9300_1()
-            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation1 = CreateCompilationWithMscorlibAndVBRuntime(
     <compilation name="NotYetImplementedInRoslyn">
         <file name="a.vb">
 Imports System.Runtime.CompilerServices
@@ -2175,12 +2171,12 @@ BC30251: Type 'Object()' has no constructors.
         Foo(Sub(x) x.New())
                    ~~~~~
                  </errors>
-            CompilationUtils.AssertTheseDiagnostics(compilation1, expectedErrors1)
+            AssertTheseDiagnostics(compilation1, expectedErrors1)
         End Sub
 
         <Fact>
         Public Sub Bug9300_2()
-            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation1 = CreateCompilationWithMscorlibAndVBRuntime(
     <compilation name="NotYetImplementedInRoslyn">
         <file name="a.vb">
 Imports System.Runtime.CompilerServices
@@ -2220,12 +2216,12 @@ BC30282: Constructor call is valid only as the first statement in an instance co
         Foo(Sub(x) x.New())
                    ~~~~~
                  </errors>
-            CompilationUtils.AssertTheseDiagnostics(compilation1, expectedErrors1)
+            AssertTheseDiagnostics(compilation1, expectedErrors1)
         End Sub
 
         <Fact>
         Public Sub Bug9300_3()
-            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation1 = CreateCompilationWithMscorlibAndVBRuntime(
     <compilation name="NotYetImplementedInRoslyn">
         <file name="a.vb">
 Imports System.Runtime.CompilerServices
@@ -2272,7 +2268,7 @@ Action(Of IEnumerable)
 
         <Fact>
         Public Sub IllegalTypeExpressionsFromParserShouldNotBlowUpBinding()
-            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation1 = CreateCompilationWithMscorlibAndVBRuntime(
     <compilation name="IllegalTypeExpressionsFromParserShouldNotBlowUpBinding">
         <file name="a.vb">
             Class Outer(Of T)
@@ -2289,7 +2285,7 @@ Action(Of IEnumerable)
         </file>
     </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation1, <expected>
+            AssertTheseDiagnostics(compilation1, <expected>
 BC32099: Comma or ')' expected.
                     System.Console.WriteLine(GetType(Outer(Of ).Inner(Of T))) ' BC32099: Comma or ')' expected.
                                                                          ~
@@ -2316,7 +2312,7 @@ BC30182: Type expected.
         </file>
     </compilation>
 
-            Dim c1 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source1_with)
+            Dim c1 = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source1_with)
 
             Dim baseBuffer = CompileAndVerify(c1).EmittedAssemblyData
 
@@ -2344,7 +2340,7 @@ BC30182: Type expected.
         </file>
     </compilation>
 
-            Dim c2 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source2, {MetadataReference.CreateFromImage(baseBuffer)})
+            Dim c2 = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source2, {MetadataReference.CreateFromImage(baseBuffer)})
 
             Dim derivedBuffer = CompileAndVerify(c2).EmittedAssemblyData
 
@@ -2370,11 +2366,11 @@ BC30182: Type expected.
     </file>
 </compilation>
 
-            Dim c1_without = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source1_without)
+            Dim c1_without = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source1_without)
 
             Dim image = CompileAndVerify(c1_without).EmittedAssemblyData
 
-            Dim c3 = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source3, {MetadataReference.CreateFromImage(derivedBuffer), MetadataReference.CreateFromImage(image)})
+            Dim c3 = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source3, {MetadataReference.CreateFromImage(derivedBuffer), MetadataReference.CreateFromImage(image)})
 
             AssertTheseDiagnostics(c3, <expected>
 BC30545: Property access must assign to the property or use its value.
@@ -2416,7 +2412,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertNoDiagnostics(compilation)
+            AssertNoDiagnostics(compilation)
         End Sub
 
         <Fact>
@@ -2447,7 +2443,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation, <expected>
+            AssertTheseDiagnostics(compilation, <expected>
 BC30455: Argument not specified for parameter 'a' of 'Public Overridable ReadOnly Property TypeSubstitution(a As Integer) As TypeSubstitution'.
          Return TypeSubstitution.Create()
                 ~~~~~~~~~~~~~~~~
@@ -2485,7 +2481,7 @@ End Class
     </file>
 </compilation>)
 
-            CompilationUtils.AssertNoDiagnostics(compilation)
+            AssertNoDiagnostics(compilation)
 
         End Sub
 
@@ -2530,7 +2526,7 @@ BC30068: Expression is a value and therefore cannot be the target of an assignme
 
         <Fact>
         Public Sub Bug12900()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation name="MemberAccessNoContainingWith">
     <file name="a.vb">
 Imports System        
@@ -2542,7 +2538,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30438: Constants must have a value.
         Const local _? As Integer
@@ -2555,7 +2551,7 @@ BC30203: Identifier expected.
 
         <Fact>
         Public Sub Bug13080()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System        
@@ -2567,7 +2563,7 @@ End Module
     </file>
 </compilation>)
 
-            CompilationUtils.AssertTheseDiagnostics(compilation,
+            AssertTheseDiagnostics(compilation,
 <expected>
 BC30203: Identifier expected.
         Const '
@@ -2581,7 +2577,7 @@ BC30438: Constants must have a value.
         <WorkItem(546469, "DevDiv")>
         <Fact>
         Public Sub GetTypeAllowsArrayOfModules()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">    
 Imports System
@@ -2644,7 +2640,7 @@ BC31422: 'System.Void' can only be used in a GetType expression.
         <WorkItem(546469, "DevDiv")>
         <Fact()>
         Public Sub GetTypeAllowsModuleAlias()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">    
 Imports ModuleAlias = Bar.Test
@@ -2694,7 +2690,7 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, { SystemCoreRef }, options:=TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, {SystemCoreRef}, options:=TestOptions.ReleaseExe)
             AssertTheseDiagnostics(compilation, <expected></expected>)
 
             CompileAndVerify(compilation, expectedOutput:="42")
@@ -2703,7 +2699,7 @@ End Class
         <WorkItem(1108036, "DevDiv")>
         <Fact()>
         Public Sub Bug1108036()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Class Color
@@ -2744,7 +2740,7 @@ BC30521: Overload resolution failed because no accessible 'Color' is most specif
         <WorkItem(1108036, "DevDiv")>
         <Fact()>
         Public Sub Bug1108036_2()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Class Color
@@ -2785,7 +2781,7 @@ BC30521: Overload resolution failed because no accessible 'Color' is most specif
         <WorkItem(969006, "DevDiv")>
         <Fact()>
         Public Sub Bug969006_1()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Enum E
@@ -2831,7 +2827,7 @@ End Class
         <WorkItem(969006, "DevDiv")>
         <Fact()>
         Public Sub Bug969006_2()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Enum E
@@ -2877,7 +2873,7 @@ End Class
         <WorkItem(969006, "DevDiv")>
         <Fact()>
         Public Sub Bug969006_3()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Enum E
@@ -2928,7 +2924,7 @@ BC42104: Variable 'e' is used before it has been assigned a value. A null refere
         <WorkItem(969006, "DevDiv")>
         <Fact()>
         Public Sub Bug969006_4()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Enum E
@@ -2979,7 +2975,7 @@ BC42104: Variable 'e' is used before it has been assigned a value. A null refere
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_1()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Class Color
@@ -3012,14 +3008,14 @@ End Class
             Assert.Equal(SymbolKind.NamedType, symbol.Kind)
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
-            
+
             CompileAndVerify(compilation, expectedOutput:="42")
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
         <ConditionalFact(GetType(x86))>
         Public Sub Bug1108007_2()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3041,7 +3037,7 @@ Class Program
             Dim x As Object = ""
             Color.M(x)
         Catch e As Exception
-            Console.WriteLine(e)
+            Console.WriteLine(e.GetType())
         End Try
     End Sub
 End Class
@@ -3059,19 +3055,13 @@ End Class
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
 
-            CompileAndVerify(compilation, expectedOutput:=<![CDATA[
-System.NullReferenceException: Reference to non-shared member 'Public Sub M(x As String)' requires an object reference.
-   at Microsoft.VisualBasic.CompilerServices.Symbols.Container.InvokeMethod(Method TargetProcedure, Object[] Arguments, Boolean[] CopyBack, BindingFlags Flags)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.CallMethod(Container BaseReference, String MethodName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, BindingFlags InvocationFlags, Boolean ReportErrors, ResolutionFailure& Failure)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.ObjectLateCall(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, Boolean IgnoreReturn)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, Boolean IgnoreReturn)
-   at Program.Main()]]>)
+            CompileAndVerify(compilation, expectedOutput:=<![CDATA[System.NullReferenceException]]>)
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_3()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
         <![CDATA[
@@ -3115,7 +3105,7 @@ End Class
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_4()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3136,7 +3126,7 @@ Class Color
                 Dim x As Object = ""
                 Color.M(x)
             Catch e As Exception
-                Console.WriteLine(e)
+                Console.WriteLine(e.GetType())
             End Try
         End Sub
 
@@ -3160,17 +3150,13 @@ End Class
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
 
-            CompileAndVerify(compilation, expectedOutput:=<![CDATA[
-System.NullReferenceException: Object variable or With block variable not set.
-   at Microsoft.VisualBasic.CompilerServices.Symbols.Container..ctor(Object Instance)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, Boolean IgnoreReturn)
-   at Color.Program.M()]]>)
+            CompileAndVerify(compilation, expectedOutput:=<![CDATA[System.NullReferenceException]]>)
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_5()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3224,7 +3210,7 @@ End Class
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_6()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3248,7 +3234,7 @@ Class Program
         Try
             Dim p = New Program()
         Catch e As Exception
-            Console.WriteLine(e)
+            Console.WriteLine(e.GetType())
         End Try
     End Sub
 End Class
@@ -3266,18 +3252,13 @@ End Class
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
 
-            CompileAndVerify(compilation, expectedOutput:=<![CDATA[
-System.NullReferenceException: Object variable or With block variable not set.
-   at Microsoft.VisualBasic.CompilerServices.Symbols.Container..ctor(Object Instance)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack)
-   at Program..ctor()
-   at Program.Main()]]>)
+            CompileAndVerify(compilation, expectedOutput:=<![CDATA[System.NullReferenceException]]>)
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_7()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3321,7 +3302,7 @@ End Class
         <WorkItem(1108007, "DevDiv")>
         <ConditionalFact(GetType(x86))>
         Public Sub Bug1108007_8()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -3344,7 +3325,7 @@ Class Outer
                 Dim x As Object = ""
                 Color.M(x)
             Catch e As Exception
-                Console.WriteLine(e)
+                Console.WriteLine(e.GetType())
             End Try
         End Sub
 
@@ -3368,19 +3349,13 @@ End Class
 
             AssertTheseDiagnostics(compilation, <expected></expected>)
 
-            CompileAndVerify(compilation, expectedOutput:=<![CDATA[
-System.NullReferenceException: Reference to non-shared member 'Public Sub M(x As String)' requires an object reference.
-   at Microsoft.VisualBasic.CompilerServices.Symbols.Container.InvokeMethod(Method TargetProcedure, Object[] Arguments, Boolean[] CopyBack, BindingFlags Flags)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.CallMethod(Container BaseReference, String MethodName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, BindingFlags InvocationFlags, Boolean ReportErrors, ResolutionFailure& Failure)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.ObjectLateCall(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, Boolean IgnoreReturn)
-   at Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object Instance, Type Type, String MemberName, Object[] Arguments, String[] ArgumentNames, Type[] TypeArguments, Boolean[] CopyBack, Boolean IgnoreReturn)
-   at Outer.Program.M()]]>)
+            CompileAndVerify(compilation, expectedOutput:=<![CDATA[System.NullReferenceException]]>)
         End Sub
 
         <WorkItem(1108007, "DevDiv")>
         <Fact()>
         Public Sub Bug1108007_9()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Class Color
@@ -3426,7 +3401,7 @@ End Class    </file>
         <WorkItem(1114969, "DevDiv")>
         <Fact()>
         Public Sub Bug1114969()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
     <file name="a.vb">
 Class Color


### PR DESCRIPTION
An exception message could vary depending on language packs installed, and should not be asserted in tests. Also, the exact stack trace in the VB late binder is an implementation detail, and should not be asserted.

Also this changeset simplifies some unnecessary qualified names in the affected file.