### PR TITLE
Clean up Solution Explorer context menus

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.cs
@@ -14,17 +14,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     {
         private readonly AnalyzersFolderItem _analyzersFolder;
         private readonly AnalyzerReference _analyzerReference;
+        private readonly IContextMenuController _contextMenuController;
 
-        private static readonly ContextMenuController s_itemContextMenuController =
-            new ContextMenuController(
-                ID.RoslynCommands.AnalyzerContextMenu,
-                items => items.All(item => item is AnalyzerItem));
-
-        public AnalyzerItem(AnalyzersFolderItem analyzersFolder, AnalyzerReference analyzerReference)
+        public AnalyzerItem(AnalyzersFolderItem analyzersFolder, AnalyzerReference analyzerReference, IContextMenuController contextMenuController)
             : base(GetNameText(analyzerReference))
         {
             _analyzersFolder = analyzersFolder;
             _analyzerReference = analyzerReference;
+            _contextMenuController = contextMenuController;
         }
 
         public override ImageMoniker IconMoniker
@@ -70,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         public override IContextMenuController ContextMenuController
         {
-            get { return s_itemContextMenuController; }
+            get { return _contextMenuController; }
         }
 
         public AnalyzersFolderItem AnalyzersFolder

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemProvider.cs
@@ -12,11 +12,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     [Order]
     internal class AnalyzerItemProvider : AttachedCollectionSourceProvider<AnalyzersFolderItem>
     {
+        [Import(typeof(AnalyzersCommandHandler))]
+        private IAnalyzersCommandHandler _commandHandler = null;
+
         protected override IAttachedCollectionSource CreateCollectionSource(AnalyzersFolderItem analyzersFolder, string relationshipName)
         {
             if (relationshipName == KnownRelationships.Contains)
             {
-                return new AnalyzerItemSource(analyzersFolder);
+                return new AnalyzerItemSource(analyzersFolder, _commandHandler);
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemSource.cs
@@ -15,14 +15,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     internal class AnalyzerItemSource : IAttachedCollectionSource, INotifyPropertyChanged
     {
         private readonly AnalyzersFolderItem _analyzersFolder;
+        private readonly IAnalyzersCommandHandler _commandHandler;
         private IReadOnlyCollection<AnalyzerReference> _analyzerReferences;
         private BulkObservableCollection<AnalyzerItem> _analyzerItems;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AnalyzerItemSource(AnalyzersFolderItem analyzersFolder)
+        public AnalyzerItemSource(AnalyzersFolderItem analyzersFolder, IAnalyzersCommandHandler commandHandler)
         {
             _analyzersFolder = analyzersFolder;
+            _commandHandler = commandHandler;
+
             _analyzersFolder.Workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
         }
 
@@ -98,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
                 foreach (var reference in referencesToAdd)
                 {
-                    _analyzerItems.Add(new AnalyzerItem(_analyzersFolder, reference));
+                    _analyzerItems.Add(new AnalyzerItem(_analyzersFolder, reference, _commandHandler.AnalyzerContextMenuController));
                 }
 
                 var sorted = _analyzerItems.OrderBy(item => item.AnalyzerReference.Display).ToArray();
@@ -161,7 +164,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                         _analyzerReferences = project.AnalyzerReferences;
                         var initialSet = _analyzerReferences
                                             .OrderBy(ar => ar.Display)
-                                            .Select(ar => new AnalyzerItem(_analyzersFolder, ar));
+                                            .Select(ar => new AnalyzerItem(_analyzersFolder, ar, _commandHandler.AnalyzerContextMenuController));
                         _analyzerItems.AddRange(initialSet);
                     }
                 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private IVsMonitorSelection _vsMonitorSelection = null;
         private uint _selectionEventsCookie = 0;
 
-        public event EventHandler SelectedDiagnosticItemsChanged;
         public event EventHandler SelectedHierarchyItemChanged;
 
         [ImportingConstructor]
@@ -87,7 +86,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                                   .Select(b => b.Folder)
                                   .FirstOrDefault();
 
-            var oldSelectedDiagnosticItems = this.SelectedDiagnosticItems;
             this.SelectedDiagnosticItems = selectedObjects
                                            .OfType<DiagnosticItem.BrowseObject>()
                                            .Select(b => b.DiagnosticItem)
@@ -97,11 +95,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 oldSelectedItemId != this.SelectedItemId)
             {
                 this.SelectedHierarchyItemChanged?.Invoke(this, EventArgs.Empty);
-            }
-
-            if (oldSelectedDiagnosticItems != this.SelectedDiagnosticItems)
-            {
-                this.SelectedDiagnosticItemsChanged?.Invoke(this, EventArgs.Empty);
             }
 
             return VSConstants.S_OK;

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItemTracker.cs
@@ -58,6 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             return VSConstants.S_OK;
         }
+
         int IVsSelectionEvents.OnSelectionChanged(
             IVsHierarchy pHierOld,
             uint itemidOld,

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -121,6 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
             UpdateSeverityMenuItemsChecked();
             UpdateSeverityMenuItemsEnabled();
+            UpdateOpenHelpLinkMenuItemVisibility();
         }
 
         private void DiagnosticItemPropertyChangedHandler(object sender, PropertyChangedEventArgs e)
@@ -144,14 +145,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _projectContextAddMenuItem.Visible = selectedProjectSupportsAnalyzers && _tracker.SelectedItemId == VSConstants.VSITEMID_ROOT;
             _referencesContextAddMenuItem.Visible = selectedProjectSupportsAnalyzers;
 
-            _openHelpLinkMenuItem.Visible = _tracker.SelectedDiagnosticItems.Length == 1 &&
-                                            !string.IsNullOrWhiteSpace(_tracker.SelectedDiagnosticItems[0].Descriptor.HelpLinkUri);
-
-
             string itemName;
             _setActiveRuleSetMenuItem.Visible = selectedProjectSupportsAnalyzers &&
                                                 _tracker.SelectedHierarchy.TryGetItemName(_tracker.SelectedItemId, out itemName) &&
                                                 Path.GetExtension(itemName).Equals(".ruleset", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void UpdateOpenHelpLinkMenuItemVisibility()
+        {
+            _openHelpLinkMenuItem.Visible = _tracker.SelectedDiagnosticItems.Length == 1 &&
+                                                        !string.IsNullOrWhiteSpace(_tracker.SelectedDiagnosticItems[0].Descriptor.HelpLinkUri);
         }
 
         private void UpdateSeverityMenuItemsChecked()

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.cs
@@ -17,21 +17,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private readonly Workspace _workspace;
         private readonly ProjectId _projectId;
         private readonly IVsHierarchyItem _parentItem;
+        private readonly IContextMenuController _contextMenuController;
 
-        private static readonly ContextMenuController s_folderContextMenuController =
-            new ContextMenuController(
-                ID.RoslynCommands.AnalyzerFolderContextMenu,
-                items => items.Count() == 1);
 
         public AnalyzersFolderItem(
             Workspace workspace,
             ProjectId projectId,
-            IVsHierarchyItem parentItem)
+            IVsHierarchyItem parentItem,
+            IContextMenuController contextMenuController)
             : base(SolutionExplorerShim.AnalyzersFolderItem_Name)
         {
             _workspace = workspace;
             _projectId = projectId;
             _parentItem = parentItem;
+            _contextMenuController = contextMenuController;
         }
 
         public override ImageMoniker IconMoniker
@@ -72,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         public override IContextMenuController ContextMenuController
         {
-            get { return s_folderContextMenuController; }
+            get { return _contextMenuController; }
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemProvider.cs
@@ -27,25 +27,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private static readonly Guid s_visualBasicProjectId = new Guid(VisualBasicProjectIdString);
 
         private readonly IComponentModel _componentModel;
+        private readonly IAnalyzersCommandHandler _commandHandler;
         private IHierarchyItemToProjectIdMap _projectMap;
         private Workspace _workspace;
 
         [ImportingConstructor]
         public AnalyzersFolderItemProvider(
-            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
+            [Import(typeof(AnalyzersCommandHandler))] IAnalyzersCommandHandler commandHandler)
         {
             _componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+            _commandHandler = commandHandler;
         }
 
         /// <summary>
         /// Constructor for use only in unit tests. Bypasses MEF to set the project mapper, workspace and glyph service.
         /// </summary>
-        /// <param name="workspace"></param>
-        /// <param name="projectMap"></param>
-        internal AnalyzersFolderItemProvider(IHierarchyItemToProjectIdMap projectMap, Workspace workspace)
+        internal AnalyzersFolderItemProvider(IHierarchyItemToProjectIdMap projectMap, Workspace workspace, IAnalyzersCommandHandler commandHandler)
         {
             _projectMap = projectMap;
             _workspace = workspace;
+            _commandHandler = commandHandler;
         }
 
         protected override IAttachedCollectionSource CreateCollectionSource(IVsHierarchyItem item, string relationshipName)
@@ -78,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 hierarchyMapper.TryGetProjectId(parentItem, out projectId))
             {
                 var workspace = TryGetWorkspace();
-                return new AnalyzersFolderItemSource(workspace, projectId, item);
+                return new AnalyzersFolderItemSource(workspace, projectId, item, _commandHandler);
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemSource.cs
@@ -14,12 +14,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private readonly Workspace _workspace;
         private readonly ProjectId _projectId;
         private readonly ObservableCollection<AnalyzersFolderItem> _folderItems;
+        private readonly IAnalyzersCommandHandler _commandHandler;
 
-        public AnalyzersFolderItemSource(Workspace workspace, ProjectId projectId, IVsHierarchyItem projectHierarchyItem)
+        public AnalyzersFolderItemSource(Workspace workspace, ProjectId projectId, IVsHierarchyItem projectHierarchyItem, IAnalyzersCommandHandler commandHandler)
         {
             _workspace = workspace;
             _projectId = projectId;
             _projectHierarchyItem = projectHierarchyItem;
+            _commandHandler = commandHandler;
 
             _folderItems = new ObservableCollection<AnalyzersFolderItem>();
 
@@ -62,7 +64,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 new AnalyzersFolderItem(
                     _workspace,
                     _projectId,
-                    _projectHierarchyItem));
+                    _projectHierarchyItem,
+                    _commandHandler.AnalyzerFolderContextMenuController));
         }
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/ContextMenuController.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/ContextMenuController.cs
@@ -17,11 +17,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     {
         private readonly int _menuId;
         private readonly Func<IEnumerable<object>, bool> _shouldShowMenu;
+        private readonly Action _updateMenu;
 
-        public ContextMenuController(int menuId, Func<IEnumerable<object>, bool> shouldShowMenu)
+        public ContextMenuController(int menuId, Func<IEnumerable<object>, bool> shouldShowMenu, Action updateMenu)
         {
             _menuId = menuId;
             _shouldShowMenu = shouldShowMenu;
+            _updateMenu = updateMenu;
         }
 
         public bool ShowContextMenu(IEnumerable<object> items, Point location)
@@ -30,6 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             {
                 return false;
             }
+
+            _updateMenu();
 
             IVsUIShell shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
             Guid guidContextMenu = Guids.RoslynGroupId;

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.BrowseObject.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.BrowseObject.cs
@@ -120,6 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 return _diagnosticItem.Descriptor.Id;
             }
 
