### PR TITLE
Restored requirement for struct constructors to always have formal param...

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6704,15 +6704,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameterless instance constructors in structs must be public.
-        /// </summary>
-        internal static string ERR_ParameterlessStructCtorsMustBePublic {
-            get {
-                return ResourceManager.GetString("ERR_ParameterlessStructCtorsMustBePublic", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Parameter not valid for the specified unmanaged type..
         /// </summary>
         internal static string ERR_ParameterNotValidForType {
@@ -9095,15 +9086,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureStaticClasses {
             get {
                 return ResourceManager.GetString("IDS_FeatureStaticClasses", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to struct instance parameterless constructors.
-        /// </summary>
-        internal static string IDS_FeatureStructParameterlessConstructors {
-            get {
-                return ResourceManager.GetString("IDS_FeatureStructParameterlessConstructors", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1550,9 +1550,6 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_EnumsCantContainDefaultConstructor" xml:space="preserve">
     <value>Enums cannot contain explicit parameterless constructors</value>
   </data>
-  <data name="ERR_ParameterlessStructCtorsMustBePublic" xml:space="preserve">
-    <value>Parameterless instance constructors in structs must be public</value>
-  </data>
   <data name="ERR_CantOverrideBogusMethod" xml:space="preserve">
     <value>'{0}': cannot override '{1}' because it is not supported by the language</value>
   </data>
@@ -4552,9 +4549,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="IDS_FeatureDictionaryInitializer" xml:space="preserve">
     <value>dictionary initializer</value>
-  </data>
-  <data name="IDS_FeatureStructParameterlessConstructors" xml:space="preserve">
-    <value>struct instance parameterless constructors</value>
   </data>
   <data name="ERR_UnclosedExpressionHole" xml:space="preserve">
     <value>Missing close delimiter '}' for interpolated expression started with '{'.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1289,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NullPropagatingOpInExpressionTree = 8072,
         WRN_NubExprIsConstBool2 = 8073,
         ERR_DictionaryInitializerInExpressionTree = 8074,
-        ERR_ParameterlessStructCtorsMustBePublic = 8075,
+        // available: 8075,
         ERR_UnclosedExpressionHole = 8076,
         ERR_SingleLineCommentInExpressionHole = 8077,
         ERR_InsufficientStack = 8078,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // IDS_VersionExperimental = MessageBase + 12694,
         IDS_FeatureNameof = MessageBase + 12695,
         IDS_FeatureDictionaryInitializer = MessageBase + 12696,
-        IDS_FeatureStructParameterlessConstructors = MessageBase + 12697,
+        // available: MessageBase + 12697,
 
         IDS_LogoLine1 = MessageBase + 12698,
         IDS_LogoLine2 = MessageBase + 12699,
@@ -158,7 +158,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureExpressionBodiedIndexer:
                 case MessageID.IDS_FeatureNameof:
                 case MessageID.IDS_FeatureDictionaryInitializer:
-                case MessageID.IDS_FeatureStructParameterlessConstructors:
                 case MessageID.IDS_FeatureUsingStatic:
                 case MessageID.IDS_FeatureInterpolatedStrings:
                     return LanguageVersion.CSharp6;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2723,13 +2723,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             diagnostics.Add(ErrorCode.ERR_EnumsCantContainDefaultConstructor, m.Locations[0]);
                         }
-                        else if (m.DeclaredAccessibility != Accessibility.Public)
-                        {
-                            diagnostics.Add(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, m.Locations[0]);
-                        }
                         else
                         {
-                            Binder.CheckFeatureAvailability(m.Locations[0], MessageID.IDS_FeatureStructParameterlessConstructors, diagnostics);
+                            diagnostics.Add(ErrorCode.ERR_StructsCantContainDefaultConstructor, m.Locations[0]);
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
@@ -300,158 +300,6 @@ class C
             CompileAndVerify(text, expectedOutput: expectedOutput);
         }
 
-
-        [Fact]
-        public void ParameterlessConstructorStruct001()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1()
-        {
-            x = 42;
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1();
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   42
-  IL_0003:  stfld      ""int C.S1.x""
-  IL_0008:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessConstructorStruct002()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1()
-        {
-            x = 42;
-        }
-
-        public S1(int a):this()
-        {
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1(123);
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor(int)", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""C.S1..ctor()""
-  IL_0006:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessConstructorStruct003()
-        {
-            var source = @"
-class C
-{
-    struct S1
-    {
-        public readonly int x;
-        public S1(): this(42)
-        {
-        }
-
-        public S1(int a)
-        {
-            x = a;
-        }
-    }
-
-    static void Main()
-    {
-        var s = new S1();
-        System.Console.WriteLine(s.x);
-    }
-}
-";
-            CompileAndVerify(source, expectedOutput: "42").
-                VerifyIL("C.S1..ctor(int)", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  stfld      ""int C.S1.x""
-  IL_0007:  ret
-}
-").
-VerifyIL("C.S1..ctor()", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   42
-  IL_0003:  call       ""C.S1..ctor(int)""
-  IL_0008:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParameterlessInstCtorInStructExprTree()
-        {
-            var source = @"
-
-using System;
-using System.Linq.Expressions;
-
-class C
-{
-    struct S1
-    {
-        public int x;
-        public S1()
-        {
-            x = 42;
-        }
-    }
-
-    static void Main()
-    {
-        Expression<Func<S1>> testExpr = () => new S1();
-        System.Console.Write(testExpr.Compile()().x);
-    }
-}
-";
-            CompileAndVerify(source, additionalRefs: new[] { ExpressionAssemblyRef }, expectedOutput: "42");
-        }
-
         [Fact]
         public void TestInitializerInCtor001()
         {
@@ -496,7 +344,7 @@ public struct S
     public int X{get;}
     public int Y{get;}
 
-    public S()
+    public S(int dummy)
     {
         X = 42;
         Y = X;
@@ -504,7 +352,7 @@ public struct S
 
     public static void Main()
     {
-        S s = new S();
+        S s = new S(1);
         System.Console.WriteLine(s.Y);
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1315,7 +1315,7 @@ struct Program
     S1 x2 { get; }
 
 
-    public Program()
+    public Program(int dummy)
     {
         x.i = 1;
         System.Console.WriteLine(x2.ii);
@@ -1364,7 +1364,7 @@ struct Program
     S1 x2 { get; set;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         x.i = 1;
         System.Console.WriteLine(x2.ii);
@@ -1413,7 +1413,7 @@ struct Program
     S1 x2 { get;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         x = new S1();
         x.i += 1;
@@ -1459,7 +1459,7 @@ struct Program
     S1 x2 { get;}
 
 
-    public Program()
+    public Program(int dummy)
     {
         this = default(Program);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -178,6 +178,9 @@ class Program
 ";
             var comp = CreateExperimentalCompilationWithMscorlib45(source);
             comp.VerifyDiagnostics(
+    // (10,12): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     public S2()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S2").WithLocation(10, 12),
     // (26,28): error CS1736: Default parameter value for 's' must be a compile-time constant
     //     static void Foo(S2 s = new S2())
     Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "new S2()").WithArguments("s").WithLocation(26, 28)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
@@ -603,12 +603,12 @@ public struct X1
 
 ";
             CreateExperimentalCompilationWithMscorlib45(source).VerifyDiagnostics(
-    // (4,13): error CS8075: Parameterless struct constructors must be public
-    //     private X()
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "X").WithLocation(4, 13),
-    // (11,5): error CS8075: Parameterless struct constructors must be public
+    // (11,5): error CS0568: Structs cannot contain explicit parameterless constructors
     //     X1()
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "X1").WithLocation(11, 5)
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "X1").WithLocation(11, 5),
+    // (4,13): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     private X()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "X").WithLocation(4, 13)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -118,12 +118,15 @@ struct S
 }
 
 ").VerifyDiagnostics(
-    // (27,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
-    //         Ps = 5;
-    Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("S.Ps").WithLocation(27, 9),
+    // (24,12): error CS0568: Structs cannot contain explicit parameterless constructors
+    //     public S()
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S").WithLocation(24, 12),
     // (9,9): error CS0200: Property or indexer 'C.Ps' cannot be assigned to -- it is read only
     //         Ps = 3;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("C.Ps").WithLocation(9, 9),
+    // (27,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
+    //         Ps = 5;
+    Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Ps").WithArguments("S.Ps").WithLocation(27, 9),
     // (14,9): error CS0200: Property or indexer 'C.P' cannot be assigned to -- it is read only
     //         P = 10;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "P").WithArguments("C.P").WithLocation(14, 9),
@@ -136,6 +139,7 @@ struct S
     // (33,9): error CS0200: Property or indexer 'S.Ps' cannot be assigned to -- it is read only
     //         S.Ps = 1;
     Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "S.Ps").WithArguments("S.Ps").WithLocation(33, 9)
+
     );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -10101,29 +10101,6 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
         }
 
         [Fact]
-        public void CS0568ERR_StructsCantContainDefaultConstructor01()
-        {
-            var text = @"namespace NS
-{
-    public struct S1
-    {
-        public S1() {}
-
-        struct S2<T>
-        {
-            S2() { }
-        }
-    }
-}
-";
-            var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription { Code = (int)ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, Line = 9, Column = 13 });
-
-            var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
-            // TODO...
-        }
-
-        [Fact]
         public void CS0569ERR_CantOverrideBogusMethod()
         {
             var source1 =
@@ -10207,7 +10184,7 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
         }
 
         [Fact]
-        public void InstanceCtorInsTructPre60()
+        public void CS0568ERR_StructsCantContainDefaultConstructor01()
         {
             var text = @"namespace x
 {
@@ -10224,12 +10201,12 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
 ";
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp5));
             comp.VerifyDiagnostics(
-    // (5,16): error CS8026: Feature 'struct instance parameterless constructors' is not available in C# 5.  Please use language version 6 or greater.
+    // (5,16): error CS0568: Structs cannot contain explicit parameterless constructors
     //         public S1() {}
-    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "S1").WithArguments("struct instance parameterless constructors", "6").WithLocation(5, 16),
-    // (9,13): error CS8075: Parameterless instance constructors in structs must be public
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S1").WithLocation(5, 16),
+    // (9,13): error CS0568: Structs cannot contain explicit parameterless constructors
     //             S2() { }
-    Diagnostic(ErrorCode.ERR_ParameterlessStructCtorsMustBePublic, "S2").WithLocation(9, 13)
+    Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S2").WithLocation(9, 13)
    );
         }
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1667,7 +1667,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_NullPropagatingOpInExpressionTree = 37240
         ERR_TooLongOrComplexExpression = 37241
 
-        ERR_StructParameterlessInstanceCtorMustBePublic = 37242
+        ' available: 37242
         ERR_AutoPropertyCantBeWriteOnly = 37243
 
         ERR_ExpressionDoesntHaveName = 37244

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -399,15 +399,8 @@ lReportErrorOnTwoTokens:
 
             If (flags And SourceMemberFlags.Shared) = 0 Then
                 If container.TypeKind = TypeKind.Structure AndAlso methodSym.ParameterCount = 0 Then
-                    If binder.Compilation.LanguageVersion < LanguageVersion.VisualBasic14 Then
-                        ' Instance constructor must have parameters.
-                        Binder.ReportDiagnostic(diagBag, syntax.NewKeyword, ERRID.ERR_NewInStruct)
-                    Else
-                        If methodSym.DeclaredAccessibility <> Accessibility.Public Then
-                            ' Instance constructor must be public.
-                            Binder.ReportDiagnostic(diagBag, syntax.NewKeyword, ERRID.ERR_StructParameterlessInstanceCtorMustBePublic)
-                        End If
-                    End If
+                    ' Instance constructor must have parameters.
+                    Binder.ReportDiagnostic(diagBag, syntax.NewKeyword, ERRID.ERR_NewInStruct)
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -7693,7 +7693,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         '''<summary>
-        '''  Looks up a localized string similar to The feature &apos;Parameterless Instance Constructors in Structures&apos; requires language version 14 or above..
+        '''  Looks up a localized string similar to Structures cannot declare a non-shared &apos;Sub New&apos; with no parameters..
         '''</summary>
         Friend ReadOnly Property ERR_NewInStruct() As String
             Get
@@ -9925,15 +9925,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_StructLayoutAttributeNotAllowed() As String
             Get
                 Return ResourceManager.GetString("ERR_StructLayoutAttributeNotAllowed", resourceCulture)
-            End Get
-        End Property
-
-        '''<summary>
-        '''  Looks up a localized string similar to Parameterless instance constructors in structures must be public..
-        '''</summary>
-        Friend ReadOnly Property ERR_StructParameterlessInstanceCtorMustBePublic() As String
-            Get
-                Return ResourceManager.GetString("ERR_StructParameterlessInstanceCtorMustBePublic", resourceCulture)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -1359,7 +1359,7 @@
     <value>Structures cannot have 'Inherits' statements.</value>
   </data>
   <data name="ERR_NewInStruct" xml:space="preserve">
-    <value>The feature 'Parameterless Instance Constructors in Structures' requires language version 14 or above.</value>
+    <value>Structures cannot declare a non-shared 'Sub New' with no parameters.</value>
   </data>
   <data name="ERR_InvalidEndGet" xml:space="preserve">
     <value>'End Get' must be preceded by a matching 'Get'.</value>
@@ -5207,9 +5207,6 @@
   </data>
   <data name="ERR_NullPropagatingOpInExpressionTree" xml:space="preserve">
     <value>A null propagating operator cannot be converted into an expression tree.</value>
-  </data>
-  <data name="ERR_StructParameterlessInstanceCtorMustBePublic" xml:space="preserve">
-    <value>Parameterless instance constructors in structures must be public.</value>
   </data>
   <data name="ERR_TooLongOrComplexExpression" xml:space="preserve">
     <value>An expression is too long or complex to compile</value>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenCtorInitializers.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenCtorInitializers.vb
@@ -10,141 +10,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         Inherits BasicTestBase
 
         <Fact()>
-        Public Sub ParameterlessCtor001()
-            CompileAndVerify(
-<compilation>
-    <file name="a.vb">
-Imports System        
-
-Structure S1
-    Public x as integer
-    Public y as integer
-    
-    public Sub New()
-        x = 42
-    end sub
-
-    public Sub New(dummy as integer)
-    end sub
-
-end structure 
-
-Module M1
-    Sub Main()
-        dim s as new S1()
-        Console.WriteLine(s.x)
-
-        s.y = 333
-        s = new S1()
-        Console.WriteLine(s.y)
-
-        s = new S1(3)
-        Console.WriteLine(s.x)
-        Console.WriteLine(s.y)
-
-    End Sub
-End Module
-
-    </file>
-</compilation>,
-expectedOutput:=<![CDATA[
-42
-0
-0
-0
-]]>).VerifyIL("S1..ctor()",
-            <![CDATA[
-{
-  // Code size       16 (0x10)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
-  IL_0007:  ldarg.0
-  IL_0008:  ldc.i4.s   42
-  IL_000a:  stfld      "S1.x As Integer"
-  IL_000f:  ret
-}
-]]>).VerifyIL("S1..ctor(Integer)",
-            <![CDATA[
-{
-  // Code size        8 (0x8)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
-  IL_0007:  ret
-}
-]]>)
-        End Sub
-
-        <Fact()>
-        Public Sub ParameterlessCtor002()
-            CompileAndVerify(
-<compilation>
-    <file name="a.vb">
-Imports System        
-
-Structure S1
-    Public x as integer
-    Public y as integer
-    
-    public Sub New()
-        x = 42
-    end sub
-
-    public Sub New(dummy as integer)
-        Me.New
-    end sub
-
-end structure 
-
-Module M1
-    Sub Main()
-        dim s as new S1()
-        Console.WriteLine(s.x)
-
-        s.y = 333
-        s = new S1()
-        Console.WriteLine(s.y)
-
-        s = new S1(3)
-        Console.WriteLine(s.x)
-        Console.WriteLine(s.y)
-
-    End Sub
-End Module
-
-    </file>
-</compilation>,
-expectedOutput:=<![CDATA[
-42
-0
-42
-0
-]]>).VerifyIL("S1..ctor()",
-            <![CDATA[
-{
-  // Code size       16 (0x10)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
-  IL_0007:  ldarg.0
-  IL_0008:  ldc.i4.s   42
-  IL_000a:  stfld      "S1.x As Integer"
-  IL_000f:  ret
-}
-]]>).VerifyIL("S1..ctor(Integer)",
-            <![CDATA[
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       "Sub S1..ctor()"
-  IL_0006:  ret
-}
-]]>)
-        End Sub
-
-        <Fact()>
         Public Sub ParameterlessCtor003()
             CompileAndVerify(
 <compilation>
@@ -205,39 +70,6 @@ expectedOutput:=<![CDATA[
   IL_001c:  ret
 }
 ]]>)
-        End Sub
-
-        <Fact()>
-        Public Sub ParameterlessCtor004()
-            Dim source =
-<compilation>
-    <file name="a.vb">
-Imports System        
-Imports System.Linq.Expressions
-
-Structure S1
-    Public x as integer
-    Public y as integer
-    
-    public Sub New()
-        x = 42
-    end sub
-end structure 
-
-Module M1
-    Sub Main()
-        Dim testExpr as Expression(of Func(of S1)) = Function()new S1()
-        System.Console.Write(testExpr.Compile()().x)
-    End Sub
-End Module
-
-    </file>
-</compilation>
-
-            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, {SystemCoreRef}, options:=TestOptions.ReleaseExe)
-
-            Dim verifier = CompileAndVerify(compilation, <![CDATA[42]]>)
-
         End Sub
 
         <Fact()>
@@ -330,14 +162,14 @@ Module Program
     Structure c1
         Public readonly Property p1 As Integer
         Public readonly Property p2 As Integer
-        Public Sub New()
+        Public Sub New(dummy as integer)
             p1 = 42
             p2 = p1
         End Sub
     End Structure
 
     Sub Main(args As String())
-        Dim c As New c1
+        Dim c As New c1(1)
         System.Console.WriteLine(c.p2)
     End Sub
 End Module
@@ -345,7 +177,7 @@ End Module
     </file>
 </compilation>,
 expectedOutput:=<![CDATA[42]]>
-            ).VerifyIL("Program.c1..ctor()",
+            ).VerifyIL("Program.c1..ctor(Integer)",
             <![CDATA[
 {
   // Code size       28 (0x1c)
@@ -450,13 +282,13 @@ expectedOutput:=<![CDATA[42]]>
 Module Program
     Structure c1
         Public readonly Property p1 As Integer
-        Public Sub New()
+        Public Sub New(dummy as integer)
             p1 += 42
         End Sub
     End Structure
 
     Sub Main(args As String())
-        Dim c As New c1
+        Dim c As New c1(1)
         System.Console.WriteLine(c.p1)
     End Sub
 End Module
@@ -464,7 +296,7 @@ End Module
     </file>
 </compilation>,
 expectedOutput:=<![CDATA[42]]>
-            ).VerifyIL("Program.c1..ctor()",
+            ).VerifyIL("Program.c1..ctor(Integer)",
             <![CDATA[
 {
   // Code size       23 (0x17)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
@@ -3027,8 +3027,10 @@ End Namespace
               options:=TestOptions.ReleaseDll.WithEmbedVbCoreRuntime(False))
 
             compilation.VerifyDiagnostics(
-                                    Diagnostic(ERRID.ERR_StructCantInherit, "Inherits System.Exception"),
-                                    Diagnostic(ERRID.ERR_UseOfKeywordFromStructure1, "MyBase").WithArguments("MyBase"))
+    Diagnostic(ERRID.ERR_NewInStruct, "New").WithLocation(20, 24),
+    Diagnostic(ERRID.ERR_StructCantInherit, "Inherits System.Exception").WithLocation(19, 13),
+    Diagnostic(ERRID.ERR_UseOfKeywordFromStructure1, "MyBase").WithArguments("MyBase").WithLocation(21, 17)
+                                    )
         End Sub
 
         Private Sub AssertTypeAndItsMembersAreImplicitlyDeclared(type As NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -2498,7 +2498,9 @@ End Structure
             Dim s2 = compilation.GlobalNamespace.GetTypeMembers("s2")(0)
             Assert.Equal(2, s2.InstanceConstructors.Length)
 
-            compilation.VerifyDiagnostics()
+            compilation.VerifyDiagnostics(
+                    Diagnostic(ERRID.ERR_NewInStruct, "new").WithLocation(2, 9)
+)
         End Sub
 
         <Fact, WorkItem(530171, "DevDiv")>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -6551,7 +6551,7 @@ BC30628: Structures cannot have 'Inherits' statements.
         ]]></file>
     </compilation>, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic12))
             Dim expectedErrors1 = <errors><![CDATA[
-BC30629: The feature 'Parameterless Instance Constructors in Structures' requires language version 14 or above.
+BC30629: Structures cannot declare a non-shared 'Sub New' with no parameters.
                     Public Sub New()
                                ~~~
                  ]]></errors>
@@ -6576,7 +6576,7 @@ BC30629: The feature 'Parameterless Instance Constructors in Structures' require
         ]]></file>
     </compilation>)
             Dim expectedErrors1 = <errors><![CDATA[
-BC37242: Parameterless instance constructors in structures must be public.
+BC30629: Structures cannot declare a non-shared 'Sub New' with no parameters.
                     Private Sub New()
                                 ~~~
                  ]]></errors>


### PR DESCRIPTION
...eters

Fixes #1029

While overall parameterless constructors in structs are valid from IL perspective, without a convenient way to declare them they were virtually nonexistent. As we performed more and more testing, we kept discovering cases where parameterless struct constructors caused inconsistent behavior in libraries or even in some versions of CLR.

After reconsidering the potential issues arising from breaking long standing assumptions, we decided it was best for our users to restore the requirement on struct constructors to always have formal parameters.