### PR TITLE
support compilation end action in v1 diagnostic engine

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -1257,7 +1257,7 @@ public class B
             End Sub
 
             Public Shared Sub OnCodeBlockEnded(context As CodeBlockEndAnalysisContext)
-                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor1, Location.None))
+                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor1, context.CodeBlock.GetLocation()))
             End Sub
 
             Public Shared Sub OnCodeBlockStarted(context As CodeBlockStartAnalysisContext(Of CodeAnalysis.CSharp.SyntaxKind))
@@ -1268,11 +1268,11 @@ public class B
             Protected Class NodeAnalyzer
                 Public Sub Initialize(registerSyntaxNodeAction As Action(Of Action(Of SyntaxNodeAnalysisContext), ImmutableArray(Of CodeAnalysis.CSharp.SyntaxKind)))
                     registerSyntaxNodeAction(Sub(context)
-                                                 context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor2, Location.None))
+                                                 context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor2, context.Node.GetLocation()))
                                              End Sub, ImmutableArray.Create(CodeAnalysis.CSharp.SyntaxKind.EqualsValueClause))
 
                     registerSyntaxNodeAction(Sub(context)
-                                                 context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor3, Location.None))
+                                                 context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Desciptor3, context.Node.GetLocation()))
                                              End Sub, ImmutableArray.Create(CodeAnalysis.CSharp.SyntaxKind.BaseConstructorInitializer))
 
                     registerSyntaxNodeAction(Sub(context)

--- a/src/Features/Core/Diagnostics/DiagnosticData.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticData.cs
@@ -284,6 +284,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static DiagnosticData Create(Workspace workspace, Diagnostic diagnostic)
         {
+            Contract.Requires(diagnostic.Location == null || !diagnostic.Location.IsInSource);
+
             return new DiagnosticData(
                 diagnostic.Id,
                 diagnostic.Descriptor.Category,
@@ -304,15 +306,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static DiagnosticData Create(Project project, Diagnostic diagnostic)
         {
-            if (diagnostic.Location.IsInSource)
-            {
-                // Project diagnostic reported at a document location (e.g. compilation end action diagnostics).
-                var document = project.GetDocument(diagnostic.Location.SourceTree);
-                if (document != null)
-                {
-                    return Create(document, diagnostic);
-                }
-            }
+            Contract.Requires(diagnostic.Location == null || !diagnostic.Location.IsInSource);
 
             return new DiagnosticData(
                 diagnostic.Id,

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         return diagnostics.ToImmutableArrayOrEmpty();
                     }
                     catch (Exception e)
-                        {
+                    {
                         OnAnalyzerException(e, analyzer, compilation);
                         return ImmutableArray<Diagnostic>.Empty;
                     }
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             if (compilation != null)
             {
                 exceptionDiagnostic = CompilationWithAnalyzers.GetEffectiveDiagnostics(ImmutableArray.Create(exceptionDiagnostic), compilation).SingleOrDefault();
-                }
+            }
 
             _onAnalyzerException(ex, analyzer, exceptionDiagnostic);
         }
@@ -458,10 +458,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             }
             catch (Exception e)
             {
-                    var compilation = await _project.GetCompilationAsync(_cancellationToken).ConfigureAwait(false);
+                var compilation = await _project.GetCompilationAsync(_cancellationToken).ConfigureAwait(false);
                 OnAnalyzerException(e, analyzer, compilation);
-                }
             }
+        }
 
         private async Task GetCompilationDiagnosticsAsync(DiagnosticAnalyzer analyzer, List<Diagnostic> diagnostics, Action<Project, DiagnosticAnalyzer, CancellationToken> forceAnalyzeAllDocuments)
         {

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
@@ -16,303 +16,305 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 {
-        internal partial class DiagnosticIncrementalAnalyzer
+    internal partial class DiagnosticIncrementalAnalyzer
+    {
+        internal class DiagnosticState : AbstractAnalyzerState<object, object, AnalysisData>
         {
-            internal class DiagnosticState : AbstractAnalyzerState<object, object, AnalysisData>
+            private const int FormatVersion = 6;
+
+            private readonly string _stateName;
+            private readonly VersionStamp _version;
+            private readonly string _language;
+
+            public DiagnosticState(string stateName, VersionStamp version, string language)
             {
-                private const int FormatVersion = 6;
+                Contract.ThrowIfNull(stateName);
 
-                private readonly string _stateName;
-                private readonly VersionStamp _version;
-                private readonly string _language;
+                _stateName = stateName;
+                _version = version;
+                _language = language;
+            }
 
-                public DiagnosticState(string stateName, VersionStamp version, string language)
+            internal string Name
+            {
+                get { return _stateName; }
+            }
+
+            internal string Language
+            {
+                get { return _language; }
+            }
+
+            protected override object GetCacheKey(object value)
+            {
+                var document = value as Document;
+                if (document != null)
                 {
-                    Contract.ThrowIfNull(stateName);
-
-                    _stateName = stateName;
-                    _version = version;
-                    _language = language;
+                    return document.Id;
                 }
 
-                internal string Name
+                var project = (Project)value;
+                return project.Id;
+            }
+
+            protected override Solution GetSolution(object value)
+            {
+                var document = value as Document;
+                if (document != null)
                 {
-                    get { return _stateName; }
+                    return document.Project.Solution;
                 }
 
-                internal string Language
+                var project = (Project)value;
+                return project.Solution;
+            }
+
+            protected override bool ShouldCache(object value)
+            {
+                var document = value as Document;
+                if (document != null)
                 {
-                    get { return _language; }
+                    return document.IsOpen();
                 }
 
-                protected override object GetCacheKey(object value)
+                var project = (Project)value;
+                return project.Solution.Workspace.GetOpenDocumentIds(project.Id).Any();
+            }
+
+            protected override Task<Stream> ReadStreamAsync(IPersistentStorage storage, object value, CancellationToken cancellationToken)
+            {
+                var document = value as Document;
+                if (document != null)
                 {
-                    var document = value as Document;
-                    if (document != null)
+                    return storage.ReadStreamAsync(document, _stateName, cancellationToken);
+                }
+
+                var project = (Project)value;
+                return storage.ReadStreamAsync(project, _stateName, cancellationToken);
+            }
+
+            protected override AnalysisData TryGetExistingData(Stream stream, object value, CancellationToken cancellationToken)
+            {
+                var document = value as Document;
+                if (document != null)
+                {
+                    return TryGetExistingData(stream, document.Project, document, cancellationToken);
+                }
+
+                var project = (Project)value;
+                return TryGetExistingData(stream, project, null, cancellationToken);
+            }
+
+            private AnalysisData TryGetExistingData(Stream stream, Project project, Document document, CancellationToken cancellationToken)
+            {
+                var list = SharedPools.Default<List<DiagnosticData>>().AllocateAndClear();
+                try
+                {
+                    using (var reader = new ObjectReader(stream))
                     {
-                        return document.Id;
-                    }
-
-                    var project = (Project)value;
-                    return project.Id;
-                }
-
-                protected override Solution GetSolution(object value)
-                {
-                    var document = value as Document;
-                    if (document != null)
-                    {
-                        return document.Project.Solution;
-                    }
-
-                    var project = (Project)value;
-                    return project.Solution;
-                }
-
-                protected override bool ShouldCache(object value)
-                {
-                    var document = value as Document;
-                    if (document != null)
-                    {
-                        return document.IsOpen();
-                    }
-
-                    var project = (Project)value;
-                    return project.Solution.Workspace.GetOpenDocumentIds(project.Id).Any();
-                }
-
-                protected override Task<Stream> ReadStreamAsync(IPersistentStorage storage, object value, CancellationToken cancellationToken)
-                {
-                    var document = value as Document;
-                    if (document != null)
-                    {
-                        return storage.ReadStreamAsync(document, _stateName, cancellationToken);
-                    }
-
-                    var project = (Project)value;
-                    return storage.ReadStreamAsync(project, _stateName, cancellationToken);
-                }
-
-                protected override AnalysisData TryGetExistingData(Stream stream, object value, CancellationToken cancellationToken)
-                {
-                    var document = value as Document;
-                    if (document != null)
-                    {
-                        return TryGetExistingData(stream, document.Project, document, cancellationToken);
-                    }
-
-                    var project = (Project)value;
-                    return TryGetExistingData(stream, project, null, cancellationToken);
-                }
-
-                private AnalysisData TryGetExistingData(Stream stream, Project project, Document document, CancellationToken cancellationToken)
-                {
-                    var list = SharedPools.Default<List<DiagnosticData>>().AllocateAndClear();
-                    try
-                    {
-                        using (var reader = new ObjectReader(stream))
+                        var format = reader.ReadInt32();
+                        if (format != FormatVersion)
                         {
-                            var format = reader.ReadInt32();
-                            if (format != FormatVersion)
-                            {
-                                return null;
-                            }
+                            return null;
+                        }
 
                         // saved data is for same analyzer of different version of dll
                         var analyzerVersion = VersionStamp.ReadFrom(reader);
                         if (analyzerVersion != _version)
-                            {
-                                return null;
-                            }
-
-                            var textVersion = VersionStamp.ReadFrom(reader);
-                            var dataVersion = VersionStamp.ReadFrom(reader);
-                            if (textVersion == VersionStamp.Default || dataVersion == VersionStamp.Default)
-                            {
-                                return null;
-                            }
-
-                            AppendItems(reader, project, document, list, cancellationToken);
-
-                            return new AnalysisData(textVersion, dataVersion, list.ToImmutableArray<DiagnosticData>());
+                        {
+                            return null;
                         }
-                    }
-                    catch (Exception)
-                    {
-                        return null;
-                    }
-                    finally
-                    {
-                        SharedPools.Default<List<DiagnosticData>>().ClearAndFree(list);
+
+                        var textVersion = VersionStamp.ReadFrom(reader);
+                        var dataVersion = VersionStamp.ReadFrom(reader);
+
+                        // textversion can be default for document from project analysis.
+                        if (dataVersion == VersionStamp.Default)
+                        {
+                            return null;
+                        }
+
+                        AppendItems(reader, project, document, list, cancellationToken);
+
+                        return new AnalysisData(textVersion, dataVersion, list.ToImmutableArray<DiagnosticData>());
                     }
                 }
-
-                private void AppendItems(ObjectReader reader, Project project, Document document, List<DiagnosticData> list, CancellationToken cancellationToken)
+                catch (Exception)
                 {
-                    var count = reader.ReadInt32();
+                    return null;
+                }
+                finally
+                {
+                    SharedPools.Default<List<DiagnosticData>>().ClearAndFree(list);
+                }
+            }
 
+            private void AppendItems(ObjectReader reader, Project project, Document document, List<DiagnosticData> list, CancellationToken cancellationToken)
+            {
+                var count = reader.ReadInt32();
+
+                for (var i = 0; i < count; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var id = reader.ReadString();
+                    var category = reader.ReadString();
+
+                    var message = reader.ReadString();
+                    var messageFormat = reader.ReadString();
+                    var title = reader.ReadString();
+                    var description = reader.ReadString();
+                    var helpLink = reader.ReadString();
+                    var severity = (DiagnosticSeverity)reader.ReadInt32();
+                    var defaultSeverity = (DiagnosticSeverity)reader.ReadInt32();
+                    var isEnabledByDefault = reader.ReadBoolean();
+                    var warningLevel = reader.ReadInt32();
+
+                    var start = reader.ReadInt32();
+                    var length = reader.ReadInt32();
+                    var textSpan = new TextSpan(start, length);
+
+                    var originalFile = reader.ReadString();
+                    var originalStartLine = reader.ReadInt32();
+                    var originalStartColumn = reader.ReadInt32();
+                    var originalEndLine = reader.ReadInt32();
+                    var originalEndColumn = reader.ReadInt32();
+
+                    var mappedFile = reader.ReadString();
+                    var mappedStartLine = reader.ReadInt32();
+                    var mappedStartColumn = reader.ReadInt32();
+                    var mappedEndLine = reader.ReadInt32();
+                    var mappedEndColumn = reader.ReadInt32();
+
+                    var customTagsCount = reader.ReadInt32();
+                    var customTags = GetCustomTags(reader, customTagsCount);
+
+                    var propertiesCount = reader.ReadInt32();
+                    var properties = GetProperties(reader, propertiesCount);
+
+                    list.Add(new DiagnosticData(
+                        id, category, message, messageFormat, severity, defaultSeverity, isEnabledByDefault, warningLevel, customTags, properties,
+                        project.Solution.Workspace, project.Id, document != null ? document.Id : null, document != null ? textSpan : (TextSpan?)null,
+                        mappedFile, mappedStartLine, mappedStartColumn, mappedEndLine, mappedEndColumn,
+                        originalFile, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,
+                        title: title,
+                        description: description,
+                        helpLink: helpLink));
+                }
+            }
+
+            private ImmutableDictionary<string, string> GetProperties(ObjectReader reader, int count)
+            {
+                if (count > 0)
+                {
+                    var properties = ImmutableDictionary.CreateBuilder<string, string>();
                     for (var i = 0; i < count; i++)
+                    {
+                        properties.Add(reader.ReadString(), reader.ReadString());
+                    }
+
+                    return properties.ToImmutable();
+                }
+
+                return ImmutableDictionary<string, string>.Empty;
+            }
+
+            private static IReadOnlyList<string> GetCustomTags(ObjectReader reader, int count)
+            {
+                if (count > 0)
+                {
+                    var tags = new List<string>(count);
+                    for (var i = 0; i < count; i++)
+                    {
+                        tags.Add(reader.ReadString());
+                    }
+
+                    return new ReadOnlyCollection<string>(tags);
+                }
+
+                return SpecializedCollections.EmptyReadOnlyList<string>();
+            }
+
+            protected override Task<bool> WriteStreamAsync(IPersistentStorage storage, object value, Stream stream, CancellationToken cancellationToken)
+            {
+                var document = value as Document;
+                if (document != null)
+                {
+                    return storage.WriteStreamAsync(document, _stateName, stream, cancellationToken);
+                }
+
+                var project = (Project)value;
+                return storage.WriteStreamAsync(project, _stateName, stream, cancellationToken);
+            }
+
+            protected override void WriteTo(Stream stream, AnalysisData data, CancellationToken cancellationToken)
+            {
+                using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
+                {
+                    writer.WriteInt32(FormatVersion);
+                    _version.WriteTo(writer);
+                    data.TextVersion.WriteTo(writer);
+                    data.DataVersion.WriteTo(writer);
+
+                    writer.WriteInt32(data.Items.Length);
+
+                    foreach (var item in data.Items)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var id = reader.ReadString();
-                        var category = reader.ReadString();
+                        writer.WriteString(item.Id);
+                        writer.WriteString(item.Category);
 
-                        var message = reader.ReadString();
-                        var messageFormat = reader.ReadString();
-                        var title = reader.ReadString();
-                        var description = reader.ReadString();
-                        var helpLink = reader.ReadString();
-                        var severity = (DiagnosticSeverity)reader.ReadInt32();
-                        var defaultSeverity = (DiagnosticSeverity)reader.ReadInt32();
-                        var isEnabledByDefault = reader.ReadBoolean();
-                        var warningLevel = reader.ReadInt32();
+                        writer.WriteString(item.Message);
+                        writer.WriteString(item.MessageFormat);
+                        writer.WriteString(item.Title);
+                        writer.WriteString(item.Description);
+                        writer.WriteString(item.HelpLink);
+                        writer.WriteInt32((int)item.Severity);
+                        writer.WriteInt32((int)item.DefaultSeverity);
+                        writer.WriteBoolean(item.IsEnabledByDefault);
+                        writer.WriteInt32(item.WarningLevel);
 
-                        var start = reader.ReadInt32();
-                        var length = reader.ReadInt32();
-                        var textSpan = new TextSpan(start, length);
-
-                        var originalFile = reader.ReadString();
-                        var originalStartLine = reader.ReadInt32();
-                        var originalStartColumn = reader.ReadInt32();
-                        var originalEndLine = reader.ReadInt32();
-                        var originalEndColumn = reader.ReadInt32();
-
-                        var mappedFile = reader.ReadString();
-                        var mappedStartLine = reader.ReadInt32();
-                        var mappedStartColumn = reader.ReadInt32();
-                        var mappedEndLine = reader.ReadInt32();
-                        var mappedEndColumn = reader.ReadInt32();
-
-                        var customTagsCount = reader.ReadInt32();
-                        var customTags = GetCustomTags(reader, customTagsCount);
-
-                        var propertiesCount = reader.ReadInt32();
-                        var properties = GetProperties(reader, propertiesCount);
-
-                        list.Add(new DiagnosticData(
-                            id, category, message, messageFormat, severity, defaultSeverity, isEnabledByDefault, warningLevel, customTags, properties,
-                            project.Solution.Workspace, project.Id, document != null ? document.Id : null, document != null ? textSpan : (TextSpan?)null,
-                            mappedFile, mappedStartLine, mappedStartColumn, mappedEndLine, mappedEndColumn,
-                            originalFile, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,
-                            title: title,
-                            description: description,
-                            helpLink: helpLink));
-                    }
-                }
-
-                private ImmutableDictionary<string, string> GetProperties(ObjectReader reader, int count)
-                {
-                    if (count > 0)
-                    {
-                        var properties = ImmutableDictionary.CreateBuilder<string, string>();
-                        for (var i = 0; i < count; i++)
+                        if (item.HasTextSpan)
                         {
-                            properties.Add(reader.ReadString(), reader.ReadString());
+                            // document state
+                            writer.WriteInt32(item.TextSpan.Start);
+                            writer.WriteInt32(item.TextSpan.Length);
+                        }
+                        else
+                        {
+                            // project state
+                            writer.WriteInt32(0);
+                            writer.WriteInt32(0);
                         }
 
-                        return properties.ToImmutable();
-                    }
+                        writer.WriteString(item.OriginalFilePath);
+                        writer.WriteInt32(item.OriginalStartLine);
+                        writer.WriteInt32(item.OriginalStartColumn);
+                        writer.WriteInt32(item.OriginalEndLine);
+                        writer.WriteInt32(item.OriginalEndColumn);
 
-                    return ImmutableDictionary<string, string>.Empty;
-                }
+                        writer.WriteString(item.MappedFilePath);
+                        writer.WriteInt32(item.MappedStartLine);
+                        writer.WriteInt32(item.MappedStartColumn);
+                        writer.WriteInt32(item.MappedEndLine);
+                        writer.WriteInt32(item.MappedEndColumn);
 
-                private static IReadOnlyList<string> GetCustomTags(ObjectReader reader, int count)
-                {
-                    if (count > 0)
-                    {
-                        var tags = new List<string>(count);
-                        for (var i = 0; i < count; i++)
+                        writer.WriteInt32(item.CustomTags.Count);
+                        foreach (var tag in item.CustomTags)
                         {
-                            tags.Add(reader.ReadString());
+                            writer.WriteString(tag);
                         }
 
-                        return new ReadOnlyCollection<string>(tags);
-                    }
-
-                    return SpecializedCollections.EmptyReadOnlyList<string>();
-                }
-
-                protected override Task<bool> WriteStreamAsync(IPersistentStorage storage, object value, Stream stream, CancellationToken cancellationToken)
-                {
-                    var document = value as Document;
-                    if (document != null)
-                    {
-                        return storage.WriteStreamAsync(document, _stateName, stream, cancellationToken);
-                    }
-
-                    var project = (Project)value;
-                    return storage.WriteStreamAsync(project, _stateName, stream, cancellationToken);
-                }
-
-                protected override void WriteTo(Stream stream, AnalysisData data, CancellationToken cancellationToken)
-                {
-                    using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
-                    {
-                        writer.WriteInt32(FormatVersion);
-                        _version.WriteTo(writer);
-                        data.TextVersion.WriteTo(writer);
-                        data.DataVersion.WriteTo(writer);
-
-                        writer.WriteInt32(data.Items.Length);
-
-                        foreach (var item in data.Items)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            writer.WriteString(item.Id);
-                            writer.WriteString(item.Category);
-
-                            writer.WriteString(item.Message);
-                            writer.WriteString(item.MessageFormat);
-                            writer.WriteString(item.Title);
-                            writer.WriteString(item.Description);
-                            writer.WriteString(item.HelpLink);
-                            writer.WriteInt32((int)item.Severity);
-                            writer.WriteInt32((int)item.DefaultSeverity);
-                            writer.WriteBoolean(item.IsEnabledByDefault);
-                            writer.WriteInt32(item.WarningLevel);
-
-                            if (item.HasTextSpan)
-                            {
-                                // document state
-                                writer.WriteInt32(item.TextSpan.Start);
-                                writer.WriteInt32(item.TextSpan.Length);
-                            }
-                            else
-                            {
-                                // project state
-                                writer.WriteInt32(0);
-                                writer.WriteInt32(0);
-                            }
-
-                            writer.WriteString(item.OriginalFilePath);
-                            writer.WriteInt32(item.OriginalStartLine);
-                            writer.WriteInt32(item.OriginalStartColumn);
-                            writer.WriteInt32(item.OriginalEndLine);
-                            writer.WriteInt32(item.OriginalEndColumn);
-
-                            writer.WriteString(item.MappedFilePath);
-                            writer.WriteInt32(item.MappedStartLine);
-                            writer.WriteInt32(item.MappedStartColumn);
-                            writer.WriteInt32(item.MappedEndLine);
-                            writer.WriteInt32(item.MappedEndColumn);
-
-                            writer.WriteInt32(item.CustomTags.Count);
-                            foreach (var tag in item.CustomTags)
-                            {
-                                writer.WriteString(tag);
-                            }
-
-                            writer.WriteInt32(item.Properties.Count);
+                        writer.WriteInt32(item.Properties.Count);
                         foreach (var property in item.Properties)
-                            {
-                                writer.WriteString(property.Key);
-                                writer.WriteString(property.Value);
-                            }
+                        {
+                            writer.WriteString(property.Key);
+                            writer.WriteString(property.Value);
                         }
                     }
                 }
             }
         }
     }
+}

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
@@ -84,13 +84,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         public class ArgumentKey
         {
             public readonly DiagnosticAnalyzer Analyzer;
-            public readonly StateType StateTypeId;
+            public readonly StateType StateType;
             public readonly object Key;
 
             public ArgumentKey(DiagnosticAnalyzer analyzer, StateType stateTypeId, object key)
             {
                 this.Analyzer = analyzer;
-                this.StateTypeId = stateTypeId;
+                this.StateType = stateTypeId;
                 this.Key = key;
             }
 
@@ -102,12 +102,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return false;
                 }
 
