### PR TITLE
Restored requirement for struct constructors to always have formal param...

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // IDS_VersionExperimental = MessageBase + 12694,
         IDS_FeatureNameof = MessageBase + 12695,
         IDS_FeatureDictionaryInitializer = MessageBase + 12696,
-        IDS_FeatureStructParameterlessConstructors = MessageBase + 12697,
+        // IDS_FeatureStructParameterlessConstructors = MessageBase + 12697,
 
         IDS_LogoLine1 = MessageBase + 12698,
         IDS_LogoLine2 = MessageBase + 12699,
@@ -158,7 +158,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureExpressionBodiedIndexer:
                 case MessageID.IDS_FeatureNameof:
                 case MessageID.IDS_FeatureDictionaryInitializer:
-                case MessageID.IDS_FeatureStructParameterlessConstructors:
                 case MessageID.IDS_FeatureUsingStatic:
                 case MessageID.IDS_FeatureInterpolatedStrings:
                     return LanguageVersion.CSharp6;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2723,13 +2723,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             diagnostics.Add(ErrorCode.ERR_EnumsCantContainDefaultConstructor, m.Locations[0]);
                         }
-                        else if (m.DeclaredAccessibility != Accessibility.Public)
-                        {
-                            diagnostics.Add(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, m.Locations[0]);
-                        }
                         else
                         {
-                            Binder.CheckFeatureAvailability(m.Locations[0], MessageID.IDS_FeatureStructParameterlessConstructors, diagnostics);
+                            diagnostics.Add(ErrorCode.ERR_StructsCantContainDefaultConstructor, m.Locations[0]);
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
@@ -300,158 +300,6 @@ class C
             CompileAndVerify(text, expectedOutput: expectedOutput);
         }
 
