### PR TITLE
Rename of VB Property Backing Fields

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2734,6 +2734,52 @@ End Class
                     result.AssertLabeledSpansAre("unresolved2", type:=RelatedLocationType.UnresolvedConflict)
                 End Using
             End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
+            Public Sub RenamingCompilerGeneratedPropertyBackingField_InvokeFromProperty()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C1
+    Public ReadOnly Property [|X$$|] As String
+
+    Sub M()
+        {|backingfield:_X|} = "test"
+    End Sub
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Y")
+
+                    result.AssertLabeledSpecialSpansAre("backingfield", "_Y", type:=RelatedLocationType.NoConflict)
+                End Using
+            End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
+            Public Sub RenamingCompilerGeneratedPropertyBackingField_InvokableFromBackingFieldReference()
+                Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C1
+    Public ReadOnly Property [|X|] As String
+
+    Sub M()
+        {|backingfield:_X$$|} = "test"
+    End Sub
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                    AssertTokenRenamable(workspace)
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2761,6 +2761,31 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
+            Public Sub RenamingCompilerGeneratedPropertyBackingField_IntroduceConflict()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C1
+    Public ReadOnly Property [|X$$|] As String
+
+    Sub M()
+        {|Conflict:_X|} = "test"
+    End Sub
+
+    Dim _Y As String
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Y")
+
+                    result.AssertLabeledSpansAre("Conflict", type:=RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
             Public Sub RenamingCompilerGeneratedPropertyBackingField_InvokableFromBackingFieldReference()
                 Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -58,12 +58,23 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             Return DirectCast(renameService.StartInlineSession(sessionInfo.Item1, sessionInfo.Item2).Session, InlineRenameSession)
         End Function
 
+        Public Sub AssertTokenRenamable(workspace As TestWorkspace)
+            Dim renameService = DirectCast(workspace.GetService(Of IInlineRenameService)(), InlineRenameService)
+            Dim sessionInfo = GetSessionInfo(workspace)
+
+            Dim editorService = sessionInfo.Item1.GetLanguageService(Of IEditorInlineRenameService)
+            Dim result = editorService.GetRenameInfoAsync(sessionInfo.Item1, sessionInfo.Item2.Start, CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+            Assert.True(result.CanRename)
+            Assert.Null(result.LocalizedErrorMessage)
+        End Sub
+
         Public Sub AssertTokenNotRenamable(workspace As TestWorkspace)
             Dim renameService = DirectCast(workspace.GetService(Of IInlineRenameService)(), InlineRenameService)
             Dim sessionInfo = GetSessionInfo(workspace)
 
             Dim editorService = sessionInfo.Item1.GetLanguageService(Of IEditorInlineRenameService)
             Dim result = editorService.GetRenameInfoAsync(sessionInfo.Item1, sessionInfo.Item2.Start, CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+            Assert.False(result.CanRename)
             Assert.NotNull(result.LocalizedErrorMessage)
         End Sub
 

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -307,12 +307,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                             var annotation = _renameAnnotations.GetAnnotations(token).OfType<RenameActionAnnotation>().FirstOrDefault();
                             if (annotation != null)
                             {
-                                newToken = RenameToken(token, newToken, annotation.Suffix, annotation.IsAccessorLocation);
+                                newToken = RenameToken(token, newToken, annotation.Prefix, annotation.Suffix);
                                 AddModifiedSpan(annotation.OriginalSpan, newToken.Span);
                             }
                             else
                             {
-                                newToken = RenameToken(token, newToken, suffix: null, isAccessorLocation: false);
+                                newToken = RenameToken(token, newToken, prefix: null, suffix: null);
                             }
                         }
 
@@ -322,6 +322,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     var symbols = RenameUtilities.GetSymbolsTouchingPosition(token.Span.Start, _semanticModel, _solution.Workspace, _cancellationToken);
 
                     string suffix = null;
+                    string prefix = isRenameLocation && _renameLocations[token.Span].IsRenamableAccessor 
+                        ? newToken.ValueText.Substring(0, newToken.ValueText.IndexOf('_') + 1) 
+                        : null;
+
                     if (symbols.Count() == 1)
                     {
                         var symbol = symbols.Single();
@@ -357,11 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     if (isRenameLocation && !this.AnnotateForComplexification)
                     {
                         var oldSpan = token.Span;
-                        newToken = RenameToken(
-                            token,
-                            newToken,
-                            suffix: suffix,
-                            isAccessorLocation: isRenameLocation && _renameLocations[token.Span].IsRenamableAccessor);
+                        newToken = RenameToken(token, newToken, prefix, suffix);
 
                         AddModifiedSpan(oldSpan, newToken.Span);
                     }
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                             new RenameActionAnnotation(
                                 token.Span,
                                 isRenameLocation,
-                                isRenameLocation ? _renameLocations[token.Span].IsRenamableAccessor : false,
+                                prefix,
                                 suffix,
                                 renameDeclarationLocations: renameDeclarationLocations,
                                 isOriginalTextLocation: isOldText,
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     var renameAnnotation = new RenameActionAnnotation(
                                                 identifierToken.Span,
                                                 isRenameLocation: false,
-                                                isAccessorLocation: false,
+                                                prefix: null,
                                                 suffix: null,
                                                 renameDeclarationLocations: renameDeclarationLocations,
                                                 isOriginalTextLocation: false,
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 return newToken;
             }
 
-            private SyntaxToken RenameToken(SyntaxToken oldToken, SyntaxToken newToken, string suffix, bool isAccessorLocation)
+            private SyntaxToken RenameToken(SyntaxToken oldToken, SyntaxToken newToken, string prefix, string suffix)
             {
                 var parent = oldToken.Parent;
                 string currentNewIdentifier = _isVerbatim ? _replacementText.Substring(1) : _replacementText;
@@ -550,14 +550,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                         }
                     }
                 }
-                else if (isAccessorLocation)
+                else
                 {
-                    var prefix = oldIdentifier.Substring(0, oldIdentifier.IndexOf('_') + 1);
-                    currentNewIdentifier = prefix + currentNewIdentifier;
-                }
-                else if (!string.IsNullOrEmpty(suffix))
-                {
-                    currentNewIdentifier = _replacementText + suffix;
+                    if (!string.IsNullOrEmpty(prefix))
+                    {
+                        currentNewIdentifier = prefix + currentNewIdentifier;
+                    }
+
+                    if (!string.IsNullOrEmpty(suffix))
+                    {
+                        currentNewIdentifier = currentNewIdentifier + suffix;
+                    }                    
                 }
 
                 // determine the canonical identifier name (unescaped, no unicode escaping, ...)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/Annotations/RenameActionAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/Annotations/RenameActionAnnotation.cs
@@ -23,15 +23,16 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         public readonly bool IsRenameLocation;
 
         /// <summary>
-        /// A flag indicating if this identifier represents an accessor. E.g. get_Foo (of property Foo).
-        /// </summary>
-        public readonly bool IsAccessorLocation;
-
-        /// <summary>
         /// A flag indicating whether the token at this location has the same ValueText then the original name 
         /// of the symbol that gets renamed.
         /// </summary>
         public readonly bool IsOriginalTextLocation;
+
+        /// <summary>
+        /// When replacing the annotated token this string will be prepended to the token's value. This is used when renaming compiler 
+        /// generated fields and methods backing properties (e.g. "get_X" or "_X" for property "X").
+        /// </summary>
+        public readonly string Prefix;
 
         /// <summary>
         /// When replacing the annotated token this string will be appended to the token's value. This is used when renaming compiler 
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         public RenameActionAnnotation(
             TextSpan originalSpan,
             bool isRenameLocation,
-            bool isAccessorLocation,
+            string prefix,
             string suffix,
             bool isOriginalTextLocation,
             RenameDeclarationLocationReference[] renameDeclarationLocations,
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         {
             this.OriginalSpan = originalSpan;
             this.IsRenameLocation = isRenameLocation;
-            this.IsAccessorLocation = isAccessorLocation;
+            this.Prefix = prefix;
             this.Suffix = suffix;
             this.RenameDeclarationLocationReferences = renameDeclarationLocations;
             this.IsOriginalTextLocation = isOriginalTextLocation;

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Rename
                     }
                 }
 
-                // If we are renameing a backing field for a property, cascade to the property
+                // If we are renaming a backing field for a property, cascade to the property
                 if (symbol.Kind == SymbolKind.Field)
                 {
                     var fieldSymbol = (IFieldSymbol)symbol;

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -96,6 +96,17 @@ namespace Microsoft.CodeAnalysis.Rename
                     }
                 }
 
+                // If we are renameing a backing field for a property, cascade to the property
+                if (symbol.Kind == SymbolKind.Field)
+                {
+                    var fieldSymbol = (IFieldSymbol)symbol;
+                    if (fieldSymbol.IsImplicitlyDeclared && 
+                        fieldSymbol.AssociatedSymbol.IsKind(SymbolKind.Property))
+                    {
+                        return fieldSymbol.AssociatedSymbol;
+                    }
+                }
+
                 // in case this is e.g. an overridden property accessor, we'll treat the property itself as the definition symbol
                 var property = await GetPropertyFromAccessorOrAnOverride(symbol, solution, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes #905

Add rename support for VB property backing fields. We now correctly
exclude the leading '_' from the rename process and allow rename to be
invoked from references to the backing field.