### PR TITLE
reduce chance to report blank entries in error list.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             ChangeStableState(stable: true);
         }
 
-        protected void OnDataAddedOrChanged(object key, TArgs data)
+        protected void OnDataAddedOrChanged(object key, TArgs data, int itemCount)
         {
             // reuse factory. it is okay to re-use factory since we make sure we remove the factory before
             // adding it back
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 }
             }
 
-            factory.OnUpdated();
+            factory.OnUpdated(itemCount);
 
             for (var i = 0; i < snapshot.Length; i++)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 _map.Remove(key);
             }
 
-            factory.OnUpdated();
+            factory.OnUpdated(0);
 
             // let table manager know that we want to clear the entries
             for (var i = 0; i < snapshot.Length; i++)
@@ -144,6 +144,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             {
                 foreach (var factory in factories)
                 {
+                    factory.OnRefreshed();
+
                     snapshot[i].AddOrUpdate(factory, newFactory: false);
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -168,13 +168,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return;
                 }
 
-                if (e.Diagnostics.Length == 0 || !e.Diagnostics.Any(ShouldInclude))
+                if (e.Diagnostics.Length == 0)
                 {
                     OnDataRemoved(e.Id);
                     return;
                 }
 
-                OnDataAddedOrChanged(e.Id, e);
+                var count = e.Diagnostics.Where(ShouldInclude).Count();
+                if (count <= 0)
+                {
+                    OnDataRemoved(e.Id);
+                    return;
+                }
+
+                OnDataAddedOrChanged(e.Id, e, count);
             }
 
             private static bool ShouldInclude(DiagnosticData diagnostic)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return;
                 }
 
-                OnDataAddedOrChanged(e.DocumentId, e);
+                OnDataAddedOrChanged(e.DocumentId, e, e.TaskItems.Length);
             }
 
             protected override AbstractTableEntriesFactory<TodoTaskItem> CreateTableEntryFactory(object key, TaskListEventArgs data)

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -157,7 +157,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim factory = TryCast(sink.Entries.First(), AbstractTableEntriesFactory(Of DiagnosticData))
                 Dim snapshot1 = factory.GetCurrentSnapshot()
 
-                factory.OnUpdated()
+                factory.OnUpdated(snapshot1.Count)
+
                 Dim snapshot2 = factory.GetCurrentSnapshot()
 
                 Assert.Equal(snapshot1.VersionNumber + 1, snapshot2.VersionNumber)

--- a/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
@@ -153,7 +153,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim factory = TryCast(sink.Entries.First(), AbstractTableEntriesFactory(Of TodoTaskItem))
                 Dim snapshot1 = factory.GetCurrentSnapshot()
 
-                factory.OnUpdated()
+                factory.OnUpdated(snapshot1.Count)
 
                 Dim snapshot2 = factory.GetCurrentSnapshot()
 
@@ -201,7 +201,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim factory = TryCast(sink.Entries.First(), AbstractTableEntriesFactory(Of TodoTaskItem))
                 Dim snapshot1 = factory.GetCurrentSnapshot()
 
-                factory.OnUpdated()
+                factory.OnUpdated(snapshot1.Count)
 
                 Dim snapshot2 = factory.GetCurrentSnapshot()
 


### PR DESCRIPTION
current design of error list is that when solution is changed, we will, for short period of time, get out of sync but eventually catch up and make error list and solution in sync. during those out-of-sync period, it is possible for error list to show blank entries in the list. this change is to reduce those cases.

more correct way to do this is making error list and diagnostic service to share same version. that requires a bit of change in both side, so I am trying cheap way first. since at the end, two should get into sync eventually even without this change, cheap way probably is enough.