+            [Browsable(false)]
             public DiagnosticItem DiagnosticItem
             {
                 get { return _diagnosticItem; }

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.cs
@@ -23,20 +23,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private readonly DiagnosticDescriptor _descriptor;
         private ReportDiagnostic _effectiveSeverity;
         private readonly AnalyzerItem _analyzerItem;
-
-        private static readonly ContextMenuController s_diagnosticContextMenuController =
-            new ContextMenuController(
-                ID.RoslynCommands.DiagnosticContextMenu,
-                items => items.All(item => item is DiagnosticItem));
+        private readonly IContextMenuController _contextMenuController;
 
         public override event PropertyChangedEventHandler PropertyChanged;
 
-        public DiagnosticItem(AnalyzerItem analyzerItem, DiagnosticDescriptor descriptor, ReportDiagnostic effectiveSeverity)
+        public DiagnosticItem(AnalyzerItem analyzerItem, DiagnosticDescriptor descriptor, ReportDiagnostic effectiveSeverity, IContextMenuController contextMenuController)
             : base(string.Format("{0}: {1}", descriptor.Id, descriptor.Title))
         {
             _analyzerItem = analyzerItem;
             _descriptor = descriptor;
             _effectiveSeverity = effectiveSeverity;
+            _contextMenuController = contextMenuController;
         }
 
         public override ImageMoniker IconMoniker
@@ -80,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             get
             {
-                return s_diagnosticContextMenuController;
+                return _contextMenuController;
             }
         }
 

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
@@ -12,11 +12,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     [Order]
     internal sealed class DiagnosticItemProvider : AttachedCollectionSourceProvider<AnalyzerItem>
     {
+        [Import(typeof(AnalyzersCommandHandler))]
+        private IAnalyzersCommandHandler _commandHandler = null;
+
         protected override IAttachedCollectionSource CreateCollectionSource(AnalyzerItem item, string relationshipName)
         {
             if (relationshipName == KnownRelationships.Contains)
             {
-                return new DiagnosticItemSource(item);
+                return new DiagnosticItemSource(item, _commandHandler);
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
@@ -17,16 +17,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     {
         private static readonly DiagnosticDescriptorComparer s_comparer = new DiagnosticDescriptorComparer();
 
-        private AnalyzerItem _item;
+        private readonly AnalyzerItem _item;
+        private readonly IAnalyzersCommandHandler _commandHandler;
         private BulkObservableCollection<DiagnosticItem> _diagnosticItems;
         private Workspace _workspace;
         private ProjectId _projectId;
         private ReportDiagnostic _generalDiagnosticOption;
         private ImmutableDictionary<string, ReportDiagnostic> _specificDiagnosticOptions;
 
-        public DiagnosticItemSource(AnalyzerItem item)
+        public DiagnosticItemSource(AnalyzerItem item, IAnalyzersCommandHandler commandHandler)
         {
             _item = item;
+            _commandHandler = commandHandler;
         }
 
         public object SourceItem
@@ -94,7 +96,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 .Select(g =>
                 {
                     var selectedDiagnostic = g.OrderBy(d => d, s_comparer).First();
-                    return new DiagnosticItem(_item, selectedDiagnostic, GetEffectiveSeverity(selectedDiagnostic.Id, _specificDiagnosticOptions, _generalDiagnosticOption, selectedDiagnostic.DefaultSeverity, selectedDiagnostic.IsEnabledByDefault));
+                    var effectiveSeverity = GetEffectiveSeverity(selectedDiagnostic.Id, _specificDiagnosticOptions, _generalDiagnosticOption, selectedDiagnostic.DefaultSeverity, selectedDiagnostic.IsEnabledByDefault);
+                    return new DiagnosticItem(_item, selectedDiagnostic, effectiveSeverity, _commandHandler.DiagnosticContextMenuController);
                 });
         }
 

--- a/src/VisualStudio/Core/SolutionExplorerShim/IAnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/IAnalyzersCommandHandler.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Internal.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
+{
+    internal interface IAnalyzersCommandHandler
+    {
+        IContextMenuController AnalyzerFolderContextMenuController { get; }
+        IContextMenuController AnalyzerContextMenuController { get; }
+        IContextMenuController DiagnosticContextMenuController { get; }
+    }
+}

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -27,7 +27,7 @@
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="Microsoft.VisualStudio.CodeAnalysis.Sdk.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll</HintPath>
-    </Reference> 
+    </Reference>
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
@@ -131,6 +131,7 @@
     <Compile Include="DiagnosticItem\DiagnosticItemSource.DiagnosticDescriptorComparer.cs" />
     <Compile Include="DiagnosticItem\RuleSelectionImage.cs" />
     <Compile Include="HierarchyItemToProjectIdMap.cs" />
+    <Compile Include="IAnalyzersCommandHandler.cs" />
     <Compile Include="IHierarchyItemToProjectIdMap.cs" />
     <Compile Include="ISolutionExplorerWorkspaceProvider.cs" />
     <Compile Include="LocalizableProperties.cs" />

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -336,6 +336,7 @@
     <Compile Include="ProjectSystemShim\Framework\MockHierarchy.vb" />
     <Compile Include="ProjectSystemShim\VisualBasicProjectTests.vb" />
     <Compile Include="Snippets\SnippetServiceWaiter.vb" />
+    <Compile Include="SolutionExplorer\FakeAnalyzersCommandHandler.vb" />
     <Compile Include="StubVsEditorAdaptersFactoryService.vb" />
     <Compile Include="Preview\PreviewChangesTests.vb" />
     <Compile Include="Progression\CallsGraphQueryTests.vb" />

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerItemTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerItemTests.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
                 Dim project = workspace.Projects.Single()
 
-                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing)
-                Dim analyzer = New AnalyzerItem(analyzerFolder, project.AnalyzerReferences.Single())
+                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing, Nothing)
+                Dim analyzer = New AnalyzerItem(analyzerFolder, project.AnalyzerReferences.Single(), Nothing)
 
                 Assert.Equal(expected:="Foo", actual:=analyzer.Text)
             End Using
@@ -37,8 +37,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
                 Dim project = workspace.Projects.Single()
 
-                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing)
-                Dim analyzer = New AnalyzerItem(analyzerFolder, project.AnalyzerReferences.Single())
+                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing, Nothing)
+                Dim analyzer = New AnalyzerItem(analyzerFolder, project.AnalyzerReferences.Single(), Nothing)
                 Dim browseObject = DirectCast(analyzer.GetBrowseObject(), AnalyzerItem.BrowseObject)
 
                 Assert.Equal(expected:="Analyzer Properties", actual:=browseObject.GetClassName())

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerItemsSourceTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerItemsSourceTests.vb
@@ -20,8 +20,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
                 Dim project = workspace.Projects.Single()
 
