### PR TITLE
Better handle dismissed rename tracking sessions

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1718,6 +1718,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The rename tracking session was cancelled and is no longer available..
+        /// </summary>
+        internal static string TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable {
+            get {
+                return ResourceManager.GetString("TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The token is not contained in the workspace..
         /// </summary>
         internal static string TheTokenIsNotContainedInWorkspace {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -727,4 +727,7 @@ Do you want to proceed?</value>
   <data name="CannotApplyOperationWhileRenameSessionIsActive" xml:space="preserve">
     <value>Cannot apply operation while a rename session is active.</value>
   </data>
+  <data name="TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable" xml:space="preserve">
+    <value>The rename tracking session was cancelled and is no longer available.</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
@@ -37,11 +37,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             var document = context.Document;
             var diagnostic = context.Diagnostics.Single();
 
-            var action1 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: false);
-            context.RegisterCodeFix(action1, diagnostic);
+            // Ensure rename can still be invoked in this document. We reanalyze the document for
+            // diagnostics when rename tracking is manually dismissed, but the existence of our
+            // diagnostic may still be cached, so we have to double check before actually providing
+            // any fixes.
+            if (RenameTrackingTaggerProvider.CanInvokeRename(document))
+            {
+                var action1 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: false);
+                context.RegisterCodeFix(action1, diagnostic);
 
-            var action2 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: true);
-            context.RegisterCodeFix(action2, diagnostic);
+                var action2 = RenameTrackingTaggerProvider.CreateCodeAction(document, diagnostic, _waitIndicator, _refactorNotifyServices, _undoHistoryRegistry, showPreview: true);
+                context.RegisterCodeFix(action2, diagnostic);
+            }
 
             return SpecializedTasks.EmptyTask;
         }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
@@ -60,7 +61,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                             return Task.FromResult(SpecializedCollections.SingletonEnumerable(committerOperation as CodeActionOperation));
                         }
 
-                        Debug.Assert(false, "RenameTracking codefix invoked on a document with a StateMachine which cannot invoke rename.");
+                        // The rename tracking could be dismissed while a codefix is still cached
+                        // in the lightbulb. If this happens, do not perform the rename requested
+                        // and instead let the user know their fix will not be applied. 
+                        _document.Project.Solution.Workspace.Services.GetService<INotificationService>()
+                            ?.SendNotification(EditorFeaturesResources.TheRenameTrackingSessionWasCancelledAndIsNoLongerAvailable, severity: NotificationSeverity.Error);
+                        return SpecializedTasks.EmptyEnumerable<CodeActionOperation>();
                     }
                 }
 

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -15,7 +17,6 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 {
@@ -30,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             private readonly IInlineRenameService _inlineRenameService;
             private readonly IAsynchronousOperationListener _asyncListener;
             private readonly ITextBuffer _buffer;
+            private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
 
             private int _refCount;
 
@@ -39,12 +41,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             public event Action TrackingSessionUpdated = delegate { };
             public event Action<ITrackingSpan> TrackingSessionCleared = delegate { };
 
-            public StateMachine(ITextBuffer buffer, IInlineRenameService inlineRenameService, IAsynchronousOperationListener asyncListener)
+            public StateMachine(
+                ITextBuffer buffer, 
+                IInlineRenameService inlineRenameService, 
+                IAsynchronousOperationListener asyncListener, 
+                IDiagnosticAnalyzerService diagnosticAnalyzerService)
             {
                 _buffer = buffer;
                 _buffer.Changed += Buffer_Changed;
                 _inlineRenameService = inlineRenameService;
                 _asyncListener = asyncListener;
+                _diagnosticAnalyzerService = diagnosticAnalyzerService;
             }
 
             private void Buffer_Changed(object sender, TextContentChangedEventArgs e)
@@ -204,6 +211,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                 if (this.TrackingSession != null && this.TrackingSession.IsDefinitelyRenamableIdentifier())
                 {
+                    var document = _buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                    if (document != null)
+                    {
+                        // When rename tracking is dismissed via escape, we no longer wish to
+                        // provide a diagnostic/codefix, but nothing has changed in the workspace
+                        // to trigger the diagnostic system to reanalyze, so we trigger it 
+                        // manually.
+
+                        _diagnosticAnalyzerService?.Reanalyze(
+                            document.Project.Solution.Workspace, 
+                            documentIds: SpecializedCollections.SingletonEnumerable(document.Id));
+                    }
+
                     // Disallow the existing TrackingSession from triggering IdentifierFound.
                     var previousTrackingSession = this.TrackingSession;
                     this.TrackingSession = null;

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -946,6 +946,7 @@ class C$$
             }
         }
 
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
         public void RenameTrackingNotWhenDeclaringEnumMembersEvenAfterCancellation()
         {
@@ -961,6 +962,29 @@ End Enum";
                 state.SendEscape();
                 state.EditorOperations.InsertText("c");
                 state.AssertNoTag();
+            }
+        }
+
+        [Fact]
+        [WorkItem(540, "https://github.com/dotnet/roslyn/issues/540")]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTrackingDoesNotProvideDiagnosticAfterCancellation()
+        {
+           var code = @"
+class C$$
+{
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("at");
+                state.AssertTag("C", "Cat");
+
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+
+                state.SendEscape();
+                state.AssertNoTag();
+
+                Assert.Empty(state.GetDocumentDiagnostics());
             }
         }
     }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -6,10 +6,10 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.RenameTracking;
 using Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Editor.VisualBasic.RenameTracking;
 using Microsoft.CodeAnalysis.Notification;
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
                 _historyRegistry,
                 Workspace.ExportProvider.GetExport<Host.IWaitIndicator>().Value,
                 Workspace.ExportProvider.GetExport<IInlineRenameService>().Value,
