### PR TITLE
fix missed or incorrect localized strings in tests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6298,7 +6298,7 @@ class Program
     }
 }";
 
-            var description = $@"({CSharpEditorResources.Awaitable}) Task Program.foo()
+            var description = $@"({CSharpFeaturesResources.Awaitable}) Task Program.foo()
 {WorkspacesResources.Usage}
   {CSharpFeaturesResources.Await} foo();";
 
@@ -6319,7 +6319,7 @@ class Program
     }
 }";
 
-            var description = $@"({CSharpEditorResources.Awaitable}) Task<int> Program.foo()
+            var description = $@"({CSharpFeaturesResources.Awaitable}) Task<int> Program.foo()
 {WorkspacesResources.Usage}
   int x = {CSharpFeaturesResources.Await} foo();";
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -1677,7 +1677,7 @@ class C : [|IDisposable|]",
 $@"using System;
 class C : IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{DisposePattern("protected virtual ", "C", "public void ")}
 }}
 ", index: 1, compareTokens: false);
         }
@@ -1720,7 +1720,8 @@ class C : System.IDisposable
     class IDisposable
     {{
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+
+{DisposePattern("protected virtual ", "C", "void System.IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -1771,7 +1772,7 @@ class C : IDisposable
 @"class C : [|System.IDisposable|]",
 $@"class C : System.IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void System.IDisposable.")}
+{DisposePattern("protected virtual ", "C", "void System.IDisposable.")}
 }}
 ", index: 3, compareTokens: false);
         }
@@ -1832,7 +1833,8 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+
+{DisposePattern("protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -1860,7 +1862,8 @@ class C : I
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+
+{DisposePattern("protected virtual ", "C", "void IDisposable.")}
 }}", index: 3, compareTokens: false);
         }
 
@@ -2297,7 +2300,7 @@ using System;
 
 class Program : IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+{DisposePattern("protected virtual ", "C", "public void ")}
 }}
 ", index: 1);
         }
@@ -2320,7 +2323,7 @@ using System;
 class Program : IDisposable
 {{
     private bool DisposedValue;
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "Program", "void IDisposable.")}
+{DisposePattern("protected virtual ", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2399,7 +2402,7 @@ using System;
 
 sealed class Program : IDisposable
 {{
-{string.Format(CSharpFeaturesResources.DisposePattern, "", "Program", "void IDisposable.")}
+{DisposePattern("", "Program", "void IDisposable.")}
 }}
 ", index: 3);
         }
@@ -2524,7 +2527,8 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "public void ")}
+
+{DisposePattern("protected virtual ", "C", "public void ")}
 }}", index: 1, compareTokens: false);
         }
 
@@ -2571,12 +2575,51 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
     {{
         throw new NotImplementedException();
     }}
-{string.Format(CSharpFeaturesResources.DisposePattern, "protected virtual ", "C", "void IDisposable.")}
+
+{DisposePattern("protected virtual ", "C", "void IDisposable.")}
 }}
 
 partial class C
 {{
 }}", index: 3, compareTokens: false);
