### PR TITLE
Fix issue introduced by recent change that breaks web scenarios

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -722,14 +722,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         {
             var subjectBuffer = (IProjectionBuffer)this.GetOpenTextBuffer();
 
-            var projectionDataBuffer = _containedLanguage as IProjectionBuffer;
+            var projectionDataBuffer = _containedLanguage.DataBuffer as IProjectionBuffer;
             if (projectionDataBuffer != null)
             {
                 return projectionDataBuffer.CurrentSnapshot
-                           .GetSourceSpans()
-                           .Where(ss => ss.Snapshot.TextBuffer == subjectBuffer)
-                           .Select(s => s.Span.ToTextSpan())
-                           .OrderBy(s => s.Start);
+                    .GetSourceSpans()
+                    .Where(ss => ss.Snapshot.TextBuffer == subjectBuffer)
+                    .Select(s => s.Span.ToTextSpan())
+                    .OrderBy(s => s.Start);
             }
             else
             {


### PR DESCRIPTION
Of course, a ContainedLanguage will never be an IProjectionBuffer. So,
this method always returns an empty enumerable. Instead, the cast should
be against _containedLanguage.DataBuffer.

#hangsheadinshame