### PR TITLE
Use empty array for unspecified public key instead of default(ImmutableArray<byte>) ...

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -192,6 +192,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public CSharpCompilationOptions WithCryptoPublicKey(ImmutableArray<byte> value)
         {
+            if (value.IsDefault)
+            {
+                value = ImmutableArray<byte>.Empty;
+            }
+
             if (value == this.CryptoPublicKey)
             {
                 return this;
@@ -526,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //          (kind == 'arm' || kind == 'appcontainer' || kind == 'winmdobj') &&
             //          (version >= "6.2")
 
-            if (!CryptoPublicKey.IsDefault)
+            if (!CryptoPublicKey.IsEmpty)
             {
                 if (CryptoKeyFile != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             _modules = moduleBuilder.ToImmutableAndFree();
 
-            if (!compilation.Options.CryptoPublicKey.IsDefault)
+            if (!compilation.Options.CryptoPublicKey.IsEmpty)
             {
                 _lazyStrongNameKeys = StrongNameKeys.Create(compilation.Options.CryptoPublicKey, MessageProvider.Instance);
             }
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Consider: should we allow to OSS sign if the key file only contains public key?
 
             if (DeclaringCompilation.Options.OutputKind != OutputKind.NetModule &&
-                DeclaringCompilation.Options.CryptoPublicKey.IsDefault&&                
+                DeclaringCompilation.Options.CryptoPublicKey.IsEmpty &&                
                 Identity.HasPublicKey&&
                 !IsDelaySigned &&
                 !StrongNameKeys.CanSign&&

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
@@ -388,5 +388,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(compilationOptions.ConcurrentBuild, deserializedCompilationOptions.ConcurrentBuild);
             Assert.Equal(compilationOptions.ExtendedCustomDebugInformation, deserializedCompilationOptions.ExtendedCustomDebugInformation);
         }
+
+        [Fact]
+        public void WithCryptoPublicKey()
+        {
+            var options = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
+
+            Assert.Equal(ImmutableArray<byte>.Empty, options.CryptoPublicKey);
+            Assert.Equal(ImmutableArray<byte>.Empty, options.WithCryptoPublicKey(default(ImmutableArray<byte>)).CryptoPublicKey);
+
+            Assert.Same(options, options.WithCryptoPublicKey(default(ImmutableArray<byte>)));
+            Assert.Same(options, options.WithCryptoPublicKey(ImmutableArray<byte>.Empty));
+        }
     }
 }

--- a/src/Compilers/Core/Desktop/SerializableCompilationOptions.cs
+++ b/src/Compilers/Core/Desktop/SerializableCompilationOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
             info.AddValue(ScriptClassNameString, options.ScriptClassName);
             info.AddValue(CryptoKeyContainerString, options.CryptoKeyContainer);
             info.AddValue(CryptoKeyFileString, options.CryptoKeyFile);
-            info.AddValue(CryptoPublicKeyString, options.CryptoPublicKey.IsDefault ? null : options.CryptoPublicKey.ToArray());
+            info.AddValue(CryptoPublicKeyString, options.CryptoPublicKey.ToArray());
             info.AddValue(DelaySignString, options.DelaySign);
             info.AddValue(CheckOverflowString, options.CheckOverflow);
             info.AddValue(PlatformString, (int)options.Platform);

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.InvalidOutputKindForSubmission, "options");
             }
 
-            if (options.CryptoKeyContainer != null || options.CryptoKeyFile != null || options.DelaySign != null || !options.CryptoPublicKey.IsDefault)
+            if (options.CryptoKeyContainer != null || options.CryptoKeyFile != null || options.DelaySign != null || !options.CryptoPublicKey.IsEmpty)
             {
                 throw new ArgumentException(CodeAnalysisResources.InvalidCompilationOptions, "options");
             }

--- a/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
@@ -42,8 +42,11 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public string MainTypeName { get; protected set; }
 
+        // Note that we avoid using default(ImmutableArray<byte>) for unspecified value since 
+        // such value is currently not serializable by JSON serializer.
+
         /// <summary>
-        /// Specifies public key used to generate strong name for the compilation assembly, or null of not specified.
+        /// Specifies public key used to generate strong name for the compilation assembly, or empty of not specified.
         /// </summary>
         /// <remarks>
         /// If specified the values of <see cref="CryptoKeyFile"/> and <see cref="CryptoKeyContainer"/> must be null.
