### PR TITLE
Use diagnostic property bag in DeclarePublicAPI

### DIFF
--- a/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIFix.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIFix.cs
@@ -40,21 +40,14 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                var location = diagnostic.Location;
+                string minimalSymbolName = diagnostic.Properties[DeclarePublicAPIAnalyzer.MinimalNamePropertyBagKey];
+                string publicSurfaceAreaSymbolName = diagnostic.Properties[DeclarePublicAPIAnalyzer.PublicApiNamePropertyBagKey];
 
-                var symbol = FindDeclaration(root, location, semanticModel, context.CancellationToken);
-
-                if (symbol != null)
-                {
-                    var minimalSymbolName = symbol.ToMinimalDisplayString(semanticModel, location.SourceSpan.Start, DeclarePublicAPIAnalyzer.ShortSymbolNameFormat);
-                    var publicSurfaceAreaSymbolName = DeclarePublicAPIAnalyzer.GetPublicApiName(symbol);
-
-                    context.RegisterCodeFix(
-                            new AdditionalDocumentChangeAction(
-                                $"Add {minimalSymbolName} to public API",
-                                c => GetFix(publicSurfaceAreaDocument, publicSurfaceAreaSymbolName, c)),
-                            diagnostic);
-                }
+                context.RegisterCodeFix(
+                        new AdditionalDocumentChangeAction(
+                            $"Add {minimalSymbolName} to public API",
+                            c => GetFix(publicSurfaceAreaDocument, publicSurfaceAreaSymbolName, c)),
+                        diagnostic);
             }
         }
 
@@ -191,18 +184,9 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
 
                         foreach (var diagnostic in grouping)
                         {
-                            var location = diagnostic.Location;
-                            var symbol = FindDeclaration(root, location, semanticModel, cancellationToken);
+                            string publicSurfaceAreaSymbolName = diagnostic.Properties[DeclarePublicAPIAnalyzer.PublicApiNamePropertyBagKey];
 
-                            if (symbol != null)
-                            {
-                                var publicSurfaceAreaSymbolName = DeclarePublicAPIAnalyzer.GetPublicApiName(symbol);
-
-                                if (symbol != null)
-                                {
-                                    newSymbolNames.Add(publicSurfaceAreaSymbolName);
-                                }
-                            }
+                            newSymbolNames.Add(publicSurfaceAreaSymbolName);
                         }
                     }
 


### PR DESCRIPTION
Use the new Diagnostic property bag to pass information from the
DeclarePublicAPI analyzer to the DeclarePublicAPI fix. Specifically, we
pass the symbol name so the fix doesn't have to recompute it.

This allows us to avoid issue #1060, which currently causes the code fix
to insert the wrong symbol string in the PublicAPI.txt file.