-                return Analyzer == other.Analyzer && StateTypeId == other.StateTypeId && Key == other.Key;
+                return Analyzer == other.Analyzer && StateType == other.StateType && Key == other.Key;
             }
 
             public override int GetHashCode()
             {
-                return Hash.Combine(Key, Hash.Combine(Analyzer.GetHashCode(), (int)StateTypeId));
+                return Hash.Combine(Key, Hash.Combine(Analyzer.GetHashCode(), (int)StateType));
             }
         }
     }

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -64,7 +64,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 get { return this.Owner._stateManger; }
             }
 
-            protected abstract Task AppendDiagnosticsFromKeyAsync(Project project, StateType stateType, object documentOrProject, CancellationToken cancellationToken);
+            protected abstract Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken);
+            protected abstract Task AppendProjectAndDocumentDiagnosticsAsync(Project project, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken);
 
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId documentId, CancellationToken cancellationToken)
             {
@@ -75,7 +76,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                 if (documentId != null)
                 {
-                    await AppendDiagnosticsAsync(solution.GetDocument(documentId), cancellationToken).ConfigureAwait(false);
+                    var document = solution.GetDocument(documentId);
+
+                    await AppendDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
+                    await AppendProjectAndDocumentDiagnosticsAsync(document.Project, d => d.DocumentId == documentId, cancellationToken).ConfigureAwait(false);
                     return GetDiagnosticData();
                 }
 
@@ -127,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return SpecializedTasks.EmptyTask;
                 }
 