@@ -220,7 +223,7 @@ namespace Microsoft.CodeAnalysis
             this.ScriptClassName = scriptClassName ?? WellKnownMemberNames.DefaultScriptClassName;
             this.CryptoKeyContainer = cryptoKeyContainer;
             this.CryptoKeyFile = cryptoKeyFile;
-            this.CryptoPublicKey = cryptoPublicKey;
+            this.CryptoPublicKey = cryptoPublicKey.NullToEmpty();
             this.DelaySign = delaySign;
             this.CheckOverflow = checkOverflow;
             this.Platform = platform;
@@ -404,7 +407,7 @@ namespace Microsoft.CodeAnalysis
                    this.ExtendedCustomDebugInformation == other.ExtendedCustomDebugInformation &&
                    string.Equals(this.CryptoKeyContainer, other.CryptoKeyContainer, StringComparison.Ordinal) &&
                    string.Equals(this.CryptoKeyFile, other.CryptoKeyFile, StringComparison.Ordinal) &&
-                   (this.CryptoPublicKey.IsDefault && other.CryptoPublicKey.IsDefault || !this.CryptoPublicKey.IsDefault && !other.CryptoPublicKey.IsDefault && this.CryptoPublicKey.SequenceEqual(other.CryptoPublicKey)) &&
+                   this.CryptoPublicKey.SequenceEqual(other.CryptoPublicKey) &&
                    this.DelaySign == other.DelaySign &&
                    this.GeneralDiagnosticOption == other.GeneralDiagnosticOption &&
                    string.Equals(this.MainTypeName, other.MainTypeName, StringComparison.Ordinal) &&

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -98,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             m_Modules = moduleBuilder.ToImmutableAndFree()
 
-            If Not compilation.Options.CryptoPublicKey.IsDefault Then
+            If Not compilation.Options.CryptoPublicKey.IsEmpty Then
                 m_lazyStrongNameKeys = StrongNameKeys.Create(compilation.Options.CryptoPublicKey, MessageProvider.Instance)
             End If
         End Sub
@@ -1185,7 +1185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' Consider: should we allow to OSS sign if the key file only contains public key?
 
                 If DeclaringCompilation.Options.OutputKind <> OutputKind.NetModule AndAlso
-                   DeclaringCompilation.Options.CryptoPublicKey.IsDefault AndAlso
+                   DeclaringCompilation.Options.CryptoPublicKey.IsEmpty AndAlso
                    Identity.HasPublicKey AndAlso
                    Not IsDelaySigned AndAlso
                    Not StrongNameKeys.CanSign Then

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -587,6 +587,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="value">The cryptography key file path. </param>        
         ''' <returns>A new instance of VisualBasicCompilationOptions, if the public key is different; otherwise current instance.</returns>        
         Public Shadows Function WithCryptoPublicKey(value As ImmutableArray(Of Byte)) As VisualBasicCompilationOptions
+            If value.IsDefault Then
+                value = ImmutableArray(Of Byte).Empty
+            End If
+
             If value = Me.CryptoPublicKey Then
                 Return Me
             End If
@@ -839,7 +843,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             '          (kind == 'arm' || kind == 'appcontainer' || kind == 'winmdobj') &&
             '          (version >= "6.2")
 
-            If Not CryptoPublicKey.IsDefault Then
+            If Not CryptoPublicKey.IsEmpty Then
                 If CryptoKeyFile IsNot Nothing Then
                     builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(CryptoPublicKey), NameOf(CryptoKeyFile)))
                 End If

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
@@ -558,5 +558,16 @@ BC2042: The options /vbruntime* and /target:module cannot be combined.
                          deserializedCompilationOptions.ExtendedCustomDebugInformation)
         End Sub
 
+        <Fact>
+        Public Sub WithCryptoPublicKey()
+            Dim options = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication)
+
+            Assert.Equal(ImmutableArray(Of Byte).Empty, options.CryptoPublicKey)
+            Assert.Equal(ImmutableArray(Of Byte).Empty, options.WithCryptoPublicKey(Nothing).CryptoPublicKey)
+
+            Assert.Same(options, options.WithCryptoPublicKey(Nothing))
+            Assert.Same(options, options.WithCryptoPublicKey(ImmutableArray(Of Byte).Empty))
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
...to avoid issues with JSON serialization. JSON serializer throws when encountering default(ImmutableArray<T>).