### PR TITLE
Increment BloomFilter serialization version

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
     internal partial class BloomFilter : IObjectWritable
     {
-        private const string SerializationFormat = "1";
+        private const string SerializationFormat = "2";
 
         public void WriteTo(ObjectWriter writer)
         {


### PR DESCRIPTION
When a BloomFilter is serialized, it includes a serialization format
version number, some other metadata, and a bitarray. Prior to PR #877,
the bitarray portion also included its own serialization format version
number, so the data serialized was Format 1 of the BloomFilter
containing Format 0 of the bitarray. PR #877 removed the (redundant)
serialization format version number from the bitarray portion but did
not also version the BloomFilter's serialization format, causing the
previous bitarray version number (0) to be read as part of the bitarray
itself. We believe this would sometimes lead to extremely long Find
References calls as the BloomFilter continually tried and failed to
understand the data in the bitarray.