### PR TITLE
Html should be the default output for tests run

### DIFF
--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -23,7 +23,7 @@ namespace RunTests
             var xunitPath = args[0];
             var index = 1;
             var test64 = false;
-            var useHtml = false;
+            var useHtml = true;
             ParseArgs(args, ref index, ref test64, ref useHtml);
 
             var list = new List<string>(args.Skip(index));


### PR DESCRIPTION
When running tests from the command line the default output for xUnit
should be HTML, not XML.  The XML output only exists to facilitate
better display in Jenkins and is controlled by the -xml command line
option.  When running locally developers should see the HTML output as
it is much easier to read.

The current behavior is just a bug I added some time ago.