-                return AppendDiagnosticsFromKeyAsync(project, StateType.Project, project, cancellationToken);
+                return AppendProjectAndDocumentDiagnosticsAsync(project, d => d.ProjectId == project.Id, cancellationToken);
             }
 
             private async Task AppendDiagnosticsAsync(Solution solution, CancellationToken cancellationToken)
@@ -151,12 +155,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return;
                 }
 
-                await AppendProjectDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+                await AppendProjectAndDocumentDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
 
                 foreach (var document in project.Documents)
                 {
                     await AppendDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
                 }
+            }
+
+            protected Task AppendProjectAndDocumentDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+            {
+                return AppendProjectAndDocumentDiagnosticsAsync(project, d => true, cancellationToken);
             }
 
             protected async Task AppendDiagnosticsAsync(Document document, CancellationToken cancellationToken)
@@ -166,8 +175,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return;
                 }
 
-                await AppendDiagnosticsFromKeyAsync(document.Project, StateType.Syntax, document, cancellationToken).ConfigureAwait(false);
-                await AppendDiagnosticsFromKeyAsync(document.Project, StateType.Document, document, cancellationToken).ConfigureAwait(false);
+                await AppendDocumentDiagnosticsOfStateTypeAsync(document, StateType.Syntax, cancellationToken).ConfigureAwait(false);
+                await AppendDocumentDiagnosticsOfStateTypeAsync(document, StateType.Document, cancellationToken).ConfigureAwait(false);
             }
 
             protected void AppendDiagnostics(IEnumerable<DiagnosticData> items)
