### PR TITLE
Simplify GetEvaluationResultsAndContinue...

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -617,14 +617,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         () =>
                         {
                             results[index] = result;
-                            if (index < numRows - 1)
-                            {
-                                GetEvaluationResultsAndContinue(rows, results, index + 1, numRows, workList, inspectionContext, stackFrame, completionRoutine);
-                            }
-                            else
-                            {
-                                completionRoutine();
-                            }
+                            GetEvaluationResultsAndContinue(rows, results, index + 1, numRows, workList, inspectionContext, stackFrame, completionRoutine);
                         }));
             }
             else


### PR DESCRIPTION
I *think* this should behave the same.  We can remove the range check in the lambda and just call GetEvaluationResultsAndContinue again with "index + 1".  The outer if should catch the index >= numRows case and call the completionRoutine.