### PR TITLE
Made auto-properties readonly where possible.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class MethodGroup
     {
         internal BoundExpression Receiver { get; private set; }
-        internal ArrayBuilder<MethodSymbol> Methods { get; private set; }
-        internal ArrayBuilder<TypeSymbol> TypeArguments { get; private set; }
+        internal ArrayBuilder<MethodSymbol> Methods { get; }
+        internal ArrayBuilder<TypeSymbol> TypeArguments { get; }
         internal bool IsExtensionMethodGroup { get; private set; }
         internal DiagnosticInfo Error { get; private set; }
         internal LookupResultKind ResultKind { get; private set; }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
     }
 
     internal partial class BoundUserDefinedConditionalLogicalOperator
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
     }
 
     internal partial class BoundUnaryOperator
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
     }
 
     internal partial class BoundIncrementOperator
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
     }
 
     internal partial class BoundCompoundAssignmentOperator
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
     }
 
     internal partial class BoundLiteral
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // will not be visiting or rewriting this error-recovery information.)
         //
         // DevDiv 1087283 tracks deciding whether or not to refactor this into BoundNodes.xml.
-        public ImmutableArray<MethodSymbol> OriginalUserDefinedConversionsOpt { get; private set; }
+        public ImmutableArray<MethodSymbol> OriginalUserDefinedConversionsOpt { get; }
 
         public override bool SuppressVirtualCalls
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundQueryClause.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundQueryClause.cs
@@ -15,18 +15,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The bound expression that invokes the operation of the query clause.
         /// </summary>
-        public BoundExpression Operation { get; private set; }
+        public BoundExpression Operation { get; }
 
         /// <summary>
         /// The bound expression that is the invocation of a "Cast" method specified by the query translation.
         /// </summary>
-        public BoundExpression Cast { get; private set; }
+        public BoundExpression Cast { get; }
 
         /// <summary>
         /// The bound expression that is the query expression in "unoptimized" form.  Specifically, a final ".Select"
         /// invocation that is omitted by the specification is included here.
         /// </summary>
-        public BoundExpression UnoptimizedForm { get; private set; }
+        public BoundExpression UnoptimizedForm { get; }
 
         public BoundQueryClause(
             CSharpSyntaxNode syntax,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilationReference.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilationReference.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Returns the referenced Compilation.
         /// </summary>
-        public new CSharpCompilation Compilation { get; private set; }
+        public new CSharpCompilation Compilation { get; }
 
         internal override Compilation CompilationCore
         {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -35,14 +35,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.Diagnostic = error;
             }
 
-            public Diagnostic Diagnostic { get; private set; }
+            public Diagnostic Diagnostic { get; }
         }
 
         public CSharpCompilation Compilation { get { return CompilationState.Compilation; } }
         public CSharpSyntaxNode Syntax { get; set; }
         public PEModuleBuilder ModuleBuilderOpt { get { return CompilationState.ModuleBuilderOpt; } }
-        public DiagnosticBag Diagnostics { get; private set; }
-        public TypeCompilationState CompilationState { get; private set; }
+        public DiagnosticBag Diagnostics { get; }
+        public TypeCompilationState CompilationState { get; }
 
         // Current enclosing type, or null if not available.
         private NamedTypeSymbol _currentType;

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.IsTransparent = isTransparent;
         }
 
