### PR TITLE
FakeSign the concord binaries

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -58,7 +58,7 @@
     <ItemGroup Condition="'$(CIBuild)' == 'true'">
       <TestAssemblies 
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
-        Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;Binaries\$(Configuration)\**\*.ExpressionCompiler.UnitTests.dll;Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll" />
+        Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll" />
     </ItemGroup>
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(RunTestArgs) @(TestAssemblies, ' ')" />

--- a/src/ExpressionEvaluator/Core/Source/Concord/Concord.csproj
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Concord.csproj
@@ -39,6 +39,7 @@
           Inputs="@(ConcordAssemblies->'$(ConcordDir)%(Identity).NetFX20.il')"
           Outputs="$(OutDir)%(Identity).dll">
     <Exec Command="$(MSBuildFrameworkToolsPath)ilasm.exe /dll /quiet /mdv:v2.0.50727 &quot;/output:$(OutDir)@(ConcordAssemblies).dll&quot; $(ConcordDir)@(ConcordAssemblies).NetFX20.il" />
+    <Exec Command="$(VSLOutDir)\FakeSign.exe &quot;$(OutDir)@(ConcordAssemblies).dll&quot;" />
   </Target>
   <Target Name="IlasmPortable" 
           AfterTargets="CoreCompile"
@@ -46,6 +47,7 @@
           Outputs="$(OutDir)Phone\%(Identity).dll">
     <MakeDir Directories="$(OutDir)Phone" />
     <Exec Command="$(MSBuildFrameworkToolsPath)ilasm.exe /dll /quiet &quot;/output:$(OutDir)Phone\@(ConcordAssemblies).dll&quot; $(ConcordDir)@(ConcordAssemblies).Portable.il" />
+    <Exec Command="$(VSLOutDir)\FakeSign.exe &quot;$(OutDir)Phone\@(ConcordAssemblies).dll&quot;" />
   </Target>
   <Target Name="CleanIlasmOutputs" AfterTargets="Clean">
     <Delete Files="@(ConcordAssemblies->'$(OutDir)%(Identity).dll')" />


### PR DESCRIPTION
Run FakeSign.exe on the concord binaries that we import as IL and
re-assemble ourselves.  This makes it possible to load them in
CI builds on Jenkins.