@@ -250,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var state = stateSet.GetState(key.StateTypeId);
+                var state = stateSet.GetState(key.StateType);
                 if (state == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
@@ -273,23 +282,52 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return existingData.Items;
             }
 
-            protected override async Task AppendDiagnosticsFromKeyAsync(Project project, StateType stateType, object documentOrProject, CancellationToken cancellationToken)
+            protected override async Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken)
             {
-                foreach (var stateSet in this.StateManager.GetStateSets(project))
+                foreach (var stateSet in this.StateManager.GetStateSets(document.Project))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
                     var state = stateSet.GetState(stateType);
 
-                    // for now, it just use wait and get result
-                    var existingData = await state.TryGetExistingDataAsync(documentOrProject, cancellationToken).ConfigureAwait(false);
-                    if (existingData == null)
+                    var existingData = await state.TryGetExistingDataAsync(document, cancellationToken).ConfigureAwait(false);
+                    if (existingData == null || existingData.Items.Length == 0)
                     {
                         continue;
                     }
 
                     AppendDiagnostics(existingData.Items);
                 }
+            }
+
+            protected override async Task AppendProjectAndDocumentDiagnosticsAsync(Project project, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken)
+            {
+                foreach (var stateSet in this.StateManager.GetStateSets(project))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var state = stateSet.GetState(StateType.Project);
+
+                    await AppendProjectAndDocumentDiagnosticsAsync(state, project, predicate, cancellationToken).ConfigureAwait(false);
+
+                    foreach (var document in project.Documents)
+                    {
+                        await AppendProjectAndDocumentDiagnosticsAsync(state, project, predicate, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            private async Task AppendProjectAndDocumentDiagnosticsAsync(DiagnosticState state, object documentOrProject, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var existingData = await state.TryGetExistingDataAsync(documentOrProject, cancellationToken).ConfigureAwait(false);
+                if (existingData == null || existingData.Items.Length == 0)
+                {
+                    return;
+                }
+
+                AppendDiagnostics(existingData.Items.Where(predicate));
             }
         }
 
@@ -302,37 +340,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 this.DiagnosticIds = diagnosticIds;
             }
 
-            protected abstract Task<AnalysisData> GetSpecificDiagnosticsAsync(Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions);
-            protected abstract void FilterDiagnostics(AnalysisData analysisData);
+            protected abstract Task<AnalysisData> GetDiagnosticAnalysisDataAsync(Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions);
+            protected abstract void FilterDiagnostics(AnalysisData analysisData, Func<DiagnosticData, bool> predicateOpt = null);
 
-            protected override async Task AppendDiagnosticsFromKeyAsync(Project project, StateType stateType, object documentOrProject, CancellationToken cancellationToken)
+            protected override Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken)
             {
-                Contract.ThrowIfNull(project);
-                var solution = GetSolution(documentOrProject);
-
-                var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, cancellationToken).ConfigureAwait(false);
-                var versions = await GetVersionsAsync(stateType, documentOrProject, cancellationToken).ConfigureAwait(false);
-
-                foreach (var stateSet in this.StateManager.GetOrCreateStateSets(project))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    if (driver.IsAnalyzerSuppressed(stateSet.Analyzer) ||
-                        !this.Owner.ShouldRunAnalyzerForStateType(driver, stateSet.Analyzer, stateType, this.DiagnosticIds))
-                    {
-                        continue;
-                    }
-
-                    var analysisData = await GetSpecificDiagnosticsAsync(solution, driver, stateSet, stateType, versions).ConfigureAwait(false);
-                    FilterDiagnostics(analysisData);
-                }
+                return AppendDiagnosticsOfStateTypeAsync(document, stateType, d => true, cancellationToken);
             }
 
