### PR TITLE
Undo nuget upgrade

### DIFF
--- a/src/Compilers/CSharp/Desktop/CSharpCodeAnalysis.Desktop.csproj
+++ b/src/Compilers/CSharp/Desktop/CSharpCodeAnalysis.Desktop.csproj
@@ -17,9 +17,9 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization" />
   </ItemGroup>
@@ -71,9 +71,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Compilers/CSharp/Desktop/packages.config
+++ b/src/Compilers/CSharp/Desktop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -878,13 +878,13 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="..\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems" Label="Shared" />

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return ImmutableArray<IAssemblySymbol>.CastUp(ReferencedAssemblySymbols);
+                return ImmutableArray.Create<IAssemblySymbol, AssemblySymbol>(ReferencedAssemblySymbols);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/packages.config
+++ b/src/Compilers/CSharp/Portable/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="portable-net45+win" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="portable-net45+win" />
 </packages>

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -61,8 +61,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/CommandLine/packages.config
+++ b/src/Compilers/CSharp/Test/CommandLine/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -60,8 +60,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Emit/packages.config
+++ b/src/Compilers/CSharp/Test/Emit/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -56,7 +56,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Semantic/packages.config
+++ b/src/Compilers/CSharp/Test/Semantic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -65,8 +65,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Symbol/packages.config
+++ b/src/Compilers/CSharp/Test/Symbol/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -22,7 +22,7 @@
     <SyntaxTestDefinition Include="..\..\Portable\Syntax\Syntax.xml" />
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Syntax/packages.config
+++ b/src/Compilers/CSharp/Test/Syntax/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
+++ b/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
@@ -56,13 +56,13 @@
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary">
       <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/src/Compilers/CSharp/Test/WinRT/packages.config
+++ b/src/Compilers/CSharp/Test/WinRT/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -63,9 +63,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/CSharp/csc/packages.config
+++ b/src/Compilers/CSharp/csc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -76,8 +76,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/Core/CodeAnalysisTest/packages.config
+++ b/src/Compilers/Core/CodeAnalysisTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -18,7 +18,7 @@
     <DefineConstants>$(DefineConstants);COMPILERCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
@@ -106,9 +106,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var analyzerOptions = new AnalyzerOptions(ImmutableArray<AdditionalText>.CastUp(additionalTextFiles));
+            var analyzerOptions = new AnalyzerOptions(ImmutableArray.Create<AdditionalText, AdditionalTextFile>(additionalTextFiles));
 
             AnalyzerDriver analyzerDriver = null;
             AnalyzerManager analyzerManager = null;

--- a/src/Compilers/Core/Desktop/packages.config
+++ b/src/Compilers/Core/Desktop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -29,9 +29,9 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\MSBuild\v14.0\Microsoft.Build.Utilities.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/packages.config
+++ b/src/Compilers/Core/MSBuildTask/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -647,12 +647,12 @@
     <PublicAPI Include="PublicAPI.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="..\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis
         public static ImmutableArray<TBase> Cast<TDerived, TBase>(this ImmutableArray<TDerived> items)
             where TDerived : class, TBase
         {
-            return ImmutableArray<TBase>.CastUp(items);
+            return ImmutableArray.Create<TBase, TDerived>(items);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Collections/StaticCast.cs
+++ b/src/Compilers/Core/Portable/Collections/StaticCast.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static ImmutableArray<T> From<TDerived>(ImmutableArray<TDerived> from) where TDerived : class, T
         {
-            return ImmutableArray<T>.CastUp(from);
+            return ImmutableArray.Create<T, TDerived>(from);
         }
     }
 }

--- a/src/Compilers/Core/Portable/packages.config
+++ b/src/Compilers/Core/Portable/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="portable-net45+win" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="portable-net45+win" />
 </packages>

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -101,10 +101,7 @@ namespace Microsoft.CodeAnalysis
 
         public void EnsureCapacity(int capacity)
         {
-            if (_builder.Capacity < capacity)
-            {
-                _builder.Capacity = capacity;
-            }
+            _builder.EnsureCapacity(capacity);
         }
 
         public void Clear()