-                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing)
-                Dim analyzerItemsSource = New AnalyzerItemSource(analyzerFolder)
+                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing, Nothing)
+                Dim analyzerItemsSource = New AnalyzerItemSource(analyzerFolder, New FakeAnalyzersCommandHandler)
 
                 Dim analyzers = analyzerItemsSource.Items.Cast(Of AnalyzerItem)().ToArray()
 

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderItemTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderItemTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
                 Dim project = workspace.Projects.Single()
 
-                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing)
+                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing, Nothing)
 
                 Assert.Equal(expected:="Analyzers", actual:=analyzerFolder.Text)
             End Using
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
                 Dim project = workspace.Projects.Single()
 
-                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing)
+                Dim analyzerFolder = New AnalyzersFolderItem(workspace, project.Id, Nothing, Nothing)
                 Dim browseObject = DirectCast(analyzerFolder.GetBrowseObject(), AnalyzersFolderItem.BrowseObject)
 
                 Assert.Equal(expected:="Analyzers", actual:=browseObject.GetComponentName())

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderProviderTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderProviderTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Sub CreateCollectionSource_NullItem()
             Using environment = New TestEnvironment()
                 Dim provider As IAttachedCollectionSourceProvider =
-                New AnalyzersFolderItemProvider(environment.ServiceProvider)
+                New AnalyzersFolderItemProvider(environment.ServiceProvider, Nothing)
 
                 Dim collectionSource = provider.CreateCollectionSource(Nothing, KnownRelationships.Contains)
 
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Sub CreateCollectionSource_NullHierarchyIdentity()
             Using environment = New TestEnvironment()
                 Dim provider As IAttachedCollectionSourceProvider =