+        }
+
+        private static string DisposePattern(string disposeVisibility, string className, string implementationVisibility)
+        {
+            return $@"    #region IDisposable Support
+    private bool disposedValue = false; // {FeaturesResources.ToDetectRedundantCalls}
+
+    {disposeVisibility}void Dispose(bool disposing)
+    {{
+        if (!disposedValue)
+        {{
+            if (disposing)
+            {{
+                // {FeaturesResources.DisposeManagedStateTodo}
+            }}
+
+            // {CSharpFeaturesResources.FreeUnmanagedResourcesTodo}
+            // {FeaturesResources.SetLargeFieldsToNullTodo}
+
+            disposedValue = true;
+        }}
+    }}
+
+    // {CSharpFeaturesResources.OverrideAFinalizerTodo}
+    // ~{className}() {{
+    //   // {CSharpFeaturesResources.DoNotChangeThisCodeUseDispose}
+    //   Dispose(false);
+    // }}
+
+    // {CSharpFeaturesResources.ThisCodeAddedToCorrectlyImplementDisposable}
+    {implementationVisibility}Dispose()
+    {{
+        // {CSharpFeaturesResources.DoNotChangeThisCodeUseDispose}
+        Dispose(true);
+        // {CSharpFeaturesResources.UncommentTheFollowingIfFinalizerOverriddenTodo}
+        // GC.SuppressFinalize(this);
+    }}
+    #endregion";
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -170,9 +170,9 @@ class Class
     void Method()
     {{
         return 0;
-#pragma warning disable CS0162 // {CSharpResources.WRN_UnreachableCode}
+#pragma warning disable CS0162 // {CSharpResources.WRN_UnreachableCode_Title}
         int x = ""0"";
-#pragma warning restore CS0162 // {CSharpResources.WRN_UnreachableCode}
+#pragma warning restore CS0162 // {CSharpResources.WRN_UnreachableCode_Title}
     }}
 }}");
                 }
@@ -1017,13 +1017,13 @@ namespace N
         }
     }
 }",
-            @"
+            $@"
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
 
 ", isAddedDocument: true);
                 }

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 var unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
-                Assert.Equal("type DogBed", itemDisplay.AdditionalInformation);
+                Assert.Equal($"{EditorFeaturesResources.Type}DogBed", itemDisplay.AdditionalInformation);
                 _glyphServiceMock.Verify();
 
                 item = items.ElementAt(1);

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 var unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
-                Assert.Equal("type DogBed", itemDisplay.AdditionalInformation);
+                Assert.Equal($"{EditorFeaturesResources.Type}DogBed", itemDisplay.AdditionalInformation);
                 _glyphServiceMock.Verify();
 
                 item = items.ElementAt(1);
@@ -503,7 +503,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             {
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate);
                 var item = _aggregator.GetItems("M").Single();
-                VerifyNavigateToResultItem(item, "M", MatchKind.Exact, NavigateToItemKind.Method, displayName: "M()", additionalInfo: "type A<T>.B.C<U>");
+                VerifyNavigateToResultItem(item, "M", MatchKind.Exact, NavigateToItemKind.Method, displayName: "M()", additionalInfo: $"{EditorFeaturesResources.Type}A<T>.B.C<U>");
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -2631,10 +2631,10 @@ $@"
                 MainDescription(@"string 'a.Name { get; }"),
                 NoTypeParameterMap,
                 AnonymousTypes(
-@"
-Anonymous Types:
-    'a is new { string Name, 'b Address }
-    'b is new { string Street, string Zip }"));
+$@"
+{FeaturesResources.AnonymousTypes}
+    'a {FeaturesResources.Is} new {{ string Name, 'b Address }}
+    'b {FeaturesResources.Is} new {{ string Street, string Zip }}"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -3155,7 +3155,7 @@ class C
 
             var documentation = $@"
 {WorkspacesResources.Usage}
-  await Foo();";
+  {CSharpFeaturesResources.Await} Foo();";
 
             VerifyWithMscorlib45(markup, new[] { MainDescription(description), Usage(documentation) });
         }
@@ -3872,7 +3872,7 @@ class C
     </Project>
 </Workspace>";
 
