### PR TITLE
Check SyntaxNodeOrToken is a SyntaxNode before converting

### DIFF
--- a/src/Features/CSharp/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -504,37 +504,44 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             var inlinedExprNodes = syntaxRootAfterInline.GetAnnotatedNodesAndTokens(ExpressionToInlineAnnotation);
             Debug.Assert(originalIdentifierNodes.Count() == inlinedExprNodes.Count());
 
-            var originalNodesEnum = originalIdentifierNodes.GetEnumerator();
-            var inlinedNodesEnum = inlinedExprNodes.GetEnumerator();
             Dictionary<SyntaxNode, SyntaxNode> replacementNodesWithChangedSemantics = null;
-
-            while (originalNodesEnum.MoveNext())
+            using (var originalNodesEnum = originalIdentifierNodes.GetEnumerator())
             {
-                inlinedNodesEnum.MoveNext();
-                var originalNode = originalNodesEnum.Current;
-
-                // expressionToInline is Parenthesized prior to replacement, so get the parenting parenthesized expression.
-                var inlinedNode = (ExpressionSyntax)inlinedNodesEnum.Current.AsNode().Parent;
-                Debug.Assert(inlinedNode.IsKind(SyntaxKind.ParenthesizedExpression));
-
-                // inlinedNode is the expanded form of the actual initializer expression in the original document.
-                // We have annotated the inner initializer with a special syntax annotation "InitializerAnnotation".
-                // Get this annotated node and compute the symbol info for this node in the inlined document.
-                var innerInitializerInInlineNode = (ExpressionSyntax)inlinedNode.GetAnnotatedNodesAndTokens(InitializerAnnotation).First().AsNode();
-                var newInializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(innerInitializerInInlineNode, cancellationToken);
-
-                // Verification: The symbol info associated with any of the inlined expressions does not match the symbol info for original initializer expression prior to inline.
-                if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInializerSymbolInfo, performEquivalenceCheck: true))
+                using (var inlinedNodesOrTokensEnum = inlinedExprNodes.GetEnumerator())
                 {
-                    newInializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(inlinedNode, cancellationToken);
-                    if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInializerSymbolInfo, performEquivalenceCheck: true))
+                    while (originalNodesEnum.MoveNext())
                     {
-                        if (replacementNodesWithChangedSemantics == null)
-                        {
-                            replacementNodesWithChangedSemantics = new Dictionary<SyntaxNode, SyntaxNode>();
-                        }
+                        inlinedNodesOrTokensEnum.MoveNext();
+                        var originalNode = originalNodesEnum.Current;
 
-                        replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
+                        // expressionToInline is Parenthesized prior to replacement, so get the parenting parenthesized expression.
+                        var inlinedNode = (ExpressionSyntax)inlinedNodesOrTokensEnum.Current.Parent;
+                        Debug.Assert(inlinedNode.IsKind(SyntaxKind.ParenthesizedExpression));
+
+                        // inlinedNode is the expanded form of the actual initializer expression in the original document.
+                        // We have annotated the inner initializer with a special syntax annotation "InitializerAnnotation".
+                        // Get this annotated node and compute the symbol info for this node in the inlined document.
+                        var innerInitializerInInlineNodeorToken = inlinedNode.GetAnnotatedNodesAndTokens(InitializerAnnotation).First();
+
+                        ExpressionSyntax innerInitializerInInlineNode = (ExpressionSyntax)(innerInitializerInInlineNodeorToken.IsNode ?
+                            innerInitializerInInlineNodeorToken.AsNode() :
+                            innerInitializerInInlineNodeorToken.AsToken().Parent);
+                        var newInializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(innerInitializerInInlineNode, cancellationToken);
+
+                        // Verification: The symbol info associated with any of the inlined expressions does not match the symbol info for original initializer expression prior to inline.
+                        if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInializerSymbolInfo, performEquivalenceCheck: true))
+                        {
+                            newInializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(inlinedNode, cancellationToken);
+                            if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInializerSymbolInfo, performEquivalenceCheck: true))
+                            {
+                                if (replacementNodesWithChangedSemantics == null)
+                                {
+                                    replacementNodesWithChangedSemantics = new Dictionary<SyntaxNode, SyntaxNode>();
+                                }
+
+                                replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix internal TFS bug 1130555 : Always check if a SyntaxNodeOrToken is a Node or Token before changing them to a SyntaxNode or SyntaxToken