-                New AnalyzersFolderItemProvider(environment.ServiceProvider)
+                New AnalyzersFolderItemProvider(environment.ServiceProvider, Nothing)
 
                 Dim hierarchyItem = New MockHierarchyItem With {.HierarchyIdentity = Nothing}
 
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
 
                 Dim mapper = New HierarchyItemMapper(environment.ProjectTracker)
 
-                Dim provider As IAttachedCollectionSourceProvider = New AnalyzersFolderItemProvider(mapper, environment.Workspace)
+                Dim provider As IAttachedCollectionSourceProvider = New AnalyzersFolderItemProvider(mapper, environment.Workspace, New FakeAnalyzersCommandHandler)
 
                 Dim collectionSource = provider.CreateCollectionSource(hierarchyItem, KnownRelationships.Contains)
 

--- a/src/VisualStudio/Core/Test/SolutionExplorer/DiagnosticItemTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/DiagnosticItemTests.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Sub Name()
             Dim descriptor = CreateDescriptor()
 
-            Dim diagnostic = New DiagnosticItem(Nothing, descriptor, ReportDiagnostic.Error)
+            Dim diagnostic = New DiagnosticItem(Nothing, descriptor, ReportDiagnostic.Error, Nothing)
 
             Assert.Equal(expected:="TST0001: A test diagnostic", actual:=diagnostic.Text)
         End Sub
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Sub BrowseObject()
             Dim descriptor = CreateDescriptor()
 