-        internal bool IsTransparent { get; private set; }
+        internal bool IsTransparent { get; }
 
         public override string Name
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxAnnotationTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxAnnotationTests.cs
@@ -663,8 +663,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private class Collector : CSharpSyntaxWalker
         {
-            public List<SyntaxNodeOrToken> NodeOrTokens { get; private set; }
-            public List<SyntaxTrivia> Trivia { get; private set; }
+            public List<SyntaxNodeOrToken> NodeOrTokens { get; }
+            public List<SyntaxTrivia> Trivia { get; }
 
             public Collector()
                 : base(SyntaxWalkerDepth.StructuredTrivia)

--- a/src/Compilers/Core/Portable/Collections/Grouping.cs
+++ b/src/Compilers/Core/Portable/Collections/Grouping.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal class Grouping<TKey, TElement> : IGrouping<TKey, TElement>
     {
-        public TKey Key { get; private set; }
+        public TKey Key { get; }
         private readonly IEnumerable<TElement> _elements;
 
         public Grouping(TKey key, IEnumerable<TElement> elements)

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis
         /// Unless <see cref="CompilationOptions.ModuleName"/> specifies otherwise the module name
         /// written to metadata is <see cref="AssemblyName"/> with an extension based upon <see cref="CompilationOptions.OutputKind"/>.
         /// </remarks>
-        public string AssemblyName { get; private set; }
+        public string AssemblyName { get; }
 
         internal static void CheckAssemblyName(string assemblyName)
         {
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The type object that represents the type of submission result the host requested.
         /// </summary>
-        internal Type SubmissionReturnType { get; private set; }
+        internal Type SubmissionReturnType { get; }
 
         internal static bool IsValidSubmissionReturnType(Type type)
         {
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The type of the host object or null if not specified for this compilation.
         /// </summary>
-        internal Type HostObjectType { get; private set; }
+        internal Type HostObjectType { get; }
 
         internal static bool IsValidHostObjectType(Type type)
         {
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Metadata references passed to the compilation constructor.
         /// </summary>
-        public ImmutableArray<MetadataReference> ExternalReferences { get; private set; }
+        public ImmutableArray<MetadataReference> ExternalReferences { get; }
 
         /// <summary>
         /// Unique metadata references specified via #r directive in the source code of this compilation.

--- a/src/Compilers/Core/Portable/Compilation/PreprocessingSymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/PreprocessingSymbolInfo.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The symbol that was referred to by the identifier, if any. 
         /// </summary>
-        public IPreprocessingSymbol Symbol { get; private set; }
+        public IPreprocessingSymbol Symbol { get; }
 
         /// <summary>
         /// Returns true if this preprocessing symbol is defined at the identifier position.
         /// </summary>
-        public bool IsDefined { get; private set; }
+        public bool IsDefined { get; }
 
         internal PreprocessingSymbolInfo(IPreprocessingSymbol symbol, bool isDefined)
             : this()

--- a/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         /// still be that case that we have one or more "best guesses" as to what symbol was
         /// intended. These best guesses are available via the CandidateSymbols property.
         /// </summary>
-        public ISymbol Symbol { get; private set; }
+        public ISymbol Symbol { get; }
 
         /// <summary>
         /// If the expression did not successfully resolve to a symbol, but there were one or more
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
         /// symbols that may have been considered but discarded, this property describes why those
         /// symbol or symbols were not considered suitable.
         /// </summary>
-        public CandidateReason CandidateReason { get; private set; }
+        public CandidateReason CandidateReason { get; }
 
         internal SymbolInfo(ISymbol symbol)
             : this(symbol, ImmutableArray<ISymbol>.Empty, CandidateReason.None)

--- a/src/Compilers/Core/Portable/Compilation/TypeInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/TypeInfo.cs
@@ -15,13 +15,13 @@ namespace Microsoft.CodeAnalysis
         /// have a type, null is returned. If the type could not be determined due to an error, than
         /// an IErrorTypeSymbol is returned.
         /// </summary>
-        public ITypeSymbol Type { get; private set; }
+        public ITypeSymbol Type { get; }
 
         /// <summary>
         /// The type of the expression after it has undergone an implicit conversion. If the type
         /// did not undergo an implicit conversion, returns the same as Type.
         /// </summary>
-        public ITypeSymbol ConvertedType { get; private set; }
+        public ITypeSymbol ConvertedType { get; }
 
         internal TypeInfo(ITypeSymbol type, ITypeSymbol convertedType)
             : this()

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -17,48 +17,48 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// An unique identifier for the diagnostic.
         /// </summary>
-        public string Id { get; private set; }
+        public string Id { get; }
 
         /// <summary>
         /// A short localizable title describing the diagnostic.
         /// </summary>
-        public LocalizableString Title { get; private set; }
+        public LocalizableString Title { get; }
 
         /// <summary>
         /// An optional longer localizable description for the diagnostic.
         /// </summary>
-        public LocalizableString Description { get; private set; }
+        public LocalizableString Description { get; }
 
         /// <summary>
         /// An optional hyperlink that provides more detailed information regarding the diagnostic.
         /// </summary>
-        public string HelpLinkUri { get; private set; }
+        public string HelpLinkUri { get; }
 
         /// <summary>
         /// A localizable format message string, which can be passed as the first argument to <see cref="String.Format(string, object[])"/> when creating the diagnostic message with this descriptor.
         /// </summary>
         /// <returns></returns>
-        public LocalizableString MessageFormat { get; private set; }
+        public LocalizableString MessageFormat { get; }
 
         /// <summary>
         /// The category of the diagnostic (like Design, Naming etc.)
         /// </summary>
-        public string Category { get; private set; }
+        public string Category { get; }
 
         /// <summary>
         /// The default severity of the diagnostic.
         /// </summary>
-        public DiagnosticSeverity DefaultSeverity { get; private set; }
+        public DiagnosticSeverity DefaultSeverity { get; }
 
         /// <summary>
         /// Returns true if the diagnostic is enabled by default.
         /// </summary>
-        public bool IsEnabledByDefault { get; private set; }
+        public bool IsEnabledByDefault { get; }
 
         /// <summary>
         /// Custom tags for the diagnostic.
         /// </summary>
-        public IEnumerable<string> CustomTags { get; private set; }
+        public IEnumerable<string> CustomTags { get; }
 
         /// <summary>
         /// Create a DiagnosticDescriptor, which provides description about a <see cref="Diagnostic"/>.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public AsyncQueue<CompilationEvent> CompilationEventQueue
         {
-            get; private set;
+            get;
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public AsyncQueue<Diagnostic> DiagnosticQueue
         {
-            get; private set;
+            get;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationEvent.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             this.Compilation = compilation;
         }
 
-        public Compilation Compilation { get; private set; }
+        public Compilation Compilation { get; }
 
         /// <summary>
         /// Flush any cached data in this <see cref="CompilationEvent"/> to minimize space usage (at the possible expense of time later).

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
         }
 
-        public SyntaxTree CompilationUnit { get; private set; }
+        public SyntaxTree CompilationUnit { get; }
         public override string ToString()
         {
             return "CompilationUnitCompletedEvent(" + CompilationUnit.FilePath + ")";

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzerAttribute.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzerAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// The source languages to which this analyzer applies.  See <see cref="LanguageNames"/>.
         /// </summary>
-        public string[] Languages { get; private set; }
+        public string[] Languages { get; }
 
         /// <summary>
         /// Attribute constructor used to specify automatic application of a diagnostic analyzer.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             _lazySemanticModel = lazySemanticModel;
         }
-        public ISymbol Symbol { get; private set; }
+        public ISymbol Symbol { get; }
 
         // At most one of these should be non-null.
         private Lazy<SemanticModel> _lazySemanticModel;

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
     /// </remarks>
     public abstract class MetadataReference
     {
-        public MetadataReferenceProperties Properties { get; private set; }
+        public MetadataReferenceProperties Properties { get; }
 
         internal MetadataReference(MetadataReferenceProperties properties)
         {

--- a/src/Compilers/Core/Portable/MetadataReference/UnresolvedMetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/UnresolvedMetadataReference.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
     /// </remarks>
     public sealed class UnresolvedMetadataReference : MetadataReference
     {
-        public string Reference { get; private set; }
+        public string Reference { get; }
 
         internal UnresolvedMetadataReference(string reference, MetadataReferenceProperties properties)
             : base(properties)

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
@@ -246,63 +246,63 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Determines how the global namespace is displayed.
         /// </summary>
-        public SymbolDisplayGlobalNamespaceStyle GlobalNamespaceStyle { get; private set; }
+        public SymbolDisplayGlobalNamespaceStyle GlobalNamespaceStyle { get; }
 
         /// <summary>
         /// Determines how types are qualified (e.g. Nested vs Containing.Nested vs Namespace.Containing.Nested).
         /// </summary>
-        public SymbolDisplayTypeQualificationStyle TypeQualificationStyle { get; private set; }
+        public SymbolDisplayTypeQualificationStyle TypeQualificationStyle { get; }
 
         /// <summary>
         /// Determines how generics (on types and methods) should be described (i.e. the level of detail).
         /// </summary>
-        public SymbolDisplayGenericsOptions GenericsOptions { get; private set; }
+        public SymbolDisplayGenericsOptions GenericsOptions { get; }
 
         /// <summary>
         /// Determines how fields, properties, events, and methods are displayed.
         /// </summary>
-        public SymbolDisplayMemberOptions MemberOptions { get; private set; }
+        public SymbolDisplayMemberOptions MemberOptions { get; }
 
         /// <summary>
         /// Determines how parameters (of methods, properties/indexers, and delegates) are displayed.
         /// </summary>
-        public SymbolDisplayParameterOptions ParameterOptions { get; private set; }
+        public SymbolDisplayParameterOptions ParameterOptions { get; }
 
         /// <summary>
         /// Determines how delegates are displayed (e.g. name vs full signature).
         /// </summary>
-        public SymbolDisplayDelegateStyle DelegateStyle { get; private set; }
+        public SymbolDisplayDelegateStyle DelegateStyle { get; }
 
         /// <summary>
         /// Determines how extension methods are displayed.
         /// </summary>
-        public SymbolDisplayExtensionMethodStyle ExtensionMethodStyle { get; private set; }
+        public SymbolDisplayExtensionMethodStyle ExtensionMethodStyle { get; }
 
         /// <summary>
         /// Determines how properties are displayed. 
         /// For example, "Prop" vs "Prop { get; set; }" in C# or "Prop" vs. "ReadOnly Prop" in Visual Basic.
         /// </summary>
-        public SymbolDisplayPropertyStyle PropertyStyle { get; private set; }
+        public SymbolDisplayPropertyStyle PropertyStyle { get; }
 
         /// <summary>
         /// Determines how local variables are displayed.
         /// </summary>
-        public SymbolDisplayLocalOptions LocalOptions { get; private set; }
+        public SymbolDisplayLocalOptions LocalOptions { get; }
 
         /// <summary>
         /// Determines which kind keywords should be included when displaying symbols.
         /// </summary>
-        public SymbolDisplayKindOptions KindOptions { get; private set; }
+        public SymbolDisplayKindOptions KindOptions { get; }
 
         /// <summary>
         /// Determines other characteristics of how symbols are displayed.
         /// </summary>
-        public SymbolDisplayMiscellaneousOptions MiscellaneousOptions { get; private set; }
+        public SymbolDisplayMiscellaneousOptions MiscellaneousOptions { get; }
 
         /// <summary>
         /// Flags that can only be set within the compiler.
         /// </summary>
-        internal SymbolDisplayCompilerInternalOptions CompilerInternalOptions { get; private set; }
+        internal SymbolDisplayCompilerInternalOptions CompilerInternalOptions { get; }
 
         /// <summary>
         /// Constructs a new instance of <see cref="SymbolDisplayFormat"/> accepting a variety of optional parameters.

--- a/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis
         private static long s_nextId;
 
         // use a value identity instead of object identity so a deserialized instance matches the original instance.
-        public string Kind { get; private set; }
-        public string Data { get; private set; }
+        public string Kind { get; }
+        public string Data { get; }
 
         public SyntaxAnnotation()
         {

--- a/src/Compilers/Core/Portable/Text/TextChange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChange.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// The original span of the changed text. 
         /// </summary>
-        public TextSpan Span { get; private set; }
+        public TextSpan Span { get; }
 
         /// <summary>
         /// The new text.
         /// </summary>
-        public string NewText { get; private set; }
+        public string NewText { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextChange"/>

--- a/src/Compilers/Core/Portable/Text/TextChangeEventArgs.cs
+++ b/src/Compilers/Core/Portable/Text/TextChangeEventArgs.cs
@@ -45,16 +45,16 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Gets the text before the change.
         /// </summary>
-        public SourceText OldText { get; private set; }
+        public SourceText OldText { get; }
 
         /// <summary>
         /// Gets the text after the change.
         /// </summary>
-        public SourceText NewText { get; private set; }
+        public SourceText NewText { get; }
 
         /// <summary>
         /// Gets the set of ranges for the change.
         /// </summary>
-        public IReadOnlyList<TextChangeRange> Changes { get; private set; }
+        public IReadOnlyList<TextChangeRange> Changes { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Text/TextChangeRange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChangeRange.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// The span of text before the edit which is being changed
         /// </summary>
-        public TextSpan Span { get; private set; }
+        public TextSpan Span { get; }
 
         /// <summary>
         /// Width of the span after the edit.  A 0 here would represent a delete
         /// </summary>
-        public int NewLength { get; private set; }
+        public int NewLength { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextChangeRange"/>.

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -208,9 +208,9 @@ namespace Microsoft.CodeAnalysis
         }
 
         public TreeDumperNode(string text) : this(text, null, null) { }
-        public object Value { get; private set; }
-        public string Text { get; private set; }
-        public IEnumerable<TreeDumperNode> Children { get; private set; }
+        public object Value { get; }
+        public string Text { get; }
+        public IEnumerable<TreeDumperNode> Children { get; }
         public TreeDumperNode this[string child]
         {
             get

--- a/src/Diagnostics/FxCop/Core/Globalization/CA1309DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Globalization/CA1309DiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Globalization
 
         protected abstract class AbstractCodeBlockAnalyzer
         {
-            protected INamedTypeSymbol StringComparisonType { get; private set; }
+            protected INamedTypeSymbol StringComparisonType { get; }
 
             public AbstractCodeBlockAnalyzer(INamedTypeSymbol stringComparisonType)
             {

--- a/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
+++ b/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EncapsulateField
     internal class EncapsulateFieldTestState : IDisposable
     {
         private TestHostDocument _testDocument;
-        public TestWorkspace Workspace { get; private set; }
-        public Document TargetDocument { get; private set; }
+        public TestWorkspace Workspace { get; }
+        public Document TargetDocument { get; }
         public string NotificationMessage { get; private set; }
 
         private static readonly ExportProvider s_exportProvider = MinimalTestExportProvider.CreateExportProvider(

--- a/src/EditorFeatures/Core/CommandArgs.cs
+++ b/src/EditorFeatures/Core/CommandArgs.cs
@@ -14,12 +14,12 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// The text buffer of where the caret is when the command happens.
         /// </summary>
-        public ITextBuffer SubjectBuffer { get; private set; }
+        public ITextBuffer SubjectBuffer { get; }
 
         /// <summary>
         /// The text view that originated this command.
         /// </summary>
-        public ITextView TextView { get; private set; }
+        public ITextView TextView { get; }
 
         public CommandArgs(ITextView textView, ITextBuffer subjectBuffer)
         {

--- a/src/EditorFeatures/Core/CommandState.cs
+++ b/src/EditorFeatures/Core/CommandState.cs
@@ -10,17 +10,17 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// If true, the command should be visible and enabled in the UI.
         /// </summary>
-        public bool IsAvailable { get; private set; }
+        public bool IsAvailable { get; }
 
         /// <summary>
         /// If true, the command should appear as checked (i.e. toggled) in the UI.
         /// </summary>
-        public bool IsChecked { get; private set; }
+        public bool IsChecked { get; }
 
         /// <summary>
         /// If specified, returns the custom text that should be displayed in the UI.
         /// </summary>
-        public string DisplayText { get; private set; }
+        public string DisplayText { get; }
 
         public CommandState(bool isAvailable = false, bool isChecked = false, string displayText = null)
             : this()

--- a/src/EditorFeatures/Core/ContentTypeLanguageMetadata.cs
+++ b/src/EditorFeatures/Core/ContentTypeLanguageMetadata.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class ContentTypeLanguageMetadata : LanguageMetadata
     {
-        public string DefaultContentType { get; private set; }
+        public string DefaultContentType { get; }
 
         public ContentTypeLanguageMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/EditorFeatures/Core/DocumentSnapshotSpan.cs
+++ b/src/EditorFeatures/Core/DocumentSnapshotSpan.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// The <see cref="CodeAnalysis.Document"/> the span was produced from.
         /// </summary>
-        public Document Document { get; private set; }
+        public Document Document { get; }
 
         /// <summary>
         /// The editor <see cref="VisualStudio.Text.SnapshotSpan"/>.
         /// </summary>
-        public SnapshotSpan SnapshotSpan { get; private set; }
+        public SnapshotSpan SnapshotSpan { get; }
 
         /// <summary>
         /// Creates a new <see cref="DocumentSnapshotSpan"/>.

--- a/src/EditorFeatures/Core/Extensibility/BraceMatching/ExportBraceMatcherAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/BraceMatching/ExportBraceMatcherAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportBraceMatcherAttribute : ExportAttribute
     {
-        public string Language { get; private set; }
+        public string Language { get; }
 
         public ExportBraceMatcherAttribute(string language)
             : base(typeof(IBraceMatcher))

--- a/src/EditorFeatures/Core/Extensibility/Commands/ExportCommandHandlerAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/ExportCommandHandlerAttribute.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportCommandHandlerAttribute : ExportAttribute
     {
-        public string Name { get; private set; }
-        public IEnumerable<string> ContentTypes { get; private set; }
+        public string Name { get; }
+        public IEnumerable<string> ContentTypes { get; }
 
         public ExportCommandHandlerAttribute(string name, params string[] contentTypes) :
             base(typeof(ICommandHandler))

--- a/src/EditorFeatures/Core/Extensibility/Completion/CompletionItemEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/CompletionItemEventArgs.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class CompletionItemEventArgs : EventArgs
     {
-        public CompletionItem CompletionItem { get; private set; }
+        public CompletionItem CompletionItem { get; }
 
         public CompletionItemEventArgs(CompletionItem completionItem)
         {

--- a/src/EditorFeatures/Core/Extensibility/Completion/ExportCompletionProviderAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ExportCompletionProviderAttribute.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportCompletionProviderAttribute : ExportAttribute
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public ExportCompletionProviderAttribute(string name, string language)
             : base(typeof(ICompletionProvider))

--- a/src/EditorFeatures/Core/Extensibility/Composition/ContentTypeMetadata.cs
+++ b/src/EditorFeatures/Core/Extensibility/Composition/ContentTypeMetadata.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class ContentTypeMetadata : IContentTypeMetadata
     {
-        public IEnumerable<string> ContentTypes { get; private set; }
+        public IEnumerable<string> ContentTypes { get; }
 
         public ContentTypeMetadata(IDictionary<string, object> data)
         {

--- a/src/EditorFeatures/Core/Extensibility/Composition/OrderableContentTypeMetadata.cs
+++ b/src/EditorFeatures/Core/Extensibility/Composition/OrderableContentTypeMetadata.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class OrderableContentTypeMetadata : OrderableMetadata, IContentTypeMetadata
     {
-        public IEnumerable<string> ContentTypes { get; private set; }
+        public IEnumerable<string> ContentTypes { get; }
 
         public OrderableContentTypeMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/EditorFeatures/Core/Extensibility/Highlighting/ExportHighlighterAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Highlighting/ExportHighlighterAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor
     [ExcludeFromCodeCoverage]
     internal class ExportHighlighterAttribute : ExportAttribute
     {
-        public string Language { get; private set; }
+        public string Language { get; }
 
         public ExportHighlighterAttribute(string language)
             : base(typeof(IHighlighter))

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class NavigationBarItem
     {
-        public string Text { get; private set; }
-        public Glyph Glyph { get; private set; }
-        public bool Bolded { get; private set; }
-        public bool Grayed { get; private set; }
-        public int Indent { get; private set; }
-        public IList<NavigationBarItem> ChildItems { get; private set; }
+        public string Text { get; }
+        public Glyph Glyph { get; }
+        public bool Bolded { get; }
+        public bool Grayed { get; }
+        public int Indent { get; }
+        public IList<NavigationBarItem> ChildItems { get; }
 
         public IList<TextSpan> Spans { get; internal set; }
         internal IList<ITrackingSpan> TrackingSpans { get; set; }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItemSelectedEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItemSelectedEventArgs.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal sealed class NavigationBarItemSelectedEventArgs : EventArgs
     {
-        public NavigationBarItem Item { get; private set; }
+        public NavigationBarItem Item { get; }
 
         public NavigationBarItemSelectedEventArgs(NavigationBarItem item)
         {

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal sealed class NavigationBarProjectItem : NavigationBarItem
     {
-        public DocumentId DocumentId { get; private set; }
-        public Workspace Workspace { get; private set; }
-        public string Language { get; private set; }
+        public DocumentId DocumentId { get; }
+        public Workspace Workspace { get; }
+        public string Language { get; }
 
         public NavigationBarProjectItem(
             string text,

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSelectedItems.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSelectedItems.cs
@@ -4,10 +4,10 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class NavigationBarSelectedTypeAndMember
     {
-        public NavigationBarItem TypeItem { get; private set; }
-        public bool ShowTypeItemGrayed { get; private set; }
-        public NavigationBarItem MemberItem { get; private set; }
-        public bool ShowMemberItemGrayed { get; private set; }
+        public NavigationBarItem TypeItem { get; }
+        public bool ShowTypeItemGrayed { get; }
+        public NavigationBarItem MemberItem { get; }
+        public bool ShowMemberItemGrayed { get; }
 
         public NavigationBarSelectedTypeAndMember(NavigationBarItem typeItem, NavigationBarItem memberItem)
         {

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSymbolItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSymbolItem.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor.Extensibility.NavigationBar
 {
     internal class NavigationBarSymbolItem : NavigationBarItem
     {
-        public SymbolKey NavigationSymbolId { get; private set; }
-        public int? NavigationSymbolIndex { get; private set; }
+        public SymbolKey NavigationSymbolId { get; }
+        public int? NavigationSymbolIndex { get; }
 
         public NavigationBarSymbolItem(
             string text,

--- a/src/EditorFeatures/Core/Extensibility/QuickInfo/ExportQuickInfoProviderAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/QuickInfo/ExportQuickInfoProviderAttribute.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Editor
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportQuickInfoProviderAttribute : ExportAttribute
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public ExportQuickInfoProviderAttribute(string name, string language)
             : base(typeof(IQuickInfoProvider))

--- a/src/EditorFeatures/Core/Extensibility/QuickInfo/QuickInfoItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/QuickInfo/QuickInfoItem.cs
@@ -6,8 +6,8 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class QuickInfoItem
     {
-        public TextSpan TextSpan { get; private set; }
-        public IDeferredQuickInfoContent Content { get; private set; }
+        public TextSpan TextSpan { get; }
+        public IDeferredQuickInfoContent Content { get; }
 
         public QuickInfoItem(TextSpan textSpan, IDeferredQuickInfoContent content)
         {

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/ExportSignatureHelpProviderAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/ExportSignatureHelpProviderAttribute.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Editor
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportSignatureHelpProviderAttribute : ExportAttribute
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public ExportSignatureHelpProviderAttribute(string name, string language)
             : base(typeof(ISignatureHelpProvider))

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItemEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItemEventArgs.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class SignatureHelpItemEventArgs : EventArgs
     {
-        public SignatureHelpItem SignatureHelpItem { get; private set; }
+        public SignatureHelpItem SignatureHelpItem { get; }
 
         public SignatureHelpItemEventArgs(SignatureHelpItem signatureHelpItem)
         {

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
@@ -12,26 +12,26 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// The list of items to present to the user.
         /// </summary>
-        public IList<SignatureHelpItem> Items { get; private set; }
+        public IList<SignatureHelpItem> Items { get; }
 
         /// <summary>
         /// The span this session applies to.
         /// 
         /// Navigation outside this span will cause signature help to be dismissed.
         /// </summary>
-        public TextSpan ApplicableSpan { get; private set; }
+        public TextSpan ApplicableSpan { get; }
 
         /// <summary>
         /// Returns the specified argument index that the provided position is at in the current document.  This 
         /// index may be greater than the number of arguments in the selected <see cref="SignatureHelpItem"/>.
         /// </summary>
-        public int ArgumentIndex { get; private set; }
+        public int ArgumentIndex { get; }
 
         /// <summary>
         /// Returns the total number of arguments that have been typed in the current document.  This may be 
         /// greater than the ArgumentIndex if there are additional arguments after the provided position.
         /// </summary>
-        public int ArgumentCount { get; private set; }
+        public int ArgumentCount { get; }
 
         /// <summary>
         /// Returns the name of specified argument at the current position in the document.  
@@ -41,14 +41,14 @@ namespace Microsoft.CodeAnalysis.Editor
         /// This value is used to determine which documentation comment should be provided for the current
         /// parameter.  Normally this is determined simply by determining the parameter by index.
         /// </summary>
-        public string ArgumentName { get; private set; }
+        public string ArgumentName { get; }
 
         /// <summary>
         /// The item to select by default.  If this is <code>null</code> then the controller will
         /// pick the first item that has enough arguments to be viable based on what argument 
         /// position the user is currently inside of.
         /// </summary>
-        public int? SelectedItemIndex { get; private set; }
+        public int? SelectedItemIndex { get; }
 
         public SignatureHelpItems(
             IList<SignatureHelpItem> items,

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpTriggerInfo.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpTriggerInfo.cs
@@ -6,8 +6,8 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal struct SignatureHelpTriggerInfo
     {
-        public SignatureHelpTriggerReason TriggerReason { get; private set; }
-        public char? TriggerCharacter { get; private set; }
+        public SignatureHelpTriggerReason TriggerReason { get; }
+        public char? TriggerCharacter { get; }
 
         internal SignatureHelpTriggerInfo(SignatureHelpTriggerReason triggerReason, char? triggerCharacter = null)
             : this()

--- a/src/EditorFeatures/Core/Extensibility/TaskList/TaskListEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/TaskList/TaskListEventArgs.cs
@@ -10,32 +10,32 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// The identity of task item group. 
         /// </summary>
-        public object Id { get; private set; }
+        public object Id { get; }
 
         /// <summary>
         /// task item type
         /// </summary>
-        public string TaskListType { get; private set; }
+        public string TaskListType { get; }
 
         /// <summary>
         /// Workspace this task items are associated with
         /// </summary>
-        public Workspace Workspace { get; private set; }
+        public Workspace Workspace { get; }
 
         /// <summary>
         /// projectId this task items are associated with
         /// </summary>
-        public ProjectId ProjectId { get; private set; }
+        public ProjectId ProjectId { get; }
 
         /// <summary>
         /// documentId this task items are associated with
         /// </summary>
-        public DocumentId DocumentId { get; private set; }
+        public DocumentId DocumentId { get; }
 
         /// <summary>
         /// The task items associated with the ID.
         /// </summary>
-        public ImmutableArray<ITaskItem> TaskItems { get; private set; }
+        public ImmutableArray<ITaskItem> TaskItems { get; }
 
         public TaskListEventArgs(
             object id, string type,

--- a/src/EditorFeatures/Core/IBraceMatchingService.cs
+++ b/src/EditorFeatures/Core/IBraceMatchingService.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal struct BraceMatchingResult
     {
-        public TextSpan LeftSpan { get; private set; }
-        public TextSpan RightSpan { get; private set; }
+        public TextSpan LeftSpan { get; }
+        public TextSpan RightSpan { get; }
 
         public BraceMatchingResult(TextSpan leftSpan, TextSpan rightSpan)
             : this()

--- a/src/EditorFeatures/Core/IInlineRenameSession.cs
+++ b/src/EditorFeatures/Core/IInlineRenameSession.cs
@@ -9,18 +9,18 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <summary>
         /// Whether or not the entity at the selected location can be renamed.
         /// </summary>
-        public bool CanRename { get; private set; }
+        public bool CanRename { get; }
 
         /// <summary>
         /// Provides the reason that can be displayed to the user if the entity at the selected 
         /// location cannot be renamed.
         /// </summary>
-        public string LocalizedErrorMessage { get; private set; }
+        public string LocalizedErrorMessage { get; }
 
         /// <summary>
         /// The session created if it was possible to rename the entity.
         /// </summary>
-        public IInlineRenameSession Session { get; private set; }
+        public IInlineRenameSession Session { get; }
 
         internal InlineRenameSessionInfo(string localizedErrorMessage)
         {

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
         {
             #region Private Members
 
-            public char OpeningBrace { get; private set; }
-            public char ClosingBrace { get; private set; }
+            public char OpeningBrace { get; }
+            public char ClosingBrace { get; }
             public ITrackingPoint OpeningPoint { get; private set; }
             public ITrackingPoint ClosingPoint { get; private set; }
-            public ITextBuffer SubjectBuffer { get; private set; }
-            public ITextView TextView { get; private set; }
+            public ITextBuffer SubjectBuffer { get; }
+            public ITextView TextView { get; }
 
             private readonly ITextUndoHistory _undoHistory;
             private readonly IEditorOperations _editorOperations;

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/Sessions/AbstractTokenBraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/Sessions/AbstractTokenBraceCompletionSession.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion.Sessi
     {
         private readonly ISyntaxFactsService _syntaxFactsService;
 
-        protected int OpeningTokenKind { get; private set; }
-        protected int ClosingTokenKind { get; private set; }
+        protected int OpeningTokenKind { get; }
+        protected int ClosingTokenKind { get; }
 
         protected AbstractTokenBraceCompletionSession(
             ISyntaxFactsService syntaxFactsService,

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceCharacterAndKind.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceCharacterAndKind.cs
@@ -4,8 +4,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
 {
     internal struct BraceCharacterAndKind
     {
-        public char Character { get; private set; }
-        public int Kind { get; private set; }
+        public char Character { get; }
+        public int Kind { get; }
 
         public BraceCharacterAndKind(char character, int kind)
             : this()

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightTag.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightTag.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
         public static readonly BraceHighlightTag StartTag = new BraceHighlightTag(navigateToStart: true);
         public static readonly BraceHighlightTag EndTag = new BraceHighlightTag(navigateToStart: false);
 
-        public bool NavigateToStart { get; private set; }
+        public bool NavigateToStart { get; }
 
         private BraceHighlightTag(bool navigateToStart)
             : base(TagId)

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
     internal partial class CallHierarchyProvider
     {
         private readonly IAsynchronousOperationListener _asyncListener;
-        public IGlyphService GlyphService { get; private set; }
+        public IGlyphService GlyphService { get; }
 
         [ImportingConstructor]
         public CallHierarchyProvider(

--- a/src/EditorFeatures/Core/Implementation/Debugging/BreakpointResolutionResult.cs
+++ b/src/EditorFeatures/Core/Implementation/Debugging/BreakpointResolutionResult.cs
@@ -7,10 +7,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Debugging
 {
     internal class BreakpointResolutionResult
     {
-        public Document Document { get; private set; }
-        public TextSpan TextSpan { get; private set; }
-        public string LocationNameOpt { get; private set; }
-        public bool IsLineBreakpoint { get; private set; }
+        public Document Document { get; }
+        public TextSpan TextSpan { get; }
+        public string LocationNameOpt { get; }
+        public bool IsLineBreakpoint { get; }
 
         private BreakpointResolutionResult(Document document, TextSpan textSpan, string locationNameOpt, bool isLineBreakpoint)
         {

--- a/src/EditorFeatures/Core/Implementation/ITextBufferAssociatedViewService.cs
+++ b/src/EditorFeatures/Core/Implementation/ITextBufferAssociatedViewService.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal class SubjectBuffersConnectedEventArgs
     {
-        public ReadOnlyCollection<ITextBuffer> SubjectBuffers { get; private set; }
-        public IWpfTextView TextView { get; private set; }
+        public ReadOnlyCollection<ITextBuffer> SubjectBuffers { get; }
+        public IWpfTextView TextView { get; }
 
         public SubjectBuffersConnectedEventArgs(IWpfTextView textView, ReadOnlyCollection<ITextBuffer> subjectBuffers)
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public bool HasOverloads { get { return false; } }
 
-            public string LocalizedErrorMessage { get; private set; }
+            public string LocalizedErrorMessage { get; }
 
             public TextSpan TriggerSpan { get { return default(TextSpan); } }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             private readonly RenameLocationSet _renameLocationSet;
             private readonly SymbolInlineRenameInfo _renameInfo;
 
-            public IList<InlineRenameLocation> Locations { get; private set; }
+            public IList<InlineRenameLocation> Locations { get; }
 
             public InlineRenameLocationSet(SymbolInlineRenameInfo renameInfo, RenameLocationSet renameLocationSet)
             {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -40,11 +40,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             private readonly bool _shortenedTriggerSpan;
             private readonly bool _isRenamingAttributePrefix;
 
-            public bool CanRename { get; private set; }
-            public string LocalizedErrorMessage { get; private set; }
-            public TextSpan TriggerSpan { get; private set; }
-            public ISymbol RenameSymbol { get; private set; }
-            public bool HasOverloads { get; private set; }
+            public bool CanRename { get; }
+            public string LocalizedErrorMessage { get; }
+            public TextSpan TriggerSpan { get; }
+            public ISymbol RenameSymbol { get; }
+            public bool HasOverloads { get; }
 
             public SymbolInlineRenameInfo(
                 IEnumerable<IRefactorNotifyService> refactorNotifyServices, Document document, TextSpan triggerSpan, ISymbol renameSymbol, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/RenameShortcutKeys.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/RenameShortcutKeys.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal class RenameShortcutKey
     {
-        public static string RenameOverloads { get; private set; }
-        public static string SearchInStrings { get; private set; }
-        public static string SearchInComments { get; private set; }
-        public static string PreviewChanges { get; private set; }
-        public static string Apply { get; private set; }
+        public static string RenameOverloads { get; }
+        public static string SearchInStrings { get; }
+        public static string SearchInComments { get; }
+        public static string PreviewChanges { get; }
+        public static string Apply { get; }
 
         static RenameShortcutKey()
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal struct InlineRenameLocation
     {
-        public Document Document { get; private set; }
-        public TextSpan TextSpan { get; private set; }
+        public Document Document { get; }
+        public TextSpan TextSpan { get; }
 
         public InlineRenameLocation(Document document, TextSpan textSpan) : this()
         {
@@ -39,9 +39,9 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal struct InlineRenameReplacement
     {
-        public InlineRenameReplacementKind Kind { get; private set; }
-        public TextSpan OriginalSpan { get; private set; }
-        public TextSpan NewSpan { get; private set; }
+        public InlineRenameReplacementKind Kind { get; }
+        public TextSpan OriginalSpan { get; }
+        public TextSpan NewSpan { get; }
 
         public InlineRenameReplacement(InlineRenameReplacementKind kind, TextSpan originalSpan, TextSpan newSpan) : this()
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.PreviousSession = previousSession;
             }
 
-            public InlineRenameSession PreviousSession { get; private set; }
+            public InlineRenameSession PreviousSession { get; }
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/CompletionProviders/MemberInsertingCompletionItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/CompletionProviders/MemberInsertingCompletionItem.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.C
 {
     internal class MemberInsertionCompletionItem : CompletionItem
     {
-        public DeclarationModifiers Modifiers { get; private set; }
-        public int Line { get; private set; }
-        public SymbolKey SymbolId { get; private set; }
-        public SyntaxToken Token { get; private set; }
+        public DeclarationModifiers Modifiers { get; }
+        public int Line { get; }
+        public SymbolKey SymbolId { get; }
+        public SyntaxToken Token { get; }
 
         public MemberInsertionCompletionItem(
             ICompletionProvider provider,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/DescriptionModifyingCompletionItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/DescriptionModifyingCompletionItem.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         private ICompletionService _completionService;
         private Workspace _workspace;
 
-        public CompletionItem CompletionItem { get; private set; }
+        public CompletionItem CompletionItem { get; }
 
         public DescriptionModifyingCompletionItem(CompletionItem completionItem, ICompletionService completionService, Workspace workspace)
             : base(default(ICompletionProvider),

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -18,29 +18,29 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         private readonly DisconnectedBufferGraph _disconnectedBufferGraph;
         public ITextSnapshot TriggerSnapshot { get { return _disconnectedBufferGraph.SubjectBufferSnapshot; } }
 
-        public IList<CompletionItem> TotalItems { get; private set; }
-        public IList<CompletionItem> FilteredItems { get; private set; }
+        public IList<CompletionItem> TotalItems { get; }
+        public IList<CompletionItem> FilteredItems { get; }
 
-        public CompletionItem SelectedItem { get; private set; }
-        public bool IsHardSelection { get; private set; }
-        public bool IsUnique { get; private set; }
+        public CompletionItem SelectedItem { get; }
+        public bool IsHardSelection { get; }
+        public bool IsUnique { get; }
 
         // The CompletionItem the model will use to represent selecting
         // and interacting with the builder. This CompletionItem includes
         // the language specific default tracking span for completion
         // as determined by CompletionUtilites for that language.
         // All models always have a DefaultBuilder set.
-        public CompletionItem DefaultBuilder { get; private set; }
+        public CompletionItem DefaultBuilder { get; }
 
         // The builder, if any, provided by the model's completionproviders.
-        public CompletionItem Builder { get; private set; }
-        public CompletionTriggerInfo TriggerInfo { get; private set; }
-        public bool UseSuggestionCompletionMode { get; private set; }
+        public CompletionItem Builder { get; }
+        public CompletionTriggerInfo TriggerInfo { get; }
+        public bool UseSuggestionCompletionMode { get; }
 
         // When committing a completion item, the span replaced ends at this point.
-        public ITrackingPoint CommitTrackingSpanEndPoint { get; private set; }
+        public ITrackingPoint CommitTrackingSpanEndPoint { get; }
 
-        public bool DismissIfEmpty { get; private set; }
+        public bool DismissIfEmpty { get; }
 
         private Model(
             DisconnectedBufferGraph disconnectedBufferGraph,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Model.cs
@@ -10,10 +10,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal class Model
     {
-        public ITextVersion TextVersion { get; private set; }
-        public QuickInfoItem Item { get; private set; }
-        public IQuickInfoProvider Provider { get; private set; }
-        public bool TrackMouse { get; private set; }
+        public ITextVersion TextVersion { get; }
+        public QuickInfoItem Item { get; }
+        public IQuickInfoProvider Provider { get; }
+        public bool TrackMouse { get; }
 
         public Model(
             ITextVersion textVersion,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/QuickInfoDisplayPanel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/QuickInfoDisplayPanel.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal class QuickInfoDisplayPanel : StackPanel
     {
-        internal TextBlock MainDescription { get; private set; }
-        internal TextBlock Documentation { get; private set; }
-        internal TextBlock TypeParameterMap { get; private set; }
-        internal TextBlock AnonymousTypes { get; private set; }
-        internal TextBlock UsageText { get; private set; }
+        internal TextBlock MainDescription { get; }
+        internal TextBlock Documentation { get; }
+        internal TextBlock TypeParameterMap { get; }
+        internal TextBlock AnonymousTypes { get; }
+        internal TextBlock UsageText { get; }
 
         public QuickInfoDisplayPanel(
             FrameworkElement symbolGlyph,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
@@ -10,14 +10,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         where TPresenterSession : IIntelliSensePresenterSession
         where TController : IController<TModel>
     {
-        public TController Controller { get; private set; }
-        public ModelComputation<TModel> Computation { get; private set; }
+        public TController Controller { get; }
+        public ModelComputation<TModel> Computation { get; }
 
         // The presenter session for the computation we've got going.  It's lifetime is tied 1:1 with
         // the computation.  When the computation starts we make a presenter (note: this does not
         // mean that the user will ever see any UI), and when the computation is stopped, we will
         // end the presentation session.
-        public TPresenterSession PresenterSession { get; private set; }
+        public TPresenterSession PresenterSession { get; }
 
         public Session(TController controller, ModelComputation<TModel> computation, TPresenterSession presenterSession)
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Model.cs
@@ -15,14 +15,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
     {
         private readonly DisconnectedBufferGraph _disconnectedBufferGraph;
 
-        public TextSpan TextSpan { get; private set; }
-        public IList<SignatureHelpItem> Items { get; private set; }
-        public SignatureHelpItem SelectedItem { get; private set; }
-        public int ArgumentIndex { get; private set; }
-        public int ArgumentCount { get; private set; }
-        public string ArgumentName { get; private set; }
-        public int? SelectedParameter { get; private set; }
-        public ISignatureHelpProvider Provider { get; private set; }
+        public TextSpan TextSpan { get; }
+        public IList<SignatureHelpItem> Items { get; }
+        public SignatureHelpItem SelectedItem { get; }
+        public int ArgumentIndex { get; }
+        public int ArgumentCount { get; }
+        public string ArgumentName { get; }
+        public int? SelectedParameter { get; }
+        public ISignatureHelpProvider Provider { get; }
 
         public Model(
             DisconnectedBufferGraph disconnectedBufferGraph,

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarModel.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarModel.cs
@@ -7,14 +7,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 {
     internal sealed class NavigationBarModel
     {
-        public IList<NavigationBarItem> Types { get; private set; }
+        public IList<NavigationBarItem> Types { get; }
 
         /// <summary>
         /// The VersionStamp of the project when this model was computed.
         /// </summary>
-        public VersionStamp SemanticVersionStamp { get; private set; }
+        public VersionStamp SemanticVersionStamp { get; }
 
-        public INavigationBarItemService ItemService { get; private set; }
+        public INavigationBarItemService ItemService { get; }
 
         public NavigationBarModel(IList<NavigationBarItem> types, VersionStamp semanticVersionStamp, INavigationBarItemService itemService)
         {

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningSpan.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningSpan.cs
@@ -9,22 +9,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
         /// <summary>
         /// The span of text to collapse.
         /// </summary>
-        public TextSpan TextSpan { get; private set; }
+        public TextSpan TextSpan { get; }
 
         /// <summary>
         /// The span of text to display in the hint on mouse hover.
         /// </summary>
-        public TextSpan HintSpan { get; private set; }
+        public TextSpan HintSpan { get; }
 
         /// <summary>
         /// The text to display inside the collapsed region.
         /// </summary>
-        public string BannerText { get; private set; }
+        public string BannerText { get; }
 
         /// <summary>
         /// Whether or not this region should be automatically collapsed when the 'Collapse to Definitions' command is invoked.
         /// </summary>
-        public bool AutoCollapse { get; private set; }
+        public bool AutoCollapse { get; }
 
         public OutliningSpan(TextSpan textSpan, TextSpan hintSpan, string bannerText, bool autoCollapse)
         {

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
             private readonly IEditorOptionsFactoryService _editorOptionsFactoryService;
             private readonly ITrackingSpan _hintSpan;
 
-            public bool IsDefaultCollapsed { get; private set; }
-            public bool IsImplementation { get; private set; }
-            public object CollapsedForm { get; private set; }
+            public bool IsDefaultCollapsed { get; }
+            public bool IsImplementation { get; }
+            public object CollapsedForm { get; }
 
             public Tag(
                 ITextBuffer subjectBuffer,

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/IDocumentHighlightsService.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/IDocumentHighlightsService.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal struct HighlightSpan
     {
-        public TextSpan TextSpan { get; private set; }
-        public bool IsDefinition { get; private set; }
+        public TextSpan TextSpan { get; }
+        public bool IsDefinition { get; }
 
         public HighlightSpan(TextSpan textSpan, bool isDefinition) : this()
         {
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal struct DocumentHighlights
     {
-        public Document Document { get; private set; }
-        public IList<HighlightSpan> HighlightSpans { get; private set; }
+        public Document Document { get; }
+        public IList<HighlightSpan> HighlightSpans { get; }
 
         public DocumentHighlights(Document document, IList<HighlightSpan> highlightSpans) : this()
         {

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Editor
         /// The base position in the document that the indent should be relative to.  This position
         /// can occur on any line (including the current line, or a previous line).
         /// </summary>
-        public int BasePosition { get; private set; }
+        public int BasePosition { get; }
 
         /// <summary>
         /// The number of columns the indent should be at relative to the BasePosition's column.
         /// </summary>
-        public int Offset { get; private set; }
+        public int Offset { get; }
 
         public IndentationResult(int basePosition, int offset) : this()
         {

--- a/src/EditorFeatures/Core/Implementation/TodoComment/ITodoCommentService.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/ITodoCommentService.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor
     /// </summary>
     internal struct TodoCommentDescriptor
     {
-        public string Text { get; private set; }
-        public int Priority { get; private set; }
+        public string Text { get; }
+        public int Priority { get; }
 
         public TodoCommentDescriptor(string text, int priority) : this()
         {
@@ -28,9 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor
     /// </summary>
     internal struct TodoComment
     {
-        public TodoCommentDescriptor Descriptor { get; private set; }
-        public string Message { get; private set; }
-        public int Position { get; private set; }
+        public TodoCommentDescriptor Descriptor { get; }
+        public string Message { get; }
+        public int Position { get; }
 
         public TodoComment(TodoCommentDescriptor descriptor, string message, int position) : this()
         {

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoTaskItem.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoTaskItem.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 {
     internal class TodoTaskItem : TaskItem
     {
-        public int Priority { get; private set; }
+        public int Priority { get; }
 
         public TodoTaskItem(
             int priority,

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractWorkspaceTrackingTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractWorkspaceTrackingTaggerEventSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     {
         private readonly WorkspaceRegistration _workspaceRegistration;
 
-        protected ITextBuffer SubjectBuffer { get; private set; }
+        protected ITextBuffer SubjectBuffer { get; }
         protected Workspace CurrentWorkspace { get; private set; }
 
         protected AbstractWorkspaceTrackingTaggerEventSource(ITextBuffer subjectBuffer, TaggerDelay delay) : base(delay)

--- a/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         private readonly Dictionary<string, IClassificationType> _identityMap;
         private readonly IClassificationTypeRegistryService _registryService;
 
-        public IClassificationFormatMapService ClassificationFormatMapService { get; private set; }
+        public IClassificationFormatMapService ClassificationFormatMapService { get; }
 
         [ImportingConstructor]
         internal ClassificationTypeMap(

--- a/src/EditorFeatures/Core/SymbolMapping/SymbolMappingResult.cs
+++ b/src/EditorFeatures/Core/SymbolMapping/SymbolMappingResult.cs
@@ -4,8 +4,8 @@ namespace Microsoft.CodeAnalysis.Editor.SymbolMapping
 {
     internal class SymbolMappingResult
     {
-        public Project Project { get; private set; }
-        public ISymbol Symbol { get; private set; }
+        public Project Project { get; }
+        public ISymbol Symbol { get; }
 
         internal SymbolMappingResult(Project project, ISymbol symbol)
         {

--- a/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
@@ -15,14 +15,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// <summary>
         /// The kind of this tagger event, likely a member of <see cref="PredefinedChangedEventKinds" />.
         /// </summary>
-        internal string Kind { get; private set; }
+        internal string Kind { get; }
 
         /// <summary>
         /// They amount of time to wait before the <see cref="AsynchronousTaggerProvider{TTag}"/>
         /// checks for new tags and updates the user interface.
         /// </summary>
-        public TaggerDelay Delay { get; private set; }
-        internal TextContentChangedEventArgs TextChangeEventArgs { get; private set; }
+        public TaggerDelay Delay { get; }
+        internal TextContentChangedEventArgs TextChangeEventArgs { get; }
 
         /// <summary>
         /// Creates a new <see cref="TaggerEventArgs"/>

--- a/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -177,8 +177,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 
         internal class Holder : IDisposable
         {
-            public TestWorkspace Workspace { get; private set; }
-            public IBraceCompletionSession Session { get; private set; }
+            public TestWorkspace Workspace { get; }
+            public IBraceCompletionSession Session { get; }
 
             public Holder(TestWorkspace workspace, IBraceCompletionSession session)
             {

--- a/src/EditorFeatures/Test/ChangeSignature/ChangeSignatureTestState.cs
+++ b/src/EditorFeatures/Test/ChangeSignature/ChangeSignatureTestState.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
     internal sealed class ChangeSignatureTestState : IDisposable
     {
         private TestHostDocument _testDocument;
-        public TestWorkspace Workspace { get; private set; }
-        public Document InvocationDocument { get; private set; }
-        public AbstractChangeSignatureService ChangeSignatureService { get; private set; }
+        public TestWorkspace Workspace { get; }
+        public Document InvocationDocument { get; }
+        public AbstractChangeSignatureService ChangeSignatureService { get; }
         public string ErrorMessage { get; private set; }
         public NotificationSeverity ErrorSeverity { get; private set; }
 

--- a/src/EditorFeatures/Test/Diagnostics/GenerateType/GenerateTypeTestState.cs
+++ b/src/EditorFeatures/Test/Diagnostics/GenerateType/GenerateTypeTestState.cs
@@ -27,12 +27,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
     {
         public static List<string> FixIds = new List<string>(new[] { "CS0246", "CS0234", "CS0103", "BC30002", "BC30451", "BC30456" });
         private TestHostDocument _testDocument;
-        public TestWorkspace Workspace { get; private set; }
-        public Document InvocationDocument { get; private set; }
-        public Document ExistingDocument { get; private set; }
-        public Project ProjectToBeModified { get; private set; }
-        public Project TriggeredProject { get; private set; }
-        public string TypeName { get; private set; }
+        public TestWorkspace Workspace { get; }
+        public Document InvocationDocument { get; }
+        public Document ExistingDocument { get; }
+        public Project ProjectToBeModified { get; }
+        public Project TriggeredProject { get; }
+        public string TypeName { get; }
         public GenerateTypeTestState(
             string initial,
             bool isLine,

--- a/src/EditorFeatures/Test/ExtractInterface/ExtractInterfaceTestState.cs
+++ b/src/EditorFeatures/Test/ExtractInterface/ExtractInterfaceTestState.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
     internal class ExtractInterfaceTestState : IDisposable
     {
         private TestHostDocument _testDocument;
-        public TestWorkspace Workspace { get; private set; }
-        public Document ExtractFromDocument { get; private set; }
-        public AbstractExtractInterfaceService ExtractInterfaceService { get; private set; }
-        public Solution OriginalSolution { get; private set; }
+        public TestWorkspace Workspace { get; }
+        public Document ExtractFromDocument { get; }
+        public AbstractExtractInterfaceService ExtractInterfaceService { get; }
+        public Solution OriginalSolution { get; }
         public string ErrorMessage { get; private set; }
         public NotificationSeverity ErrorSeverity { get; private set; }
 

--- a/src/EditorFeatures/Test/LineSeparators/AdornmentManagerTests.cs
+++ b/src/EditorFeatures/Test/LineSeparators/AdornmentManagerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.LineSeparators
             private Mock<IMappingSpan> _mappingSpan;
             private readonly Mock<IAdornmentLayer> _adornmentLayer;
 
-            public AdornmentManager<Tag> Manager { get; private set; }
+            public AdornmentManager<Tag> Manager { get; }
 
             private SnapshotSpan MySnapshotSpan
             {

--- a/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
@@ -89,9 +89,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
-        public int? CursorPosition { get; private set; }
-        public IList<TextSpan> SelectedSpans { get; private set; }
-        public IDictionary<string, IList<TextSpan>> AnnotatedSpans { get; private set; }
+        public int? CursorPosition { get; }
+        public IList<TextSpan> SelectedSpans { get; }
+        public IDictionary<string, IList<TextSpan>> AnnotatedSpans { get; }
 
         /// <summary>
         /// If a file exists in ProjectA and is added to ProjectB as a link, then this returns

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspace.cs
@@ -24,16 +24,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     {
         public const string WorkspaceName = "Test";
 
-        public ExportProvider ExportProvider { get; private set; }
+        public ExportProvider ExportProvider { get; }
 
         public bool CanApplyChangeDocument { get; set; }
 
         internal override bool CanChangeActiveContextDocument { get { return true; } }
 
-        public IList<TestHostProject> Projects { get; private set; }
-        public IList<TestHostDocument> Documents { get; private set; }
-        public IList<TestHostDocument> AdditionalDocuments { get; private set; }
-        public IList<TestHostDocument> ProjectionDocuments { get; private set; }
+        public IList<TestHostProject> Projects { get; }
+        public IList<TestHostDocument> Documents { get; }
+        public IList<TestHostDocument> AdditionalDocuments { get; }
+        public IList<TestHostDocument> ProjectionDocuments { get; }
 
         private readonly BackgroundCompiler _backgroundCompiler;
         private readonly BackgroundParser _backgroundParser;

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmGetChildrenAsyncResult.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmGetChildrenAsyncResult.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
             this.EnumContext = EnumContext;
         }
 
-        public DkmEvaluationResultEnumContext EnumContext { get; private set; }
-        public DkmEvaluationResult[] InitialChildren { get; private set; }
+        public DkmEvaluationResultEnumContext EnumContext { get; }
+        public DkmEvaluationResult[] InitialChildren { get; }
 
         internal Exception Exception { get; set; }
 

--- a/src/Features/CSharp/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
+++ b/src/Features/CSharp/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
     {
         private readonly bool _isValidInPreprocessorContext;
 
-        protected internal SyntaxKind KeywordKind { get; private set; }
+        protected internal SyntaxKind KeywordKind { get; }
 
-        internal bool ShouldFormatOnCommit { get; private set; }
+        internal bool ShouldFormatOnCommit { get; }
 
         protected AbstractSyntacticSingleKeywordRecommender(
             SyntaxKind keywordKind,

--- a/src/Features/Core/ChangeSignature/ChangeSignatureResult.cs
+++ b/src/Features/Core/ChangeSignature/ChangeSignatureResult.cs
@@ -4,11 +4,11 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 {
     internal sealed class ChangeSignatureResult
     {
-        public bool Succeeded { get; private set; }
-        public Solution UpdatedSolution { get; private set; }
-        public string Name { get; private set; }
-        public Glyph? Glyph { get; private set; }
-        public bool PreviewChanges { get; private set; }
+        public bool Succeeded { get; }
+        public Solution UpdatedSolution { get; }
+        public string Name { get; }
+        public Glyph? Glyph { get; }
+        public bool PreviewChanges { get; }
 
         public ChangeSignatureResult(bool succeeded, Solution updatedSolution = null, string name = null, Glyph? glyph = null, bool previewChanges = false)
         {

--- a/src/Features/Core/CodeFixes/CodeFixCollection.cs
+++ b/src/Features/Core/CodeFixes/CodeFixCollection.cs
@@ -13,14 +13,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// </summary>
     internal class CodeFixCollection
     {
-        public object Provider { get; private set; }
-        public TextSpan TextSpan { get; private set; }
-        public ImmutableArray<CodeFix> Fixes { get; private set; }
+        public object Provider { get; }
+        public TextSpan TextSpan { get; }
+        public ImmutableArray<CodeFix> Fixes { get; }
 
         /// <summary>
         /// Optional fix all context, which is non-null if the given <see cref="Provider"/> supports fix all occurrences code fix.
         /// </summary>
-        public FixAllCodeActionContext FixAllContext { get; private set; }
+        public FixAllCodeActionContext FixAllContext { get; }
 
         public CodeFixCollection(object provider, TextSpan span, IEnumerable<CodeFix> fixes, FixAllCodeActionContext fixAllContext = null) :
             this(provider, span, fixes.ToImmutableArray(), fixAllContext)

--- a/src/Features/Core/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
+++ b/src/Features/Core/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         /// <summary>
         /// The name of the <see cref="ISuppressionFixProvider"/>.  
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The source languages this provider can provide fixes for.  See <see cref="LanguageNames"/>.
         /// </summary>
-        public string[] Languages { get; private set; }
+        public string[] Languages { get; }
 
         public ExportSuppressionFixProviderAttribute(
             string name,

--- a/src/Features/Core/Completion/CompletionItem.cs
+++ b/src/Features/Core/Completion/CompletionItem.cs
@@ -19,23 +19,23 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <summary>
         /// An appropriate icon to present to the user for this completion item.
         /// </summary>
-        public Glyph? Glyph { get; private set; }
+        public Glyph? Glyph { get; }
 
         /// <summary>
         /// The ICompletionProvider that this CompletionItem was created from.
         /// </summary>
-        public virtual ICompletionProvider CompletionProvider { get; private set; }
+        public virtual ICompletionProvider CompletionProvider { get; }
 
         /// <summary>
         /// The text for the completion item should be presented to the user (for example, in a
         /// completion list in an IDE).
         /// </summary>
-        public string DisplayText { get; private set; }
+        public string DisplayText { get; }
 
         /// <summary>
         /// Text to compare against when filtering completion items against user entered text.
         /// </summary>
-        public string FilterText { get; private set; }
+        public string FilterText { get; }
 
         /// <summary>
         /// A string that is used for comparing completion items so that they can be ordered.  This
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// "int" so that it would appear next to other items with similar names instead of
         /// appearing before, or after all the items due to the leading @ character.
         /// </summary>
-        public string SortText { get; private set; }
+        public string SortText { get; }
 
         /// <summary>
         /// Whether or not this item should be preselected when presented to the user.  It is up to
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// preferred over another item if the ICompletionRules currently in effect deem them
         /// otherwise identical.
         /// </summary>
-        public bool Preselect { get; private set; }
+        public bool Preselect { get; }
 
         /// <summary>
         /// The span(respective to the original document text when this completion item was created)
@@ -66,13 +66,13 @@ namespace Microsoft.CodeAnalysis.Completion
         /// However, the text change may extend further backward so that if that item is committed
         /// the resultant text becomes "((int)foo).
         /// </summary>
-        public TextSpan FilterSpan { get; private set; }
+        public TextSpan FilterSpan { get; }
 
         /// <summary>
         /// A CompletionItem marked as a builder will be presented as an Intellisense Builder,
         /// initially with its display text, which will be replaced as the user types.
         /// </summary>
-        public bool IsBuilder { get; private set; }
+        public bool IsBuilder { get; }
 
         /// <summary>
         /// When this property is true, the completion list will display a warning icon to the
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// available in every project a linked file is linked into.
         /// </summary>
         /// <returns></returns>
-        public bool ShowsWarningIcon { get; private set; }
+        public bool ShowsWarningIcon { get; }
 
         /// <summary>
         /// When this property is true, after performing the action associated with the item, 

--- a/src/Features/Core/Completion/CompletionItemGroup.cs
+++ b/src/Features/Core/Completion/CompletionItemGroup.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// If multiple groups are marked as exclusive, only the first one returned from a provider
         /// will be used.  Providers can be ordered using the OrderAttribute.
         /// </summary>
-        public bool IsExclusive { get; private set; }
+        public bool IsExclusive { get; }
 
         /// <summary>
         /// The list of completion items to present to the user.  Can not be empty.
         /// </summary>
-        public IEnumerable<CompletionItem> Items { get; private set; }
+        public IEnumerable<CompletionItem> Items { get; }
 
         /// <summary>
         /// A completion builder to present to the user.  Can be null if no builder need be
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// can be declared.  By offering a builder the user has the option of declaring a new item
         /// in an unimpeded manner.
         /// </summary>
-        public CompletionItem Builder { get; private set; }
+        public CompletionItem Builder { get; }
 
         public CompletionItemGroup(IEnumerable<CompletionItem> items, CompletionItem builder = null, bool isExclusive = false)
         {

--- a/src/Features/Core/Completion/CompletionTriggerInfo.cs
+++ b/src/Features/Core/Completion/CompletionTriggerInfo.cs
@@ -12,30 +12,30 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <summary>
         /// Provides the reason that completion was triggered.
         /// </summary>
-        public CompletionTriggerReason TriggerReason { get; private set; }
+        public CompletionTriggerReason TriggerReason { get; }
 
         /// <summary>
         /// If the <see cref="TriggerReason"/> was <see
         /// cref="CompletionTriggerReason.TypeCharCommand"/> then this was the character that was
         /// typed or deleted by backspace.  Otherwise it is null.
         /// </summary>
-        public char? TriggerCharacter { get; private set; }
+        public char? TriggerCharacter { get; }
 
         /// <summary>
         /// Returns true if the reason completion was triggered was to augment an existing list of
         /// completion items.
         /// </summary>
-        public bool IsAugment { get; private set; }
+        public bool IsAugment { get; }
 
         /// <summary>
         ///  Returns true if completion was triggered by the debugger.
         /// </summary>
-        internal bool IsDebugger { get; private set; }
+        internal bool IsDebugger { get; }
 
         /// <summary>
         /// Return true if completion is running in the Immediate Window.
         /// </summary>
-        internal bool IsImmediateWindow { get; private set; }
+        internal bool IsImmediateWindow { get; }
 
         private CompletionTriggerInfo(CompletionTriggerReason triggerReason, char? triggerCharacter, bool isAugment, bool isDebugger, bool isImmediateWindow)
             : this()

--- a/src/Features/Core/Completion/Providers/KeywordCompletionItem.cs
+++ b/src/Features/Core/Completion/Providers/KeywordCompletionItem.cs
@@ -19,6 +19,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             this.IsIntrinsic = isIntrinsic;
         }
 
-        public bool IsIntrinsic { get; private set; }
+        public bool IsIntrinsic { get; }
     }
 }

--- a/src/Features/Core/Completion/Providers/RecommendedKeyword.cs
+++ b/src/Features/Core/Completion/Providers/RecommendedKeyword.cs
@@ -9,11 +9,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     internal sealed class RecommendedKeyword
     {
-        public Glyph Glyph { get; private set; }
-        public string Keyword { get; private set; }
-        public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; private set; }
-        public bool IsIntrinsic { get; private set; }
-        public bool ShouldFormatOnCommit { get; private set; }
+        public Glyph Glyph { get; }
+        public string Keyword { get; }
+        public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; }
+        public bool IsIntrinsic { get; }
+        public bool ShouldFormatOnCommit { get; }
 
         public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false)
             : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit)

--- a/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
@@ -162,8 +162,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public abstract Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, CancellationToken cancellationToken);
         #endregion
 
-        protected Workspace Workspace { get; private set; }
-        protected AbstractHostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; private set; }
+        protected Workspace Workspace { get; }
+        protected AbstractHostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }
 
         public virtual bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
         {

--- a/src/Features/Core/Diagnostics/DiagnosticProviderMetadata.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticProviderMetadata.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal class DiagnosticProviderMetadata : ILanguageMetadata
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public DiagnosticProviderMetadata(IDictionary<string, object> data)
         {

--- a/src/Features/Core/Diagnostics/DiagnosticsUpdatedArgs.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticsUpdatedArgs.cs
@@ -7,12 +7,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal class DiagnosticsUpdatedArgs : EventArgs
     {
-        public object Id { get; private set; }
-        public Workspace Workspace { get; private set; }
-        public Solution Solution { get; private set; }
-        public ProjectId ProjectId { get; private set; }
-        public DocumentId DocumentId { get; private set; }
-        public ImmutableArray<DiagnosticData> Diagnostics { get; private set; }
+        public object Id { get; }
+        public Workspace Workspace { get; }
+        public Solution Solution { get; }
+        public ProjectId ProjectId { get; }
+        public DocumentId DocumentId { get; }
+        public ImmutableArray<DiagnosticData> Diagnostics { get; }
 
         public DiagnosticsUpdatedArgs(
             object id, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)

--- a/src/Features/Core/ExtractInterface/ExtractInterfaceOptionsResult.cs
+++ b/src/Features/Core/ExtractInterface/ExtractInterfaceOptionsResult.cs
@@ -8,10 +8,10 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
     {
         public static readonly ExtractInterfaceOptionsResult Cancelled = new ExtractInterfaceOptionsResult(isCancelled: true);
 
-        public bool IsCancelled { get; private set; }
-        public IEnumerable<ISymbol> IncludedMembers { get; private set; }
-        public string InterfaceName { get; private set; }
-        public string FileName { get; private set; }
+        public bool IsCancelled { get; }
+        public IEnumerable<ISymbol> IncludedMembers { get; }
+        public string InterfaceName { get; }
+        public string FileName { get; }
 
         public ExtractInterfaceOptionsResult(bool isCancelled, IEnumerable<ISymbol> includedMembers, string interfaceName, string fileName)
         {

--- a/src/Features/Core/ExtractInterface/ExtractInterfaceResult.cs
+++ b/src/Features/Core/ExtractInterface/ExtractInterfaceResult.cs
@@ -4,9 +4,9 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
 {
     internal sealed class ExtractInterfaceResult
     {
-        public bool Succeeded { get; private set; }
-        public Solution UpdatedSolution { get; private set; }
-        public DocumentId NavigationDocumentId { get; private set; }
+        public bool Succeeded { get; }
+        public Solution UpdatedSolution { get; }
+        public DocumentId NavigationDocumentId { get; }
 
         public ExtractInterfaceResult(bool succeeded, Solution updatedSolution = null, DocumentId navigationDocumentId = null)
         {

--- a/src/Features/Core/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/ExtractMethod/ExtractMethodMatrix.cs
@@ -157,14 +157,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
         private struct Key : IEquatable<Key>
         {
-            public bool DataFlowIn { get; private set; }
-            public bool DataFlowOut { get; private set; }
-            public bool AlwaysAssigned { get; private set; }
-            public bool VariableDeclared { get; private set; }
-            public bool ReadInside { get; private set; }
-            public bool WrittenInside { get; private set; }
-            public bool ReadOutside { get; private set; }
-            public bool WrittenOutside { get; private set; }
+            public bool DataFlowIn { get; }
+            public bool DataFlowOut { get; }
+            public bool AlwaysAssigned { get; }
+            public bool VariableDeclared { get; }
+            public bool ReadInside { get; }
+            public bool WrittenInside { get; }
+            public bool ReadOutside { get; }
+            public bool WrittenOutside { get; }
 
             public Key(
                 bool dataFlowIn,

--- a/src/Features/Core/ExtractMethod/ExtractMethodResult.cs
+++ b/src/Features/Core/ExtractMethod/ExtractMethodResult.cs
@@ -10,32 +10,32 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         /// <summary>
         /// True if the extract method operation succeeded.
         /// </summary>
-        public bool Succeeded { get; private set; }
+        public bool Succeeded { get; }
 
         /// <summary>
         /// True if the extract method operation is possible if the original span is adjusted.
         /// </summary>
-        public bool SucceededWithSuggestion { get; private set; }
+        public bool SucceededWithSuggestion { get; }
 
         /// <summary>
         /// The transformed document that was produced as a result of the extract method operation.
         /// </summary>
-        public Document Document { get; private set; }
+        public Document Document { get; }
 
         /// <summary>
         /// The reasons why the extract method operation did not succeed.
         /// </summary>
-        public IEnumerable<string> Reasons { get; private set; }
+        public IEnumerable<string> Reasons { get; }
 
         /// <summary>
         /// the generated method node that contains the extracted code.
         /// </summary>
-        public SyntaxNode MethodDeclarationNode { get; private set; }
+        public SyntaxNode MethodDeclarationNode { get; }
 
         /// <summary>
         /// The name token for the invocation node that replaces the extracted code.
         /// </summary>
-        public SyntaxToken InvocationNameToken { get; private set; }
+        public SyntaxToken InvocationNameToken { get; }
 
         internal ExtractMethodResult(
             OperationStatusFlag status,
@@ -59,6 +59,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         /// <summary>
         /// internal status of result. more fine grained reason why it is failed. 
         /// </summary>
-        internal OperationStatusFlag Status { get; private set; }
+        internal OperationStatusFlag Status { get; }
     }
 }

--- a/src/Features/Core/ExtractMethod/InsertionPoint.cs
+++ b/src/Features/Core/ExtractMethod/InsertionPoint.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             _context = CreateLazyContextNode();
         }
 
-        public SemanticDocument SemanticDocument { get; private set; }
+        public SemanticDocument SemanticDocument { get; }
 
         public SyntaxNode GetRoot()
         {

--- a/src/Features/Core/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -66,32 +66,32 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             /// <summary>
             /// used to determine whether static can be used
             /// </summary>
-            public bool UseInstanceMember { get; private set; }
+            public bool UseInstanceMember { get; }
 
             /// <summary>
             /// used to determine whether "return" statement needs to be inserted
             /// </summary>
-            public bool EndOfSelectionReachable { get; private set; }
+            public bool EndOfSelectionReachable { get; }
 
             /// <summary>
             /// document this result is based on
             /// </summary>
-            public SemanticDocument SemanticDocument { get; private set; }
+            public SemanticDocument SemanticDocument { get; }
 
             /// <summary>
             /// flag to show whether task return type is due to await
             /// </summary>
-            public bool AwaitTaskReturn { get; private set; }
+            public bool AwaitTaskReturn { get; }
 
             /// <summary>
             /// return type
             /// </summary>
-            public ITypeSymbol ReturnType { get; private set; }
+            public ITypeSymbol ReturnType { get; }
 
             /// <summary>
             /// analyzer result operation status
             /// </summary>
-            public OperationStatus Status { get; private set; }
+            public OperationStatus Status { get; }
 
             public ReadOnlyCollection<ITypeParameterSymbol> MethodTypeParametersInDeclaration
             {

--- a/src/Features/Core/ExtractMethod/MethodExtractor.GeneratedCode.cs
+++ b/src/Features/Core/ExtractMethod/MethodExtractor.GeneratedCode.cs
@@ -27,12 +27,12 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 this.MethodDefinitionAnnotation = methodDefinitionAnnotation;
             }
 
-            public OperationStatus Status { get; private set; }
-            public SemanticDocument SemanticDocument { get; private set; }
+            public OperationStatus Status { get; }
+            public SemanticDocument SemanticDocument { get; }
 
-            public SyntaxAnnotation MethodNameAnnotation { get; private set; }
-            public SyntaxAnnotation CallSiteAnnotation { get; private set; }
-            public SyntaxAnnotation MethodDefinitionAnnotation { get; private set; }
+            public SyntaxAnnotation MethodNameAnnotation { get; }
+            public SyntaxAnnotation CallSiteAnnotation { get; }
+            public SyntaxAnnotation MethodDefinitionAnnotation { get; }
         }
     }
 }

--- a/src/Features/Core/ExtractMethod/MethodExtractor.TriviaResult.cs
+++ b/src/Features/Core/ExtractMethod/MethodExtractor.TriviaResult.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected abstract AnnotationResolver GetAnnotationResolver(SyntaxNode callsite, SyntaxNode methodDefinition);
             protected abstract TriviaResolver GetTriviaResolver(SyntaxNode methodDefinition);
 
-            public SemanticDocument SemanticDocument { get; private set; }
+            public SemanticDocument SemanticDocument { get; }
 
             public async Task<OperationStatus<SemanticDocument>> ApplyAsync(GeneratedCode generatedCode, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -39,12 +39,12 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             /// <summary>
             /// return true if original type had anonymous type or delegate somewhere in the type
             /// </summary>
-            public bool OriginalTypeHadAnonymousTypeOrDelegate { get; private set; }
+            public bool OriginalTypeHadAnonymousTypeOrDelegate { get; }
 
             /// <summary>
             /// get the original type with anonymous type removed
             /// </summary>
-            public ITypeSymbol OriginalType { get; private set; }
+            public ITypeSymbol OriginalType { get; }
 
             public static int Compare(VariableSymbol left, VariableSymbol right)
             {

--- a/src/Features/Core/ExtractMethod/OperationStatus.cs
+++ b/src/Features/Core/ExtractMethod/OperationStatus.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             return Create(this, data);
         }
 
-        public OperationStatusFlag Flag { get; private set; }
-        public IEnumerable<string> Reasons { get; private set; }
+        public OperationStatusFlag Flag { get; }
+        public IEnumerable<string> Reasons { get; }
     }
 }

--- a/src/Features/Core/ExtractMethod/OperationStatus`1.cs
+++ b/src/Features/Core/ExtractMethod/OperationStatus`1.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             this.Data = data;
         }
 
-        public OperationStatus Status { get; private set; }
-        public T Data { get; private set; }
+        public OperationStatus Status { get; }
+        public T Data { get; }
 
         public OperationStatus<T> With(OperationStatus status)
         {

--- a/src/Features/Core/ExtractMethod/SelectionResult.cs
+++ b/src/Features/Core/ExtractMethod/SelectionResult.cs
@@ -51,14 +51,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public abstract SyntaxNode GetContainingScope();
         public abstract ITypeSymbol GetContainingScopeType();
 
-        public OperationStatus Status { get; private set; }
-        public TextSpan OriginalSpan { get; private set; }
-        public TextSpan FinalSpan { get; private set; }
-        public OptionSet Options { get; private set; }
-        public bool SelectionInExpression { get; private set; }
+        public OperationStatus Status { get; }
+        public TextSpan OriginalSpan { get; }
+        public TextSpan FinalSpan { get; }
+        public OptionSet Options { get; }
+        public bool SelectionInExpression { get; }
         public SemanticDocument SemanticDocument { get; private set; }
-        public SyntaxAnnotation FirstTokenAnnotation { get; private set; }
-        public SyntaxAnnotation LastTokenAnnotation { get; private set; }
+        public SyntaxAnnotation FirstTokenAnnotation { get; }
+        public SyntaxAnnotation LastTokenAnnotation { get; }
 
         public SelectionResult With(SemanticDocument document)
         {

--- a/src/Features/Core/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/GenerateType/AbstractGenerateTypeService.State.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             public IMethodSymbol DelegateMethodSymbol { get; private set; }
             public bool IsDelegateAllowed { get; private set; }
             public bool IsEnumNotAllowed { get; private set; }
-            public Compilation Compilation { get; private set; }
+            public Compilation Compilation { get; }
             public bool IsDelegateOnly { get; private set; }
             public bool IsClassInterfaceTypes { get; private set; }
             public List<TSimpleNameSyntax> PropertiesToGenerate { get; private set; }
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             public TExpressionSyntax NameOrMemberAccessExpression { get; set; }
             public TObjectCreationExpressionSyntax ObjectCreationExpressionOpt { get; set; }
             public IMethodSymbol DelegateCreationMethodSymbol { get; set; }
-            public List<TSimpleNameSyntax> PropertiesToGenerate { get; private set; }
+            public List<TSimpleNameSyntax> PropertiesToGenerate { get; }
             public bool IsMembersWithModule { get; set; }
             public bool IsTypeGeneratedIntoNamespaceFromMemberAccess { get; set; }
             public bool IsInterfaceOrEnumNotAllowedInTypeContext { get; set; }

--- a/src/Features/Core/GenerateType/GenerateTypeDialogOptions.cs
+++ b/src/Features/Core/GenerateType/GenerateTypeDialogOptions.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.GenerateType
 {
     internal class GenerateTypeDialogOptions
     {
-        public bool IsPublicOnlyAccessibility { get; private set; }
-        public TypeKindOptions TypeKindOptions { get; private set; }
-        public bool IsAttribute { get; private set; }
+        public bool IsPublicOnlyAccessibility { get; }
+        public TypeKindOptions TypeKindOptions { get; }
+        public bool IsAttribute { get; }
 
         public GenerateTypeDialogOptions(
             bool isPublicOnlyAccessibility = false,

--- a/src/Features/Core/GenerateType/GenerateTypeOptionsResult.cs
+++ b/src/Features/Core/GenerateType/GenerateTypeOptionsResult.cs
@@ -8,17 +8,17 @@ namespace Microsoft.CodeAnalysis.GenerateType
     {
         public static readonly GenerateTypeOptionsResult Cancelled = new GenerateTypeOptionsResult(isCancelled: true);
 
-        public Accessibility Accessibility { get; private set; }
-        public Document ExistingDocument { get; private set; }
-        public bool IsCancelled { get; private set; }
-        public bool IsNewFile { get; private set; }
-        public IList<string> Folders { get; private set; }
-        public string NewFileName { get; private set; }
-        public Project Project { get; private set; }
-        public TypeKind TypeKind { get; private set; }
-        public string FullFilePath { get; private set; }
-        public string TypeName { get; private set; }
-        public bool AreFoldersValidIdentifiers { get; private set; }
+        public Accessibility Accessibility { get; }
+        public Document ExistingDocument { get; }
+        public bool IsCancelled { get; }
+        public bool IsNewFile { get; }
+        public IList<string> Folders { get; }
+        public string NewFileName { get; }
+        public Project Project { get; }
+        public TypeKind TypeKind { get; }
+        public string FullFilePath { get; }
+        public string TypeName { get; }
+        public bool AreFoldersValidIdentifiers { get; }
 
         public GenerateTypeOptionsResult(
             Accessibility accessibility,

--- a/src/Features/Core/ImplementAbstractClass/AbstractImplementAbstractClassService.State.cs
+++ b/src/Features/Core/ImplementAbstractClass/AbstractImplementAbstractClassService.State.cs
@@ -13,12 +13,12 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
     {
         private class State
         {
-            public SyntaxNode Location { get; private set; }
-            public INamedTypeSymbol ClassType { get; private set; }
-            public INamedTypeSymbol AbstractClassType { get; private set; }
+            public SyntaxNode Location { get; }
+            public INamedTypeSymbol ClassType { get; }
+            public INamedTypeSymbol AbstractClassType { get; }
 
             // The members that are not implemented at all.
-            public IList<Tuple<INamedTypeSymbol, IList<ISymbol>>> UnimplementedMembers { get; private set; }
+            public IList<Tuple<INamedTypeSymbol, IList<ISymbol>>> UnimplementedMembers { get; }
 
             private State(SyntaxNode node, INamedTypeSymbol classType, INamedTypeSymbol abstractClassType, IList<Tuple<INamedTypeSymbol, IList<ISymbol>>> unimplementedMembers)
             {

--- a/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.State.cs
+++ b/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.State.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
     {
         internal class State
         {
-            public SyntaxNode Location { get; private set; }
-            public SyntaxNode ClassOrStructDecl { get; private set; }
-            public INamedTypeSymbol ClassOrStructType { get; private set; }
-            public IEnumerable<INamedTypeSymbol> InterfaceTypes { get; private set; }
-            public SemanticModel Model { get; private set; }
+            public SyntaxNode Location { get; }
+            public SyntaxNode ClassOrStructDecl { get; }
+            public INamedTypeSymbol ClassOrStructType { get; }
+            public IEnumerable<INamedTypeSymbol> InterfaceTypes { get; }
+            public SemanticModel Model { get; }
 
             // The members that are not implemented at all.
             public IList<Tuple<INamedTypeSymbol, IList<ISymbol>>> UnimplementedMembers { get; private set; }

--- a/src/Features/Core/LanguageServices/AnonymousTypeDisplayService/AnonymousTypeDisplayInfo.cs
+++ b/src/Features/Core/LanguageServices/AnonymousTypeDisplayService/AnonymousTypeDisplayInfo.cs
@@ -6,8 +6,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 {
     internal struct AnonymousTypeDisplayInfo
     {
-        public IDictionary<INamedTypeSymbol, string> AnonymousTypeToName { get; private set; }
-        public IList<SymbolDisplayPart> AnonymousTypesParts { get; private set; }
+        public IDictionary<INamedTypeSymbol, string> AnonymousTypeToName { get; }
+        public IList<SymbolDisplayPart> AnonymousTypesParts { get; }
 
         public AnonymousTypeDisplayInfo(
             IDictionary<INamedTypeSymbol, string> anonymousTypeToName,

--- a/src/Features/Core/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
+++ b/src/Features/Core/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
@@ -15,6 +15,6 @@ namespace Microsoft.CodeAnalysis.Organizing.Organizers
             this.Language = languageName;
         }
 
-        public string Language { get; private set; }
+        public string Language { get; }
     }
 }

--- a/src/Features/Core/Shared/TestHooks/FeatureMetadata.cs
+++ b/src/Features/Core/Shared/TestHooks/FeatureMetadata.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
     /// </remarks>
     internal class FeatureMetadata
     {
-        public string FeatureName { get; private set; }
+        public string FeatureName { get; }
 
         public FeatureMetadata(IDictionary<string, object> data)
         {

--- a/src/Features/Core/Shared/Utilities/PatternMatch.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatch.cs
@@ -9,17 +9,17 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// The weight of a CamelCase match. A higher number indicates a more accurate match.
         /// </summary>
-        public int? CamelCaseWeight { get; private set; }
+        public int? CamelCaseWeight { get; }
 
         /// <summary>
         /// True if this was a case sensitive match.
         /// </summary>
-        public bool IsCaseSensitive { get; private set; }
+        public bool IsCaseSensitive { get; }
 
         /// <summary>
         /// The type of match that occurred.
         /// </summary>
-        public PatternMatchKind Kind { get; private set; }
+        public PatternMatchKind Kind { get; }
 
         private bool _punctuationStripped;
 

--- a/src/Features/Core/Snippets/SnippetInfo.cs
+++ b/src/Features/Core/Snippets/SnippetInfo.cs
@@ -4,10 +4,10 @@ namespace Microsoft.CodeAnalysis.Snippets
 {
     internal sealed class SnippetInfo
     {
-        public string Shortcut { get; private set; }
-        public string Title { get; private set; }
-        public string Description { get; private set; }
-        public string Path { get; private set; }
+        public string Shortcut { get; }
+        public string Title { get; }
+        public string Description { get; }
+        public string Path { get; }
 
         public SnippetInfo(string shortcut, string title, string description, string path)
         {

--- a/src/Features/Core/SolutionCrawler/Extensibility/ExportIncrementalAnalyzerProviderAttribute.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/ExportIncrementalAnalyzerProviderAttribute.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportIncrementalAnalyzerProviderAttribute : ExportAttribute
     {
-        public bool HighPriorityForActiveFile { get; private set; }
-        public string[] WorkspaceKinds { get; private set; }
+        public bool HighPriorityForActiveFile { get; }
+        public string[] WorkspaceKinds { get; }
 
         public ExportIncrementalAnalyzerProviderAttribute(params string[] workspaceKinds)
             : base(typeof(IIncrementalAnalyzerProvider))

--- a/src/Features/Core/SolutionCrawler/Extensibility/ExportPerLanguageIncrementalAnalyzerProviderAttribute.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/ExportPerLanguageIncrementalAnalyzerProviderAttribute.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportPerLanguageIncrementalAnalyzerProviderAttribute : ExportAttribute
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public ExportPerLanguageIncrementalAnalyzerProviderAttribute(string name, string language)
             : base(typeof(IPerLanguageIncrementalAnalyzerProvider))

--- a/src/Features/Core/SolutionCrawler/Extensibility/IncrementalAnalyzerProviderMetadata.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/IncrementalAnalyzerProviderMetadata.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal class IncrementalAnalyzerProviderMetadata
     {
-        public bool HighPriorityForActiveFile { get; private set; }
-        public string[] WorkspaceKinds { get; private set; }
+        public bool HighPriorityForActiveFile { get; }
+        public string[] WorkspaceKinds { get; }
 
         public IncrementalAnalyzerProviderMetadata(IDictionary<string, object> data)
         {

--- a/src/Features/Core/SolutionCrawler/Extensibility/PerLanguageIncrementalAnalyzerProviderMetadata.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/PerLanguageIncrementalAnalyzerProviderMetadata.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal class PerLanguageIncrementalAnalyzerProviderMetadata : LanguageMetadata
     {
-        public string Name { get; private set; }
+        public string Name { get; }
 
         public PerLanguageIncrementalAnalyzerProviderMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/Features/Core/SolutionCrawler/IDocumentDifferenceService.cs
+++ b/src/Features/Core/SolutionCrawler/IDocumentDifferenceService.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal class DocumentDifferenceResult
     {
-        public InvocationReasons ChangeType { get; private set; }
-        public SyntaxNode ChangedMember { get; private set; }
+        public InvocationReasons ChangeType { get; }
+        public SyntaxNode ChangedMember { get; }
 
         public DocumentDifferenceResult(InvocationReasons changeType, SyntaxNode changedMember = null)
         {

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
     {
         private readonly ISolutionCrawlerRegistrationService _registrationService;
 
-        internal InteractiveEvaluator Engine { get; private set; }
+        internal InteractiveEvaluator Engine { get; }
         private SourceTextContainer _openTextContainer;
         private DocumentId _openDocumentId;
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHostObject.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHostObject.cs
@@ -5,8 +5,8 @@ namespace Microsoft.CodeAnalysis.Interactive
     //// TODO: This should be in a separate dll (InteractiveHost.dll)
     public sealed class InteractiveHostObject
     {
-        public SearchPaths ReferencePaths { get; private set; }
-        public SearchPaths SourcePaths { get; private set; }
+        public SearchPaths ReferencePaths { get; }
+        public SearchPaths SourcePaths { get; }
 
         internal InteractiveHostObject()
         {

--- a/src/Interactive/Features/Interactive/Core/InteractiveHostOptions.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHostOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         /// <summary>
         /// Optional path to the .rsp file to process when initializing context of the process.
         /// </summary>
-        public string InitializationFile { get; private set; }
+        public string InitializationFile { get; }
 
         private InteractiveHostOptions(string initializationFile)
         {

--- a/src/InteractiveWindow/Editor/ContentTypeMetadata.cs
+++ b/src/InteractiveWindow/Editor/ContentTypeMetadata.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 {
     internal class ContentTypeMetadata
     {
-        public IEnumerable<string> ContentTypes { get; private set; }
+        public IEnumerable<string> ContentTypes { get; }
 
         public ContentTypeMetadata(IDictionary<string, object> data)
         {

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         private IIntellisenseSessionStack _sessionStack; // TODO: remove
 
-        public PropertyCollection Properties { get; private set; }
+        public PropertyCollection Properties { get; }
 
         ////
         //// Buffer composition.

--- a/src/InteractiveWindow/Editor/ReplInput.cs
+++ b/src/InteractiveWindow/Editor/ReplInput.cs
@@ -8,8 +8,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow
     internal sealed class ReplSpan
     {
         // ITrackingSpan or string
-        public object Span { get; private set; }
-        public ReplSpanKind Kind { get; private set; }
+        public object Span { get; }
+        public ReplSpanKind Kind { get; }
 
         public ReplSpan(CustomTrackingSpan span, ReplSpanKind kind)
         {

--- a/src/Scripting/Core/ObjectFormattingOptions.cs
+++ b/src/Scripting/Core/ObjectFormattingOptions.cs
@@ -9,15 +9,15 @@ namespace Microsoft.CodeAnalysis.Scripting
     {
         public static readonly ObjectFormattingOptions Default = new ObjectFormattingOptions();
 
-        public bool QuoteStrings { get; private set; }
-        public MemberDisplayFormat MemberFormat { get; private set; }
-        public int MaxLineLength { get; private set; }
-        public int MaxOutputLength { get; private set; }
-        public bool UseHexadecimalNumbers { get; private set; }
-        public string MemberIndentation { get; private set; }
-        public string Ellipsis { get; private set; }
-        public string NewLine { get; private set; }
-        public bool IncludeCodePoints { get; private set; }
+        public bool QuoteStrings { get; }
+        public MemberDisplayFormat MemberFormat { get; }
+        public int MaxLineLength { get; }
+        public int MaxOutputLength { get; }
+        public bool UseHexadecimalNumbers { get; }
+        public string MemberIndentation { get; }
+        public string Ellipsis { get; }
+        public string NewLine { get; }
+        public bool IncludeCodePoints { get; }
 
         public ObjectFormattingOptions(
             MemberDisplayFormat memberFormat = MemberDisplayFormat.NoMembers,

--- a/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
+++ b/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
@@ -43,7 +43,7 @@ namespace Roslyn.Hosting.Diagnostics.PerfMargin
 
         public event EventHandler IsActiveChanged;
 
-        public string Name { get; private set; }
+        public string Name { get; }
 
         public bool IsActive
         {

--- a/src/Test/Diagnostics/PerfMargin/DataModel.cs
+++ b/src/Test/Diagnostics/PerfMargin/DataModel.cs
@@ -9,7 +9,7 @@ namespace Roslyn.Hosting.Diagnostics.PerfMargin
 {
     internal class DataModel
     {
-        public ActivityLevel RootNode { get; private set; }
+        public ActivityLevel RootNode { get; }
 
         private readonly ActivityLevel[] _activities;
 

--- a/src/Test/Utilities/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/HostedRuntimeEnvironment.cs
@@ -891,7 +891,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     [Serializable]
     public class EmitException : Exception
     {
-        public IEnumerable<Diagnostic> Diagnostics { get; private set; }
+        public IEnumerable<Diagnostic> Diagnostics { get; }
 
         protected EmitException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 

--- a/src/Test/Utilities/ProcessResult.cs
+++ b/src/Test/Utilities/ProcessResult.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     /// </summary>
     public sealed class ProcessResult
     {
-        public int ExitCode { get; private set; }
-        public string Output { get; private set; }
-        public string Errors { get; private set; }
+        public int ExitCode { get; }
+        public string Output { get; }
+        public string Errors { get; }
 
         public ProcessResult(int exitCode, string output, string errors)
         {

--- a/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 internal IEnumerable<MSB.Framework.ITaskItem> AdditionalFiles { get; private set; }
                 internal IReadOnlyList<string> LibPaths { get; private set; }
                 internal bool NoStandardLib { get; private set; }
-                internal Dictionary<string, ReportDiagnostic> Warnings { get; private set; }
+                internal Dictionary<string, ReportDiagnostic> Warnings { get; }
                 internal string OutputFileName { get; private set; }
 
                 private static readonly CSharpParseOptions s_defaultParseOptions = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, documentationMode: DocumentationMode.Parse);

--- a/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveInfo.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveInfo.cs
@@ -14,17 +14,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         private class DirectiveInfo
         {
             // Maps a directive to its pair
-            public IDictionary<DirectiveTriviaSyntax, DirectiveTriviaSyntax> DirectiveMap { get; private set; }
+            public IDictionary<DirectiveTriviaSyntax, DirectiveTriviaSyntax> DirectiveMap { get; }
 
             // Maps a #If/#elif/#else/#endIf directive to its list of matching #If/#elif/#else/#endIf directives
-            public IDictionary<DirectiveTriviaSyntax, IEnumerable<DirectiveTriviaSyntax>> ConditionalMap { get; private set; }
+            public IDictionary<DirectiveTriviaSyntax, IEnumerable<DirectiveTriviaSyntax>> ConditionalMap { get; }
 
             // A set of inactive regions spans.  The items in the tuple are the start and end line
             // *both inclusive* of the inactive region. Actual PP lines are not contined within.
             //
             // Note: an interval tree might be a better structure here if there are lots of inactive
             // regions.  Consider switching to that if necessary.
-            public ISet<Tuple<int, int>> InactiveRegionLines { get; private set; }
+            public ISet<Tuple<int, int>> InactiveRegionLines { get; }
 
             public DirectiveInfo(
                 IDictionary<DirectiveTriviaSyntax, DirectiveTriviaSyntax> directiveMap,

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/DocumentFileInfo.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/DocumentFileInfo.cs
@@ -15,25 +15,25 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <summary>
         /// The absolute path to the document file on disk.
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; }
 
         /// <summary>
         /// A fictional path to the document, relative to the project.
         /// The document may not actually exist at this location, and is used
         /// to represent linked documents. This includes the file name.
         /// </summary>
-        public string LogicalPath { get; private set; }
+        public string LogicalPath { get; }
 
         /// <summary>
         /// True if the document has a logical path that differs from its 
         /// absolute file path.
         /// </summary>
-        public bool IsLinked { get; private set; }
+        public bool IsLinked { get; }
 
         /// <summary>
         /// True if the file was generated during build.
         /// </summary>
-        public bool IsGenerated { get; private set; }
+        public bool IsGenerated { get; }
 
         public DocumentFileInfo(string filePath, string logicalPath, bool isLinked, bool isGenerated)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -15,52 +15,52 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <summary>
         /// The path to the output file this project generates.
         /// </summary>
-        public string OutputFilePath { get; private set; }
+        public string OutputFilePath { get; }
 
         /// <summary>
         /// The assembly name of the output.
         /// </summary>
-        public string AssemblyName { get; private set; }
+        public string AssemblyName { get; }
 
         /// <summary>
         /// The compilation options for this project.
         /// </summary>
-        public CompilationOptions CompilationOptions { get; private set; }
+        public CompilationOptions CompilationOptions { get; }
 
         /// <summary>
         /// The parse options for this project.
         /// </summary>
-        public ParseOptions ParseOptions { get; private set; }
+        public ParseOptions ParseOptions { get; }
 
         /// <summary>
         /// The codepage for this project.
         /// </summary>
-        public int CodePage { get; private set; }
+        public int CodePage { get; }
 
         /// <summary>
         /// The source documents.
         /// </summary>
-        public IReadOnlyList<DocumentFileInfo> Documents { get; private set; }
+        public IReadOnlyList<DocumentFileInfo> Documents { get; }
 
         /// <summary>
         /// The additional documents.
         /// </summary>
-        public IReadOnlyList<DocumentFileInfo> AdditionalDocuments { get; private set; }
+        public IReadOnlyList<DocumentFileInfo> AdditionalDocuments { get; }
 
         /// <summary>
         /// References to other projects.
         /// </summary>
-        public IReadOnlyList<ProjectFileReference> ProjectReferences { get; private set; }
+        public IReadOnlyList<ProjectFileReference> ProjectReferences { get; }
 
         /// <summary>
         /// References to other metadata files; libraries and executables.
         /// </summary>
-        public IReadOnlyList<MetadataReference> MetadataReferences { get; private set; }
+        public IReadOnlyList<MetadataReference> MetadataReferences { get; }
 
         /// <summary>
         /// References to analyzer assembly files; contains diagnostic analyzers.
         /// </summary>
-        public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; private set; }
+        public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; }
 
         public ProjectFileInfo(
             string outputPath,

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileReference.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileReference.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// The path on disk to the other project file. 
         /// This path may be relative to the referencing project's file or an absolute path.
         /// </summary>
-        public string Path { get; private set; }
+        public string Path { get; }
 
         /// <summary>
         /// The aliases assigned to this reference, if any.
         /// </summary>
-        public ImmutableArray<string> Aliases { get; private set; }
+        public ImmutableArray<string> Aliases { get; }
 
         public ProjectFileReference(string path, ImmutableArray<string> aliases)
         {

--- a/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     public struct ClassifiedSpan : IEquatable<ClassifiedSpan>
     {
-        public string ClassificationType { get; private set; }
-        public TextSpan TextSpan { get; private set; }
+        public string ClassificationType { get; }
+        public TextSpan TextSpan { get; }
 
         public ClassifiedSpan(string classificationType, TextSpan textSpan)
             : this(textSpan, classificationType)

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -616,14 +616,14 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             /// <summary>
             /// Indicates the current marker type
             /// </summary>
-            public SpanMarkerType Type { get; private set; }
+            public SpanMarkerType Type { get; }
 
             /// <summary>
             /// Indicates how to find the other side of the span marker if it is missing
             /// </summary>
-            public SpanMarkerType OppositeMarkerType { get; private set; }
+            public SpanMarkerType OppositeMarkerType { get; }
 
-            public SyntaxAnnotation Annotation { get; private set; }
+            public SyntaxAnnotation Annotation { get; }
 
             public static readonly string AnnotationId = "SpanMarker";
 

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/ExportCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/ExportCodeCleanupProvider.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportCodeCleanupProvider : ExportAttribute
     {
-        public string Name { get; private set; }
-        public IEnumerable<string> Languages { get; private set; }
+        public string Name { get; }
+        public IEnumerable<string> Languages { get; }
 
         public ExportCodeCleanupProvider(string name, params string[] languages)
             : base(typeof(ICodeCleanupProvider))

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimpleCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimpleCodeCleanupProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
             _syntaxDelegatee = syntaxDelegatee;
         }
 
-        public string Name { get; private set; }
+        public string Name { get; }
 
         public async Task<Document> CleanupAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// The source languages this provider can provide fixes for.  See <see cref="LanguageNames"/>.
         /// </summary>
-        public string[] Languages { get; private set; }
+        public string[] Languages { get; }
 
         /// <summary>
         /// Attribute constructor used to specify automatic application of a code fix provider.

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.cs
@@ -27,39 +27,39 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// Project within which fix all occurrences was triggered.
         /// </summary>
-        public Project Project { get; private set; }
+        public Project Project { get; }
 
         /// <summary>
         /// Document within which fix all occurrences was triggered.
         /// </summary>
-        public Document Document { get; private set; }
+        public Document Document { get; }
 
         /// <summary>
         /// Underlying <see cref="CodeFixes.CodeFixProvider"/> which triggered this fix all.
         /// </summary>
-        public CodeFixProvider CodeFixProvider { get; private set; }
+        public CodeFixProvider CodeFixProvider { get; }
 
         /// <summary>
         /// FixAllScope to fix all occurrences.
         /// </summary>
-        public FixAllScope Scope { get; private set; }
+        public FixAllScope Scope { get; }
 
         /// <summary>
         /// Diagnostic Ids to fix.
         /// Note that <see cref="GetDocumentDiagnosticsAsync(Document)"/>, <see cref="GetProjectDiagnosticsAsync(Project)"/> and <see cref="GetAllDiagnosticsAsync(Project)"/> methods
         /// return only diagnostics whose IDs are contained in this set of Ids.
         /// </summary>
-        public ImmutableHashSet<string> DiagnosticIds { get; private set; }
+        public ImmutableHashSet<string> DiagnosticIds { get; }
 
         /// <summary>
         /// The <see cref="CodeAction.EquivalenceKey"/> value expected of a <see cref="CodeAction"/> participating in this fix all.
         /// </summary>
-        public string CodeActionEquivalenceKey { get; private set; }
+        public string CodeActionEquivalenceKey { get; }
 
         /// <summary>
         /// CancellationToken for fix all session.
         /// </summary>
-        public CancellationToken CancellationToken { get; private set; }
+        public CancellationToken CancellationToken { get; }
 
         internal FixAllContext(
             Document document,

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// This option is not necessary if <see cref="AfterThisLocation"/> or <see cref="BeforeThisLocation"/> are
         /// provided.
         /// </summary>
-        public Location ContextLocation { get; private set; }
+        public Location ContextLocation { get; }
 
         /// <summary>
         /// A hint to the code generation service to specify where the generated code should be
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// If this option is provided, neither <see cref="ContextLocation"/> nor <see cref="BeforeThisLocation"/> are
         /// needed.
         /// </summary>
-        public Location AfterThisLocation { get; private set; }
+        public Location AfterThisLocation { get; }
 
         /// <summary>
         /// A hint to the code generation service to specify where the generated code should be
@@ -46,32 +46,32 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// If this option is provided, neither <see cref="ContextLocation"/> nor <see cref="AfterThisLocation"/> are
         /// needed.
         /// </summary>
-        public Location BeforeThisLocation { get; private set; }
+        public Location BeforeThisLocation { get; }
 
         /// <summary>
         /// True if the code generation service should try to automatically add imports to the file
         /// for any generated code.  Defaults to true.  Not used when generating directly into a
         /// declaration.
         /// </summary>
-        public bool AddImports { get; private set; }
+        public bool AddImports { get; }
 
         /// <summary>
         /// True if, when adding a System import, the import should be placed above non-System
         /// imports.  Defaults to true.  Only used if <see cref="AddImports"/> is true.
         /// </summary>
-        public bool PlaceSystemNamespaceFirst { get; private set; }
+        public bool PlaceSystemNamespaceFirst { get; }
 
         /// <summary>
         /// Contains additional imports to be automatically added.  This is useful for adding
         /// imports that are part of a list of statements.
         /// </summary>
-        public IEnumerable<INamespaceSymbol> AdditionalImports { get; private set; }
+        public IEnumerable<INamespaceSymbol> AdditionalImports { get; }
 
         /// <summary>
         /// True if members of a symbol should also be generated along with the declaration.  If
         /// false, only the symbol's declaration will be generated.
         /// </summary>
-        public bool GenerateMembers { get; private set; }
+        public bool GenerateMembers { get; }
 
         /// <summary>
         /// True if the code generator should merge namespaces which only contain other namespaces
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// Merging can only occur if the namespace only contains a single member that is also a
         /// namespace.
         /// </summary>
-        public bool MergeNestedNamespaces { get; private set; }
+        public bool MergeNestedNamespaces { get; }
 
         /// <summary>
         /// True if the code generation should put multiple attributes in a single attribute
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// example, in C# setting this to True this would produce "[Foo, Bar]" while setting it to
         /// False would produce "[Foo][Bar]"
         /// </summary>
-        public bool MergeAttributes { get; private set; }
+        public bool MergeAttributes { get; }
 
         /// <summary>
         /// True if the code generator should always generate accessibility modifiers, even if they
@@ -98,32 +98,32 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// not need its accessibility specified as it will be private by default.  However, if this
         /// option is set to true 'private' will still be generated.
         /// </summary>
-        public bool GenerateDefaultAccessibility { get; private set; }
+        public bool GenerateDefaultAccessibility { get; }
 
         /// <summary>
         /// True if the code generator should generate empty bodies for methods along with the
         /// method declaration.  If false, only method declarations will be generated.
         /// </summary>
-        public bool GenerateMethodBodies { get; private set; }
+        public bool GenerateMethodBodies { get; }
 
         /// <summary>
         /// True if the code generator should generate documentation comments where available
         /// </summary>
-        public bool GenerateDocumentationComments { get; private set; }
+        public bool GenerateDocumentationComments { get; }
 
         /// <summary>
         /// True if the code generator should automatically attempt to choose the appropriate location
         /// to insert members.  If false and a generation location is not specified by AfterThisLocation,
         /// or BeforeThisLocation, members will be inserted at the end of the destination definition.
         /// </summary>
-        public bool AutoInsertionLocation { get; private set; }
+        public bool AutoInsertionLocation { get; }
 
         /// <summary>
         /// True if the code generator should attempt to reuse the syntax of the constituent entities, such as members, access modifier tokens, etc. while attempting to generate code.
         /// If any of the member symbols have zero declaring syntax references (non-source symbols) OR two or more declaring syntax references (partial definitions), then syntax is not reused.
         /// If false, then the code generator will always synthesize a new syntax node and ignore the declaring syntax references.
         /// </summary>
-        public bool ReuseSyntax { get; private set; }
+        public bool ReuseSyntax { get; }
 
         public CodeGenerationOptions(
             Location contextLocation = null,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationArrayTypeSymbol : CodeGenerationTypeSymbol, IArrayTypeSymbol
     {
-        public ITypeSymbol ElementType { get; private set; }
+        public ITypeSymbol ElementType { get; }
 
-        public int Rank { get; private set; }
+        public int Rank { get; }
 
         public CodeGenerationArrayTypeSymbol(ITypeSymbol elementType, int rank)
             : base(null, null, Accessibility.NotApplicable, default(DeclarationModifiers), string.Empty, SpecialType.None)

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationEventSymbol : CodeGenerationSymbol, IEventSymbol
     {
-        public ITypeSymbol Type { get; private set; }
+        public ITypeSymbol Type { get; }
 
         public bool IsWindowsRuntimeEvent
         {
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; private set; }
+        public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; }
 
-        public IMethodSymbol AddMethod { get; private set; }
-        public IMethodSymbol RemoveMethod { get; private set; }
-        public IMethodSymbol RaiseMethod { get; private set; }
-        public IList<IParameterSymbol> ParameterList { get; private set; }
+        public IMethodSymbol AddMethod { get; }
+        public IMethodSymbol RemoveMethod { get; }
+        public IMethodSymbol RaiseMethod { get; }
+        public IList<IParameterSymbol> ParameterList { get; }
 
         public CodeGenerationEventSymbol(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationFieldSymbol : CodeGenerationSymbol, IFieldSymbol
     {
-        public ITypeSymbol Type { get; private set; }
-        public object ConstantValue { get; private set; }
-        public bool HasConstantValue { get; private set; }
+        public ITypeSymbol Type { get; }
+        public object ConstantValue { get; }
+        public bool HasConstantValue { get; }
 
         public CodeGenerationFieldSymbol(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
@@ -10,14 +10,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationParameterSymbol : CodeGenerationSymbol, IParameterSymbol
     {
-        public RefKind RefKind { get; private set; }
-        public bool IsParams { get; private set; }
-        public ITypeSymbol Type { get; private set; }
-        public bool IsOptional { get; private set; }
-        public int Ordinal { get; private set; }
+        public RefKind RefKind { get; }
+        public bool IsParams { get; }
+        public ITypeSymbol Type { get; }
+        public bool IsOptional { get; }
+        public int Ordinal { get; }
 
-        public bool HasExplicitDefaultValue { get; private set; }
-        public object ExplicitDefaultValue { get; private set; }
+        public bool HasExplicitDefaultValue { get; }
+        public object ExplicitDefaultValue { get; }
 
         public CodeGenerationParameterSymbol(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationPointerTypeSymbol : CodeGenerationTypeSymbol, IPointerTypeSymbol
     {
-        public ITypeSymbol PointedAtType { get; private set; }
+        public ITypeSymbol PointedAtType { get; }
 
         public CodeGenerationPointerTypeSymbol(ITypeSymbol pointedAtType)
             : base(null, null, Accessibility.NotApplicable, default(DeclarationModifiers), string.Empty, SpecialType.None)

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -11,14 +11,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationPropertySymbol : CodeGenerationSymbol, IPropertySymbol
     {
-        public ITypeSymbol Type { get; private set; }
-        public bool IsIndexer { get; private set; }
+        public ITypeSymbol Type { get; }
+        public bool IsIndexer { get; }
 
-        public ImmutableArray<IParameterSymbol> Parameters { get; private set; }
-        public ImmutableArray<IPropertySymbol> ExplicitInterfaceImplementations { get; private set; }
+        public ImmutableArray<IParameterSymbol> Parameters { get; }
+        public ImmutableArray<IPropertySymbol> ExplicitInterfaceImplementations { get; }
 
-        public IMethodSymbol GetMethod { get; private set; }
-        public IMethodSymbol SetMethod { get; private set; }
+        public IMethodSymbol GetMethod { get; }
+        public IMethodSymbol SetMethod { get; }
 
         public CodeGenerationPropertySymbol(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         private ImmutableArray<AttributeData> _attributes;
 
-        public Accessibility DeclaredAccessibility { get; private set; }
-        protected internal DeclarationModifiers Modifiers { get; private set; }
-        public string Name { get; private set; }
+        public Accessibility DeclaredAccessibility { get; }
+        protected internal DeclarationModifiers Modifiers { get; }
+        public string Name { get; }
         public INamedTypeSymbol ContainingType { get; protected set; }
 
         protected CodeGenerationSymbol(

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -10,12 +10,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationTypeParameterSymbol : CodeGenerationTypeSymbol, ITypeParameterSymbol
     {
-        public VarianceKind Variance { get; private set; }
+        public VarianceKind Variance { get; }
         public ImmutableArray<ITypeSymbol> ConstraintTypes { get; internal set; }
-        public bool HasConstructorConstraint { get; private set; }
-        public bool HasReferenceTypeConstraint { get; private set; }
-        public bool HasValueTypeConstraint { get; private set; }
-        public int Ordinal { get; private set; }
+        public bool HasConstructorConstraint { get; }
+        public bool HasReferenceTypeConstraint { get; }
+        public bool HasValueTypeConstraint { get; }
+        public int Ordinal { get; }
 
         public CodeGenerationTypeParameterSymbol(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// <summary>
         /// The source languages for which this provider can provide refactorings. See <see cref="LanguageNames"/>.
         /// </summary>
-        public string[] Languages { get; private set; }
+        public string[] Languages { get; }
 
         /// <summary>
         /// Attribute constructor used to specify availability of a code refactoring provider.

--- a/src/Workspaces/Core/Portable/FindSymbols/ReferenceLocation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/ReferenceLocation.cs
@@ -16,17 +16,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// The document that the reference was found in.
         /// </summary>
-        public Document Document { get; private set; }
+        public Document Document { get; }
 
         /// <summary>
         /// If the symbol was bound through an alias, then this is the alias that was used.
         /// </summary>
-        public IAliasSymbol Alias { get; private set; }
+        public IAliasSymbol Alias { get; }
 
         /// <summary>
         /// The actual source location for a given symbol.
         /// </summary>
-        public Location Location { get; private set; }
+        public Location Location { get; }
 
         /// <summary>
         /// Indicates if this is an implicit reference to the definition.  i.e. the definition wasn't
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// example, this can happen with special methods like GetEnumerator that are used
         /// implicitly by a 'for each' statement.
         /// </summary>
-        public bool IsImplicit { get; private set; }
+        public bool IsImplicit { get; }
 
-        public CandidateReason CandidateReason { get; private set; }
+        public CandidateReason CandidateReason { get; }
 
         internal ReferenceLocation(Document document, IAliasSymbol alias, Location location, bool isImplicit, CandidateReason candidateReason)
             : this()

--- a/src/Workspaces/Core/Portable/FindSymbols/ReferencedSymbol.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/ReferencedSymbol.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// The symbol definition that these are references to.
         /// </summary>
-        public ISymbol Definition { get; private set; }
+        public ISymbol Definition { get; }
 
         /// <summary>
         /// The set of reference locations in the solution.
         /// </summary>
-        public IEnumerable<ReferenceLocation> Locations { get; private set; }
+        public IEnumerable<ReferenceLocation> Locations { get; }
 
         internal ReferencedSymbol(ISymbol definition, IEnumerable<ReferenceLocation> locations)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolCallerInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolCallerInfo.cs
@@ -27,17 +27,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// The symbol that is calling the symbol being called.
         /// </summary>
-        public ISymbol CallingSymbol { get; private set; }
+        public ISymbol CallingSymbol { get; }
 
         /// <summary>
         /// The locations inside the calling symbol where the called symbol is referenced.
         /// </summary>
-        public IEnumerable<Location> Locations { get; private set; }
+        public IEnumerable<Location> Locations { get; }
 
         /// <summary>
         /// The symbol being called.
         /// </summary>
-        public ISymbol CalledSymbol { get; private set; }
+        public ISymbol CalledSymbol { get; }
 
         /// <summary>
         /// True if the CallingSymbol is directly calling CalledSymbol.  False if it is calling a
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// symbol is a class method, then an indirect call might be through an interface method that
         /// the class method implements.
         /// </summary>
-        public bool IsDirect { get; private set; }
+        public bool IsDirect { get; }
 
         internal SymbolCallerInfo(ISymbol callingSymbol, ISymbol calledSymbol, IEnumerable<Location> locations, bool isDirect)
             : this()

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeDeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeDeclarationInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly ConditionalWeakTable<BranchId, ConditionalWeakTable<DocumentId, AbstractSyntaxTreeInfo>> s_cache =
             new ConditionalWeakTable<BranchId, ConditionalWeakTable<DocumentId, AbstractSyntaxTreeInfo>>();
 
-        public IEnumerable<DeclaredSymbolInfo> DeclaredSymbolInfos { get; private set; }
+        public IEnumerable<DeclaredSymbolInfo> DeclaredSymbolInfos { get; }
 
         public SyntaxTreeDeclarationInfo(VersionStamp version, IEnumerable<DeclaredSymbolInfo> declaredSymbolInfos)
             : base(version)

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.AnchorData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.AnchorData.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 }
             }
 
-            public int OriginalColumn { get; private set; }
+            public int OriginalColumn { get; }
         }
 
         int IIntervalIntrospector<AnchorData>.GetStart(AnchorData value)

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.IndentationData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.IndentationData.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 this.TextSpan = textSpan;
             }
 
-            public TextSpan TextSpan { get; private set; }
+            public TextSpan TextSpan { get; }
             public abstract int Indentation { get; }
         }
 
@@ -75,8 +75,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                 this.InseparableRegionSpan = TextSpan.FromBounds(inseparableRegionSpanStart, textSpan.End);
             }
 
-            public TextSpan InseparableRegionSpan { get; private set; }
-            public IndentBlockOperation Operation { get; private set; }
+            public TextSpan InseparableRegionSpan { get; }
+            public IndentBlockOperation Operation { get; }
 
             public SyntaxToken EndToken
             {

--- a/src/Workspaces/Core/Portable/Formatting/Context/SuppressSpacingData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/SuppressSpacingData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             this.NoSpacing = noSpacing;
         }
 
-        public TextSpan TextSpan { get; private set; }
-        public bool NoSpacing { get; private set; }
+        public TextSpan TextSpan { get; }
+        public bool NoSpacing { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Context/SuppressWrappingData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/SuppressWrappingData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             this.NoWrapping = noWrapping;
         }
 
-        public TextSpan TextSpan { get; private set; }
-        public bool NoWrapping { get; private set; }
+        public TextSpan TextSpan { get; }
+        public bool NoWrapping { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             private readonly SyntaxToken _token1;
             private readonly SyntaxToken _token2;
 
-            public TreeData TreeInfo { get; private set; }
-            public string OriginalString { get; private set; }
+            public TreeData TreeInfo { get; }
+            public string OriginalString { get; }
 
             private readonly bool _treatAsElastic;
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/ActionCache`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/ActionCache`1.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal class ActionCache<TArgument> : IActionHolder<TArgument>
     {
-        public Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> NextOperation { get; private set; }
-        public Action<int, List<TArgument>, SyntaxNode, IActionHolder<TArgument>> Continuation { get; private set; }
+        public Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> NextOperation { get; }
+        public Action<int, List<TArgument>, SyntaxNode, IActionHolder<TArgument>> Continuation { get; }
 
         public ActionCache(
             Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> nextOperation,

--- a/src/Workspaces/Core/Portable/Formatting/Engine/NodeOperations.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/NodeOperations.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         public static NodeOperations Empty = new NodeOperations();
 
-        public Task<List<IndentBlockOperation>> IndentBlockOperationTask { get; private set; }
-        public Task<List<SuppressOperation>> SuppressOperationTask { get; private set; }
-        public Task<List<AlignTokensOperation>> AlignmentOperationTask { get; private set; }
-        public Task<List<AnchorIndentationOperation>> AnchorIndentationOperationsTask { get; private set; }
+        public Task<List<IndentBlockOperation>> IndentBlockOperationTask { get; }
+        public Task<List<SuppressOperation>> SuppressOperationTask { get; }
+        public Task<List<AlignTokensOperation>> AlignmentOperationTask { get; }
+        public Task<List<AnchorIndentationOperation>> AnchorIndentationOperationsTask { get; }
 
         public NodeOperations(Task<List<IndentBlockOperation>> indentBlockOperationTask, Task<List<SuppressOperation>> suppressOperationTask, Task<List<AnchorIndentationOperation>> anchorIndentationOperationsTask, Task<List<AlignTokensOperation>> alignmentOperationTask)
         {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/OperationCache`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/OperationCache`1.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             this.Continuation = continuation;
         }
 
-        public Func<int, SyntaxToken, SyntaxToken, NextOperation<TResult>, TResult> NextOperation { get; private set; }
-        public Func<int, SyntaxToken, SyntaxToken, IOperationHolder<TResult>, TResult> Continuation { get; private set; }
+        public Func<int, SyntaxToken, SyntaxToken, NextOperation<TResult>, TResult> NextOperation { get; }
+        public Func<int, SyntaxToken, SyntaxToken, IOperationHolder<TResult>, TResult> Continuation { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             this.Token = token;
         }
 
-        public TokenStream TokenStream { get; private set; }
-        public int IndexInStream { get; private set; }
-        public SyntaxToken Token { get; private set; }
+        public TokenStream TokenStream { get; }
+        public int IndexInStream { get; }
+        public SyntaxToken Token { get; }
 
         public TokenData GetPreviousTokenData()
         {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenPairWithOperations.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenPairWithOperations.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Formatting
     /// </summary>
     internal struct TokenPairWithOperations
     {
-        public TokenStream TokenStream { get; private set; }
-        public AdjustSpacesOperation SpaceOperation { get; private set; }
-        public AdjustNewLinesOperation LineOperation { get; private set; }
+        public TokenStream TokenStream { get; }
+        public AdjustSpacesOperation SpaceOperation { get; }
+        public AdjustNewLinesOperation LineOperation { get; }
 
-        public int PairIndex { get; private set; }
+        public int PairIndex { get; }
 
         public TokenPairWithOperations(
             TokenStream tokenStream,

--- a/src/Workspaces/Core/Portable/Formatting/Rules/ExportFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/ExportFormattingRule.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportFormattingRule : ExportAttribute
     {
-        public string Name { get; private set; }
-        public string Language { get; private set; }
+        public string Name { get; }
+        public string Language { get; }
 
         public ExportFormattingRule(string name, string language)
             : base(typeof(IFormattingRule))

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AdjustNewLinesOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AdjustNewLinesOperation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.Option = option;
         }
 
-        public int Line { get; private set; }
-        public AdjustNewLinesOption Option { get; private set; }
+        public int Line { get; }
+        public AdjustNewLinesOption Option { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AdjustSpacesOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AdjustSpacesOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.Option = option;
         }
 
-        public int Space { get; private set; }
-        public AdjustSpacesOption Option { get; private set; }
+        public int Space { get; }
+        public AdjustSpacesOption Option { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AlignTokensOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AlignTokensOperation.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.Tokens = tokens;
         }
 
-        public SyntaxToken BaseToken { get; private set; }
-        public IEnumerable<SyntaxToken> Tokens { get; private set; }
-        public AlignTokensOption Option { get; private set; }
+        public SyntaxToken BaseToken { get; }
+        public IEnumerable<SyntaxToken> Tokens { get; }
+        public AlignTokensOption Option { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AnchorIndentationOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/AnchorIndentationOperation.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.EndToken = endToken;
         }
 
-        public SyntaxToken AnchorToken { get; private set; }
-        public TextSpan TextSpan { get; private set; }
+        public SyntaxToken AnchorToken { get; }
+        public TextSpan TextSpan { get; }
 
-        public SyntaxToken StartToken { get; private set; }
-        public SyntaxToken EndToken { get; private set; }
+        public SyntaxToken StartToken { get; }
+        public SyntaxToken EndToken { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
@@ -52,15 +52,15 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.IndentationDeltaOrPosition = indentationDelta;
         }
 
-        public SyntaxToken BaseToken { get; private set; }
-        public TextSpan TextSpan { get; private set; }
+        public SyntaxToken BaseToken { get; }
+        public TextSpan TextSpan { get; }
 
-        public IndentBlockOption Option { get; private set; }
+        public IndentBlockOption Option { get; }
 
-        public SyntaxToken StartToken { get; private set; }
-        public SyntaxToken EndToken { get; private set; }
+        public SyntaxToken StartToken { get; }
+        public SyntaxToken EndToken { get; }
 
-        public bool IsRelativeIndentation { get; private set; }
-        public int IndentationDeltaOrPosition { get; private set; }
+        public bool IsRelativeIndentation { get; }
+        public int IndentationDeltaOrPosition { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             this.EndToken = endToken;
         }
 
-        public TextSpan TextSpan { get; private set; }
-        public SuppressOption Option { get; private set; }
+        public TextSpan TextSpan { get; }
+        public SuppressOption Option { get; }
 
-        public SyntaxToken StartToken { get; private set; }
-        public SyntaxToken EndToken { get; private set; }
+        public SyntaxToken StartToken { get; }
+        public SyntaxToken EndToken { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
     {
         public IEnumerable<DocumentId> DocumentIds { get; internal set; }
         public SourceText MergedSourceText { get; internal set; }
-        public IEnumerable<TextSpan> MergeConflictResolutionSpans { get; private set; }
+        public IEnumerable<TextSpan> MergeConflictResolutionSpans { get; }
         public bool HasMergeConflicts { get { return MergeConflictResolutionSpans.Any(); } }
 
         public LinkedFileMergeResult(IEnumerable<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class LinkedFileMergeSessionResult
     {
-        public Solution MergedSolution { get; private set; }
+        public Solution MergedSolution { get; }
 
         private readonly Dictionary<DocumentId, IEnumerable<TextSpan>> _mergeConflictCommentSpans = new Dictionary<DocumentId, IEnumerable<TextSpan>>();
         public Dictionary<DocumentId, IEnumerable<TextSpan>> MergeConflictCommentSpans { get { return _mergeConflictCommentSpans; } }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
@@ -7,9 +7,9 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class UnmergedDocumentChanges
     {
-        public IEnumerable<TextChange> UnmergedChanges { get; private set; }
-        public string ProjectName { get; private set; }
-        public DocumentId DocumentId { get; private set; }
+        public IEnumerable<TextChange> UnmergedChanges { get; }
+        public string ProjectName { get; }
+        public DocumentId DocumentId { get; }
 
         public UnmergedDocumentChanges(IEnumerable<TextChange> unmergedChanges, string projectName, DocumentId documentId)
         {

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationEventArgs.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.Notification
 {
     internal class GlobalOperationEventArgs : EventArgs
     {
-        public IReadOnlyList<string> Operations { get; private set; }
-        public bool Cancelled { get; private set; }
+        public IReadOnlyList<string> Operations { get; }
+        public bool Cancelled { get; }
 
         public GlobalOperationEventArgs(IReadOnlyList<string> operations, bool cancelled)
         {

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationRegistration.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationRegistration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Notification
             _done = false;
         }
 
-        public string Operation { get; private set; }
+        public string Operation { get; }
 
         public void Done()
         {

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// Feature this option is associated with.
         /// </summary>
-        public string Feature { get; private set; }
+        public string Feature { get; }
 
         /// <summary>
         /// The name of the option.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The type of the option value.
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// The default value of the option.
         /// </summary>
-        public T DefaultValue { get; private set; }
+        public T DefaultValue { get; }
 
         public Option(string feature, string name, T defaultValue = default(T))
         {

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -13,12 +13,12 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// Feature this option is associated with.
         /// </summary>
-        public string Feature { get; private set; }
+        public string Feature { get; }
 
         /// <summary>
         /// The name of the option.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The type of the option value.
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// The default option value.
         /// </summary>
-        public T DefaultValue { get; private set; }
+        public T DefaultValue { get; }
 
         public PerLanguageOption(string feature, string name, T defaultValue)
         {

--- a/src/Workspaces/Core/Portable/Options/Providers/OptionSerializerMetadata.cs
+++ b/src/Workspaces/Core/Portable/Options/Providers/OptionSerializerMetadata.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Options.Providers
 {
     internal class OptionSerializerMetadata : LanguageMetadata
     {
-        public IEnumerable<string> Features { get; private set; }
+        public IEnumerable<string> Features { get; }
 
         public OptionSerializerMetadata(IDictionary<string, object> data) : base(data)
         {

--- a/src/Workspaces/Core/Portable/OrderableMetadata.cs
+++ b/src/Workspaces/Core/Portable/OrderableMetadata.cs
@@ -9,15 +9,15 @@ namespace Microsoft.CodeAnalysis
     internal class OrderableMetadata : IOrderableMetadata
     {
         [DefaultValue(new string[] { })]
-        public object After { get; private set; }
+        public object After { get; }
 
         [DefaultValue(new string[] { })]
-        public object Before { get; private set; }
+        public object Before { get; }
 
         internal IEnumerable<string> AfterTyped { get; set; }
         internal IEnumerable<string> BeforeTyped { get; set; }
 
-        public string Name { get; private set; }
+        public string Name { get; }
 
         IEnumerable<string> IOrderableMetadata.After
         {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
@@ -190,11 +190,11 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         /// Whether the text that was resolved with was even valid. This may be false if the
         /// identifier was not valid in some language that was involved in the rename.
         /// </summary>
-        public bool ReplacementTextValid { get; private set; }
+        public bool ReplacementTextValid { get; }
 
         /// <summary>
         /// The original text that is the rename replacement.
         /// </summary>
-        public string ReplacementText { get; private set; }
+        public string ReplacementText { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RelatedLocation.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RelatedLocation.cs
@@ -10,13 +10,13 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
     internal sealed class RelatedLocation
     {
         // The Span of the original identifier if it was in source, otherwise the span to check for implicit references
-        public TextSpan ConflictCheckSpan { get; private set; }
+        public TextSpan ConflictCheckSpan { get; }
         public RelatedLocationType Type { get; set; }
-        public bool IsReference { get; private set; }
-        public DocumentId DocumentId { get; private set; }
+        public bool IsReference { get; }
+        public DocumentId DocumentId { get; }
 
         // If there was a conflict at ConflictCheckSpan during rename, then the next phase in rename uses ComplexifiedTargetSpan span to be expanded to resolve the conflict
-        public TextSpan ComplexifiedTargetSpan { get; private set; }
+        public TextSpan ComplexifiedTargetSpan { get; }
 
         public RelatedLocation(TextSpan location, DocumentId documentId, RelatedLocationType type, bool isReference = false, TextSpan complexifiedTargetSpan = default(TextSpan))
         {

--- a/src/Workspaces/Core/Portable/Shared/Collections/IntervalTree`1.Node.cs
+++ b/src/Workspaces/Core/Portable/Shared/Collections/IntervalTree`1.Node.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
     {
         protected class Node
         {
-            internal T Value { get; private set; }
+            internal T Value { get; }
 
             internal Node Left { get; private set; }
             internal Node Right { get; private set; }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
@@ -49,28 +49,28 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             this.IsInImportsDirective = isInImportsDirective;
         }
 
-        public Workspace Workspace { get; private set; }
-        public SemanticModel SemanticModel { get; private set; }
-        public SyntaxTree SyntaxTree { get; private set; }
-        public int Position { get; private set; }
+        public Workspace Workspace { get; }
+        public SemanticModel SemanticModel { get; }
+        public SyntaxTree SyntaxTree { get; }
+        public int Position { get; }
 
-        public SyntaxToken LeftToken { get; private set; }
-        public SyntaxToken TargetToken { get; private set; }
+        public SyntaxToken LeftToken { get; }
+        public SyntaxToken TargetToken { get; }
 
-        public bool IsTypeContext { get; private set; }
-        public bool IsNamespaceContext { get; private set; }
+        public bool IsTypeContext { get; }
+        public bool IsNamespaceContext { get; }
 
-        public bool IsPreProcessorDirectiveContext { get; private set; }
+        public bool IsPreProcessorDirectiveContext { get; }
 
-        public bool IsRightOfNameSeparator { get; private set; }
-        public bool IsStatementContext { get; private set; }
-        public bool IsAnyExpressionContext { get; private set; }
-        public bool IsAttributeNameContext { get; private set; }
-        public bool IsEnumTypeMemberAccessContext { get; private set; }
-        public bool IsNameOfContext { get; private set; }
+        public bool IsRightOfNameSeparator { get; }
+        public bool IsStatementContext { get; }
+        public bool IsAnyExpressionContext { get; }
+        public bool IsAttributeNameContext { get; }
+        public bool IsEnumTypeMemberAccessContext { get; }
+        public bool IsNameOfContext { get; }
 
-        public bool IsInQuery { get; private set; }
-        public bool IsInImportsDirective { get; private set; }
+        public bool IsInQuery { get; }
+        public bool IsInImportsDirective { get; }
 
         private ISet<INamedTypeSymbol> ComputeOuterTypes(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Utilities/SyntaxPath.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SyntaxPath.cs
@@ -25,8 +25,8 @@ namespace Roslyn.Utilities
         // a different tree will either return the same type of node as the original, or will fail.  
         protected struct PathSegment
         {
-            public int Ordinal { get; private set; }
-            public int Kind { get; private set; }
+            public int Ordinal { get; }
+            public int Kind { get; }
 
             public PathSegment(int ordinal, int kind)
                 : this()

--- a/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis
 {
     public class DocumentEventArgs : EventArgs
     {
-        public Document Document { get; private set; }
+        public Document Document { get; }
 
         public DocumentEventArgs(Document document)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/CodeChangeProviderMetadata.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/CodeChangeProviderMetadata.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 {
     internal class CodeChangeProviderMetadata : OrderableMetadata, ILanguagesMetadata
     {
-        public IEnumerable<string> Languages { get; private set; }
+        public IEnumerable<string> Languages { get; }
 
         public CodeChangeProviderMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
@@ -15,17 +15,17 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// <summary>
         /// The assembly qualified name of the service's type.
         /// </summary>
-        public string ServiceType { get; private set; }
+        public string ServiceType { get; }
 
         /// <summary>
         /// The language that the service is target for; LanguageNames.CSharp, etc.
         /// </summary>
-        public string Language { get; private set; }
+        public string Language { get; }
 
         /// <summary>
         /// The layer that the service is specified for; ServiceLayer.Default, etc.
         /// </summary>
-        public string Layer { get; private set; }
+        public string Layer { get; }
 
         /// <summary>
         /// Declares a <see cref="ILanguageService"/> implementation for inclusion in a MEF-based workspace.

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceFactoryAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceFactoryAttribute.cs
@@ -15,17 +15,17 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// <summary>
         /// The assembly qualified name of the service's type.
         /// </summary>
-        public string ServiceType { get; private set; }
+        public string ServiceType { get; }
 
         /// <summary>
         /// The language that the service is target for; LanguageNames.CSharp, etc.
         /// </summary>
-        public string Language { get; private set; }
+        public string Language { get; }
 
         /// <summary>
         /// The layer that the service is specified for; ServiceLayer.Default, etc.
         /// </summary>
-        public string Layer { get; private set; }
+        public string Layer { get; }
 
         /// <summary>
         /// Declares a <see cref="ILanguageServiceFactory"/> implementation for inclusion in a MEF-based workspace.

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// <summary>
         /// The assembly qualified name of the service's type.
         /// </summary>
-        public string ServiceType { get; private set; }
+        public string ServiceType { get; }
 
         /// <summary>
         /// The layer that the service is specified for; ServiceLayer.Default, etc.
         /// </summary>
-        public string Layer { get; private set; }
+        public string Layer { get; }
 
         /// <summary>
         /// Declares a <see cref="IWorkspaceService"/> implementation for inclusion in a MEF-based workspace.

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceFactoryAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceFactoryAttribute.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// <summary>
         /// The assembly qualified name of the service's type.
         /// </summary>
-        public string ServiceType { get; private set; }
+        public string ServiceType { get; }
 
         /// <summary>
         /// The layer that the service is specified for; ServiceLayer.Default, etc.
         /// </summary>
-        public string Layer { get; private set; }
+        public string Layer { get; }
 
         /// <summary>
         /// Declares a <see cref="IWorkspaceServiceFactory"/> implementation for inclusion in a MEF-based workspace.

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/LanguageMetadata.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/LanguageMetadata.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
     /// </summary>
     internal class LanguageMetadata : ILanguageMetadata
     {
-        public string Language { get; private set; }
+        public string Language { get; }
 
         public LanguageMetadata(IDictionary<string, object> data)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/LanguageServiceMetadata.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/LanguageServiceMetadata.cs
@@ -11,10 +11,10 @@ namespace Microsoft.CodeAnalysis.Host.Mef
     /// </summary>
     internal class LanguageServiceMetadata : LanguageMetadata
     {
-        public string ServiceType { get; private set; }
-        public string Layer { get; private set; }
+        public string ServiceType { get; }
+        public string Layer { get; }
 
-        public IReadOnlyDictionary<string, object> Data { get; private set; }
+        public IReadOnlyDictionary<string, object> Data { get; }
 
         public LanguageServiceMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/OrderableLanguageMetadata.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/OrderableLanguageMetadata.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 {
     internal class OrderableLanguageMetadata : OrderableMetadata, ILanguageMetadata
     {
-        public string Language { get; private set; }
+        public string Language { get; }
 
         public OrderableLanguageMetadata(IDictionary<string, object> data)
             : base(data)

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/WorkspaceServiceMetadata.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/WorkspaceServiceMetadata.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Host.Mef
     /// </summary>
     internal class WorkspaceServiceMetadata
     {
-        public string ServiceType { get; private set; }
-        public string Layer { get; private set; }
+        public string ServiceType { get; }
+        public string Layer { get; }
 
         public WorkspaceServiceMetadata(Type serviceType, string layer)
             : this(serviceType.AssemblyQualifiedName, layer)

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Host
             _disposer = disposer;
         }
 
-        public string WorkingFolderPath { get; private set; }
-        public string SolutionFilePath { get; private set; }
+        public string WorkingFolderPath { get; }
+        public string SolutionFilePath { get; }
 
         protected bool PersistenceEnabled
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentDiagnostic.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis
 {
     public class DocumentDiagnostic : WorkspaceDiagnostic
     {
-        public DocumentId DocumentId { get; private set; }
+        public DocumentId DocumentId { get; }
 
         public DocumentDiagnostic(WorkspaceDiagnosticKind kind, string message, DocumentId documentId)
             : base(kind, message)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public class DocumentId : IEquatable<DocumentId>
     {
-        public ProjectId ProjectId { get; private set; }
-        public Guid Id { get; private set; }
+        public ProjectId ProjectId { get; }
+        public Guid Id { get; }
 
         private string _debugName;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -16,37 +16,37 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The Id of the document.
         /// </summary>
-        public DocumentId Id { get; private set; }
+        public DocumentId Id { get; }
 
         /// <summary>
         /// The name of the document.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The names of the logical nested folders the document is contained in.
         /// </summary>
-        public IReadOnlyList<string> Folders { get; private set; }
+        public IReadOnlyList<string> Folders { get; }
 
         /// <summary>
         /// The kind of the source code.
         /// </summary>
-        public SourceCodeKind SourceCodeKind { get; private set; }
+        public SourceCodeKind SourceCodeKind { get; }
 
         /// <summary>
         /// The file path of the document.
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; }
 
         /// <summary>
         /// A loader that can retrieve the document text.
         /// </summary>
-        public TextLoader TextLoader { get; private set; }
+        public TextLoader TextLoader { get; }
 
         /// <summary>
         /// True if the document is a side effect of the build.
         /// </summary>
-        public bool IsGenerated { get; private set; }
+        public bool IsGenerated { get; }
 
         /// <summary>
         /// Create a new instance of a <see cref="DocumentInfo"/>.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDiagnostic.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis
 {
     public class ProjectDiagnostic : WorkspaceDiagnostic
     {
-        public ProjectId ProjectId { get; private set; }
+        public ProjectId ProjectId { get; }
 
         public ProjectDiagnostic(WorkspaceDiagnosticKind kind, string message, ProjectId projectId)
             : base(kind, message)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The system generated unique id.
         /// </summary>
-        public Guid Id { get; private set; }
+        public Guid Id { get; }
 
         private ProjectId(string debugName)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -17,82 +17,82 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The unique Id of the project.
         /// </summary>
-        public ProjectId Id { get; private set; }
+        public ProjectId Id { get; }
 
         /// <summary>
         /// The version of the project.
         /// </summary>
-        public VersionStamp Version { get; private set; }
+        public VersionStamp Version { get; }
 
         /// <summary>
         /// The name of the project. This may differ from the project's filename.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The name of the assembly that this project will create, without file extension.
         /// </summary>,
-        public string AssemblyName { get; private set; }
+        public string AssemblyName { get; }
 
         /// <summary>
         /// The language of the project.
         /// </summary>
-        public string Language { get; private set; }
+        public string Language { get; }
 
         /// <summary>
         /// The path to the project file or null if there is no project file.
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; }
 
         /// <summary>
         /// The path to the output file (module or assembly).
         /// </summary>
-        public string OutputFilePath { get; private set; }
+        public string OutputFilePath { get; }
 
         /// <summary>
         /// The initial compilation options for the project, or null if the default options should be used.
         /// </summary>
-        public CompilationOptions CompilationOptions { get; private set; }
+        public CompilationOptions CompilationOptions { get; }
 
         /// <summary>
         /// The initial parse options for the source code documents in this project, or null if the default options should be used.
         /// </summary>
-        public ParseOptions ParseOptions { get; private set; }
+        public ParseOptions ParseOptions { get; }
 
         /// <summary>
         /// The list of source documents initially associated with the project.
         /// </summary>
-        public IReadOnlyList<DocumentInfo> Documents { get; private set; }
+        public IReadOnlyList<DocumentInfo> Documents { get; }
 
         /// <summary>
         /// The project references initially defined for the project.
         /// </summary>
-        public IReadOnlyList<ProjectReference> ProjectReferences { get; private set; }
+        public IReadOnlyList<ProjectReference> ProjectReferences { get; }
 
         /// <summary>
         /// The metadata references initially defined for the project.
         /// </summary>
-        public IReadOnlyList<MetadataReference> MetadataReferences { get; private set; }
+        public IReadOnlyList<MetadataReference> MetadataReferences { get; }
 
         /// <summary>
         /// The analyzers initially associated with this project.
         /// </summary>
-        public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; private set; }
+        public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; }
 
         /// <summary>
         /// The list of non-source documents associated with this project.
         /// </summary>
-        public IReadOnlyList<DocumentInfo> AdditionalDocuments { get; private set; }
+        public IReadOnlyList<DocumentInfo> AdditionalDocuments { get; }
 
         /// <summary>
         /// True if this is a submission project for interactive sessions.
         /// </summary>
-        public bool IsSubmission { get; private set; }
+        public bool IsSubmission { get; }
 
         /// <summary>
         /// Type of the host object.
         /// </summary>
-        public Type HostObjectType { get; private set; }
+        public Type HostObjectType { get; }
 
         private ProjectInfo(
             ProjectId id,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis
                 // strong reference to declaration only compilation. 
                 // this doesn't make any expensive information such as symbols or references alive. just
                 // things like decleration table alive.
-                public Compilation DeclarationOnlyCompilation { get; private set; }
+                public Compilation DeclarationOnlyCompilation { get; }
 
                 // The compilation available.  May be an InProgress, Full Declaration, or Final compilation
-                public ValueSource<Compilation> Compilation { get; private set; }
+                public ValueSource<Compilation> Compilation { get; }
 
                 // The Final compilation if available, otherwise an empty IValueSource
                 public virtual ValueSource<Compilation> FinalCompilation
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis
             // DeclarationCompilation from by iteratively processing IntermediateProjects
             private sealed class InProgressState : State
             {
-                public ImmutableArray<ValueTuple<ProjectState, CompilationTranslationAction>> IntermediateProjects { get; private set; }
+                public ImmutableArray<ValueTuple<ProjectState, CompilationTranslationAction>> IntermediateProjects { get; }
 
                 public InProgressState(
                     Compilation inProgressCompilation,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis
         {
             private static readonly Func<ProjectState, string> s_logBuildCompilationAsync = LogBuildCompilationAsync;
 
-            public ProjectState ProjectState { get; private set; }
+            public ProjectState ProjectState { get; }
 
             /// <summary>
             /// Access via the <see cref="ReadState"/> and <see cref="WriteState"/> methods.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The unique id of the solution.
         /// </summary>
-        public Guid Id { get; private set; }
+        public Guid Id { get; }
 
         private string _debugName;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -19,22 +19,22 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The unique Id of the solution.
         /// </summary>
-        public SolutionId Id { get; private set; }
+        public SolutionId Id { get; }
 
         /// <summary>
         /// The version of the solution.
         /// </summary>
-        public VersionStamp Version { get; private set; }
+        public VersionStamp Version { get; }
 
         /// <summary>
         /// The path to the solution file, or null if there is no solution file.
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; }
 
         /// <summary>
         /// A list of projects initially associated with the solution.
         /// </summary>
-        public IReadOnlyList<ProjectInfo> Projects { get; private set; }
+        public IReadOnlyList<ProjectInfo> Projects { get; }
 
         private SolutionInfo(
             SolutionId id,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextAndVersion.cs
@@ -18,17 +18,17 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The source text.
         /// </summary>
-        public SourceText Text { get; private set; }
+        public SourceText Text { get; }
 
         /// <summary>
         /// The version of the source text
         /// </summary>
-        public VersionStamp Version { get; private set; }
+        public VersionStamp Version { get; }
 
         /// <summary>
         /// An optional file path that identifies the origin of the source text
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; }
 
         private TextAndVersion(SourceText text, VersionStamp version, string filePath)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TreeAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TreeAndVersion.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The syntax tree
         /// </summary>
-        public SyntaxTree Tree { get; private set; }
+        public SyntaxTree Tree { get; }
 
         /// <summary>
         /// The version of the top level signature of the tree
         /// </summary>
-        public VersionStamp Version { get; private set; }
+        public VersionStamp Version { get; }
 
         private TreeAndVersion(SyntaxTree tree, VersionStamp version)
         {

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeEventArgs.cs
@@ -7,11 +7,11 @@ namespace Microsoft.CodeAnalysis
 {
     public class WorkspaceChangeEventArgs : EventArgs
     {
-        public WorkspaceChangeKind Kind { get; private set; }
-        public Solution OldSolution { get; private set; }
-        public Solution NewSolution { get; private set; }
-        public ProjectId ProjectId { get; private set; }
-        public DocumentId DocumentId { get; private set; }
+        public WorkspaceChangeKind Kind { get; }
+        public Solution OldSolution { get; }
+        public Solution NewSolution { get; }
+        public ProjectId ProjectId { get; }
+        public DocumentId DocumentId { get; }
 
         public WorkspaceChangeEventArgs(WorkspaceChangeKind kind, Solution oldSolution, Solution newSolution, ProjectId projectId = null, DocumentId documentId = null)
         {

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public class WorkspaceDiagnostic
     {
-        public WorkspaceDiagnosticKind Kind { get; private set; }
-        public string Message { get; private set; }
+        public WorkspaceDiagnosticKind Kind { get; }
+        public string Message { get; }
 
         public WorkspaceDiagnostic(WorkspaceDiagnosticKind kind, string message)
         {

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticEventArgs.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis
 {
     public class WorkspaceDiagnosticEventArgs : EventArgs
     {
-        public WorkspaceDiagnostic Diagnostic { get; private set; }
+        public WorkspaceDiagnostic Diagnostic { get; }
 
         public WorkspaceDiagnosticEventArgs(WorkspaceDiagnostic diagnostic)
         {

--- a/src/Workspaces/CoreTest/ExtensionOrdererTests.cs
+++ b/src/Workspaces/CoreTest/ExtensionOrdererTests.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         private class ExtensionMetadata : IOrderableMetadata
         {
-            public string Name { get; private set; }
-            public IEnumerable<string> Before { get; private set; }
-            public IEnumerable<string> After { get; private set; }
+            public string Name { get; }
+            public IEnumerable<string> Before { get; }
+            public IEnumerable<string> After { get; }
 
             public ExtensionMetadata(string name = null, IEnumerable<string> before = null, IEnumerable<string> after = null)
             {


### PR DESCRIPTION
Used the CSharpEssentials analyzer to fix all instances of "use getter only autoproperty" in RoslynLight.
(This was already reviewed once, but I resubmitted with just a single commit)