@@ -134,7 +131,7 @@ namespace Microsoft.CodeAnalysis
 
         public void ReverseContents()
         {
-            _builder.Reverse();
+            _builder.ReverseContents();
         }
 
         public void Sort()

--- a/src/Compilers/Core/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Core/VBCSCompiler/VBCSCompiler.csproj
@@ -77,15 +77,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/Core/VBCSCompiler/packages.config
+++ b/src/Compilers/Core/VBCSCompiler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -68,8 +68,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="Microsoft.Build.Framework">
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\MSBuild\v14.0\Microsoft.Build.Framework.dll</HintPath>

--- a/src/Compilers/Core/VBCSCompilerTests/packages.config
+++ b/src/Compilers/Core/VBCSCompilerTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Test/Resources/Core/WinRt/WinMDPrefixing.ildump
+++ b/src/Compilers/Test/Resources/Core/WinRt/WinMDPrefixing.ildump
@@ -5,7 +5,7 @@
 .assembly extern System.ObjectModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 .assembly extern System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 .assembly extern System.Runtime.WindowsRuntime.UI.Xaml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
-.assembly extern System.Numerics.Vectors, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+.assembly extern System.Numerics.Vectors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 .class private auto ansi <Module>
 {
 }

--- a/src/Compilers/Test/Resources/Core/packages.config
+++ b/src/Compilers/Test/Resources/Core/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Test/Utilities/CSharp/CSharpCompilerTestUtilities.csproj
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpCompilerTestUtilities.csproj
@@ -64,14 +64,14 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/Test/Utilities/CSharp/packages.config
+++ b/src/Compilers/Test/Utilities/CSharp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Test/Utilities/Core2/CompilerTestUtilities2.csproj
+++ b/src/Compilers/Test/Utilities/Core2/CompilerTestUtilities2.csproj
@@ -31,8 +31,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/Test/Utilities/Core2/packages.config
+++ b/src/Compilers/Test/Utilities/Core2/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
@@ -75,14 +75,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/Test/Utilities/VisualBasic/packages.config
+++ b/src/Compilers/Test/Utilities/VisualBasic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Desktop/BasicCodeAnalysis.Desktop.vbproj
+++ b/src/Compilers/VisualBasic/Desktop/BasicCodeAnalysis.Desktop.vbproj
@@ -91,13 +91,13 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Compilers/VisualBasic/Desktop/packages.config
+++ b/src/Compilers/VisualBasic/Desktop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -1005,13 +1005,13 @@
     <Folder Include="My Project\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -2020,7 +2020,7 @@ ExitForFor:
                     ' Only named types have members that are types. Go through all the types in this type and
                     ' validate them. If there's multiple, give an error.
                     If TypeOf container Is NamedTypeSymbol Then
-                        members = ImmutableArray(Of Symbol).CastUp(container.GetTypeMembers(name))
+                        members = ImmutableArray.Create(Of Symbol, NamedTypeSymbol)(container.GetTypeMembers(name))
                     End If
                 ElseIf (options And LookupOptions.LabelsOnly) = 0 Then
                     members = container.GetMembers(name)

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -817,7 +817,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IMethodSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IMethodSymbol.Parameters
             Get
-                Return ImmutableArray(Of IParameterSymbol).CastUp(Me.Parameters)
+                Return ImmutableArray.Create(Of IParameterSymbol, ParameterSymbol)(Me.Parameters)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -290,7 +290,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IModuleSymbol_ReferencedAssemblySymbols As ImmutableArray(Of IAssemblySymbol) Implements IModuleSymbol.ReferencedAssemblySymbols
             Get
