### PR TITLE
Fix ContainedLanguage support for Workflow v1 XOML files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ContainedLanguageRefactorNotifyService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ContainedLanguageRefactorNotifyService.cs
@@ -33,17 +33,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     var containedDocument = visualStudioWorkspace.GetHostDocument(documentId) as ContainedDocument;
                     if (containedDocument != null)
                     {
-                        var hresult = containedDocument.ContainedLanguage.ContainedLanguageHost.OnRenamed(
-                            GetRenameType(symbol), symbol.ToDisplayString(s_qualifiedDisplayFormat), newName);
-                        if (hresult < 0)
+                        var containedLanguageHost = containedDocument.ContainedLanguage.ContainedLanguageHost;
+                        if (containedLanguageHost != null)
                         {
-                            if (throwOnFailure)
+                            var hresult = containedLanguageHost.OnRenamed(
+                                GetRenameType(symbol), symbol.ToDisplayString(s_qualifiedDisplayFormat), newName);
+                            if (hresult < 0)
                             {
-                                Marshal.ThrowExceptionForHR(hresult);
-                            }
-                            else
-                            {
-                                return false;
+                                if (throwOnFailure)
+                                {
+                                    Marshal.ThrowExceptionForHR(hresult);
+                                }
+                                else
+                                {
+                                    return false;
+                                }
                             }
                         }
                     }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioVenusSpanMappingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioVenusSpanMappingService.cs
@@ -156,7 +156,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             }
 
             // we can't directly map span in subject buffer to surface buffer. see whether there is any visible span we can use from the subject buffer span
-            if (VSConstants.S_OK != containedLanguageHost.GetNearestVisibleToken(originalSpanOnSecondaryBuffer, spansOnPrimaryBuffer))
+            if (containedLanguageHost != null &&
+                VSConstants.S_OK != containedLanguageHost.GetNearestVisibleToken(originalSpanOnSecondaryBuffer, spansOnPrimaryBuffer))
             {
                 // no visible span we can use.
                 return false;

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.IVsContainedLanguageFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.IVsContainedLanguageFactory.cs
@@ -3,12 +3,8 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
-using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 using VsServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -541,11 +541,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             var containedLanguageHost = containedDocument.ContainedLanguage.ContainedLanguageHost as IVsContainedLanguageHostInternal;
-            foreach (var importClause in memberImportsNamespaces)
+            if (containedLanguageHost != null)
             {
-                if (containedLanguageHost.InsertImportsDirective(importClause) != VSConstants.S_OK)
+                foreach (var importClause in memberImportsNamespaces)
                 {
-                    return false;
+                    if (containedLanguageHost.InsertImportsDirective(importClause) != VSConstants.S_OK)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/VisualStudioTaskItemBase.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/VisualStudioTaskItemBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 {
                     return mappedLocation[0];
                 }
-                else if (VSConstants.S_OK == containedLanguageHost.GetNearestVisibleToken(displayLocation, mappedLocation))
+                else if (containedLanguageHost != null && VSConstants.S_OK == containedLanguageHost.GetNearestVisibleToken(displayLocation, mappedLocation))
                 {
                     return mappedLocation[0];
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/AbstractContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/AbstractContainedLanguage.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         /// workspace, that most language operations deal with.  The surface buffer is the one that the
         /// view is created over, and the Document buffer is the one that is saved to disk.
         /// </summary>
-        public IProjectionBuffer DataBuffer { get; private set; }
+        public ITextBuffer DataBuffer { get; private set; }
 
         public IVsContainedLanguageHost ContainedLanguageHost { get; protected set; }
         public IVsTextBufferCoordinator BufferCoordinator { get; protected set; }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         /// <summary>
         /// To be called from the derived class constructor!
         /// </summary>
-        protected void SetDataBuffer(IProjectionBuffer dataBuffer)
+        protected void SetDataBuffer(ITextBuffer dataBuffer)
         {
             if (dataBuffer == null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -1052,6 +1053,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         private RazorCodeBlockType GetRazorCodeBlockType(int position)
         {
+            Debug.Assert(_hostType == HostType.Razor);
+
             var subjectBuffer = (IProjectionBuffer)this.GetOpenTextBuffer();
             var subjectSnapshot = subjectBuffer.CurrentSnapshot;
             var surfaceSnapshot = ((IProjectionBuffer)_containedLanguage.DataBuffer).CurrentSnapshot;

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguage.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Editor;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.TextManager.Interop;
 
@@ -64,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             IVsTextLines primaryTextLines;
             Marshal.ThrowExceptionForHR(bufferCoordinator.GetPrimaryBuffer(out primaryTextLines));
             var primaryVsTextBuffer = (IVsTextBuffer)primaryTextLines;
-            var dataBuffer = (IProjectionBuffer)_editorAdaptersFactoryService.GetDataBuffer(primaryVsTextBuffer);
+            var dataBuffer = _editorAdaptersFactoryService.GetDataBuffer(primaryVsTextBuffer);
             SetDataBuffer(dataBuffer);
 
             this.ContainedDocument = new ContainedDocument(


### PR DESCRIPTION
Workflow XOML files call into IVsContainedLanguageFactory.GetLanguage(), passing an IVsTextBufferCoordinator. However, that IVsTextBufferCoordinator is constructed differently than the one we get from Venus and breaks some assumptions in the C#/VB language services.

The critical assumption that XOML breaks is that the primary buffer is an IProjectionBuffer. This is not true for XOML. Instead, it is simply a non-projected buffer with the HTML content type.  So, our code attempts to cast to an IProjectionBuffer and we crash before ever creating a ContainedDocument and adding it to the workspace. To fix this, we need to break the IProjectionBuffer assumption and update any calling code depending on projections to dynamically cast to IProjectionBuffer first. This unblocks several Workflow v1 scenarios.

Next, it turns out that XOML never calls SetHost() on the IVsContainedLanguage that we return. So, there's never an IVsContainedLanguageHost hooked up and calling code needs to be updated to guard against null hosts.