-            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.LocalVariable}) int x"), Usage("\r\n    Proj1 - Available\r\n    Proj2 - Not Available\r\n\r\nYou can use the navigation bar to switch context.", expectsWarningGlyph: true) });
+            VerifyWithReferenceWorker(markup, new[] { MainDescription($"({FeaturesResources.LocalVariable}) int x"), Usage($"\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}", expectsWarningGlyph: true) });
         }
 
         [WorkItem(1020944)]

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
@@ -79,7 +79,7 @@ class Program
   int x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task<int> Program.Foo<T>()", documentation, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpEditorResources.Awaitable}) Task<int> Program.Foo<T>()", documentation, string.Empty, currentParameterIndex: 0));
 
             // TODO: Enable the script case when we have support for extension methods in scripts
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false, sourceCodeKind: Microsoft.CodeAnalysis.SourceCodeKind.Regular);
@@ -259,7 +259,7 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem("void IFoo.Bar<T>()", currentParameterIndex: 0),
-                new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
+                new SignatureHelpTestItem($"({CSharpEditorResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
             };
 
             // Extension methods are supported in Interactive/Script (yet).

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -543,7 +543,7 @@ static class FooClass
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void G.Foo<T>()", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpEditorResources.Extension}) void G.Foo<T>()", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Enable the script case when we have support for extension methods in scripts
             Test(markup, expectedOrderedItems, usePreviousCharAsTrigger: false, sourceCodeKind: Microsoft.CodeAnalysis.SourceCodeKind.Regular);

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -317,7 +317,7 @@ public static class MyExtension
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) int string.ExtensionMethod(int x)", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpEditorResources.Extension}) int string.ExtensionMethod(int x)", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Once we do the work to allow extension methods in nested types, we should change this.
             Test(markup, expectedOrderedItems, sourceCodeKind: SourceCodeKind.Regular);
@@ -1509,7 +1509,7 @@ class C
   await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpEditorResources.Awaitable}) Task C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
 
             TestSignatureHelpWithMscorlib45(markup, expectedOrderedItems, "C#");
         }
@@ -1532,7 +1532,7 @@ class C
   Task<int> x = await Foo();";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpFeaturesResources.Awaitable}) Task<Task<int>> C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"({CSharpEditorResources.Awaitable}) Task<Task<int>> C.Foo()", methodDocumentation: description, currentParameterIndex: 0));
 
             TestSignatureHelpWithMscorlib45(markup, expectedOrderedItems, "C#");
         }
@@ -1621,7 +1621,7 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem("void IFoo.Bar<T>()", currentParameterIndex: 0),
-                new SignatureHelpTestItem($"({CSharpFeaturesResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
+                new SignatureHelpTestItem($"({CSharpEditorResources.Extension}) void IFoo.Bar<T1, T2>()", currentParameterIndex: 0),
             };
 
             // Extension methods are supported in Interactive/Script (yet).

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -852,8 +852,8 @@ class C$$
                 state.EditorOperations.InsertText("at");
                 state.AssertTag("C", "Cat", invokeAction: true, actionIndex: 1);
                 Assert.True(mockPreview.Called);
-                Assert.Equal("Rename 'C' to 'Cat':", mockPreview.Description);
-                Assert.Equal("Preview Changes - Rename", mockPreview.Title);
+                Assert.Equal(string.Format(EditorFeaturesResources.RenameToTitle, "C", "Cat"), mockPreview.Description);
+                Assert.Equal(string.Format(EditorFeaturesResources.PreviewChangesOf, EditorFeaturesResources.Rename), mockPreview.Title);
                 Assert.Equal("C", mockPreview.TopLevelName);
                 Assert.Equal(Glyph.ClassInternal, mockPreview.TopLevelGlyph);
             }

--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -348,33 +348,33 @@ End Class
             AssertGeneratedResultIs(
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
-                        <Document><![CDATA[
-<Microsoft.VisualBasic.CompilerServices.DesignerGeneratedAttribute>
+                        <Document>
+&lt;Microsoft.VisualBasic.CompilerServices.DesignerGeneratedAttribute&gt;
 Class C
 
     Sub InitializeComponent()
     End Sub
 End Class
-                        ]]></Document>
+                        </Document>
                     </Project>
                 </Workspace>,
                 "C", NavigationItemNew,
-                <Result><![CDATA[
-<Microsoft.VisualBasic.CompilerServices.DesignerGeneratedAttribute>
+                <Result>
+&lt;Microsoft.VisualBasic.CompilerServices.DesignerGeneratedAttribute&gt;
 Class C
     Public Sub New()
 
-        ' This call is required by the designer.
+        ' <%= ThisCallIsRequiredByTheDesigner %>
         InitializeComponent()
 
-        ' Add any initialization after the InitializeComponent() call.
+        ' <%= AddAnyInitializationAfter %>
 
     End Sub
 
     Sub InitializeComponent()
     End Sub
 End Class
-                ]]></Result>)
+                </Result>)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -1984,9 +1984,38 @@ End Interface", index:=1, compareTokens:=False)
         End Sub
 
         Private Shared Function DisposePattern(disposeMethodModifiers As String, Optional simplifySystem As Boolean = True) As String
