### PR TITLE
correct text navigation in VB and C# strings

### DIFF
--- a/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
                 TestString,
                 pos: startOfString,
                 isSignificant: true,
-                start: startOfString, length: lengthOfStringIncludingQuotes);
+                start: startOfString, length: 1);
 
             // Selects whitespace
             AssertExtent(
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
                 TestString,
                 pos: TestString.LastIndexOf('"'),
                 isSignificant: true,
-                start: startOfString + lengthOfStringIncludingQuotes - 1, length: 2);
+                start: startOfString + lengthOfStringIncludingQuotes - 1, length: 1);
 
             AssertExtent(
                 TestString,

--- a/src/EditorFeatures/VisualBasic/TextStructureNavigation/TextStructureNavigatorProvider.vb
+++ b/src/EditorFeatures/VisualBasic/TextStructureNavigation/TextStructureNavigatorProvider.vb
@@ -3,6 +3,7 @@
 Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.TextStructureNavigation
+Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
 
@@ -28,32 +29,40 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.TextStructureNavigation
         Protected Overrides Function IsWithinNaturalLanguage(token As SyntaxToken, position As Integer) As Boolean
             Select Case token.Kind
                 Case SyntaxKind.StringLiteralToken
-
-                    ' Before the " is considered outside the string
-                    If position = token.SpanStart Then
-                        Return False
-                    End If
-
-                    If position = token.Span.End AndAlso token.Text.EndsWith("""", StringComparison.Ordinal) Then
+                    ' This, in combination with the override of GetExtentOfWordFromToken() below, treats the closing
+                    ' quote as a separate token.  This maintains behavior with VS2013.
+                    If position = token.Span.End - 1 AndAlso token.Text.EndsWith("""", StringComparison.Ordinal) Then
                         Return False
                     End If
 
                     Return True
 
                 Case SyntaxKind.CharacterLiteralToken
-
-                    ' Before the ' is considered outside the character
+                    ' Before the opening quote is considered outside the character
                     If position = token.SpanStart Then
                         Return False
                     End If
 
                     Return True
 
-                Case SyntaxKind.XmlTextLiteralToken
+                Case SyntaxKind.InterpolatedStringTextToken,
+                     SyntaxKind.XmlTextLiteralToken
                     Return True
             End Select
 
             Return False
+        End Function
+
+        Protected Overrides Function GetExtentOfWordFromToken(token As SyntaxToken, position As SnapshotPoint) As TextExtent
+            If token.Kind() = SyntaxKind.StringLiteralToken AndAlso position.Position = token.Span.End - 1 AndAlso token.Text.EndsWith("""", StringComparison.Ordinal) Then
+                ' Special case to treat the closing quote of a string literal as a separate token.  This allows the
+                ' cursor to stop during word navigation (Ctrl+LeftArrow, etc.) immediately before AND after the
+                ' closing quote, just like it did in VS2013 and like it currently does for interpolated strings.
+                Dim Span = New Span(position.Position, 1)
+                Return New TextExtent(New SnapshotSpan(position.Snapshot, Span), isSignificant:=True)
+            Else
+                Return MyBase.GetExtentOfWordFromToken(token, position)
+            End If
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/TextStructureNavigation/TextStructureNavigatorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TextStructureNavigation/TextStructureNavigatorTests.vb
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TextStructureNavig
                 "Class Test : Dim str As String = "" () test  "" : End Class",
                 pos:=33,
                 isSignificant:=True,
-                start:=33, length:=12)
+                start:=33, length:=1)
 
             AssertExtent(
                 "Class Test : Dim str As String = "" () test  "" : End Class",
@@ -185,6 +185,39 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TextStructureNavig
                 pos:=44,
                 isSignificant:=True,
                 start:=44, length:=1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.TextStructureNavigator)>
+        Public Sub InterpolatedString()
+            AssertExtent(
+                "Class Test : Dim str As String = $"" () test  "" : End Class",
+                pos:=33,
+                isSignificant:=True,
+                start:=33, length:=2)
+
+            AssertExtent(
+                "Class Test : Dim str As String = $"" () test  "" : End Class",
+                pos:=35,
+                isSignificant:=False,
+                start:=35, length:=1)
+
+            AssertExtent(
+                "Class Test : Dim str As String = $"" () test  "" : End Class",
+                pos:=36,
+                isSignificant:=True,
+                start:=36, length:=2)
+
+            AssertExtent(
+                "Class Test : Dim str As String = $"" () test  "" : End Class",
+                pos:=44,
+                isSignificant:=False,
+                start:=43, length:=2)
+
+            AssertExtent(
+                "Class Test : Dim str As String = "" () test  "" : End Class",
+                pos:=45,
+                isSignificant:=False,
+                start:=45, length:=1)
         End Sub
 
         Private Shared Sub AssertExtent(


### PR DESCRIPTION
Correct text navigation in VB and C# strings to match that of the old language service (i.e., VS 2013.)  Now when navigating inside of strings with Ctrl+LeftArrow, RightArrow the cursor will move on word/token boundaries and Ctrl+Delete, Backspace behave appropriately as well as double-click word selection.

Fixes #551.