-                Return ImmutableArray(Of IAssemblySymbol).CastUp(ReferencedAssemblySymbols)
+                Return ImmutableArray.Create(Of IAssemblySymbol, AssemblySymbol)(ReferencedAssemblySymbols)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
@@ -332,7 +332,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overloads Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
             Dim members As ImmutableArray(Of NamespaceOrTypeSymbol) = Nothing
             If Me.GetNameToMembersMap().TryGetValue(name, members) Then
-                Return ImmutableArray(Of Symbol).CastUp(members)
+                Return ImmutableArray.Create(Of Symbol, NamespaceOrTypeSymbol)(members)
             Else
                 Return ImmutableArray(Of Symbol).Empty
             End If

--- a/src/Compilers/VisualBasic/Portable/packages.config
+++ b/src/Compilers/VisualBasic/Portable/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
@@ -66,8 +66,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.0.0-rc1-20150208-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/VisualBasic/Test/CommandLine/packages.config
+++ b/src/Compilers/VisualBasic/Test/CommandLine/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -58,8 +58,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/VisualBasic/Test/Emit/packages.config
+++ b/src/Compilers/VisualBasic/Test/Emit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -54,8 +54,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Compilers/VisualBasic/Test/Semantic/packages.config
+++ b/src/Compilers/VisualBasic/Test/Semantic/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
@@ -59,8 +59,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/VisualBasic/Test/Symbol/packages.config
+++ b/src/Compilers/VisualBasic/Test/Symbol/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
@@ -20,7 +20,7 @@
     <SyntaxTestDefinition Include="..\..\Portable\Syntax\Syntax.xml" />
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Tools\Source\CompilerGeneratorTools\Source\VisualBasicSyntaxGenerator\VisualBasicSyntaxGenerator.vbproj">

--- a/src/Compilers/VisualBasic/Test/Syntax/packages.config
+++ b/src/Compilers/VisualBasic/Test/Syntax/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/vbc/packages.config
+++ b/src/Compilers/VisualBasic/vbc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   </packages>

