### PR TITLE
fix crash due to control following through next statement

### DIFF
--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.IncrementalAnalyzer.AnalyzerExecutor.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.IncrementalAnalyzer.AnalyzerExecutor.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 var existingData = await state.TryGetExistingDataAsync(project, cancellationToken).ConfigureAwait(false);
 
                 // quick path.
-                if (existingData?.Items.Length == 0)
+                if (existingData == null || existingData.Items.Length == 0)
                 {
                     return existingData;
                 }

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -352,6 +352,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 if (kv.Key == null)
                 {
                     await state.PersistAsync(project, new AnalysisData(data.TextVersion, data.DataVersion, kv.ToImmutableArrayOrEmpty()), CancellationToken.None).ConfigureAwait(false);
+                    continue;
                 }
 
                 await state.PersistAsync(project.GetDocument(kv.Key), new AnalysisData(data.TextVersion, data.DataVersion, kv.ToImmutableArrayOrEmpty()), CancellationToken.None).ConfigureAwait(false);
@@ -699,6 +700,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 if (kv.Key == null)
                 {
                     RaiseDiagnosticsUpdated(StateType.Project, project.Id, analyzer, new SolutionArgument(project), kv.ToImmutableArrayOrEmpty());
+                    continue;
                 }
 
                 RaiseDiagnosticsUpdated(StateType.Project, kv.Key, analyzer, new SolutionArgument(project.GetDocument(kv.Key)), kv.ToImmutableArrayOrEmpty());


### PR DESCRIPTION
I forgot to put "continue" in some places and it made null to pass into next statement.

it looks like I missed this case since I was concentrated on project document case not project case so this call path never exercised.