### PR TITLE
Add a CI build script

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,0 +1,7 @@
+
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+msbuild /v:m /m BuildAndTest.proj /p:CIBuild=true
+
+REM Kill any instances of VBCSCompiler.exe to release locked files;
+REM otherwise future CI runs may fail while trying to delete those files.
+taskkill /F /IM vbcscompiler.exe


### PR DESCRIPTION
Instances of vbcscompiler.exe may hang around for a few minutes after a
Jenkins run, locking files and causing new runs on the same system to
fail. To address this, we add a script to setup the environment, run the
build and test, and then kill any instances of vbcscompiler.exe that are
left around.