### PR TITLE
Command line options should override rule sets

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -554,8 +554,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     generalDiagnosticOption = ReportDiagnostic.Error;
 
-                                    // Clear specific warnaserror options (since last /warnaserror flag on the command line always wins).
+                                    // Reset specific warnaserror options (since last /warnaserror flag on the command line always wins),
+                                    // and bump warnings to errors.
                                     warnAsErrors.Clear();
+                                    foreach (var key in diagnosticOptions.Keys)
+                                    {
+                                        if (diagnosticOptions[key] == ReportDiagnostic.Warn)
+                                        {
+                                            warnAsErrors[key] = ReportDiagnostic.Error;
+                                        }
+                                    }
 
                                     continue;
                                 }
@@ -587,7 +595,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else
                                 {
-                                    AddWarnings(warnAsErrors, ReportDiagnostic.Default, ParseWarnings(value));
+                                    foreach (var id in ParseWarnings(value))
+                                    {
+                                        ReportDiagnostic ruleSetValue;
+                                        if (diagnosticOptions.TryGetValue(id, out ruleSetValue))
+                                        {
+                                            warnAsErrors[id] = ruleSetValue;
+                                        }
+                                        else
+                                        {
+                                            warnAsErrors[id] = ReportDiagnostic.Default;
+                                        }
+                                    }
                                 }
                                 continue;
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1738,9 +1738,9 @@ class C
             CleanupAllGeneratedFiles(file.Path);
         }
 
-        [WorkItem(912906)]
         [Fact]
