### PR TITLE
Debugger IntellIiSense and linked files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -172,12 +172,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             _projectionBuffer = this.ProjectionBufferFactoryService.CreateProjectionBuffer(null,
                 new object[] { previousStatementSpan, debuggerMappedSpan, this.StatementTerminator, restOfFileSpan }, ProjectionBufferOptions.None, _contentType);
 
-            // fork the solution using this new primary buffer
+            // Fork the solution using this new primary buffer for the document and all of its linked documents.
             var forkedSolution = solution.WithDocumentText(document.Id, _projectionBuffer.CurrentSnapshot.AsText(), PreservationMode.PreserveIdentity);
+            foreach (var link in document.GetLinkedDocumentIds())
+            {
+                forkedSolution = forkedSolution.WithDocumentText(link, _projectionBuffer.CurrentSnapshot.AsText(), PreservationMode.PreserveIdentity);
+            }
 
-            // put it into a new workspace 
+            // Put it into a new workspace, and open it and its related documents
+            // with the projection buffer as the text.
             _workspace = new DebuggerIntelliSenseWorkspace(forkedSolution);
             _workspace.OpenDocument(document.Id, _projectionBuffer.AsTextContainer());
+            foreach (var link in document.GetLinkedDocumentIds())
+            {
+                _workspace.OpenDocument(link, _projectionBuffer.AsTextContainer());
+            }
 
             // Start getting the compilation so the PartialSolution will be ready when the user starts typing in the window
             _workspace.CurrentSolution.GetCompilationAsync(document.Project.Id, System.Threading.CancellationToken.None);

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -615,6 +615,35 @@ $$</Document>
             End Using
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
+        Public Sub CompletionOnTypeCharacterInLinkedFileContext()
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>
+123123123123123123123123123 + $$</Document>
+                               <Document IsLinkFile="true" LinkAssemblyName="CSProj" LinkFilePath="C.cs"/>
+                           </Project>
+                           <Project Language="C#" CommonReferences="true" AssemblyName="CSProj">
+                               <Document FilePath="C.cs">
+{
+    static void Main(string[] args)
+    [|{|]
+
+    }
+}
+                              </Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, True)
+                state.SendTypeChars("arg")
+                Assert.Equal("123123123123123123123123123 + arg", state.GetCurrentViewLineText())
+                state.AssertCompletionSession()
+                state.SendTab()
+                Assert.Contains("args", state.GetCurrentViewLineText())
+            End Using
+        End Sub
+
         Private Sub VerifyCompletionAndDotAfter(item As String, state As TestState)
             state.SendTypeChars(item)
             state.AssertSelectedCompletionItem(item)

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -377,7 +377,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Sub
 #End Region
 
-        Function GetCurrentViewLineText() As Object
+        Function GetCurrentViewLineText() As String
             Return Me.TextView.TextViewLines.Last().Extent.GetText()
         End Function
 


### PR DESCRIPTION
Since we did the shared project work, completion computes results for
every related document. Since debugger intellisense only replaced the
Text of the context document and not its related documents, completion
in a linked file in debugger intellisense could easily query invalid
caret positions and crash with ArgumentOutOfRange.

To fix this, we replace the text for all the related documents of the
context document. I believe this is consistent with normal handling of
linked files where we ensure that linked files always have the same
TextContainer.