### PR TITLE
EE: Add support for COM object Inspection

### DIFF
--- a/Src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
+++ b/Src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class NativeViewTests : CSharpResultProviderTestBase
+    {
+        [Fact]
+        public void NativeView1()
+        {
+            TestNativeView(true);
+        }
+
+        [Fact]
+        public void NativeViewManagedOnly()
+        {
+            TestNativeView(false);
+        }
+
+        private void TestNativeView(bool enableNativeDebugging)
+        {
+            var source =
+@"using System.Collections;
+class C
+{
+}";
+            using (new EnsureEnglishUICulture())
+            {
+                var assembly = GetAssembly(source);
+                var assemblies = ReflectionUtilities.GetMscorlibAndSystemCore(assembly);
+                using (ReflectionUtilities.LoadAssemblies(assemblies))
+                {
+                    var runtime = new DkmClrRuntimeInstance(assemblies, enableNativeDebugging: enableNativeDebugging);
+                    var inspectionContext = CreateDkmInspectionContext(runtimeInstance: runtime);
+                    var type = assembly.GetType("C");
+                    var value = CreateDkmClrValue(
+                        value: type.Instantiate(),
+                        type: runtime.GetType((TypeImpl)type),
+                        isComObject: true);
+                    var evalResult = FormatResult("o", value, inspectionContext: inspectionContext);
+                    Verify(evalResult,
+                        EvalResult("o", "{C}", "C", "o", DkmEvaluationResultFlags.Expandable));
+                    var children = GetChildren(evalResult, inspectionContext);
+                    if (enableNativeDebugging)
+                    {
+                        DkmLanguage language = new DkmLanguage(new DkmCompilerId(DkmVendorId.Microsoft, DkmLanguageId.Cpp));
+                        Verify(children,
+                            EvalIntermediateResult("Native View", "{C++}(IUnknown*)0x00000001", "(IUnknown*)0x00000001", language));
+                    }
+                    else
+                    {
+                        Verify(children,
+                            EvalFailedResult("Native View", "To inspect the native object, enable native code debugging."));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
+++ b/Src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using System;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class NativeViewExpansion : Expansion
+    {
+        internal override void GetRows(
+            ResultProvider resultProvider,
+            ArrayBuilder<EvalResultDataItem> rows,
+            DkmInspectionContext inspectionContext,
+            EvalResultDataItem parent,
+            DkmClrValue value,
+            int startIndex,
+            int count,
+            bool visitAll,
+            ref int index)
+        {
+            if (InRange(startIndex, count, index))
+            {
+                rows.Add(GetRow(resultProvider, inspectionContext, value, parent));
+            }
+
+            index++;
+        }
+
+        private EvalResultDataItem GetRow(
+            ResultProvider resultProvider,
+            DkmInspectionContext inspectionContext,
+            DkmClrValue comObject,
+            EvalResultDataItem parent)
+        {
+            try
+            {
+                inspectionContext.RuntimeInstance.Process.GetNativeRuntimeInstance();
+            }
+            catch (DkmException)
+            {
+                // Native View requires native debugging to be enabled.
+                return new EvalResultDataItem(Resources.NativeView, Resources.NativeViewNotNativeDebugging);
+            }
+            
+            var name = "(IUnknown*)0x" + string.Format(IntPtr.Size == 4 ? "{0:X8}" : "{0:X16}", comObject.NativeComPointer);
+            var fullName = "{C++}" + name;
+            
+            return new EvalResultDataItem(
+                ExpansionKind.NativeView,
+                name: name,
+                typeDeclaringMember: null,
+                declaredType: comObject.Type.GetLmrType(),
+                parent: null,
+                value: comObject,
+                displayValue: null,
+                expansion: this,
+                childShouldParenthesize: false,
+                fullName: fullName,
+                childFullNamePrefixOpt: fullName,
+                formatSpecifiers: Formatter.NoFormatSpecifiers,
+                category: DkmEvaluationResultCategory.Data,
+                flags: DkmEvaluationResultFlags.ReadOnly,
+                editableValue: null,
+                inspectionContext: inspectionContext);
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmCompilerId.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmCompilerId.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using System;
+
+namespace Microsoft.VisualStudio.Debugger.Evaluation
+{
+    public struct DkmCompilerId
+    {
+        public readonly Guid LanguageId;
+        public readonly Guid VendorId;
+
+        public DkmCompilerId(Guid vendorId, Guid languageId)
+        {
+            VendorId = vendorId;
+            LanguageId = languageId;
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEngineSettings.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEngineSettings.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using Microsoft.VisualStudio.Debugger.Evaluation;
+
+namespace Microsoft.VisualStudio.Debugger
+{
+    public class DkmEngineSettings
+    {
+        public DkmLanguage GetLanguage(DkmCompilerId compilerId)
+        {
+            return new DkmLanguage(compilerId);
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmIntermediateEvaluationResult.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmIntermediateEvaluationResult.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using Microsoft.VisualStudio.Debugger.CallStack;
+
+namespace Microsoft.VisualStudio.Debugger.Evaluation
+{
+    public class DkmIntermediateEvaluationResult : DkmEvaluationResult
+    {
+        public string Expression { get; private set; }
+        public DkmLanguage IntermediateLanguage { get; private set; }
+        public DkmRuntimeInstance TargetRuntime { get; private set; }
+        
+        public static DkmIntermediateEvaluationResult Create(DkmInspectionContext InspectionContext, DkmStackWalkFrame StackFrame, string Name, string FullName, string Expression, DkmLanguage IntermediateLanguage, DkmRuntimeInstance TargetRuntime, DkmDataItem DataItem)
+        {
+            DkmIntermediateEvaluationResult result = new DkmIntermediateEvaluationResult
+            {
+                InspectionContext = InspectionContext,
+                Name = Name,
+                FullName = FullName,
+                Expression = Expression,
+                IntermediateLanguage = IntermediateLanguage,
+                TargetRuntime = TargetRuntime
+            };
+
+            if (DataItem != null)
+            {
+                result.SetDataItem(DkmDataCreationDisposition.CreateNew, DataItem);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmLanguage.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmLanguage.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+namespace Microsoft.VisualStudio.Debugger.Evaluation
+{
+    public class DkmLanguage
+    {
+        public readonly DkmCompilerId Id;
+
+        internal DkmLanguage(DkmCompilerId compilerId)
+        {
+            Id = compilerId;
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmLanguageId.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmLanguageId.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using System;
+
+namespace Microsoft.VisualStudio.Debugger.Evaluation
+{
+    public static class DkmLanguageId
+    {
+        public static Guid Cpp
+        {
+            get
+            {
+                return new Guid("3A12D0B7-C26C-11D0-B442-00A0244A1DD2");
+            }
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmProcess.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmProcess.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+
+namespace Microsoft.VisualStudio.Debugger
+{
+    public class DkmProcess
+    {
+        public readonly DkmEngineSettings EngineSettings = new DkmEngineSettings();
+
+        private readonly bool _nativeDebuggingEnabled;
+
+        public DkmProcess()
+        {
+        }
+
+        public DkmProcess(bool enableNativeDebugging)
+        {
+            _nativeDebuggingEnabled = enableNativeDebugging;
+        }
+
+        public DkmRuntimeInstance GetNativeRuntimeInstance()
+        {
+            if (!_nativeDebuggingEnabled)
+            {
+                throw new DkmException(DkmExceptionCode.E_XAPI_DATA_ITEM_NOT_FOUND);
+            }
+
+            return null; // Value isn't required for testing
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmRuntimeInstance.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmRuntimeInstance.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+
+namespace Microsoft.VisualStudio.Debugger
+{
+    public class DkmRuntimeInstance
+    {
+        internal static readonly DkmProcess DefaultProcess = new DkmProcess();
+        internal static readonly DkmProcess ProcessWithNativeDebugging = new DkmProcess(enableNativeDebugging: true);
+
+        public readonly DkmProcess Process;
+
+        public DkmRuntimeInstance(bool enableNativeDebugging)
+        {
+            Process = enableNativeDebugging ?
+                ProcessWithNativeDebugging :
+                DefaultProcess;
+        }
+    }
+}

--- a/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmVendorId.cs
+++ b/Src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmVendorId.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using System;
+
+namespace Microsoft.VisualStudio.Debugger.Evaluation
+{
+    public static class DkmVendorId
+    {
+        public static Guid Microsoft
+        {
+            get
+            {
+                return new Guid("994B45C4-E6E9-11D2-903F-00C04FA302A1");
+            }
+        }
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="FormatSpecifierTests.cs" />
     <Compile Include="FullNameTests.cs" />
     <Compile Include="Helpers\TestTypeExtensions.cs" />
+    <Compile Include="NativeViewTests.cs" />
     <Compile Include="ObjectIdTests.cs" />
     <Compile Include="ResultsViewTests.cs" />
     <Compile Include="TypeNameFormatterTests.cs" />

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -108,6 +108,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 expansions.Add(staticMembersExpansion);
             }
 
+            if (value.NativeComPointer != 0)
+            {
+                expansions.Add(new NativeViewExpansion());
+            }
+
             if (nonPublicInstanceExpansion != null)
             {
                 expansions.Add(nonPublicInstanceExpansion);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         Default,
         Error,
+        NativeView,
         NonPublicMembers,
         PointerDereference,
         RawView,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Resources.Designer.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Resources.Designer.cs
@@ -88,6 +88,24 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Native View.
+        /// </summary>
+        internal static string NativeView {
+            get {
+                return ResourceManager.GetString("NativeView", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To inspect the native object, enable native code debugging..
+        /// </summary>
+        internal static string NativeViewNotNativeDebugging {
+            get {
+                return ResourceManager.GetString("NativeViewNotNativeDebugging", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Non-Public members.
         /// </summary>
         internal static string NonPublicMembers {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Resources.resx
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Resources.resx
@@ -129,6 +129,14 @@
     <value>Cannot dereference '{0}'. The pointer is not valid.</value>
     <comment>Invalid pointer dereference</comment>
   </data>
+  <data name="NativeView" xml:space="preserve">
+    <value>Native View</value>
+    <comment>Native COM object expansion</comment>
+  </data>
+  <data name="NativeViewNotNativeDebugging" xml:space="preserve">
+    <value>To inspect the native object, enable native code debugging.</value>
+    <comment>Display value of Native View node when native debugging is not enabled</comment>
+  </data>
   <data name="NonPublicMembers" xml:space="preserve">
     <value>Non-Public members</value>
     <comment>Non-public type members</comment>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -132,6 +132,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         Type: null,
                         DataItem: null));
                     break;
+                case ExpansionKind.NativeView:
                 case ExpansionKind.NonPublicMembers:
                 case ExpansionKind.StaticMembers:
                     completionRoutine(CreateEvaluationResult(
@@ -213,6 +214,22 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     ErrorMessage: display,
                     Flags: dataItem.Flags,
                     Type: typeName,
+                    DataItem: dataItem);
+            }
+            else if (dataItem.Kind == ExpansionKind.NativeView)
+            {
+                // For Native View, create a DkmIntermediateEvaluationResult.  This will allow the C++ EE
+                // to take over expansion.
+                DkmProcess process = inspectionContext.RuntimeInstance.Process;
+                DkmLanguage cpp = process.EngineSettings.GetLanguage(new DkmCompilerId(DkmVendorId.Microsoft, DkmLanguageId.Cpp));
+                return DkmIntermediateEvaluationResult.Create(
+                    InspectionContext: inspectionContext,
+                    StackFrame: value.StackFrame,
+                    Name: Resources.NativeView,
+                    FullName: dataItem.FullName,
+                    Expression: dataItem.Name,
+                    IntermediateLanguage: cpp,
+                    TargetRuntime: process.GetNativeRuntimeInstance(),
                     DataItem: dataItem);
             }
             else

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\DebuggerTypeProxyExpansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\Expansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\MemberExpansion.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expansion\NativeViewExpansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\PointerDereferenceExpansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\ResultsViewExpansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\TypeVariablesExpansion.cs" />

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrRuntimeInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrRuntimeInstance.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
 
     internal delegate DkmClrModuleInstance GetModuleDelegate(DkmClrRuntimeInstance runtime, Assembly assembly);
 
-    public class DkmClrRuntimeInstance
+    public class DkmClrRuntimeInstance : DkmRuntimeInstance
     {
         internal static readonly DkmClrRuntimeInstance DefaultRuntime = new DkmClrRuntimeInstance(new Assembly[0]);
 
@@ -30,7 +30,9 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         internal DkmClrRuntimeInstance(
             Assembly[] assemblies,
             GetModuleDelegate getModule = null,
-            GetMemberValueDelegate getMemberValue = null)
+            GetMemberValueDelegate getMemberValue = null,
+            bool enableNativeDebugging = false)
+            : base(enableNativeDebugging)
         {
             if (getModule == null)
             {

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
@@ -30,7 +30,8 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
             string alias,
             IDkmClrFormatter formatter,
             DkmEvaluationResultFlags evalFlags,
-            DkmClrValueFlags valueFlags)
+            DkmClrValueFlags valueFlags,
+            bool isComObject = false)
         {
             Debug.Assert(!type.GetLmrType().IsTypeVariables() || (valueFlags == DkmClrValueFlags.Synthetic));
             Debug.Assert((alias == null) || evalFlags.Includes(DkmEvaluationResultFlags.HasObjectId));
@@ -44,6 +45,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
             this.Alias = alias;
             this.EvalFlags = evalFlags;
             this.ValueFlags = valueFlags;
+            this.NativeComPointer = isComObject ? 1UL : 0;
         }
 
         public readonly DkmEvaluationResultFlags EvalFlags;
@@ -57,6 +59,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         public readonly DkmDataAddress Address;
         public readonly object HostObjectValue;
         public readonly string Alias;
+        public readonly ulong NativeComPointer;
 
         private readonly IDkmClrFormatter _formatter;
         private readonly object _rawValue;

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
@@ -18,16 +18,18 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
     [Guid("0807c826-3338-dd99-2f3a-202ba8fb9da7")]
     public class DkmInspectionContext
     {
-        internal DkmInspectionContext(IDkmClrFormatter formatter, DkmEvaluationFlags evaluationFlags, uint radix)
+        internal DkmInspectionContext(IDkmClrFormatter formatter, DkmEvaluationFlags evaluationFlags, uint radix, DkmRuntimeInstance runtimeInstance = null)
         {
             _formatter = formatter;
             this.EvaluationFlags = evaluationFlags;
             this.Radix = radix;
+            this.RuntimeInstance = runtimeInstance ?? DkmClrRuntimeInstance.DefaultRuntime;
         }
 
         private readonly IDkmClrFormatter _formatter;
 
         public readonly DkmEvaluationFlags EvaluationFlags;
+        public readonly DkmRuntimeInstance RuntimeInstance;
 
         //
         // Summary:

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
     <Import Project="..\..\..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Targets\VSL.Settings.targets" />
@@ -83,7 +84,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Debugger\Engine\DkmCompilerId.cs" />
     <Compile Include="Debugger\Engine\DkmContinueCorruptingException.cs" />
+    <Compile Include="Debugger\Engine\DkmEngineSettings.cs" />
     <Compile Include="Debugger\Engine\DkmEvaluateDebuggerDisplayStringAsyncResult.cs" />
     <Compile Include="Debugger\Engine\DkmEvaluationAsyncResult.cs" />
     <Compile Include="Debugger\Engine\DkmExceptionCode.cs" />
@@ -111,11 +114,17 @@
     <Compile Include="Debugger\Engine\DkmFailedEvaluationResult.cs" />
     <Compile Include="Debugger\Engine\DkmInspectionContext.cs" />
     <Compile Include="Debugger\Engine\DkmDataItem.cs" />
+    <Compile Include="Debugger\Engine\DkmIntermediateEvaluationResult.cs" />
+    <Compile Include="Debugger\Engine\DkmLanguage.cs" />
+    <Compile Include="Debugger\Engine\DkmLanguageId.cs" />
     <Compile Include="Debugger\Engine\DkmMisc.cs" />
     <Compile Include="Debugger\Engine\DkmModule.cs" />
     <Compile Include="Debugger\Engine\DkmModuleInstance.cs" />
+    <Compile Include="Debugger\Engine\DkmProcess.cs" />
     <Compile Include="Debugger\Engine\DkmReportNonFatalWatsonExceptionAttribute.cs" />
+    <Compile Include="Debugger\Engine\DkmRuntimeInstance.cs" />
     <Compile Include="Debugger\Engine\DkmSuccessEvaluationResult.cs" />
+    <Compile Include="Debugger\Engine\DkmVendorId.cs" />
     <Compile Include="Debugger\Engine\DkmWorkList.cs" />
     <Compile Include="Debugger\Engine\IDkmClrFormatter.cs" />
     <Compile Include="Debugger\Engine\IDkmClrResultProvider.cs" />


### PR DESCRIPTION
Implement support for inspecting native COM objects in the new EE. The native view of the COM object now shows up under a "Native View" node.