-
-        [Fact]
-        public void ParameterlessConstructorStruct001()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1()
-        {
-            x = 42;
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1();
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   42
-  IL_0003:  stfld      ""int C.S1.x""
-  IL_0008:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessConstructorStruct002()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1()
-        {
-            x = 42;
-        }
-
-        public S1(int a):this()
-        {
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1(123);
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor(int)", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""C.S1..ctor()""
-  IL_0006:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessConstructorStruct003()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1(): this(42)
-        {
-        }
-
-        public S1(int a)
-        {
-            x = a;
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1();
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor(int)", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  stfld      ""int C.S1.x""
-  IL_0007:  ret
-}
-").
-VerifyIL("C.S1..ctor()", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   42
-  IL_0003:  call       ""C.S1..ctor(int)""
-  IL_0008:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessInstCtorInStructExprTree()
-        {
-            var source = @"
-
-using System;
-using System.Linq.Expressions;
-
-class C
-{
-    struct S1
-    {
-        public int x;
-        public S1()
-        {
-            x = 42;
-        }
-    }
-
-    static void Main()
-    {
-        Expression<Func<S1>> testExpr = () => new S1();
-        System.Console.Write(testExpr.Compile()().x);
-    }
-}
-";
-            CompileAndVerify(source, additionalRefs: new[] { ExpressionAssemblyRef }, expectedOutput: "42");
-        }
-
         [Fact]
         public void TestInitializerInCtor001()
         {
@@ -496,7 +344,7 @@ public struct S
     public int X{get;}
     public int Y{get;}
 
-    public S()
+    public S(int dummy)
     {
         X = 42;
         Y = X;
@@ -504,7 +352,7 @@ public struct S
 
     public static void Main()
     {
-        S s = new S();
+        S s = new S(1);
         System.Console.WriteLine(s.Y);
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1315,7 +1315,7 @@ struct Program
     S1 x2 { get; }
 
 
-    public Program()
+    public Program(int dummy)
     {
         x.i = 1;
         System.Console.WriteLine(x2.ii);
@@ -1364,7 +1364,7 @@ struct Program
     S1 x2 { get; set;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         x.i = 1;
         System.Console.WriteLine(x2.ii);
@@ -1413,7 +1413,7 @@ struct Program
     S1 x2 { get;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         x = new S1();
         x.i += 1;
@@ -1459,7 +1459,7 @@ struct Program
     S1 x2 { get;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         this = default(Program);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -178,6 +178,9 @@ class Program
 ";
             var comp = CreateExperimentalCompilationWithMscorlib45(source);
             comp.VerifyDiagnostics(
+    // (10,12): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     public S2()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S2").WithLocation(10, 12),
     // (26,28): error CS1736: Default parameter value for 's' must be a compile-time constant
     //     static void Foo(S2 s = new S2())
     Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "new S2()").WithArguments("s").WithLocation(26, 28)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
@@ -603,12 +603,12 @@ public struct X1
 
 ";
             CreateExperimentalCompilationWithMscorlib45(source).VerifyDiagnostics(
-    // (4,13): error CS8075: Parameterless struct constructors must be public
-    //     private X()
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "X").WithLocation(4, 13),
-    // (11,5): error CS8075: Parameterless struct constructors must be public
+    // (11,5): error CS0568: Structs cannot contain explicit parameterless constructors
     //     X1()
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "X1").WithLocation(11, 5)
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "X1").WithLocation(11, 5),
+    // (4,13): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     private X()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "X").WithLocation(4, 13)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -118,12 +118,15 @@ struct S
 }
 
 ").VerifyDiagnostics(
-    // (27,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
-    //         Ps = 5;
-    Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("S.Ps").WithLocation(27, 9),
+    // (24,12): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     public S()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S").WithLocation(24, 12),
     // (9,9): error CS0200: Property or indexer 'C.Ps' cannot be assigned to -- it is read only
     //         Ps = 3;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("C.Ps").WithLocation(9, 9),
+    // (27,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
+    //         Ps = 5;
+    Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("S.Ps").WithLocation(27, 9),
     // (14,9): error CS0200: Property or indexer 'C.P' cannot be assigned to -- it is read only
     //         P = 10;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "P").WithArguments("C.P").WithLocation(14, 9),
@@ -136,6 +139,7 @@ struct S
     // (33,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
     //         S.Ps = 1;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "S.Ps").WithArguments("S.Ps").WithLocation(33, 9)
+
     );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -10101,29 +10101,6 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
         }
 
         [Fact]
-        public void CS0568ERR_StructsCantContainDefaultConstructor01()
-        {
-            var text = @"namespace NS
-{
-    public struct S1
-    {
-        public S1() {}
-
-        struct S2<T>
-        {
-            S2() { }
-        }
-    }
-}
-";
-            var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription { Code = (int)ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, Line = 9, Column = 13 });
-
-            var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
-            // TODO...
-        }
-
-        [Fact]
         public void CS0569ERR_CantOverrideBogusMethod()
         {
             var source1 =
@@ -10207,7 +10184,7 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
         }
 
         [Fact]
-        public void InstanceCtorInsTructPre60()
+        public void CS0568ERR_StructsCantContainDefaultConstructor01()
         {
             var text = @"namespace x
 {
@@ -10224,12 +10201,12 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
 ";
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp5));
             comp.VerifyDiagnostics(
-    // (5,16): error CS8026: Feature 'struct instance parameterless constructors' is not available in C# 5.  Please use language version 6 or greater.
+    // (5,16): error CS0568: Structs cannot contain explicit parameterless constructors
     //         public S1() {}
-    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "S1").WithArguments("struct instance parameterless constructors", "6").WithLocation(5, 16),
-    // (9,13): error CS8075: Parameterless instance constructors in structs must be public
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S1").WithLocation(5, 16),
+    // (9,13): error CS0568: Structs cannot contain explicit parameterless constructors
     //             S2() { }
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "S2").WithLocation(9, 13)
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S2").WithLocation(9, 13)
    );
         }
 


### PR DESCRIPTION
...eters  (C#)

Issue #1029

While overall parameterless constructors in structs are valid from IL perspective, without a convenient way to declare them they were virtually nonexistent. As we performed more and more testing, we kept discovering cases where parameterless struct constructors caused inconsistent behavior in libraries or even in some versions of CLR.

After reconsidering the potential issues arising from breaking long standing assumptions, we decided it was best for our users to restore the requirement on struct constructors to always have formal parameters.