### PR TITLE
Make ExpressionCompiler and ResultProvider public...

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal abstract class ExpressionCompiler :
+    public abstract class ExpressionCompiler :
         IDkmClrExpressionCompiler,
         IDkmClrExpressionCompilerCallback,
         IDkmModuleModifiedNotification

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     /// <remarks>
     /// This class provides implementation for the default ResultProvider component.
     /// </remarks>
-    internal abstract class ResultProvider : IDkmClrResultProvider
+    public abstract class ResultProvider : IDkmClrResultProvider
     {
         internal readonly Formatter Formatter;
 


### PR DESCRIPTION
Reflection APIs used by the dispatcher to create these classes may not be available on all platforms.