-            ' the simplifier removes the "Me." prefix
-            Dim code = String.Format(VBFeaturesResources.DisposePattern, disposeMethodModifiers).
-                Replace("Me.disposedValue", "disposedValue")
+            Dim code = $"
+#Region ""IDisposable Support""
+    Private disposedValue As Boolean ' {FeaturesResources.ToDetectRedundantCalls}
+
+    ' IDisposable
+    Protected {disposeMethodModifiers}Sub Dispose(disposing As Boolean)
+        If Not disposedValue Then
+            If disposing Then
+                ' {FeaturesResources.DisposeManagedStateTodo}
+            End If
+
+            ' {VBFeaturesResources.FreeUnmanagedResourcesTodo}
+            ' {FeaturesResources.SetLargeFieldsToNullTodo}
+        End If
+        disposedValue = True
+    End Sub
+
+    ' {VBFeaturesResources.OverrideFinalizerTodo}
+    'Protected Overrides Sub Finalize()
+    '    ' {VBFeaturesResources.DoNotChangeThisCodeUseDispose}
+    '    Dispose(False)
+    '    MyBase.Finalize()
+    'End Sub
+
+    ' {VBFeaturesResources.ThisCodeAddedToCorrectlyImplementDisposable}
+    Public Sub Dispose() Implements System.IDisposable.Dispose
+        ' {VBFeaturesResources.DoNotChangeThisCodeUseDispose}
+        Dispose(True)
+        ' {VBFeaturesResources.UncommentTheFollowingLineIfFinalizeIsOverridden}
+        ' GC.SuppressFinalize(Me)
+    End Sub
+#End Region"
 
             ' some tests count on "System." being simplified out
             If simplifySystem Then

--- a/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/CSharpFeaturesResources.Designer.cs
@@ -187,27 +187,11 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     #region IDisposable Support
-        ///    private bool disposedValue = false; // To detect redundant calls
-        ///
-        ///    {0}void Dispose(bool disposing)
-        ///    {{
-        ///        if (!disposedValue)
-        ///        {{
-        ///            if (disposing)
-        ///            {{
-        ///                // TODO: dispose managed state (managed objects).
-        ///            }}
-        ///
-        ///            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-        ///            // TODO: set large fields to null.
-        ///
-        ///            disposedValue = true;
-        ///         [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Do not change this code. Put cleanup code in Dispose(bool disposing) above..
         /// </summary>