-            protected async Task<DiagnosticAnalyzerDriver> GetDiagnosticAnalyzerDriverAsync(object documentOrProject, CancellationToken cancellationToken)
+            protected override Task AppendProjectAndDocumentDiagnosticsAsync(Project project, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken)
+            {
+                return AppendDiagnosticsOfStateTypeAsync(project, StateType.Project, predicate, cancellationToken);
+            }
+
+            protected async Task<DiagnosticAnalyzerDriver> GetDiagnosticAnalyzerDriverAsync(object documentOrProject, StateType stateType, CancellationToken cancellationToken)
             {
                 var document = documentOrProject as Document;
                 if (document != null)
                 {
+                    Contract.Requires(stateType != StateType.Project);
                     var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                     return new DiagnosticAnalyzerDriver(document, root.FullSpan, root, this.DiagnosticLogAggregator, this.Owner.HostDiagnosticUpdateSource, cancellationToken);
                 }
@@ -340,13 +366,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 var project = documentOrProject as Project;
                 if (project != null)
                 {
+                    Contract.Requires(stateType == StateType.Project);
                     return new DiagnosticAnalyzerDriver(project, this.DiagnosticLogAggregator, this.Owner.HostDiagnosticUpdateSource, cancellationToken);
                 }
 
                 return Contract.FailWithReturn<DiagnosticAnalyzerDriver>("Can't reach here");
             }
 