--- a/src/Compilers/VisualBasic/vbc/vbc.vbproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.vbproj
@@ -67,9 +67,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Diagnostics/CodeAnalysis/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/CodeAnalysis/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
@@ -43,9 +43,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Diagnostics/CodeAnalysis/CSharp/packages.config
+++ b/src/Diagnostics/CodeAnalysis/CSharp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/CodeAnalysis/Core/CodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/CodeAnalysis/Core/CodeAnalysisDiagnosticAnalyzers.csproj
@@ -35,9 +35,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Diagnostics/CodeAnalysis/Core/packages.config
+++ b/src/Diagnostics/CodeAnalysis/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/CodeAnalysis/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
+++ b/src/Diagnostics/CodeAnalysis/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
@@ -81,9 +81,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Diagnostics/CodeAnalysis/Test/packages.config
+++ b/src/Diagnostics/CodeAnalysis/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/CodeAnalysis/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/CodeAnalysis/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
@@ -42,9 +42,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Diagnostics/CodeAnalysis/VisualBasic/packages.config
+++ b/src/Diagnostics/CodeAnalysis/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/CSharp/CSharpFxCopRulesDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/CSharp/CSharpFxCopRulesDiagnosticAnalyzers.csproj
@@ -18,7 +18,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/FxCop/CSharp/packages.config
+++ b/src/Diagnostics/FxCop/CSharp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/Core/FxCopRulesDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/Core/FxCopRulesDiagnosticAnalyzers.csproj
@@ -24,7 +24,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/FxCop/Core/packages.config
+++ b/src/Diagnostics/FxCop/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
@@ -43,9 +43,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/packages.config
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.csproj
@@ -35,9 +35,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/packages.config
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/SystemRuntimeAnalyzersTest.csproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/SystemRuntimeAnalyzersTest.csproj
@@ -81,9 +81,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/packages.config
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
@@ -42,9 +42,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/packages.config
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/FxCop/Test/FxCopRulesDiagnosticAnalyzersTest.csproj
+++ b/src/Diagnostics/FxCop/Test/FxCopRulesDiagnosticAnalyzersTest.csproj
@@ -116,9 +116,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Diagnostics/FxCop/Test/packages.config
+++ b/src/Diagnostics/FxCop/Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/Diagnostics/FxCop/VisualBasic/BasicFxCopRulesDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/FxCop/VisualBasic/BasicFxCopRulesDiagnosticAnalyzers.vbproj
@@ -17,7 +17,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/FxCop/VisualBasic/packages.config
+++ b/src/Diagnostics/FxCop/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/Roslyn/CSharp/CSharpRoslynDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/Roslyn/CSharp/CSharpRoslynDiagnosticAnalyzers.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/Roslyn/CSharp/packages.config
+++ b/src/Diagnostics/Roslyn/CSharp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/Roslyn/Core/RoslynDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/Roslyn/Core/RoslynDiagnosticAnalyzers.csproj
@@ -17,7 +17,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/Roslyn/Core/packages.config
+++ b/src/Diagnostics/Roslyn/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
@@ -17,7 +17,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/Roslyn/VisualBasic/packages.config
+++ b/src/Diagnostics/Roslyn/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Diagnostics/Test/Utilities/DiagnosticsTestUtilities.csproj
+++ b/src/Diagnostics/Test/Utilities/DiagnosticsTestUtilities.csproj
@@ -70,9 +70,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Diagnostics/Test/Utilities/packages.config
+++ b/src/Diagnostics/Test/Utilities/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -237,9 +237,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/EditorFeatures/CSharp/packages.config
+++ b/src/EditorFeatures/CSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -141,9 +141,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/EditorFeatures/CSharpTest/app.config
+++ b/src/EditorFeatures/CSharpTest/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/EditorFeatures/CSharpTest/packages.config
+++ b/src/EditorFeatures/CSharpTest/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -21,7 +21,7 @@
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\</SolutionDir>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/EditorFeatures/Core/packages.config
+++ b/src/EditorFeatures/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -30,7 +30,7 @@
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
       <CopyLocal>True</CopyLocal>
     </Reference>
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor.Interop.dll">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Platform.VSEditor.Interop.dll</HintPath>

--- a/src/EditorFeatures/Test/app.config
+++ b/src/EditorFeatures/Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/EditorFeatures/Test/packages.config
+++ b/src/EditorFeatures/Test/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -25,7 +25,7 @@
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/EditorFeatures/Test2/app.config
+++ b/src/EditorFeatures/Test2/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/EditorFeatures/Test2/packages.config
+++ b/src/EditorFeatures/Test2/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/EditorFeatures/TestUtilities/ServicesTestUtilities.csproj
+++ b/src/EditorFeatures/TestUtilities/ServicesTestUtilities.csproj
@@ -36,9 +36,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="ReachFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/EditorFeatures/TestUtilities/packages.config
+++ b/src/EditorFeatures/TestUtilities/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/Text/TextEditorFeatures.csproj
+++ b/src/EditorFeatures/Text/TextEditorFeatures.csproj
@@ -17,7 +17,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/EditorFeatures/Text/packages.config
+++ b/src/EditorFeatures/Text/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
@@ -14,7 +14,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/EditorFeatures/VisualBasic/packages.config
+++ b/src/EditorFeatures/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -121,9 +121,9 @@
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Drawing" />

