### PR TITLE
Removed file locking when opening resource files.

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -1477,19 +1477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                             {
                                                 // Use FileShare.ReadWrite because the file could be opened by the current process.
                                                 // For example, it is an XML doc file produced by the build.
-                                                var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-                                                // Lock the entire content to prevent others from modifying it while we are reading.
-                                                try
-                                                {
-                                                    stream.Lock(0, long.MaxValue);
-                                                    return stream;
-                                                }
-                                                catch
-                                                {
-                                                    stream.Dispose();
-                                                    throw;
-                                                }
+                                                return new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                                             };
             return new ResourceDescription(resourceName, fileName, dataProvider, isPublic, embedded, checkArgs: false);
         }

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -1388,16 +1388,7 @@ lVbRuntimePlus:
             Dim dataProvider As Func(Of Stream) = Function()
                                                       ' Use FileShare.ReadWrite because the file could be opened by the current process.
                                                       ' For example, it Is an XML doc file produced by the build.
-                                                      Dim stream = New FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
-
-                                                      ' Lock the entire content to prevent others from modifying it while we are reading.
-                                                      Try
-                                                          stream.Lock(0, Long.MaxValue)
-                                                          Return stream
-                                                      Catch
-                                                          stream.Dispose()
-                                                          Throw
-                                                      End Try
+                                                      Return New FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
                                                   End Function
             Return New ResourceDescription(resourceName, fileName, dataProvider, isPublic, embedded, checkArgs:=False)
         End Function


### PR DESCRIPTION
The file locking cannot be consistently guaranteed on multiple platform, on remote files, when builds share process via compile server vs. running separately.
Besides we are unable to handle sharing conflicts regardless, so at best the locking was serving only diagnostical purposes.