-            protected async Task<VersionArgument> GetVersionsAsync(StateType stateType, object documentOrProject, CancellationToken cancellationToken)
+            protected async Task<VersionArgument> GetVersionsAsync(object documentOrProject, StateType stateType, CancellationToken cancellationToken)
             {
                 switch (stateType)
                 {
@@ -379,21 +406,39 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 }
             }
 
-            private Solution GetSolution(object value)
+            private async Task AppendDiagnosticsOfStateTypeAsync(object documentOrProject, StateType stateType, Func<DiagnosticData, bool> predicateOpt, CancellationToken cancellationToken)
             {
-                var document = value as Document;
+                Contract.ThrowIfNull(documentOrProject);
+                var project = GetProject(documentOrProject);
+                var solution = project.Solution;
+
+                var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, stateType, cancellationToken).ConfigureAwait(false);
+                var versions = await GetVersionsAsync(documentOrProject, stateType, cancellationToken).ConfigureAwait(false);
+
+                foreach (var stateSet in this.StateManager.GetOrCreateStateSets(project))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (driver.IsAnalyzerSuppressed(stateSet.Analyzer) ||
+                        !this.Owner.ShouldRunAnalyzerForStateType(driver, stateSet.Analyzer, stateType, this.DiagnosticIds))
+                    {
+                        continue;
+                    }
+
+                    var analysisData = await GetDiagnosticAnalysisDataAsync(solution, driver, stateSet, stateType, versions).ConfigureAwait(false);
+                    FilterDiagnostics(analysisData, predicateOpt);
+                }
+            }
+
+            protected Project GetProject(object documentOrProject)
+            {
+                var document = documentOrProject as Document;
                 if (document != null)
                 {
-                    return document.Project.Solution;
+                    return document.Project;
                 }
 
-                var project = value as Project;
-                if (project != null)
-                {
-                    return project.Solution;
-                }
-
-                return Contract.FailWithReturn<Solution>("Can't reach here");
+                return (Project)documentOrProject;
             }
 
             private DiagnosticLogAggregator DiagnosticLogAggregator