-            Dim diagnostic = New DiagnosticItem(Nothing, descriptor, ReportDiagnostic.Info)
+            Dim diagnostic = New DiagnosticItem(Nothing, descriptor, ReportDiagnostic.Info, Nothing)
             Dim browseObject = DirectCast(diagnostic.GetBrowseObject(), DiagnosticItem.BrowseObject)
 
             Assert.Equal(expected:="Diagnostic Properties", actual:=browseObject.GetClassName())

--- a/src/VisualStudio/Core/Test/SolutionExplorer/FakeAnalyzersCommandHandler.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/FakeAnalyzersCommandHandler.vb
@@ -1,0 +1,24 @@
+﻿Imports Microsoft.Internal.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
+
+Public Class FakeAnalyzersCommandHandler
+    Implements IAnalyzersCommandHandler
+
+    Public ReadOnly Property AnalyzerContextMenuController As IContextMenuController Implements IAnalyzersCommandHandler.AnalyzerContextMenuController
+        Get
+            Return Nothing
+        End Get
+    End Property
+
+    Public ReadOnly Property AnalyzerFolderContextMenuController As IContextMenuController Implements IAnalyzersCommandHandler.AnalyzerFolderContextMenuController
+        Get
+            Return Nothing
+        End Get
+    End Property
+
+    Public ReadOnly Property DiagnosticContextMenuController As IContextMenuController Implements IAnalyzersCommandHandler.DiagnosticContextMenuController
+        Get
+            Return Nothing
+        End Get
+    End Property
+End Class