-        internal static string DisposePattern {
+        internal static string DoNotChangeThisCodeUseDispose {
             get {
-                return ResourceManager.GetString("DisposePattern", resourceCulture);
+                return ResourceManager.GetString("DoNotChangeThisCodeUseDispose", resourceCulture);
             }
         }
         
@@ -226,6 +210,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string Extension {
             get {
                 return ResourceManager.GetString("Extension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: free unmanaged resources (unmanaged objects) and override a finalizer below..
+        /// </summary>
+        internal static string FreeUnmanagedResourcesTodo {
+            get {
+                return ResourceManager.GetString("FreeUnmanagedResourcesTodo", resourceCulture);
             }
         }
         
@@ -388,6 +381,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string OrganizeUsingsWithAccelerator {
             get {
                 return ResourceManager.GetString("OrganizeUsingsWithAccelerator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources..
+        /// </summary>
+        internal static string OverrideAFinalizerTodo {
+            get {
+                return ResourceManager.GetString("OverrideAFinalizerTodo", resourceCulture);
             }
         }
         
@@ -577,6 +579,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string TheSelectionContainsSyntacticErrors {
             get {
                 return ResourceManager.GetString("TheSelectionContainsSyntacticErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This code added to correctly implement the disposable pattern..
+        /// </summary>
+        internal static string ThisCodeAddedToCorrectlyImplementDisposable {
+            get {
+                return ResourceManager.GetString("ThisCodeAddedToCorrectlyImplementDisposable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: uncomment the following line if the finalizer is overridden above..
+        /// </summary>
+        internal static string UncommentTheFollowingIfFinalizerOverriddenTodo {
+            get {
+                return ResourceManager.GetString("UncommentTheFollowingIfFinalizerOverriddenTodo", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -255,42 +255,6 @@
   <data name="OrganizeUsingsWithAccelerator" xml:space="preserve">
     <value>&amp;Organize Usings</value>
   </data>
-  <data name="DisposePattern" xml:space="preserve">
-    <value>    #region IDisposable Support
-    private bool disposedValue = false; // To detect redundant calls
-
-    {0}void Dispose(bool disposing)
-    {{
-        if (!disposedValue)
-        {{
-            if (disposing)
-            {{
-                // TODO: dispose managed state (managed objects).
-            }}
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
-            disposedValue = true;
-        }}
-    }}
-
-    // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-    // ~{1}() {{
-    //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-    //   Dispose(false);
-    // }}
-
-    // This code added to correctly implement the disposable pattern.
-    {2}Dispose()
-    {{
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(true);
-        // TODO: uncomment the following line if the finalizer is overridden above.
-        // GC.SuppressFinalize(this);
-    }}
-    #endregion</value>
-  </data>
   <data name="AutoselectDisabledDueToPotentialImplicitArray" xml:space="preserve">
     <value>Autoselect disabled due to potential implicit array creation.</value>
   </data>
@@ -320,5 +284,20 @@
   </data>
   <data name="ImplicitConversionDisplayText" xml:space="preserve">
     <value>Generate implicit conversion operator in '{0}'</value>
+  </data>
+  <data name="DoNotChangeThisCodeUseDispose" xml:space="preserve">
+    <value>Do not change this code. Put cleanup code in Dispose(bool disposing) above.</value>
+  </data>
+  <data name="FreeUnmanagedResourcesTodo" xml:space="preserve">
+    <value>TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.</value>
+  </data>
+  <data name="OverrideAFinalizerTodo" xml:space="preserve">
+    <value>TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.</value>
+  </data>
+  <data name="ThisCodeAddedToCorrectlyImplementDisposable" xml:space="preserve">
+    <value>This code added to correctly implement the disposable pattern.</value>
+  </data>
+  <data name="UncommentTheFollowingIfFinalizerOverriddenTodo" xml:space="preserve">
+    <value>TODO: uncomment the following line if the finalizer is overridden above.</value>
   </data>
 </root>

--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -583,6 +583,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TODO: dispose managed state (managed objects)..
+        /// </summary>
+        internal static string DisposeManagedStateTodo {
+            get {
+                return ResourceManager.GetString("DisposeManagedStateTodo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit and Continue.
         /// </summary>
         internal static string EditAndContinue {
@@ -1789,6 +1798,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TODO: set large fields to null..
+        /// </summary>
+        internal static string SetLargeFieldsToNullTodo {
+            get {
+                return ResourceManager.GetString("SetLargeFieldsToNullTodo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Simplify Member Access.
         /// </summary>
         internal static string SimplifyMemberAccess {
@@ -1931,6 +1949,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string ThisSymbolHasRelatedDefinitionsOrReferencesInMetadata {
             get {
                 return ResourceManager.GetString("ThisSymbolHasRelatedDefinitionsOrReferencesInMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To detect redundant calls.
+        /// </summary>
+        internal static string ToDetectRedundantCalls {
+            get {
+                return ResourceManager.GetString("ToDetectRedundantCalls", resourceCulture);
             }
         }
         

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -833,4 +833,13 @@ Do you want to continue?</value>
   <data name="FixAllTitle_Solution" xml:space="preserve">
     <value>Solution</value>
   </data>
+  <data name="DisposeManagedStateTodo" xml:space="preserve">
+    <value>TODO: dispose managed state (managed objects).</value>
+  </data>
+  <data name="SetLargeFieldsToNullTodo" xml:space="preserve">
+    <value>TODO: set large fields to null.</value>
+  </data>
+  <data name="ToDetectRedundantCalls" xml:space="preserve">
+    <value>To detect redundant calls</value>
+  </data>
 </root>

--- a/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/VBFeaturesResources.Designer.vb
@@ -582,28 +582,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to #Region &quot;IDisposable Support&quot;
-        '''    Private disposedValue As Boolean &apos; To detect redundant calls
-        '''
-        '''    &apos; IDisposable
-        '''    Protected {0}Sub Dispose(disposing As Boolean)
-        '''        If Not Me.disposedValue Then
-        '''            If disposing Then
-        '''                &apos; TODO: dispose managed state (managed objects).
-        '''            End If
-        '''
-        '''            &apos; TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-        '''            &apos; TODO: set large fields to null.
-        '''        End If
-        '''        Me.disposedValue  [rest of string was truncated]&quot;;.
-        '''</summary>
-        Friend ReadOnly Property DisposePattern() As String
-            Get
-                Return ResourceManager.GetString("DisposePattern", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Restricts the values of a query result to eliminate duplicate values..
         '''</summary>
         Friend ReadOnly Property DistinctQueryKeywordToolTip() As String
@@ -628,6 +606,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         Friend ReadOnly Property DoKeywordToolTip() As String
             Get
                 Return ResourceManager.GetString("DoKeywordToolTip", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above..
+        '''</summary>
+        Friend ReadOnly Property DoNotChangeThisCodeUseDispose() As String
+            Get
+                Return ResourceManager.GetString("DoNotChangeThisCodeUseDispose", resourceCulture)
             End Get
         End Property
         
@@ -983,6 +970,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         Friend ReadOnly Property ForKeywordToolTip() As String
             Get
                 Return ResourceManager.GetString("ForKeywordToolTip", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to TODO: free unmanaged resources (unmanaged objects) and override Finalize() below..
+        '''</summary>
+        Friend ReadOnly Property FreeUnmanagedResourcesTodo() As String
+            Get
+                Return ResourceManager.GetString("FreeUnmanagedResourcesTodo", resourceCulture)
             End Get
         End Property
         
@@ -2046,6 +2042,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources..
+        '''</summary>
+        Friend ReadOnly Property OverrideFinalizerTodo() As String
+            Get
+                Return ResourceManager.GetString("OverrideFinalizerTodo", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Specifies that a property or procedure overrides an identically named property or procedure inherited from a base class..
         '''</summary>
         Friend ReadOnly Property OverridesKeywordToolTip() As String
@@ -2538,6 +2543,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to This code added by Visual Basic to correctly implement the disposable pattern..
+        '''</summary>
+        Friend ReadOnly Property ThisCodeAddedToCorrectlyImplementDisposable() As String
+            Get
+                Return ResourceManager.GetString("ThisCodeAddedToCorrectlyImplementDisposable", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Throws an exception within a procedure so that you can handle it with structured or unstructured exception-handling code..
         '''</summary>
         Friend ReadOnly Property ThrowKeywordToolTip() As String
@@ -2626,6 +2640,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         Friend ReadOnly Property TypeOfKeywordToolTip() As String
             Get
                 Return ResourceManager.GetString("TypeOfKeywordToolTip", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to TODO: uncomment the following line if Finalize() is overridden above..
+        '''</summary>
+        Friend ReadOnly Property UncommentTheFollowingLineIfFinalizeIsOverridden() As String
+            Get
+                Return ResourceManager.GetString("UncommentTheFollowingLineIfFinalizeIsOverridden", resourceCulture)
             End Get
         End Property
         

--- a/src/Features/VisualBasic/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/VBFeaturesResources.resx
@@ -330,39 +330,6 @@
   <data name="RemoveUnnecessaryImportsWithAccelerator" xml:space="preserve">
     <value>&amp;Remove Unnecessary Imports</value>
   </data>
-  <data name="DisposePattern" xml:space="preserve">
-    <value>#Region "IDisposable Support"
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected {0}Sub Dispose(disposing As Boolean)
-        If Not Me.disposedValue Then
-            If disposing Then
-                ' TODO: dispose managed state (managed objects).
-            End If
-
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
-        End If
-        Me.disposedValue = True
-    End Sub
-
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
-    'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-    '    Dispose(False)
-    '    MyBase.Finalize()
-    'End Sub
-
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
-    Public Sub Dispose() Implements System.IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
-        Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
-        ' GC.SuppressFinalize(Me)
-    End Sub
-#End Region</value>
-  </data>
   <data name="AddressOfKeywordToolTip" xml:space="preserve">
     <value>Creates a delegate procedure instance that references the specified procedure.
 AddressOf &lt;procedureName&gt;</value>
@@ -1065,5 +1032,20 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   </data>
   <data name="ImplicitConversionDisplayText" xml:space="preserve">
     <value>Generate widening conversion in '{0}'</value>
+  </data>
+  <data name="DoNotChangeThisCodeUseDispose" xml:space="preserve">
+    <value>Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.</value>
+  </data>
+  <data name="FreeUnmanagedResourcesTodo" xml:space="preserve">
+    <value>TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.</value>
+  </data>
+  <data name="OverrideFinalizerTodo" xml:space="preserve">
+    <value>TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.</value>
+  </data>
+  <data name="ThisCodeAddedToCorrectlyImplementDisposable" xml:space="preserve">
+    <value>This code added by Visual Basic to correctly implement the disposable pattern.</value>
+  </data>
+  <data name="UncommentTheFollowingLineIfFinalizeIsOverridden" xml:space="preserve">
+    <value>TODO: uncomment the following line if Finalize() is overridden above.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -1086,10 +1086,10 @@ class C
 vbTab & "where TResult : class" & vbCrLf &
 $"    {String.Format(ServicesVSResources.Library_MemberOf, "C")}" & vbCrLf &
 "" & vbCrLf &
-FeaturesResources.Summary & vbCrLf &
+ServicesVSResources.Library_Summary & vbCrLf &
 "The M method." & vbCrLf &
 "" & vbCrLf &
-FeaturesResources.Returns & vbCrLf &
+ServicesVSResources.Library_Returns & vbCrLf &
 "Returns a TResult.")
             End Using
         End Sub

--- a/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
@@ -2074,17 +2074,17 @@ End Class
 "Public Sub M(Of T)(i As Integer, s As String)" & vbCrLf &
 $"    {String.Format(ServicesVSResources.Library_MemberOf, "C")}" & vbCrLf &
 "" & vbCrLf &
-FeaturesResources.Summary & vbCrLf &
+ServicesVSResources.Library_Summary & vbCrLf &
 "The is my summary!" & vbCrLf &
 "" & vbCrLf &
 ServicesVSResources.Library_TypeParameters & vbCrLf &
 "T: Hello from a type parameter" & vbCrLf &
 "" & vbCrLf &
-FeaturesResources.Parameters & vbCrLf &
+ServicesVSResources.Library_Parameters & vbCrLf &
 "i: The parameter i" & vbCrLf &
 "s: The parameter t" & vbCrLf &
 "" & vbCrLf &
-FeaturesResources.Remarks & vbCrLf &
+ServicesVSResources.Library_Remarks & vbCrLf &
 "Takes i and s.")
             End Using
         End Sub


### PR DESCRIPTION
Also, remove the `*.DisposePattern` resource strings and replace them with multiple smaller strings.  This was done because `DisposePattern` needed to be parsed, simplified, and formatted and pseudo-localized builds add a special prefix/suffix that would break the parser.  See `CSharpImplementInterfaceService.cs` and `VisualBasicImplementInterfaceService.vb` for details.