### PR TITLE
Remove private setters in generated BoundNode code.

### DIFF
--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -797,7 +797,7 @@ namespace BoundTreeGenerator
                     }
                     else
                     {
-                        WriteLine("public {0}{1} {2} {{ get; private set; }}", (IsNew(field) ? "new " : ""), field.Type, field.Name);
+                        WriteLine("public {0}{1} {2} {{ get; }}", (IsNew(field) ? "new " : ""), field.Type, field.Name);
                     }
                     break;
 


### PR DESCRIPTION
Modify the C# BoundNodeGenerator to emit getter-only autoprops.