--- a/src/EditorFeatures/VisualBasicTest/app.config
+++ b/src/EditorFeatures/VisualBasicTest/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/EditorFeatures/VisualBasicTest/packages.config
+++ b/src/EditorFeatures/VisualBasicTest/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Label="Project References">
@@ -51,9 +51,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
@@ -76,13 +76,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
@@ -73,9 +73,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -70,8 +70,8 @@
     <Compile Include="RuntimeInspectionContext.cs" />
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
@@ -21,10 +21,10 @@
   <ItemGroup Label="File References">
     <Reference Include="System" />
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
@@ -20,9 +20,9 @@
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Metadata.dll" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/packages.config
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -16,8 +16,8 @@
     <!-- Don't transitively copy output files, since everything builds to the same folder. -->
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
@@ -17,8 +17,8 @@
     <!-- Don't transitively copy output files, since everything builds to the same folder. -->
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/BasicResultProviderTest.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/BasicResultProviderTest.vbproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Metadata.dll" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Features/CSharp/CSharpFeatures.csproj
+++ b/src/Features/CSharp/CSharpFeatures.csproj
@@ -16,7 +16,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Features/CSharp/packages.config
+++ b/src/Features/CSharp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -15,8 +15,8 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Features/Core/packages.config
+++ b/src/Features/Core/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Features/VisualBasic/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/BasicFeatures.vbproj
@@ -16,7 +16,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Features/VisualBasic/packages.config
+++ b/src/Features/VisualBasic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Interactive/EditorFeatures/CSharp/CSharpInteractiveEditorFeatures.csproj
+++ b/src/Interactive/EditorFeatures/CSharp/CSharpInteractiveEditorFeatures.csproj
@@ -114,9 +114,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Xaml" />

--- a/src/Interactive/EditorFeatures/CSharp/packages.config
+++ b/src/Interactive/EditorFeatures/CSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
@@ -17,7 +17,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Desktop\CodeAnalysis.Desktop.csproj">

--- a/src/Interactive/EditorFeatures/Core/packages.config
+++ b/src/Interactive/EditorFeatures/Core/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Interactive/EditorFeatures/VisualBasic/packages.config
+++ b/src/Interactive/EditorFeatures/VisualBasic/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Interactive/Features/InteractiveFeatures.csproj
+++ b/src/Interactive/Features/InteractiveFeatures.csproj
@@ -15,7 +15,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Desktop\CodeAnalysis.Desktop.csproj">

--- a/src/Interactive/Features/packages.config
+++ b/src/Interactive/Features/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Interactive/HostTest/InteractiveHostTest.csproj
+++ b/src/Interactive/HostTest/InteractiveHostTest.csproj
@@ -110,9 +110,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Interactive/HostTest/packages.config
+++ b/src/Interactive/HostTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -41,9 +41,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/Interactive/csi/packages.config
+++ b/src/Interactive/csi/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Interactive/vbi/packages.config
+++ b/src/Interactive/vbi/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   </packages>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -55,9 +55,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
@@ -46,9 +46,9 @@
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsft.VisualStudio.Platform.VSEditor.Interop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Xml" />

--- a/src/InteractiveWindow/EditorTest/packages.config
+++ b/src/InteractiveWindow/EditorTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="BasicUndo" version="0.9.3" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/APISampleUnitTests/APISampleUnitTestsCS.csproj
+++ b/src/Samples/CSharp/APISampleUnitTests/APISampleUnitTestsCS.csproj
@@ -58,9 +58,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/Samples/CSharp/APISampleUnitTests/packages.config
+++ b/src/Samples/CSharp/APISampleUnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/AsyncPackage/AsyncPackage.csproj
+++ b/src/Samples/CSharp/AsyncPackage/AsyncPackage.csproj
@@ -94,9 +94,9 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -122,9 +122,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Samples/CSharp/AsyncPackage/Test/AsyncPackage.Test.csproj
+++ b/src/Samples/CSharp/AsyncPackage/Test/AsyncPackage.Test.csproj
@@ -79,9 +79,9 @@
       <Private>false</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/src/Samples/CSharp/AsyncPackage/Test/packages.config