@@ -416,13 +461,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 }
             }
 
-            protected override void FilterDiagnostics(AnalysisData analysisData)
+            protected override void FilterDiagnostics(AnalysisData analysisData, Func<DiagnosticData, bool> predicateOpt = null)
             {
                 // we don't care about result
                 return;
             }
 
-            protected override async Task<AnalysisData> GetSpecificDiagnosticsAsync(
+            protected override async Task<AnalysisData> GetDiagnosticAnalysisDataAsync(
                 Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions)
             {
                 // we don't care about result
@@ -473,27 +518,60 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var project = solution.GetProject(GetProjectId(key.Key));
+                if (key.StateType != StateType.Project)
+                {
+                    return await GetDiagnosticsAsync(documentOrProject, key, cancellationToken).ConfigureAwait(false);
+                }
 
-                var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, cancellationToken).ConfigureAwait(false);
-                var versions = await GetVersionsAsync(key.StateTypeId, documentOrProject, cancellationToken).ConfigureAwait(false);
+                return await GetDiagnosticsAsync(GetProject(documentOrProject), key, cancellationToken).ConfigureAwait(false);
+            }
 
+            private async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(object documentOrProject, ArgumentKey key, CancellationToken cancellationToken)
+            {
+                var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, key.StateType, cancellationToken).ConfigureAwait(false);
+                var versions = await GetVersionsAsync(documentOrProject, key.StateType, cancellationToken).ConfigureAwait(false);
+
+                var project = GetProject(documentOrProject);
                 var stateSet = this.StateManager.GetOrCreateStateSet(project, key.Analyzer);
                 if (stateSet == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var analysisData = await GetSpecificDiagnosticsAsync(solution, driver, stateSet, key.StateTypeId, versions).ConfigureAwait(false);
-                return analysisData.Items;
+                var analysisData = await GetDiagnosticAnalysisDataAsync(project.Solution, driver, stateSet, key.StateType, versions).ConfigureAwait(false);
+                if (key.StateType != StateType.Project)
+                {
+                    return analysisData.Items;
+                }
+
+                return analysisData.Items.Where(d =>
+                {
+                    if (key.Key is DocumentId)
+                    {
+                        return object.Equals(d.DocumentId, key.Key);
+                    }
+
+                    if (key.Key is ProjectId)
+                    {
+                        return object.Equals(d.ProjectId, key.Key);
+                    }
+
+                    return false;
+                }).ToImmutableArray();
             }
 
-            protected override void FilterDiagnostics(AnalysisData analysisData)
+            protected override void FilterDiagnostics(AnalysisData analysisData, Func<DiagnosticData, bool> predicateOpt)
             {
-                AppendDiagnostics(analysisData.Items.Where(d => this.DiagnosticIds == null || this.DiagnosticIds.Contains(d.Id)));
+                if (predicateOpt == null)
+                {
+                    AppendDiagnostics(analysisData.Items.Where(d => this.DiagnosticIds == null || this.DiagnosticIds.Contains(d.Id)));
+                    return;
+                }
+
+                AppendDiagnostics(analysisData.Items.Where(d => this.DiagnosticIds == null || this.DiagnosticIds.Contains(d.Id)).Where(predicateOpt));
             }
 
-            protected override Task<AnalysisData> GetSpecificDiagnosticsAsync(
+            protected override Task<AnalysisData> GetDiagnosticAnalysisDataAsync(
                 Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions)
             {
                 switch (stateType)


### PR DESCRIPTION
went thorough v1 diagnostic engine to fully support compilation end actions.

now it should properly cache and report errors to associated services when there is compilation end actions registered.

but admittedly I didn't tighten it as much as I can assuming all these will change once we move to v2. but this should do its job.