--- a/src/VisualStudio/Setup/Commands.vsct
+++ b/src/VisualStudio/Setup/Commands.vsct
@@ -193,10 +193,10 @@
       <Button guid="guidRoslynGrpId" id="cmdidOpenRuleSet" priority="200" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpAnalyzerFolderContextMenu" />
         <Strings>
-          <ButtonText>&amp;Open Rule Set</ButtonText>
-          <CanonicalName>OpenRuleSet</CanonicalName>
-          <LocCanonicalName>OpenRuleSet</LocCanonicalName>
-          <CommandName>OpenRuleSet</CommandName>
+          <ButtonText>&amp;Open Active Rule Set</ButtonText>
+          <CanonicalName>OpenActiveRuleSet</CanonicalName>
+          <LocCanonicalName>OpenActiveRuleSet</LocCanonicalName>
+          <CommandName>OpenActiveRuleSet</CommandName>
         </Strings>
       </Button>
       <!-- Buttons to set severity of diagnostics -->

--- a/src/VisualStudio/Setup/Commands.vsct
+++ b/src/VisualStudio/Setup/Commands.vsct
@@ -50,6 +50,10 @@
         <Parent guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu"/>
       </Group>
 
+      <Group guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" priority="0x000">
+        <Parent guid="guidRoslynGrpId" id="cmdidSetSeveritySubMenu"/>
+      </Group>
+
       <Group guid="guidRoslynGrpId" id="grpDiagnosticProperties" priority="0x002">
         <Parent guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu"/>
       </Group>
