### PR TITLE
Use cached true, false, and empty tasks in a handful of places

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             private readonly CancellationToken _cancellationToken;
             private readonly IAsynchronousOperationListener _asyncListener;
 
-            private Task<bool> _newIdentifierBindsTask = Task.FromResult(false);
+            private Task<bool> _newIdentifierBindsTask = SpecializedTasks.False;
 
             private readonly string _originalName;
             public string OriginalName { get { return _originalName; } }

--- a/src/Features/CSharp/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
+++ b/src/Features/CSharp/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.Async;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Roslyn.Utilities;
 using Resources = Microsoft.CodeAnalysis.CSharp.CSharpFeaturesResources;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
@@ -51,17 +52,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
                 case CS4016:
                     if (expression == null)
                     {
-                        return Task.FromResult<SyntaxNode>(null);
+                        return SpecializedTasks.Default<SyntaxNode>();
                     }
 
                     if (!IsCorrectReturnType(expression, semanticModel))
                     {
-                        return Task.FromResult<SyntaxNode>(null);
+                        return SpecializedTasks.Default<SyntaxNode>();
                     }
 
                     return Task.FromResult(root.ReplaceNode(oldNode, ConvertToAwaitExpression(expression)));
                 default:
-                    return Task.FromResult<SyntaxNode>(null);
+                    return SpecializedTasks.Default<SyntaxNode>();
             }
         }
 

--- a/src/Features/Core/Completion/AbstractCompletionService.cs
+++ b/src/Features/Core/Completion/AbstractCompletionService.cs
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return Task.FromResult(string.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, insertionText));
             }
 
-            return Task.FromResult((string)null);
+            return SpecializedTasks.Default<string>();
         }
 
         public virtual bool SupportSnippetCompletionListOnTab

--- a/src/Features/Core/Completion/CompletionItem.cs
+++ b/src/Features/Core/Completion/CompletionItem.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Completion
         public virtual Task<ImmutableArray<SymbolDisplayPart>> GetDescriptionAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.LazyDescription == null
-                ? Task.FromResult(ImmutableArray.Create<SymbolDisplayPart>())
+                ? SpecializedTasks.EmptyImmutableArray<SymbolDisplayPart>()
                 : this.LazyDescription.GetValueAsync(cancellationToken);
         }
 

--- a/src/Features/Core/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public override Task AnalyzeSyntaxAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
         {
             // No syntax diagnostics produced by the EnC engine.  
-            return Task.FromResult(false);
+            return SpecializedTasks.EmptyTask;
         }
 
         public override async Task AnalyzeSemanticsAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)

--- a/src/Features/Core/ExtractInterface/ExtractInterfaceCodeAction.cs
+++ b/src/Features/Core/ExtractInterface/ExtractInterfaceCodeAction.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
     {
         private readonly ExtractInterfaceTypeAnalysisResult _typeAnalysisResult;
         private readonly AbstractExtractInterfaceService _extractInterfaceService;
-        private readonly Task<IEnumerable<CodeActionOperation>> _taskReturningNoCodeActionOperations = Task.FromResult(SpecializedCollections.EmptyEnumerable<CodeActionOperation>());
+        private readonly Task<IEnumerable<CodeActionOperation>> _taskReturningNoCodeActionOperations = SpecializedTasks.EmptyEnumerable<CodeActionOperation>();
 
         public ExtractInterfaceCodeAction(AbstractExtractInterfaceService extractInterfaceService, ExtractInterfaceTypeAnalysisResult typeAnalysisResult)
         {

--- a/src/Features/Core/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.State.cs
+++ b/src/Features/Core/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.State.cs
@@ -42,14 +42,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 {
                     if (!TryInitializeImplicitConversion(service, document, node, cancellationToken))
                     {
-                        return Task.FromResult(false);
+                        return SpecializedTasks.False;
                     }
                 }
                 else if (service.IsExplicitConversionGeneration(node))
                 {
                     if (!TryInitializeExplicitConversion(service, document, node, cancellationToken))
                     {
-                        return Task.FromResult(false);
+                        return SpecializedTasks.False;
                     }
                 }
 

--- a/src/Features/Core/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
+++ b/src/Features/Core/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
@@ -58,14 +58,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 {
                     if (!TryInitializeExplicitInterface(service, document, node, cancellationToken))
                     {
-                        return Task.FromResult(false);
+                        return SpecializedTasks.False;
                     }
                 }
                 else if (service.IsSimpleNameGeneration(node))
                 {
                     if (!TryInitializeSimpleName(service, document, (TSimpleNameSyntax)node, cancellationToken))
                     {
-                        return Task.FromResult(false);
+                        return SpecializedTasks.False;
                     }
                 }
 

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -382,14 +382,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         if (project == null)
                         {
                             data.AsyncToken.Dispose();
-                            return Task.FromResult(true);
+                            return SpecializedTasks.EmptyTask;
                         }
 
                         if (!data.NeedDependencyTracking)
                         {
                             EnqueueWorkItem(project);
                             data.AsyncToken.Dispose();
-                            return Task.FromResult(true);
+                            return SpecializedTasks.EmptyTask;
                         }
 
                         // do dependency tracking here with current solution
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
 
                         data.AsyncToken.Dispose();
-                        return Task.FromResult(true);
+                        return SpecializedTasks.EmptyTask;
                     }
 
                     private Data Dequeue()

--- a/src/Interactive/Features/Interactive/InteractiveCommandCompletionService.cs
+++ b/src/Interactive/Features/Interactive/InteractiveCommandCompletionService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         public override Task<TextSpan> GetDefaultTrackingSpanAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            return Task.FromResult(default(TextSpan));
+            return SpecializedTasks.Default<TextSpan>();
         }
 
         protected override bool TriggerOnBackspace(SourceText text, int position, CompletionTriggerInfo triggerInfo, OptionSet options)

--- a/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
             {
                 editAction(e, d);
-                return Task.FromResult(true);
+                return SpecializedTasks.EmptyTask;
             },
             cancellationToken);
         }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.FromResult(true);
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }
@@ -448,7 +448,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.FromResult(true);
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.FromResult(true);
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis
             // immediately.
             if (!this.SupportsSyntaxTree)
             {
-                return Task.FromResult<SyntaxTree>(null);
+                return SpecializedTasks.Default<SyntaxTree>();
             }
 
             if (_syntaxTreeResultTask != null)


### PR DESCRIPTION
In a handful of places, Task.FromResult(true), Task.FromResult(false), and Task.FromResult(default(T)) were being used, even though equivalent cached tasks are available in SpecializedTasks.  This commit just changes those ~20 call sites to use already cached tasks.