+++ b/src/Samples/CSharp/AsyncPackage/Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/AsyncPackage/packages.config
+++ b/src/Samples/CSharp/AsyncPackage/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/ConsoleClassifier/ConsoleClassifierCS.csproj
+++ b/src/Samples/CSharp/ConsoleClassifier/ConsoleClassifierCS.csproj
@@ -54,9 +54,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/src/Samples/CSharp/ConsoleClassifier/packages.config
+++ b/src/Samples/CSharp/ConsoleClassifier/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/ConvertToAutoPropertyCS.csproj
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/ConvertToAutoPropertyCS.csproj
@@ -65,9 +65,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/packages.config
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/FormatSolution/FormatSolutionCS.csproj
+++ b/src/Samples/CSharp/FormatSolution/FormatSolutionCS.csproj
@@ -46,9 +46,9 @@
       <HintPath>$(VSLOutDir)\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
@@ -90,9 +90,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/packages.config
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedCS.UnitTests.csproj
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedCS.UnitTests.csproj
@@ -52,9 +52,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/packages.config
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
+++ b/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
@@ -69,9 +69,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/CSharp/MakeConst/Impl/packages.config
+++ b/src/Samples/CSharp/MakeConst/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/CSharp/MakeConst/Test/MakeConstCS.UnitTests.csproj
+++ b/src/Samples/CSharp/MakeConst/Test/MakeConstCS.UnitTests.csproj
@@ -48,9 +48,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Samples/CSharp/MakeConst/Test/packages.config
+++ b/src/Samples/CSharp/MakeConst/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Samples/Shared/UnitTestFramework/UnitTestFramework.csproj
+++ b/src/Samples/Shared/UnitTestFramework/UnitTestFramework.csproj
@@ -49,9 +49,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/Samples/Shared/UnitTestFramework/packages.config
+++ b/src/Samples/Shared/UnitTestFramework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/APISampleUnitTests/APISampleUnitTestsVB.vbproj
+++ b/src/Samples/VisualBasic/APISampleUnitTests/APISampleUnitTestsVB.vbproj
@@ -63,9 +63,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Samples/VisualBasic/APISampleUnitTests/packages.config
+++ b/src/Samples/VisualBasic/APISampleUnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/ConsoleClassifier/ConsoleClassifierVB.vbproj
+++ b/src/Samples/VisualBasic/ConsoleClassifier/ConsoleClassifierVB.vbproj
@@ -51,9 +51,9 @@
       <HintPath>$(VSLOutDir)\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Samples/VisualBasic/ConsoleClassifier/packages.config
+++ b/src/Samples/VisualBasic/ConsoleClassifier/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/ConvertToAutoPropertyVB.vbproj
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/ConvertToAutoPropertyVB.vbproj
@@ -73,9 +73,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/packages.config
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/ConvertToAutoPropertyVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/ConvertToAutoPropertyVB.UnitTests.vbproj
@@ -56,9 +56,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/packages.config
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/FormatSolution/packages.config
+++ b/src/Samples/VisualBasic/FormatSolution/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
@@ -84,9 +84,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/packages.config
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedVB.UnitTests.vbproj
@@ -46,9 +46,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/packages.config
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/MakeConst/Impl/MakeConstVB.vbproj
+++ b/src/Samples/VisualBasic/MakeConst/Impl/MakeConstVB.vbproj
@@ -94,9 +94,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Samples/VisualBasic/MakeConst/Impl/packages.config
+++ b/src/Samples/VisualBasic/MakeConst/Impl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-    <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+    <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Samples/VisualBasic/MakeConst/Test/MakeConstVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/MakeConst/Test/MakeConstVB.UnitTests.vbproj
@@ -62,9 +62,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Samples/VisualBasic/MakeConst/Test/packages.config
+++ b/src/Samples/VisualBasic/MakeConst/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Scripting/CSharp/CSharpScripting.csproj
+++ b/src/Scripting/CSharp/CSharpScripting.csproj
@@ -46,9 +46,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/Scripting/CSharp/packages.config
+++ b/src/Scripting/CSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Scripting/CSharpTest/CSharpScriptingTest.csproj
+++ b/src/Scripting/CSharpTest/CSharpScriptingTest.csproj
@@ -82,9 +82,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Scripting/CSharpTest/packages.config
+++ b/src/Scripting/CSharpTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -69,14 +69,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Scripting/Core/packages.config
+++ b/src/Scripting/Core/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Scripting/Test/ScriptingTest.csproj
+++ b/src/Scripting/Test/ScriptingTest.csproj
@@ -65,9 +65,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Scripting/Test/packages.config
+++ b/src/Scripting/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Scripting/VisualBasic/BasicScripting.vbproj
+++ b/src/Scripting/VisualBasic/BasicScripting.vbproj
@@ -67,9 +67,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Scripting/VisualBasic/packages.config
+++ b/src/Scripting/VisualBasic/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   </packages>