@@ -201,7 +205,7 @@
       </Button>
       <!-- Buttons to set severity of diagnostics -->
       <Button guid="guidRoslynGrpId" id="cmdidSetSeverityError" priority="100" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Error</ButtonText>
           <CanonicalName>Error</CanonicalName>
@@ -210,7 +214,7 @@
         </Strings>
       </Button>
       <Button guid="guidRoslynGrpId" id="cmdidSetSeverityWarning" priority="200" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Warning</ButtonText>
           <CanonicalName>Warning</CanonicalName>
@@ -219,7 +223,7 @@
         </Strings>
       </Button>
       <Button guid="guidRoslynGrpId" id="cmdidSetSeverityInfo" priority="300" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Info</ButtonText>
           <CanonicalName>Info</CanonicalName>
@@ -228,7 +232,7 @@
         </Strings>
       </Button>
       <Button guid="guidRoslynGrpId" id="cmdidSetSeverityHidden" priority="400" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Hidden</ButtonText>
           <CanonicalName>Hidden</CanonicalName>
@@ -237,7 +241,7 @@
         </Strings>
       </Button>
       <Button guid="guidRoslynGrpId" id="cmdidSetSeverityNone" priority="500" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;None</ButtonText>
           <CanonicalName>None</CanonicalName>
@@ -314,6 +318,16 @@
           <ButtonText>Diagnostic</ButtonText>
           <CanonicalName>Diagnostic</CanonicalName>
           <LocCanonicalName>Diagnostic</LocCanonicalName>
+        </Strings>
+      </Menu>
+
+      <Menu guid="guidRoslynGrpId" id="cmdidSetSeveritySubMenu" priority="50" type="Menu">
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverity" />
+        <Strings>
+          <ButtonText>Set Rule Set Severity</ButtonText>
+          <CommandName>Set Rule Set Severity</CommandName>
+          <CanonicalName>Set Rule Set Severity</CanonicalName>
+          <LocCanonicalName>Set Rule Set Severity</LocCanonicalName>
         </Strings>
       </Menu>
     </Menus>
@@ -398,6 +412,8 @@
       <IDSymbol name="cmdidOpenDiagnosticHelpLink"    value="0x0116" />
       <IDSymbol name="grpSetActiveRuleSet"            value="0x0117" />
       <IDSymbol name="cmdidSetActiveRuleSet"          value="0x0118" />
+      <IDSymbol name="cmdidSetSeveritySubMenu"        value="0x0119" />
+      <IDSymbol name="grpDiagnosticSeverityItems"     value="0x011a" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
Fixes #619.

I suggest looking at the individual commits one at a time, from top to bottom. Each one is fairly small.

The major work here is to move the context menu items for setting a diagnostic's severity (Error, Warning, etc.) into a sub menu and making it clear that the check marks represent the severity in the rule set specifically, and clicking the menu items will update the rule set file.

Along the way I encountered other bugs I needed to fix to ensure the proper experience here.