### PR TITLE
Disable the UnusedDeclarationsAnalyzer by default

### DIFF
--- a/src/Diagnostics/Roslyn/Core/Maintainability/UnusedDeclarationsAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Maintainability/UnusedDeclarationsAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Diagnostics.Analyzers
 
         private static readonly LocalizableString s_messageFormat = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UnusedDeclarationsMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
-        internal static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(RoslynDiagnosticIds.DeadCodeRuleId, s_title, s_messageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        internal static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(RoslynDiagnosticIds.DeadCodeRuleId, s_title, s_messageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: false);
 
         internal static readonly DiagnosticDescriptor s_triggerRule = new TriggerDiagnosticDescriptor(RoslynDiagnosticIds.DeadCodeTriggerRuleId, WellKnownDiagnosticTags.Unnecessary, WellKnownDiagnosticTags.Telemetry);
 


### PR DESCRIPTION
Related to issue #1058.

The analyzer reports thousands of spurious errors when running over
Roslyn.sln. In order to move forward to newer builds of the toolset
compilers and diagnostics, it needs to be disabled.