-        public void Analyzers_CommandLineOverridesRuleset1a()
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
+        public void RuleSet_GeneralCommandLineOptionOverridesGeneralRuleSetOption()
         {
             var dir = Temp.CreateDirectory();
 
@@ -1769,6 +1769,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_GeneralWarnAsErrorPromotesWarningFromRuleSet()
         {
             var dir = Temp.CreateDirectory();
@@ -1801,6 +1802,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_GeneralWarnAsErrorDoesNotPromoteInfoFromRuleSet()
         {
             var dir = Temp.CreateDirectory();
@@ -1833,6 +1835,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_SpecificWarnAsErrorPromotesInfoFromRuleSet()
         {
             var dir = Temp.CreateDirectory();
@@ -1865,6 +1868,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_GeneralWarnAsErrorMinusResetsRules()
         {
             var dir = Temp.CreateDirectory();
@@ -1898,6 +1902,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_SpecificWarnAsErrorMinusResetsRules()
         {
             var dir = Temp.CreateDirectory();
@@ -1931,6 +1936,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_SpecificWarnAsErrorMinusDefaultsRuleNotInRuleSet()
         {
             var dir = Temp.CreateDirectory();

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -6808,6 +6808,239 @@ out
             CleanupAllGeneratedFiles(src.Path)
         End Sub
 
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralCommandLineOptionOverridesGeneralRuleSetOption()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <IncludeAll Action=""Warning"" />
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=0, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralWarnAsErrorPromotesWarningFromRuleSet()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralWarnAsErrorDoesNotPromoteInfoFromRuleSet()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Info"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Info, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorPromotesInfoFromRuleSet()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Info"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test001", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralWarnAsErrorMinusResetsRules()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorMinusResetsRules()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorMinusDefaultsRuleNotInRuleSet()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test002", "/WarnAsError-:Test002", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=2, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test002"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_LastGeneralWarnAsErrorTrumpsNoWarn()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn", "/WarnAsError+", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralNoWarnTrumpsGeneralWarnAsErrorMinus()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/NoWarn", "/WarnAsError-", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralNoWarnTurnsOffAllButErrors()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Error"" />
+    <Rule Id=""Test002"" Action=""Warning"" />
+    <Rule Id=""Test003"" Action=""Info"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=3, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test002"))
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test003"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificNoWarnAlwaysWins()
+            Dim dir = Temp.CreateDirectory()
+
+            Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
+<RuleSet Name=""Ruleset1"" Description=""Test"" ToolsVersion=""12.0"">
+  <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
+    <Rule Id=""Test001"" Action=""Warning"" />
+  </Rules>
+</RuleSet>
+"
+            Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
+
+            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn:Test001", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
+
+            Assert.Empty(arguments.Errors)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
     End Class
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
         protected override CSharpCompilationOptions CreateCompilationOptions()
         {
-            IDictionary<string, ReportDiagnostic> warningOptions = null;
+            IDictionary<string, ReportDiagnostic> ruleSetSpecificDiagnosticOptions = null;
 
             // Get options from the ruleset file, if any, first. That way project-specific
             // options can override them.
@@ -99,21 +99,68 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             if (this.ruleSet != null)
             {
                 ruleSetGeneralDiagnosticOption = this.ruleSet.GetGeneralDiagnosticOption();
-                warningOptions = new Dictionary<string, ReportDiagnostic>(this.ruleSet.GetSpecificDiagnosticOptions());
+                ruleSetSpecificDiagnosticOptions = new Dictionary<string, ReportDiagnostic>(this.ruleSet.GetSpecificDiagnosticOptions());
             }
             else
             {
-                warningOptions = new Dictionary<string, ReportDiagnostic>();
+                ruleSetSpecificDiagnosticOptions = new Dictionary<string, ReportDiagnostic>();
             }
 
             UpdateRuleSetError(ruleSet);
 
-            UpdateWarning(warningOptions, CompilerOptions.OPTID_WARNASERRORLIST, ReportDiagnostic.Error);
-            UpdateWarning(warningOptions, CompilerOptions.OPTID_WARNNOTASERRORLIST, ReportDiagnostic.Warn);
+            ReportDiagnostic generalDiagnosticOption;
+            var warningsAreErrors = GetNullableBooleanOption(CompilerOptions.OPTID_WARNINGSAREERRORS);
+            if (warningsAreErrors.HasValue)
+            {
+                generalDiagnosticOption = warningsAreErrors.Value ? ReportDiagnostic.Error : ReportDiagnostic.Default;
+            }
+            else if (ruleSetGeneralDiagnosticOption.HasValue)
+            {
+                generalDiagnosticOption = ruleSetGeneralDiagnosticOption.Value;
+            }
+            else
+            {
+                generalDiagnosticOption = ReportDiagnostic.Default;
+            }
 
-            // Add the warning suppressions second, since the if a warning appears in both lists the
-            // suppression takes priority
-            UpdateWarning(warningOptions, CompilerOptions.OPTID_NOWARNLIST, ReportDiagnostic.Suppress);
+            // Start with the rule set options
+            IDictionary<string, ReportDiagnostic> diagnosticOptions = new Dictionary<string, ReportDiagnostic>(ruleSetSpecificDiagnosticOptions);
+
+            // Update the specific options based on the general settings
+            if (warningsAreErrors.HasValue && warningsAreErrors.Value == true)
+            {
+                foreach (var pair in ruleSetSpecificDiagnosticOptions)
+                {
+                    if (pair.Value == ReportDiagnostic.Warn)
+                    {
+                        diagnosticOptions[pair.Key] = ReportDiagnostic.Error;
+                    }
+                }
+            }
+
+            // Update the specific options based on the specific settings
+            foreach (var diagnosticID in ParseWarningCodes(CompilerOptions.OPTID_WARNASERRORLIST))
+            {
+                diagnosticOptions[diagnosticID] = ReportDiagnostic.Error;
+            }
+
+            foreach (var diagnosticID in ParseWarningCodes(CompilerOptions.OPTID_WARNNOTASERRORLIST))
+            {
+                ReportDiagnostic ruleSetOption;
+                if (ruleSetSpecificDiagnosticOptions.TryGetValue(diagnosticID, out ruleSetOption))
+                {
+                    diagnosticOptions[diagnosticID] = ruleSetOption;
+                }
+                else
+                {
+                    diagnosticOptions[diagnosticID] = ReportDiagnostic.Default;
+                }
+            }
+
+            foreach (var diagnosticID in ParseWarningCodes(CompilerOptions.OPTID_NOWARNLIST))
+            {
+                diagnosticOptions[diagnosticID] = ReportDiagnostic.Suppress;
+            }
 
             Platform platform;
 
@@ -136,21 +183,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
             // TODO: #load support
             var sourceSearchPaths = ImmutableArray<string>.Empty;
-
-            ReportDiagnostic generalDiagnosticOption;
-            var warningsAreErrors = GetNullableBooleanOption(CompilerOptions.OPTID_WARNINGSAREERRORS);
-            if (warningsAreErrors.HasValue)
-            {
-                generalDiagnosticOption = warningsAreErrors.Value ? ReportDiagnostic.Error : ReportDiagnostic.Default;
-            }
-            else if (ruleSetGeneralDiagnosticOption.HasValue)
-            {
-                generalDiagnosticOption = ruleSetGeneralDiagnosticOption.Value;
-            }
-            else
-            {
-                generalDiagnosticOption = ReportDiagnostic.Default;
-            }
 
             MetadataReferenceResolver referenceResolver;
             if (this.Workspace != null)
@@ -179,7 +211,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 optimizationLevel: GetBooleanOption(CompilerOptions.OPTID_OPTIMIZATIONS) ? OptimizationLevel.Release : OptimizationLevel.Debug,
                 outputKind: _outputKind,
                 platform: platform,
-                specificDiagnosticOptions: warningOptions,
+                specificDiagnosticOptions: diagnosticOptions,
                 warningLevel: warningLevel,
                 xmlReferenceResolver: new XmlFileResolver(projectDirectory),
                 sourceReferenceResolver: new SourceFileResolver(sourceSearchPaths, projectDirectory),
@@ -188,7 +220,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 strongNameProvider: new DesktopStrongNameProvider(GetStrongNameKeyPaths()));
         }
 
-        private void UpdateWarning(IDictionary<string, ReportDiagnostic> warningOptions, CompilerOptions compilerOptions, ReportDiagnostic reportDiagnostic)
+        private IEnumerable<string> ParseWarningCodes(CompilerOptions compilerOptions)
         {
             Contract.ThrowIfFalse(compilerOptions == CompilerOptions.OPTID_NOWARNLIST || compilerOptions == CompilerOptions.OPTID_WARNASERRORLIST || compilerOptions == CompilerOptions.OPTID_WARNNOTASERRORLIST);
             foreach (var warning in GetStringOption(compilerOptions, defaultValue: "").Split(new[] { ' ', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
@@ -200,7 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                     warningStringID = GetIdForErrorCode(warningId);
                 }
 
-                warningOptions[warningStringID] = reportDiagnostic;
+                yield return warningStringID;
             }
         }
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/ConvertedVisualBasicProjectOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/ConvertedVisualBasicProjectOptionsTests.vb
@@ -1,0 +1,174 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.IO
+Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Editor.UnitTests
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.VisualBasicHelpers
+Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
+Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
+Imports Roslyn.Test.Utilities
+Imports Roslyn.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+
+    Public Class ConvertedVisualBasicProjectOptionsTests
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralCommandLineOptionOverridesGeneralRuleSetOption()
+            Dim convertedOptions = GetConvertedOptions(ruleSetGeneralOption:=ReportDiagnostic.Warn, commandLineGeneralOption:=WarningLevel.WARN_AsError)
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=0, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralWarnAsErrorPromotesWarningFromRuleSet()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Warn}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(commandLineGeneralOption:=WarningLevel.WARN_AsError, ruleSetSpecificOptions:=ruleSetSpecificOptions)
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralWarnAsErrorDoesNotPromoteInfoFromRuleSet()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Info}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(commandLineGeneralOption:=WarningLevel.WARN_AsError, ruleSetSpecificOptions:=ruleSetSpecificOptions)
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Info, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorPromotesInfoFromRuleSet()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Info}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(
+                ruleSetSpecificOptions:=ruleSetSpecificOptions,
+                commandLineGeneralOption:=WarningLevel.WARN_AsError,
+                commandLineWarnAsErrors:="Test001")
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorMinusResetsRules()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Warn}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(
+                ruleSetSpecificOptions:=ruleSetSpecificOptions,
+                commandLineGeneralOption:=WarningLevel.WARN_AsError,
+                commandLineWarnNotAsErrors:="Test001")
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificWarnAsErrorMinusDefaultsRuleNotInRuleSet()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Warn}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(
+                ruleSetSpecificOptions:=ruleSetSpecificOptions,
+                commandLineGeneralOption:=WarningLevel.WARN_AsError,
+                commandLineWarnNotAsErrors:="Test001;Test002")
+
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=2, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test002"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_GeneralNoWarnTurnsOffAllButErrors()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+               {
+                   {"Test001", ReportDiagnostic.Error},
+                   {"Test002", ReportDiagnostic.Warn},
+                   {"Test003", ReportDiagnostic.Info}
+               }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(
+                ruleSetSpecificOptions:=ruleSetSpecificOptions,
+                commandLineGeneralOption:=WarningLevel.WARN_None)
+
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=3, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test002"))
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test003"))
+        End Sub
+
+        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        Public Sub RuleSet_SpecificNoWarnAlwaysWins()
+            Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
+                {
+                    {"Test001", ReportDiagnostic.Warn}
+                }.ToImmutableDictionary()
+
+            Dim convertedOptions = GetConvertedOptions(
+                ruleSetSpecificOptions:=ruleSetSpecificOptions,
+                commandLineWarnAsErrors:="Test001",
+                commandLineNoWarns:="Test001")
+
+            Assert.Equal(expected:=ReportDiagnostic.Default, actual:=convertedOptions.CompilationOptions.GeneralDiagnosticOption)
+            Assert.Equal(expected:=1, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
+            Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
+        End Sub
+
+        Private Shared Function GetConvertedOptions(
+            Optional ruleSetGeneralOption As ReportDiagnostic = ReportDiagnostic.Default,
+            Optional ruleSetSpecificOptions As ImmutableDictionary(Of String, ReportDiagnostic) = Nothing,
+            Optional commandLineGeneralOption As WarningLevel = WarningLevel.WARN_Regular,
+            Optional commandLineWarnAsErrors As String = "",
+            Optional commandLineWarnNotAsErrors As String = "",
+            Optional commandLineNoWarns As String = "") As ConvertedVisualBasicProjectOptions
+
+            ruleSetSpecificOptions = If(ruleSetSpecificOptions Is Nothing, ImmutableDictionary(Of String, ReportDiagnostic).Empty, ruleSetSpecificOptions)
+
+            Dim compilerOptions = New VBCompilerOptions With
+                            {
+                                .WarningLevel = commandLineGeneralOption,
+                                .wszWarningsAsErrors = commandLineWarnAsErrors,
+                                .wszWarningsNotAsErrors = commandLineWarnNotAsErrors,
+                                .wszDisabledWarnings = commandLineNoWarns
+                            }
+            Dim compilerHost = New MockCompilerHost("C:\SDK")
+            Dim convertedOptions = New ConvertedVisualBasicProjectOptions(
+                                    compilerOptions,
+                                    compilerHost,
+                                    SpecializedCollections.EmptyEnumerable(Of GlobalImport),
+                                    ImmutableArray(Of String).Empty,
+                                    Nothing,
+                                    New MockRuleSetFile(ruleSetGeneralOption, ruleSetSpecificOptions))
+            Return convertedOptions
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/MockRuleSetFile.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/MockRuleSetFile.vb
@@ -1,0 +1,37 @@
+﻿Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    Public Class MockRuleSetFile
+        Implements IRuleSetFile
+
+        Private ReadOnly _generalOption As ReportDiagnostic
+        Private ReadOnly _specificOptions As ImmutableDictionary(Of String, ReportDiagnostic)
+
+        Public Sub New(generalOption As ReportDiagnostic, specificOptions As ImmutableDictionary(Of String, ReportDiagnostic))
+            _generalOption = generalOption
+            _specificOptions = specificOptions
+        End Sub
+
+        Public ReadOnly Property FilePath As String Implements IRuleSetFile.FilePath
+            Get
+                Throw New NotImplementedException()
+            End Get
+        End Property
+
+        Public Event UpdatedOnDisk As EventHandler Implements IRuleSetFile.UpdatedOnDisk
+
+        Public Function GetException() As Exception Implements IRuleSetFile.GetException
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function GetGeneralDiagnosticOption() As ReportDiagnostic Implements IRuleSetFile.GetGeneralDiagnosticOption
+            Return _generalOption
+        End Function
+
+        Public Function GetSpecificDiagnosticOptions() As ImmutableDictionary(Of String, ReportDiagnostic) Implements IRuleSetFile.GetSpecificDiagnosticOptions
+            Return _specificOptions
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/MockCompilerHost.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/MockCompilerHost.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
 
         Private ReadOnly _sdkPath As String
 
-        Private Sub New(sdkPath As String)
+        Public Sub New(sdkPath As String)
             _sdkPath = sdkPath
         End Sub
 

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -332,8 +332,10 @@
     <Compile Include="ObjectBrowser\NavInfoNodeDescriptor.vb" />
     <Compile Include="ObjectBrowser\VisualBasic\ObjectBrowerTests.vb" />
     <Compile Include="Progression\GraphProviderTests.vb" />
+    <Compile Include="ProjectSystemShim\ConvertedVisualBasicProjectOptionsTests.vb" />
     <Compile Include="ProjectSystemShim\DeferredProjectLoadingTests.vb" />
     <Compile Include="ProjectSystemShim\Framework\MockHierarchy.vb" />
+    <Compile Include="ProjectSystemShim\MockRuleSetFile.vb" />
     <Compile Include="ProjectSystemShim\VisualBasicProjectTests.vb" />
     <Compile Include="Snippets\SnippetServiceWaiter.vb" />
     <Compile Include="StubVsEditorAdaptersFactoryService.vb" />

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/ConvertedVisualBasicProjectOptions.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/ConvertedVisualBasicProjectOptions.vb
@@ -188,27 +188,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
             Return AddPredefinedPreprocessorSymbols(kind, defines.AsImmutableOrEmpty())
         End Function
 
-        Private Shared Function GetWarningOptions(options As VBCompilerOptions) As Dictionary(Of String, ReportDiagnostic)
-            Dim dictionary As New Dictionary(Of String, ReportDiagnostic)
-            UpdateDictionaryForWarning(dictionary, options.wszWarningsAsErrors, ReportDiagnostic.Error)
-            UpdateDictionaryForWarning(dictionary, options.wszWarningsNotAsErrors, ReportDiagnostic.Default)
-            UpdateDictionaryForWarning(dictionary, options.wszDisabledWarnings, ReportDiagnostic.Suppress)
-
-            Return dictionary
-        End Function
-
-        Private Shared Sub UpdateDictionaryForWarning(dictionary As Dictionary(Of String, ReportDiagnostic), warnings As String, reportDiagnostic As ReportDiagnostic)
+        Private Shared Iterator Function ParseWarningCodes(warnings As String) As IEnumerable(Of String)
             If warnings IsNot Nothing Then
                 For Each warning In warnings.Split(New String() {" ", ",", ";"}, StringSplitOptions.RemoveEmptyEntries)
                     Dim warningId As Integer
                     If Integer.TryParse(warning, warningId) Then
-                        dictionary("BC" + warning) = reportDiagnostic
+                        Yield "BC" + warning
                     Else
-                        dictionary(warning) = reportDiagnostic
+                        Yield warning
                     End If
                 Next
             End If
-        End Sub
+        End Function
 
         Private Shared Function DetermineGeneralDiagnosticOption(level As WarningLevel, ruleSetGeneralDiagnosticOption As ReportDiagnostic?) As ReportDiagnostic
             'If no option was supplied in the project file, but there is one in the ruleset file, use that one.
@@ -222,18 +213,45 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         End Function
 
         Private Shared Function DetermineSpecificDiagnosticOptions(options As VBCompilerOptions, ruleSetSpecificDiagnosticOptions As IDictionary(Of String, ReportDiagnostic)) As IReadOnlyDictionary(Of String, ReportDiagnostic)
-            Dim diagnosticOptions As Dictionary(Of String, ReportDiagnostic)
-            Dim diagnosticOptionsFromCompilerOptions = GetWarningOptions(options)
-
-            If ruleSetSpecificDiagnosticOptions IsNot Nothing Then
-                diagnosticOptions = New Dictionary(Of String, ReportDiagnostic)(ruleSetSpecificDiagnosticOptions)
-
-                For Each kvp In diagnosticOptionsFromCompilerOptions
-                    diagnosticOptions(kvp.Key) = kvp.Value
-                Next
-            Else
-                diagnosticOptions = diagnosticOptionsFromCompilerOptions
+            If ruleSetSpecificDiagnosticOptions Is Nothing Then
+                ruleSetSpecificDiagnosticOptions = New Dictionary(Of String, ReportDiagnostic)
             End If
+
+            ' Start with the rule set options
+            Dim diagnosticOptions = New Dictionary(Of String, ReportDiagnostic)(ruleSetSpecificDiagnosticOptions)
+
+            ' Update the specific options based on the general settings
+            If options.WarningLevel = WarningLevel.WARN_AsError Then
+                For Each pair In ruleSetSpecificDiagnosticOptions
+                    If pair.Value = ReportDiagnostic.Warn Then
+                        diagnosticOptions(pair.Key) = ReportDiagnostic.Error
+                    End If
+                Next
+            ElseIf options.WarningLevel = WarningLevel.WARN_None
+                For Each pair In ruleSetSpecificDiagnosticOptions
+                    If pair.Value <> ReportDiagnostic.Error Then
+                        diagnosticOptions(pair.Key) = ReportDiagnostic.Suppress
+                    End If
+                Next
+            End If
+
+            ' Update the specific options based on the specific settings
+            For Each diagnosticID In ParseWarningCodes(options.wszWarningsAsErrors)
+                diagnosticOptions(diagnosticID) = ReportDiagnostic.Error
+            Next
+
+            For Each diagnosticID In ParseWarningCodes(options.wszWarningsNotAsErrors)
+                Dim ruleSetOption As ReportDiagnostic
+                If ruleSetSpecificDiagnosticOptions.TryGetValue(diagnosticID, ruleSetOption) Then
+                    diagnosticOptions(diagnosticID) = ruleSetOption
+                Else
+                    diagnosticOptions(diagnosticID) = ReportDiagnostic.Default
+                End If
+            Next
+
+            For Each diagnosticID In ParseWarningCodes(options.wszDisabledWarnings)
+                diagnosticOptions(diagnosticID) = ReportDiagnostic.Suppress
+            Next
 
             Return New ReadOnlyDictionary(Of String, ReportDiagnostic)(diagnosticOptions)
         End Function


### PR DESCRIPTION
If a diagnostic is disabled by default, you have two ways of turning it
on in the C# compiler:

1. Add a command line switch, e.g., `/WarningAsError+:MyDiagnosticID`.
2. Add a rule to the .ruleset file, e.g., `<Rule Id="MyDiagnosticID"
Action="Warn" />`.

The former turns the diagnostic on and always makes it an error. The
latter turns it on and sets its severity to whatever the `Action`
attribute specifies.

We run into problems when you use a rule set to turn on MyDiagnosticID
and make it a warning, and then specify `/WarnAsError+` to turn all
warnings into errors. Currently, MyDiagnosticID remains a warning
because since the rule set supplies a specific option ("MyDiagnosticID
is a warning") and specific options always override general options
("All warnings should be treated as errors").

What we want instead is for command line options to override the options
in rule sets. With this change, when you specify `/WarnAsError+` on the
command line we'll now go through the options from the rule set file and
turn any warnings into errors. A subsequent `/WarnAsError-:MyDiagnostic`
will restore the severity to whatever was in the rule set (or Default,
if it isn't in the ruleset).

These changes update the command line parsers and VS language
services to implement these rules, update existing unit tests, and add
further tests where they were lacking.

Fixes #468.