+                Workspace.ExportProvider.GetExport<IDiagnosticAnalyzerService>().Value,
                 SpecializedCollections.SingletonEnumerable(_mockRefactorNotifyService),
                 Workspace.ExportProvider.GetExports<IAsynchronousOperationListener, FeatureMetadata>());
 
@@ -146,6 +147,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
             Assert.Equal(0, tags.Count());
         }
 
+        public IList<Diagnostic> GetDocumentDiagnostics(Document document = null)
+        {
+            document = document ?? this.Workspace.CurrentSolution.GetDocument(_hostDocument.Id);
+            var analyzer = new RenameTrackingDiagnosticAnalyzer();
+            return DiagnosticProviderTestUtilities.GetDocumentDiagnostics(analyzer, document, document.GetSyntaxRootAsync(CancellationToken.None).Result.FullSpan).ToList();
+        }
+
         public void AssertTag(string expectedFromName, string expectedToName, bool invokeAction = false, int actionIndex = 0)
         {
             WaitForAsyncOperations();
@@ -158,9 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
             var tag = tags.Single();
 
             var document = this.Workspace.CurrentSolution.GetDocument(_hostDocument.Id);
-
-            var analyzer = new RenameTrackingDiagnosticAnalyzer();
-            var diagnostics = DiagnosticProviderTestUtilities.GetDocumentDiagnostics(analyzer, document, tag.Span.Span.ToTextSpan()).ToList();
+            var diagnostics = GetDocumentDiagnostics(document);
 
             // There should be a single rename tracking diagnostic
             Assert.Equal(1, diagnostics.Count);

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -1,20 +1,21 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+Imports Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Operations
-Imports Roslyn.Utilities
 Imports Microsoft.VisualStudio.Text.Tagging
-Imports Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
-Imports System.Threading
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
-Imports Microsoft.VisualStudio.Composition
+Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Module RenameTestHelpers
@@ -108,6 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 workspace.ExportProvider.GetExport(Of ITextUndoHistoryRegistry)().Value,
                 workspace.ExportProvider.GetExport(Of IWaitIndicator)().Value,
                 workspace.ExportProvider.GetExport(Of IInlineRenameService)().Value,
+                workspace.ExportProvider.GetExport(Of IDiagnosticAnalyzerService)().Value,
                 SpecializedCollections.SingletonEnumerable(New MockRefactorNotifyService()),
                 DirectCast(workspace.ExportProvider.GetExports(Of IAsynchronousOperationListener, FeatureMetadata), IEnumerable(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata))))
 


### PR DESCRIPTION
Fixes #540 "Stale rename entries in the lightbulb menu"

Prior to this change, dismissed rename tracking sessions continued to
provide codefixes which would silently fail when invoked, without
completing the rename operation.

With this change, we now do the following when rename tracking is
manually dismissed:

- Trigger the diagnostic service to reanalyze the document, thus
removing the rename tracking diagnostic.
- Stop providing a codefix when requested
- Show a dialog if a cached codefix is invoked explaining that the
rename was not performed.

Here are the there user scenarios:

1. The user dismisses rename tracking

- The lightbulb will continue to show in the margin, regardless of
whether any codefix/refactoring is actually still available.

2. The user expands the lightbulb without it ever having been expanded
before.

- In this case, we are queried for fixes and will not return any, so
either the lightbulb will disappear or it will contain other relevant
codefixes/refactorings at that position, excluding rename.

3. The user expands the lightbulb after it was previously expanded.

- Our fix was already cached, so we can only give a reasonable message
when it is invoked.

Once #885 is fixed, we can instead implement IDiagnosticUpdateSource and
avoid forcing diagnostic reanalysis.