### PR TITLE
Fixing parentheses simplification in the presence of a conditional member access.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3483,10 +3483,8 @@ class A
 
         [WorkItem(1091946)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
-        public void TestSimpleConditionalAccess()
+        public void TestConditionalAccessWithConversion()
         {
-            // Note: The expected value here shouldnt have parentheses around args[0]. That's caused by
-            // Bug 1091936.
             Test(
             @"
 class A
@@ -3502,7 +3500,53 @@ class A
 {
     bool M(string[] args)
     {
-        return (args[0])?.Length == 0;
+        return args[0]?.Length == 0;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void TestSimpleConditionalAccess()
+        {
+            Test(
+            @"
+class A
+{
+    void M(string[] args)
+    {
+        var [|x|] = args.Length.ToString();
+        var y = x?.ToString();
+    }
+}
+", @"
+class A
+{
+    void M(string[] args)
+    {
+        var y = args.Length.ToString()?.ToString();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void TestConditionalAccessWithConditionalExpression()
+        {
+            Test(
+            @"
+class A
+{
+    void M(string[] args)
+    {
+        var [|x|] = args[0]?.Length ?? 10;
+        var y = x == 10 ? 10 : 4;
+    }
+}
+", @"
+class A
+{
+    void M(string[] args)
+    {
+        var y = (args[0]?.Length ?? 10) == 10 ? 10 : 4;
     }
 }");
         }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -3831,5 +3831,111 @@ End Class
 
             Test(code, expected, compareTokens:=False)
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub TestSimpleConditionalAccess()
+            Dim code =
+<File>
+Class C
+    Sub M(args As String())
+        Dim [|x|] = args.Length.ToString()
+        Dim y = x?.ToString()
+        Dim y1 = x?!dictionarykey
+        Dim y2 = x?.&lt;xmlelement&gt;
+        Dim y3 = x?...&lt;xmldescendant&gt;
+        Dim y4 = x?.@xmlattribute
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Class C
+    Sub M(args As String())
+        Dim y = args.Length.ToString()?.ToString()
+        Dim y1 = args.Length.ToString()?!dictionarykey
+        Dim y2 = args.Length.ToString()?.&lt;xmlelement&gt;
+        Dim y3 = args.Length.ToString()?...&lt;xmldescendant&gt;
+        Dim y4 = args.Length.ToString()?.@xmlattribute
+    End Sub
+End Class
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/1025"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub TestConditionalAccessWithConversion()
+            Dim code =
+<File>
+Class C
+    Function M(args As String()) As Boolean
+        Dim [|x|] = args(0)
+        Return x?.Length = 0
+    End Function
+End Class
+</File>
+
+            Dim expected =
+<File>
+Class C
+    Function M(args As String()) As Boolean
+        Return args(0)?.Length = 0
+    End Function
+End Class
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub TestConditionalAccessWithConditionalExpression()
+            Dim code =
+<File>
+Class C
+    Sub M(args As String())
+        Dim [|x|] = If(args(0)?.Length, 10)
+        Dim y = If(x = 10, 10, 4)
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Class C
+    Sub M(args As String())
+        Dim y = If(If(args(0)?.Length, 10) = 10, 10, 4)
+    End Sub
+End Class
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub TestXmlLiteral()
+            Dim code =
+<File>
+Class C
+    Sub M(args As String())
+        Dim [|x|] = &lt;xml&gt;Hello&lt;/xml&gt;
+        Dim y = x.&lt;xmlelement&gt;
+        Dim y1 = x?.&lt;xmlelement&gt;
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Class C
+    Sub M(args As String())
+        Dim y = (&lt;xml&gt;Hello&lt;/xml&gt;).&lt;xmlelement&gt;
+        Dim y1 = (&lt;xml&gt;Hello&lt;/xml&gt;)?.&lt;xmlelement&gt;
+    End Sub
+End Class
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2231,6 +2231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             switch (expression.Kind())
             {
                 case SyntaxKind.SimpleMemberAccessExpression:
+                case SyntaxKind.ConditionalAccessExpression:
                 case SyntaxKind.InvocationExpression:
                 case SyntaxKind.ElementAccessExpression:
                 case SyntaxKind.PostIncrementExpression:


### PR DESCRIPTION
Fixes #987

Giving the ConditionalMemberAcces the same precedence as member access while determining associativity fixes the issue.

In VB, removing parentheses simplification works fine. There is a case where cast simplfication doesn't work and I've filed #1025 to track that.