--- a/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
+++ b/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
@@ -66,9 +66,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Scripting/VisualBasicTest/packages.config
+++ b/src/Scripting/VisualBasicTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Test/Diagnostics/Diagnostics.csproj
+++ b/src/Test/Diagnostics/Diagnostics.csproj
@@ -47,9 +47,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />

--- a/src/Test/Diagnostics/packages.config
+++ b/src/Test/Diagnostics/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -67,11 +67,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.XML" />
   </ItemGroup>

--- a/src/Test/PdbUtilities/packages.config
+++ b/src/Test/PdbUtilities/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MDbg" version="0.1.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Test/Utilities/TestUtilities.csproj
+++ b/src/Test/Utilities/TestUtilities.csproj
@@ -56,8 +56,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc1-20150208-02" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Tools/Source/DebuggerVisualizers/Roslyn.DebuggerVisualizers.csproj
+++ b/src/Tools/Source/DebuggerVisualizers/Roslyn.DebuggerVisualizers.csproj
@@ -46,15 +46,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/src/Tools/Source/DebuggerVisualizers/packages.config
+++ b/src/Tools/Source/DebuggerVisualizers/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Tools/Source/FakeSign/FakeSign.csproj
+++ b/src/Tools/Source/FakeSign/FakeSign.csproj
@@ -22,11 +22,11 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>true</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Tools/Source/FakeSign/packages.config
+++ b/src/Tools/Source/FakeSign/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/Tools/Source/MetadataVisualizer/MetadataVisualizer.csproj
+++ b/src/Tools/Source/MetadataVisualizer/MetadataVisualizer.csproj
@@ -28,10 +28,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Tools/Source/MetadataVisualizer/packages.config
+++ b/src/Tools/Source/MetadataVisualizer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
+++ b/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
@@ -14,7 +14,7 @@
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\..\</SolutionDir>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Desktop\CodeAnalysis.Desktop.csproj">

--- a/src/VisualStudio/CSharp/Impl/packages.config
+++ b/src/VisualStudio/CSharp/Impl/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -132,9 +132,9 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/src/VisualStudio/CSharp/Test/app.config
+++ b/src/VisualStudio/CSharp/Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/VisualStudio/CSharp/Test/packages.config
+++ b/src/VisualStudio/CSharp/Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -186,8 +186,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="Microsoft.VisualStudio.CallHierarchy.Package.Definitions.dll">
       <HintPath>$(DevEnvDir)\Microsoft.VisualStudio.CallHierarchy.Package.Definitions.dll</HintPath>
     </Reference>

--- a/src/VisualStudio/Core/Def/app.config
+++ b/src/VisualStudio/Core/Def/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/VisualStudio/Core/Def/packages.config
+++ b/src/VisualStudio/Core/Def/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="ManagedEsent" version="1.9.2.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -76,8 +76,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/VisualStudio/Core/Impl/packages.config
+++ b/src/VisualStudio/Core/Impl/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -24,7 +24,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="Microsoft.VisualStudio.CodeAnalysis.Sdk.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll</HintPath>
     </Reference>

