### PR TITLE
Introduce AbstractLookupSymbolsInfo.Count property and use it.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LookupSymbolsInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupSymbolsInfo.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static LookupSymbolsInfo GetInstance()
         {
             var info = s_pool.Allocate();
-            Debug.Assert(info.Names.Count == 0);
+            Debug.Assert(info.Count == 0);
             return info;
         }
     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1393,7 +1393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binder.AddMemberLookupSymbolsInfo(info, container, options, binder);
             }
 
-            var results = ArrayBuilder<Symbol>.GetInstance(info.Names.Count);
+            var results = ArrayBuilder<Symbol>.GetInstance(info.Count);
 
             if (name == null)
             {

--- a/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
+++ b/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
@@ -258,6 +258,8 @@ namespace Microsoft.CodeAnalysis
 
         public ICollection<String> Names => _nameMap.Keys;
 
+        public int Count => _nameMap.Count;
+
         /// <summary>
         /// If <paramref name="uniqueSymbol"/> is set, then <paramref name="arities"/> will be null.
         /// The only arity in that case will be encoded in the symbol. 

--- a/src/Compilers/VisualBasic/Portable/Compilation/LookupSymbolsInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/LookupSymbolsInfo.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function GetInstance() As LookupSymbolsInfo
             Dim info As LookupSymbolsInfo = pool.Allocate()
-            Debug.Assert(info.Names.Count = 0)
+            Debug.Assert(info.Count = 0)
             Return info
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -1839,7 +1839,7 @@ _Default:
                 Dim info = LookupSymbolsInfo.GetInstance()
                 Me.AddLookupSymbolsInfo(position, info, container, options)
 
-                Dim results = ArrayBuilder(Of Symbol).GetInstance(info.Names.Count)
+                Dim results = ArrayBuilder(Of Symbol).GetInstance(info.Count)
 
                 For Each foundName In info.Names
                     AppendSymbolsWithName(results, foundName, binder, container, options, info)
@@ -1872,7 +1872,7 @@ _Default:
                 Dim info = LookupSymbolsInfo.GetInstance()
                 Me.AddLookupSymbolsInfo(position, info, container, options)
 
-                Dim results = ArrayBuilder(Of Symbol).GetInstance(info.Names.Count)
+                Dim results = ArrayBuilder(Of Symbol).GetInstance(info.Count)
 
                 AppendSymbolsWithName(results, name, binder, container, options, info)
 


### PR DESCRIPTION
I noticed we were allocating a KeyCollection just to get the count. Fixed it.