### PR TITLE
Fixes #950: Seal public methods of DiagnosticAnalyzer that can be overri...

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
@@ -456,25 +456,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 analyze();
             }
-            catch (OperationCanceledException oce)
-            {
-                if (oce.CancellationToken != cancellationToken)
-                {
-                    // Diagnostic for analyzer exception.
-                    var diagnostic = GetAnalyzerDiagnostic(analyzer, oce);
-                    onAnalyzerException(oce, analyzer, diagnostic);
-                }
-            }
             catch (Exception e)
             {
                 // Diagnostic for analyzer exception.
-                var diagnostic = GetAnalyzerDiagnostic(analyzer, e);
-                onAnalyzerException(e, analyzer, diagnostic);
+                var diagnostic = GetAnalyzerExceptionDiagnostic(analyzer, e);
+                if (diagnostic != null)
+                {
+                    onAnalyzerException(e, analyzer, diagnostic);
+                }
             }
         }
 
-        internal static Diagnostic GetAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Exception e)
+        internal static Diagnostic GetAnalyzerExceptionDiagnostic(DiagnosticAnalyzer analyzer, Exception e)
         {
+            if (e is OperationCanceledException)
+            {
+                return null;
+            }
+
             var descriptor = new DiagnosticDescriptor(AnalyzerExceptionDiagnosticId,
                 AnalyzerDriverResources.AnalyzerFailure,
                 AnalyzerDriverResources.AnalyzerThrows,
@@ -482,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 defaultSeverity: DiagnosticSeverity.Info,
                 isEnabledByDefault: true,
                 customTags: WellKnownDiagnosticTags.AnalyzerException);
-            return Diagnostic.Create(descriptor, Location.None, analyzer.GetType().ToString(), e.Message);
+            return Diagnostic.Create(descriptor, Location.None, analyzer.ToString(), e.Message);
         }
 
         internal static Diagnostic GetDescriptorDiagnostic(string faultedDescriptorId, Exception e)

--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
@@ -188,8 +188,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 var handler = new EventHandler<Exception>((sender, ex) =>
                     {
-                        var diagnostic = AnalyzerExecutor.GetAnalyzerDiagnostic(analyzer, ex);
-                        analyzerExecutor.OnAnalyzerException?.Invoke(ex, analyzer, diagnostic);
+                        var diagnostic = AnalyzerExecutor.GetAnalyzerExceptionDiagnostic(analyzer, ex);
+                        if (diagnostic != null)
+                        {
+                            analyzerExecutor.OnAnalyzerException?.Invoke(ex, analyzer, diagnostic);
+                        }
                     });
 
                 // Subscribe for exceptions from lazily evaluated localizable strings in the descriptors.

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -89,6 +89,11 @@ namespace Microsoft.CodeAnalysis
 
         private void RaiseOnException(Exception ex)
         {
+            if (ex is OperationCanceledException)
+            {
+                return;
+            }
+
             try
             {
                 OnException?.Invoke(this, ex);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -19,5 +20,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="context"></param>
         public abstract void Initialize(AnalysisContext context);
+
+        public sealed override bool Equals(object obj)
+        {
+            return ReferenceEqualityComparer.Instance.Equals(this, obj);
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return ReferenceEqualityComparer.Instance.GetHashCode(this);
+        }
+
+        public sealed override string ToString()
+        {
+            return this.GetType().ToString();
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.txt
@@ -1855,6 +1855,9 @@ override abstract Microsoft.CodeAnalysis.StrongNameProvider.GetHashCode()
 override abstract Microsoft.CodeAnalysis.SyntaxNode.ToString()
 override abstract Microsoft.CodeAnalysis.XmlReferenceResolver.Equals(object other)
 override abstract Microsoft.CodeAnalysis.XmlReferenceResolver.GetHashCode()
+override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.Equals(object obj)
+override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.GetHashCode()
+override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.ToString()
 override sealed Microsoft.CodeAnalysis.LocalizableString.ToString()
 readonly Microsoft.CodeAnalysis.Emit.EmitBaseline.OriginalMetadata
 readonly Microsoft.CodeAnalysis.Emit.SemanticEdit.Kind


### PR DESCRIPTION
...dden and can throw: Equals,GetHashCode and ToString. This is required as we use analyzers as keys for various caches in our diagnostic engines.

Also fix an issue pointed out by CyrusN: Don't report analyzer diagnostics for OperationCanceledException during analyzer execution.

@JohnHamby @srivatsn @heejaechang @jmarolf @tmeschter @shyamnamboodiripad can you please take a look?