--- a/src/VisualStudio/Core/SolutionExplorerShim/packages.config
+++ b/src/VisualStudio/Core/SolutionExplorerShim/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -27,7 +27,7 @@
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/VisualStudio/Core/Test/app.config
+++ b/src/VisualStudio/Core/Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.34.0" newVersion="1.1.34.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.33.0" newVersion="1.1.33.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/VisualStudio/Core/Test/packages.config
+++ b/src/VisualStudio/Core/Test/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/VisualStudio/InteractiveServices/VisualStudioInteractiveServices.csproj
+++ b/src/VisualStudio/InteractiveServices/VisualStudioInteractiveServices.csproj
@@ -127,9 +127,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/src/VisualStudio/InteractiveServices/packages.config
+++ b/src/VisualStudio/InteractiveServices/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
@@ -21,7 +21,7 @@
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\..\</SolutionDir>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Desktop\CodeAnalysis.Desktop.csproj">

--- a/src/VisualStudio/VisualBasic/Impl/packages.config
+++ b/src/VisualStudio/VisualBasic/Impl/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/VisualBasic/Repl/BasicVisualStudioRepl.vbproj
+++ b/src/VisualStudio/VisualBasic/Repl/BasicVisualStudioRepl.vbproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\InteractiveWindow\Editor\InteractiveWindow.csproj">

--- a/src/Workspaces/CSharp/Desktop/CSharpWorkspace.Desktop.csproj
+++ b/src/Workspaces/CSharp/Desktop/CSharpWorkspace.Desktop.csproj
@@ -20,9 +20,9 @@
     <Reference Include="Microsoft.Build, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.$(MSBuildAssemblyNameFragment), Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Workspaces/CSharp/Desktop/packages.config
+++ b/src/Workspaces/CSharp/Desktop/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
+++ b/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Workspaces/CSharp/Portable/packages.config
+++ b/src/Workspaces/CSharp/Portable/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
 </packages>

--- a/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
+++ b/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
@@ -63,7 +63,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Workspaces/CSharpTest/packages.config
+++ b/src/Workspaces/CSharpTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -38,8 +38,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
-    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/Core/Desktop/packages.config
+++ b/src/Workspaces/Core/Desktop/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -19,7 +19,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>

--- a/src/Workspaces/Core/Portable/packages.config
+++ b/src/Workspaces/Core/Portable/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
 </packages>

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -82,7 +82,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Workspaces/CoreTest/packages.config
+++ b/src/Workspaces/CoreTest/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Workspaces/VisualBasic/Desktop/BasicWorkspace.Desktop.vbproj
+++ b/src/Workspaces/VisualBasic/Desktop/BasicWorkspace.Desktop.vbproj
@@ -21,9 +21,9 @@
     <Reference Include="Microsoft.Build, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.$(MSBuildAssemblyNameFragment), Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Workspaces/VisualBasic/Desktop/packages.config
+++ b/src/Workspaces/VisualBasic/Desktop/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
 </packages>

--- a/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
+++ b/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Workspaces/VisualBasic/Portable/packages.config
+++ b/src/Workspaces/VisualBasic/Portable/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
 </packages>

--- a/src/Workspaces/VisualBasicTest/VisualBasicServicesTest.vbproj
+++ b/src/Workspaces/VisualBasicTest/VisualBasicServicesTest.vbproj
@@ -64,7 +64,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="File References">
-    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
+    <Reference Include="..\..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Workspaces/VisualBasicTest/packages.config
+++ b/src/Workspaces/VisualBasicTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is an undo for PR #1077.  

There is an API change associated with this upgrade and it will require more extensive work to integrate into both Roslyn and Visual Studio.  Given the proximity to ZBB we decided to undo this change for now.  It will be reapplied next Thursday.  

Issue #1097 tracks reapplying this change.