### PR TITLE
Make nuget packages path use forward slashes.

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -6,6 +6,6 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <config>
-    <add key="repositoryPath" value="..\..\packages" />
+    <add key="repositoryPath" value="../../packages" />
   </config>
 </configuration>


### PR DESCRIPTION
Need to use forward slashes to be compatible with Unix-like platforms.