### PR TITLE
Provide explicit `StringComparison.Ordinal` in invocations of Xunit methods

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1722,7 +1722,7 @@ class C
             int exitCode = csc.Run(outWriter);
             Assert.Equal(1, exitCode);
             // Diagnostic thrown as error: command line always overrides ruleset.
-            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", outWriter.ToString());
+            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             csc = new MockCSharpCompiler(null, dir.Path,
@@ -1733,7 +1733,7 @@ class C
             exitCode = csc.Run(outWriter);
             Assert.Equal(1, exitCode);
             // Diagnostic thrown as error: command line always overrides ruleset.
-            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", outWriter.ToString());
+            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", outWriter.ToString(), StringComparison.Ordinal);
 
             // Clean up temp files
             CleanupAllGeneratedFiles(file.Path);
@@ -2108,7 +2108,7 @@ class C
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
             // Diagnostic suppressed: commandline always overrides ruleset.
-            Assert.DoesNotContain("Warning01", outWriter.ToString());
+            Assert.DoesNotContain("Warning01", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             csc = new MockCSharpCompiler(null, dir.Path,
@@ -2119,7 +2119,7 @@ class C
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
             // Diagnostic suppressed: commandline always overrides ruleset.
-            Assert.DoesNotContain("Warning01", outWriter.ToString());
+            Assert.DoesNotContain("Warning01", outWriter.ToString(), StringComparison.Ordinal);
 
             // Clean up temp files
             CleanupAllGeneratedFiles(file.Path);
@@ -3613,7 +3613,7 @@ class Test { static void Main() {} }").Path;
             exitCode = new MockCSharpCompiler(null, baseDir, new[] { "/nologo", "/preferreduilang:en", "/addmodule:" + modfile, source }).Run(outWriter);
             Assert.Equal(1, exitCode);
             // Dev11: CS0647 (Emit)
-            Assert.Contains("error CS7061: Duplicate 'CompilationRelaxationsAttribute' attribute in", outWriter.ToString());
+            Assert.Contains("error CS7061: Duplicate 'CompilationRelaxationsAttribute' attribute in", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source1);
             CleanupAllGeneratedFiles(source2);
@@ -4586,7 +4586,7 @@ public class C
             int exitCode = csc.Run(outWriter);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("error CS2012: Cannot open '" + dir.Path + "\\sub\\a.exe' for writing", outWriter.ToString());
+            Assert.Contains("error CS2012: Cannot open '" + dir.Path + "\\sub\\a.exe' for writing", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -4613,8 +4613,8 @@ public class C
 
             Assert.Equal(1, exitCode);
             var message = outWriter.ToString();
-            Assert.Contains("error CS2021: File name", message);
-            Assert.Contains("sub", message);
+            Assert.Contains("error CS2021: File name", message, StringComparison.Ordinal);
+            Assert.Contains("sub", message, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -4641,8 +4641,8 @@ public class C
 
             Assert.Equal(1, exitCode);
             var message = outWriter.ToString();
-            Assert.Contains("error CS2021: File name", message);
-            Assert.Contains("sub", message);
+            Assert.Contains("error CS2021: File name", message, StringComparison.Ordinal);
+            Assert.Contains("sub", message, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -4668,7 +4668,7 @@ public class C
             int exitCode = csc.Run(outWriter);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains(@"error CS2021: File name 'aaa:\a.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long", outWriter.ToString());
+            Assert.Contains(@"error CS2021: File name 'aaa:\a.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -4694,7 +4694,7 @@ public class C
             int exitCode = csc.Run(outWriter);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("error CS2005: Missing file specification for '/out:' option", outWriter.ToString());
+            Assert.Contains("error CS2005: Missing file specification for '/out:' option", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -5140,28 +5140,28 @@ public class C
             var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("error CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString());
+            Assert.Contains("error CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with /noconfig (expect to see warning, instead of error)
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/noconfig", "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString());
+            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with /NOCONFIG (expect to see warning, instead of error)
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/NOCONFIG", "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString());
+            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with -noconfig (expect to see warning, instead of error)
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "-noconfig", "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString());
+            Assert.Contains("warning CS0168: The variable 'x' is declared but never used\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
@@ -5187,7 +5187,7 @@ public class C
             var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with /noconfig inside the response file as along with /nowarn (expect to see warning)
             // to verify that this warning is not suppressed by the /nowarn option (See MSDN).
@@ -5195,7 +5195,7 @@ public class C
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en", "/nowarn:2023" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
@@ -5221,7 +5221,7 @@ public class C
             var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with /NOCONFIG inside the response file as along with /nowarn (expect to see warning)
             // to verify that this warning is not suppressed by the /nowarn option (See MSDN).
@@ -5229,7 +5229,7 @@ public class C
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en", "/nowarn:2023" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
@@ -5255,7 +5255,7 @@ public class C
             var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with -noconfig inside the response file as along with /nowarn (expect to see warning)
             // to verify that this warning is not suppressed by the /nowarn option (See MSDN).
@@ -5263,7 +5263,7 @@ public class C
             csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en", "/nowarn:2023" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString());
+            Assert.Contains("warning CS2023: Ignoring /noconfig option because it was specified in a response file\r\n", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
@@ -5669,7 +5669,7 @@ public class C
             var csc = new MockCSharpCompiler(null, baseDir, new[] { source, "/preferreduilang:en" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(fileName + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
+            Assert.Contains(fileName + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the base case without /fullpaths when the file is located in the sub-folder (expect to see relative path name)
             //      c:\temp> csc.exe c:\temp\example\a.cs
@@ -5678,8 +5678,8 @@ public class C
             csc = new MockCSharpCompiler(null, Directory.GetParent(baseDir).FullName, new[] { source, "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(fileName + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
-            Assert.DoesNotContain(source, outWriter.ToString());
+            Assert.Contains(fileName + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain(source, outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the base case without /fullpaths when the file is not located under the base directory (expect to see the full path name)
             //      c:\temp> csc.exe c:\test\a.cs
@@ -5688,7 +5688,7 @@ public class C
             csc = new MockCSharpCompiler(null, Temp.CreateDirectory().Path, new[] { source, "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
+            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the case with /fullpaths (expect to see the full paths)
             //      c:\temp> csc.exe c:\temp\a.cs /fullpaths
@@ -5697,7 +5697,7 @@ public class C
             csc = new MockCSharpCompiler(null, baseDir, new[] { source, "/fullpaths", "/preferreduilang:en" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(source + @"(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
+            Assert.Contains(source + @"(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the base case without /fullpaths when the file is located in the sub-folder (expect to see the full path name)
             //      c:\temp> csc.exe c:\temp\example\a.cs /fullpaths
@@ -5706,7 +5706,7 @@ public class C
             csc = new MockCSharpCompiler(null, Directory.GetParent(baseDir).FullName, new[] { source, "/preferreduilang:en", "/fullpaths" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
+            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
 
             // Checks the base case without /fullpaths when the file is not located under the base directory (expect to see the full path name)
             //      c:\temp> csc.exe c:\test\a.cs /fullpaths
@@ -5715,7 +5715,7 @@ public class C
             csc = new MockCSharpCompiler(null, Temp.CreateDirectory().Path, new[] { source, "/preferreduilang:en", "/fullpaths" });
             exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString());
+            Assert.Contains(source + "(6,16): warning CS0168: The variable 'x' is declared but never used", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(source);
         }
@@ -6540,8 +6540,8 @@ public class C { }
                                         };
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             var result = comp.Run(outWriter);
-            Assert.Contains("CS1619", outWriter.ToString());
-            Assert.Contains("Ronnie James Dio", outWriter.ToString());
+            Assert.Contains("CS1619", outWriter.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ronnie James Dio", outWriter.ToString(), StringComparison.Ordinal);
         }
 
         [Fact]
@@ -6577,43 +6577,43 @@ using System*
         }
 
         [WorkItem(1119609, "DevDiv")]
-        [Fact(Skip = "1119609")]
+        [Fact]
         public void PreferredUILang()
         {
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             int exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("CS2006", outWriter.ToString());
+            Assert.Contains("CS2006", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("CS2006", outWriter.ToString());
+            Assert.Contains("CS2006", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:zz" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("CS2038", outWriter.ToString());
+            Assert.Contains("CS2038", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:en-zz" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("CS2038", outWriter.ToString());
+            Assert.Contains("CS2038", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:en-US" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.DoesNotContain("CS2038", outWriter.ToString());
+            Assert.DoesNotContain("CS2038", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:de" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.DoesNotContain("CS2038", outWriter.ToString());
+            Assert.DoesNotContain("CS2038", outWriter.ToString(), StringComparison.Ordinal);
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/preferreduilang:de-AT" }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.DoesNotContain("CS2038", outWriter.ToString());
+            Assert.DoesNotContain("CS2038", outWriter.ToString(), StringComparison.Ordinal);
         }
 
         [WorkItem(531263, "DevDiv")]
@@ -6625,7 +6625,7 @@ using System*
             Assert.NotEqual(0, exitCode);
 
             // error CS2021: File name '' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
-            Assert.Contains("CS2021", outWriter.ToString());
+            Assert.Contains("CS2021", outWriter.ToString(), StringComparison.Ordinal);
         }
 
         [WorkItem(747219, "DevDiv")]
@@ -6748,19 +6748,19 @@ using System.Diagnostics; // Unused.
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             var exitCode = cmd.Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("error CS0006: Metadata file 'com2.dll' could not be found", outWriter.ToString().Trim());
+            Assert.Contains("error CS0006: Metadata file 'com2.dll' could not be found", outWriter.ToString(), StringComparison.Ordinal);
 
             cmd = new MockCSharpCompiler(null, _baseDirectory, new[] { "/link:..\\lpt8.dll", "/target:library", "/preferreduilang:en", filePath });
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = cmd.Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("error CS0006: Metadata file '..\\lpt8.dll' could not be found", outWriter.ToString().Trim());
+            Assert.Contains("error CS0006: Metadata file '..\\lpt8.dll' could not be found", outWriter.ToString(), StringComparison.Ordinal);
 
             cmd = new MockCSharpCompiler(null, _baseDirectory, new[] { "/lib:aux", "/preferreduilang:en", filePath });
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = cmd.Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.Contains("warning CS1668: Invalid search path 'aux' specified in '/LIB option' -- 'directory does not exist'", outWriter.ToString().Trim());
+            Assert.Contains("warning CS1668: Invalid search path 'aux' specified in '/LIB option' -- 'directory does not exist'", outWriter.ToString(), StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(filePath);
         }
@@ -6901,11 +6901,11 @@ using System.Diagnostics; // Unused.
                 string.Format("Expected exit code to be '{0}' was '{1}'.{2} Output:{3}{4}",
                 expectedExitCode, exitCode, Environment.NewLine, Environment.NewLine, output));
 
-            Assert.DoesNotContain("hidden", output);
+            Assert.DoesNotContain("hidden", output, StringComparison.Ordinal);
 
             if (expectedInfoCount == 0)
             {
-                Assert.DoesNotContain("info", output);
+                Assert.DoesNotContain("info", output, StringComparison.Ordinal);
             }
             else
             {
@@ -6914,7 +6914,7 @@ using System.Diagnostics; // Unused.
 
             if (expectedWarningCount == 0)
             {
-                Assert.DoesNotContain("warning", output);
+                Assert.DoesNotContain("warning", output, StringComparison.Ordinal);
             }
             else
             {
@@ -6923,7 +6923,7 @@ using System.Diagnostics; // Unused.
 
             if (expectedErrorCount == 0)
             {
-                Assert.DoesNotContain("error", output);
+                Assert.DoesNotContain("error", output, StringComparison.Ordinal);
             }
             else
             {
@@ -6945,7 +6945,7 @@ using System.Diagnostics; // Unused.
             file.WriteAllText(source);
 
             var output = VerifyOutput(dir, file, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS8032 can be suppressed via /warn:0.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0" });
@@ -6955,11 +6955,11 @@ using System.Diagnostics; // Unused.
 
             // TEST: Verify that compiler warning CS8032 can be promoted to an error via /warnaserror.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS8032 can be individually promoted to an error via /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:8032" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -6980,46 +6980,46 @@ using System.Diagnostics; // Unused.
             file.WriteAllText(source);
 
             var output = VerifyOutput(dir, file, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warn:0 has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0" });
 
             // TEST: Verify that /nowarn: has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warnaserror+ has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/nowarn:8032" });
 
             // TEST: Verify that /warnaserror- has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warnaserror: promotes custom hidden diagnostic Hidden01 to an error.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Hidden01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warnaserror-: has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Hidden01", "/nowarn:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Hidden01", "/warnaserror:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Hidden01", "/nowarn:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Hidden01", "/warnaserror-:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warn:0 has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0", "/warnaserror:Hidden01" });
@@ -7029,43 +7029,43 @@ using System.Diagnostics; // Unused.
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:Hidden01", "/warnaserror-:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Hidden01", "/warnaserror+:Hidden01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/warnaserror+:Hidden01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Hidden01", "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/warnaserror+:Hidden01", "/nowarn:8032" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output);
+            Assert.Contains("a.cs(2,1): error Hidden01: Throwing a diagnostic for #region", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:Hidden01", "/warnaserror+", "/nowarn:8032" });
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:Hidden01", "/warnaserror-" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/warnaserror-:Hidden01", "/nowarn:8032" });
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Hidden01", "/warnaserror-" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/warnaserror-:Hidden01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -7083,50 +7083,50 @@ using System.Diagnostics; // Unused.
             var name = "a.cs";
             string output;
             output = GetOutput(name, source, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warn:0 suppresses custom info diagnostic Info01.
             output = GetOutput(name, source, additionalFlags: new[] { "/warn:0" });
 
             // TEST: Verify that custom info diagnostic Info01 can be individually suppressed via /nowarn:.
             output = GetOutput(name, source, additionalFlags: new[] { "/nowarn:Info01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom info diagnostic Info01 can never be promoted to an error via /warnaserror+.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+", "/nowarn:8032" }, expectedInfoCount: 1);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom info diagnostic Info01 is still reported as an info when /warnaserror- is used.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom info diagnostic Info01 can be individually promoted to an error via /warnaserror:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror:Info01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom info diagnostic Info01 is still reported as an info when passed to /warnaserror-:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-:Info01" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn overrides /warnaserror.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror:Info01", "/nowarn:Info01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn overrides /warnaserror.
             output = GetOutput(name, source, additionalFlags: new[] { "/nowarn:Info01", "/warnaserror:Info01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn overrides /warnaserror-.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-:Info01", "/nowarn:Info01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify /nowarn overrides /warnaserror-.
             output = GetOutput(name, source, additionalFlags: new[] { "/nowarn:Info01", "/warnaserror-:Info01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warn:0 has no impact on custom info diagnostic Info01.
             output = GetOutput(name, source, additionalFlags: new[] { "/warn:0", "/warnaserror:Info01" });
@@ -7136,49 +7136,49 @@ using System.Diagnostics; // Unused.
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+:Info01", "/warnaserror-:Info01" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-:Info01", "/warnaserror+:Info01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-", "/warnaserror+:Info01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-:Info01", "/warnaserror+", "/nowarn:8032" }, expectedInfoCount: 1);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+:Info01", "/warnaserror+", "/nowarn:8032" }, expectedInfoCount: 1);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+", "/warnaserror+:Info01", "/nowarn:8032" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("a.cs(2,1): error Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+:Info01", "/warnaserror-" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror+", "/warnaserror-:Info01", "/nowarn:8032" }, expectedInfoCount: 1);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-:Info01", "/warnaserror-" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = GetOutput(name, source, additionalFlags: new[] { "/warnaserror-", "/warnaserror-:Info01" }, expectedWarningCount: 1, expectedInfoCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): info Info01: Throwing a diagnostic for #pragma restore", output, StringComparison.Ordinal);
         }
 
         private string GetOutput(
@@ -7223,62 +7223,62 @@ class C
             file.WriteAllText(source);
 
             var output = VerifyOutput(dir, file, expectedWarningCount: 3);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS0168 as well as custom warning diagnostic Warning01 can be suppressed via /warn:0.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0" });
 
             // TEST: Verify that compiler warning CS0168 as well as custom warning diagnostic Warning01 can be individually suppressed via /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:0168,Warning01,58000" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that diagnostic ids are processed in case-sensitive fashion inside /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:cs0168,warning01,700000" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS0168 as well as custom warning diagnostic Warning01 can be promoted to errors via /warnaserror.
             // Promoting compiler warning CS0168 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror", "/nowarn:8032" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output);
+            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS0168 as well as custom warning diagnostic Warning01 can be promoted to errors via /warnaserror+.
             // Promoting compiler warning CS0168 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/nowarn:8032" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output);
+            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warnaserror- keeps compiler warning CS0168 as well as custom warning diagnostic Warning01 as warnings.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom warning diagnostic Warning01 can be individually promoted to an error via /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Something,Warning01" }, expectedWarningCount: 2, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler warning CS0168 can be individually promoted to an error via /warnaserror+:.
             // This doesn't work correctly currently - promoting compiler warning CS0168 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:CS0168" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that diagnostic ids are processed in case-sensitive fashion inside /warnaserror.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:cs0168,warning01,58000" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom warning diagnostic Warning01 as well as compiler warning CS0168 can be promoted to errors via /warnaserror:.
             // This doesn't work currently - promoting CS0168 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:CS0168,Warning01" }, expectedWarningCount: 1, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(6,13): error CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /warn:0 overrides /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0", "/warnaserror+" });
@@ -7294,19 +7294,19 @@ class C
 
             // TEST: Verify that /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Something,CS0168,Warning01", "/nowarn:0168,Warning01,58000" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:0168,Warning01,58000", "/warnaserror:Something,CS0168,Warning01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Something,CS0168,Warning01", "/nowarn:0168,Warning01,58000" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:0168,Warning01,58000", "/warnaserror-:Something,CS0168,Warning01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/nowarn:0168,Warning01,58000,8032" });
@@ -7328,67 +7328,67 @@ class C
 
             // TEST: Verify that last /warnaserror[+/-] flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last /warnaserror[+/-] flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror", "/warnaserror-" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Warning01", "/warnaserror+:Warning01" }, expectedWarningCount: 2, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:Warning01", "/warnaserror-:Warning01" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Warning01,CS0168,58000,8032", "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror", "/warnaserror-:Warning01,CS0168,58000,8032" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Warning01,58000,8032", "/warnaserror-" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/warnaserror+:Warning01" }, expectedWarningCount: 2, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Warning01,CS0168,58000", "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror", "/warnaserror+:Warning01,CS0168,58000" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-]: and /warnaserror[+/-].
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Warning01,58000,8032", "/warnaserror-" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that last one wins between /warnaserror[+/-] and /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/warnaserror-:Warning01,58000,8032" }, expectedWarningCount: 3);
-            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output);
-            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("a.cs(2,7): warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(6,13): warning CS0168: The variable 'i' is declared but never used", output, StringComparison.Ordinal);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -7407,72 +7407,72 @@ class C
             file.WriteAllText(source);
 
             var output = VerifyOutput(dir, file, expectedErrorCount: 1, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom error diagnostic Error01 can't be suppressed via /warn:0.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warn:0" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             // TEST: Verify that custom error diagnostic Error01 can be suppressed via /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+", "/nowarn:Error01" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Error01", "/warnaserror" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror+:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Error01", "/warnaserror+:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Error01", "/nowarn:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-", "/nowarn:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Error01", "/warnaserror-" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Error01", "/nowarn:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that /nowarn: overrides /warnaserror-.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/nowarn:Error01", "/warnaserror-:Error01" }, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
 
             // TEST: Verify that nothing bad happens when using /warnaserror[+/-] when custom error diagnostic Error01 is present.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("error CS8032", output);
+            Assert.Contains("error CS8032", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-" }, expectedErrorCount: 1, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             // TEST: Verify that nothing bad happens if someone passes custom error diagnostic Error01 to /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror:Error01" }, expectedErrorCount: 1, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror+:Error01" }, expectedErrorCount: 1, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, additionalFlags: new[] { "/warnaserror-:Error01" }, expectedErrorCount: 1, expectedWarningCount: 1);
-            Assert.Contains("warning CS8032", output);
-            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output);
+            Assert.Contains("warning CS8032", output, StringComparison.Ordinal);
+            Assert.Contains("a.cs(2,1): error Error01: Throwing a diagnostic for #pragma disable", output, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }
@@ -7494,41 +7494,41 @@ class C
             file.WriteAllText(source);
 
             var output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler error CS0029 can't be suppressed via /warn:0.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warn:0" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             // TEST: Verify that compiler error CS0029 can't be suppressed via /nowarn:.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/nowarn:29" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/nowarn:CS0029" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             // TEST: Verify that nothing bad happens when using /warnaserror[+/-] when compiler error CS0029 is present.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror+" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror-" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             // TEST: Verify that nothing bad happens if someone passes compiler error CS0029 to /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror:0029" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror+:CS0029" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror-:29" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne: false, additionalFlags: new[] { "/warnaserror-:CS0029" }, expectedErrorCount: 1);
-            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output);
+            Assert.Contains("a.cs(6,17): error CS0029: Cannot implicitly convert type 'System.Exception' to 'int'", output, StringComparison.Ordinal);
 
             CleanupAllGeneratedFiles(file.Path);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -1946,7 +1946,7 @@ class Program
             var comp = CreateCompilationWithMscorlib45(parsed);
             var verifier = this.CompileAndVerify(comp);
             var il = verifier.VisualizeIL("Program.<Foo>d__0.System.Collections.Generic.IEnumerable<int>.GetEnumerator()");
-            Assert.Contains("System.Environment.CurrentManagedThreadId.get", il);
+            Assert.Contains("System.Environment.CurrentManagedThreadId.get", il, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -1979,7 +1979,7 @@ namespace System
             comp.MakeMemberMissing(WellKnownMember.System_Threading_Thread__ManagedThreadId);
             var verifier = this.CompileAndVerify(comp);
             var il = verifier.VisualizeIL("Program.<Foo>d__0.System.Collections.Generic.IEnumerable<int>.GetEnumerator()");
-            Assert.Contains("System.Environment.CurrentManagedThreadId.get", il);
+            Assert.Contains("System.Environment.CurrentManagedThreadId.get", il, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.IO;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -1288,7 +1286,7 @@ class B : ILErrors.ModReqClassEventsNonVirtual, ILErrors.ModReqInterfaceEvents {
 
             foreach (var diag in compilation.GetDiagnostics())
             {
-                Assert.DoesNotContain("System.Runtime.CompilerServices.CompilerGeneratedAttribute", diag.GetMessage());
+                Assert.DoesNotContain("System.Runtime.CompilerServices.CompilerGeneratedAttribute", diag.GetMessage(), StringComparison.Ordinal);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/CrefLexerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/CrefLexerTests.cs
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         internal override IEnumerable<InternalSyntax.SyntaxToken> GetTokens(string text)
         {
-            Assert.DoesNotContain("'", text);
+            Assert.DoesNotContain("'", text, StringComparison.Ordinal);
             using (var lexer = new InternalSyntax.Lexer(SourceText.From(text + "'"), TestOptions.RegularWithDocumentationComments))
             {
                 while (true)

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/NameAttributeValueLexerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/NameAttributeValueLexerTests.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         internal override IEnumerable<InternalSyntax.SyntaxToken> GetTokens(string text)
         {
-            Assert.DoesNotContain("'", text);
+            Assert.DoesNotContain("'", text, StringComparison.Ordinal);
             using (var lexer = new InternalSyntax.Lexer(SourceText.From(text + "'"), TestOptions.RegularWithDocumentationComments))
             {
                 while (true)

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3178,7 +3178,7 @@ x = 1;
             VerifyDirectivesSpecial(tree.GetCompilationUnitRoot(), new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 100, Text = "test.cs" });
 
             var diagnostics = tree.GetDiagnostics();
-            Assert.Contains("100", diagnostics.First().ToString()); // one-based line number
+            Assert.Contains("100", diagnostics.First().ToString(), StringComparison.Ordinal); // one-based line number
 
             var lineSpan = diagnostics.First().Location.GetMappedLineSpan();
             Assert.Equal(99, lineSpan.StartLinePosition.Line); // zero-based line number

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -5126,8 +5127,8 @@ System.Console.WriteLine(""Bad, breaking change"");
             var stmtText = statement.ToString();
 
             //make sure we compiled out the right statement
-            Assert.Contains(desiredText, stmtText);
-            Assert.DoesNotContain(undesiredText, stmtText);
+            Assert.Contains(desiredText, stmtText, StringComparison.Ordinal);
+            Assert.DoesNotContain(undesiredText, stmtText, StringComparison.Ordinal);
         }
 
         private void TestError(string text, ErrorCode error)

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -968,7 +968,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
                 catch (InvalidRuleSetException e)
                 {
-                    Assert.Contains(string.Format(CodeAnalysisResources.InvalidRuleSetInclude, newFile.Path, string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "")), e.Message);
+                    Assert.Contains(string.Format(CodeAnalysisResources.InvalidRuleSetInclude, newFile.Path, string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "")), e.Message, StringComparison.Ordinal);
                 }
             }
         }

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -525,8 +525,8 @@ class Hello
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello.cs", _tempDirectory, files);
 
             // Should output errors, but not create output file.                  
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("hello.cs(5,42): error CS1002: ; expected\r\n", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("hello.cs(5,42): error CS1002: ; expected\r\n", result.Output, StringComparison.Ordinal);
             Assert.Equal("", result.Errors);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "hello.exe")));
@@ -550,9 +550,9 @@ End Class"}};
             var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/r:Microsoft.VisualBasic.dll hellovb.vb", _tempDirectory, files);
 
             // Should output errors, but not create output file.
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("hellovb.vb(3) : error BC30625: 'Module' statement must end with a matching 'End Module'.\r\n", result.Output);
-            Assert.Contains("hellovb.vb(7) : error BC30460: 'End Class' must be preceded by a matching 'Class'.\r\n", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("hellovb.vb(3) : error BC30625: 'Module' statement must end with a matching 'End Module'.\r\n", result.Output, StringComparison.Ordinal);
+            Assert.Contains("hellovb.vb(7) : error BC30460: 'End Class' must be preceded by a matching 'Class'.\r\n", result.Output, StringComparison.Ordinal);
             Assert.Equal("", result.Errors);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "hello.exe")));
@@ -566,8 +566,8 @@ End Class"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("error CS2001: Source file", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("error CS2001: Source file", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "missingfile.exe")));
         }
@@ -580,8 +580,8 @@ End Class"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("error CS0006: Metadata file", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("error CS0006: Metadata file", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "hello.exe")));
         }
@@ -601,8 +601,8 @@ End Class"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("error CS0009: Metadata file", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("error CS0009: Metadata file", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "app.exe")));
         }
@@ -615,8 +615,8 @@ End Class"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output);
-            Assert.Contains("error BC2001", result.Output);
+            Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("error BC2001", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "missingfile.exe")));
         }
@@ -641,7 +641,7 @@ End Module"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("error BC2017: could not find library", result.Output);
+            Assert.Contains("error BC2017: could not find library", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "hellovb.exe")));
         }
@@ -666,7 +666,7 @@ End Module"}};
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
-            Assert.Contains("error BC31519", result.Output);
+            Assert.Contains("error BC31519", result.Output, StringComparison.Ordinal);
             Assert.Equal(1, result.ExitCode);
             Assert.False(File.Exists(Path.Combine(_tempDirectory.Path, "app.exe")));
         }

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -408,7 +408,7 @@ Friend Module CompilationUtils
 
         Assert.NotNull(node)  ' If this trips, then node  wasn't found
         Assert.IsAssignableFrom(GetType(TNode), node)
-        Assert.Contains(bindText, node.ToString())
+        Assert.Contains(bindText, node.ToString(), StringComparison.Ordinal)
 
         Return DirectCast(node, TNode)
     End Function

--- a/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
@@ -93,7 +93,7 @@ Public MustInherit Class SemanticModelTestBase : Inherits BasicTestBase
 
         Assert.NotNull(node)  ' If this trips, then node  wasn't found
         Assert.IsAssignableFrom(GetType(TNode), node)
-        Assert.Contains(bindText, node.ToString())
+        Assert.Contains(bindText, node.ToString(), StringComparison.Ordinal)
 
         Return DirectCast(node, TNode)
     End Function

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1884,8 +1884,8 @@ a.vb
             Assert.Equal(1, exitCode)
             ' Diagnostics thrown as error: command line always overrides ruleset.
             Dim output = outWriter.ToString()
-            Assert.Contains("error Warning01", output)
-            Assert.Contains("error Warning03", output)
+            Assert.Contains("error Warning01", output, StringComparison.Ordinal)
+            Assert.Contains("error Warning03", output, StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             vbc = New MockVisualBasicCompiler(Nothing, dir.Path,
@@ -1898,8 +1898,8 @@ a.vb
             Assert.Equal(1, exitCode)
             ' Diagnostics thrown as error: command line always overrides ruleset.
             output = outWriter.ToString()
-            Assert.Contains("error Warning01", output)
-            Assert.Contains("error Warning03", output)
+            Assert.Contains("error Warning01", output, StringComparison.Ordinal)
+            Assert.Contains("error Warning03", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -1934,9 +1934,9 @@ a.vb
             Assert.Equal(0, exitCode)
             ' Diagnostics suppressed: command line always overrides ruleset.
             Dim output = outWriter.ToString()
-            Assert.DoesNotContain("Warning01", output)
-            Assert.DoesNotContain("BC31072", output)
-            Assert.DoesNotContain("Warning03", output)
+            Assert.DoesNotContain("Warning01", output, StringComparison.Ordinal)
+            Assert.DoesNotContain("BC31072", output, StringComparison.Ordinal)
+            Assert.DoesNotContain("Warning03", output, StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             vbc = New MockVisualBasicCompiler(Nothing, dir.Path,
@@ -1949,9 +1949,9 @@ a.vb
             Assert.Equal(0, exitCode)
             ' Diagnostics suppressed: command line always overrides ruleset.
             output = outWriter.ToString()
-            Assert.DoesNotContain("Warning01", output)
-            Assert.DoesNotContain("BC31072", output)
-            Assert.DoesNotContain("Warning03", output)
+            Assert.DoesNotContain("Warning01", output, StringComparison.Ordinal)
+            Assert.DoesNotContain("BC31072", output, StringComparison.Ordinal)
+            Assert.DoesNotContain("Warning03", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -3622,7 +3622,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf))
 
             Dim output = RunAndGetOutput(BasicCompilerExecutable, "/nologo /preferreduilang:en /nostdlib /t:library " & src.ToString(), startFolder:=dir.Path, expectedRetCode:=1)
-            Assert.Contains("error BC30002: Type 'Global.System.ComponentModel.EditorBrowsable' is not defined.", output)
+            Assert.Contains("error BC30002: Type 'Global.System.ComponentModel.EditorBrowsable' is not defined.", output, StringComparison.Ordinal)
 
             output = RunAndGetOutput(BasicCompilerExecutable, "/nologo /nostdlib /define:_MYTYPE=\""Empty\"" /t:library " & src.ToString(), startFolder:=dir.Path)
             AssertOutput(<text></text>, output)
@@ -4609,7 +4609,7 @@ End Module
             Dim exitCode = vbc.Run(output, Nothing)
 
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2012: can't open '" + dir.Path + "\sub\a.exe' for writing", output.ToString())
+            Assert.Contains("error BC2012: can't open '" + dir.Path + "\sub\a.exe' for writing", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -4642,8 +4642,8 @@ End Module
 
             Assert.Equal(1, exitCode)
             Dim message = output.ToString()
-            Assert.Contains("error BC2032: File name", message)
-            Assert.Contains("sub", message)
+            Assert.Contains("error BC2032: File name", message, StringComparison.Ordinal)
+            Assert.Contains("sub", message, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -4676,8 +4676,8 @@ End Module
 
             Assert.Equal(1, exitCode)
             Dim message = output.ToString()
-            Assert.Contains("error BC2032: File name", message)
-            Assert.Contains("sub", message)
+            Assert.Contains("error BC2032: File name", message, StringComparison.Ordinal)
+            Assert.Contains("sub", message, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -4709,7 +4709,7 @@ End Module
             Dim exitCode = vbc.Run(output, Nothing)
 
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2032: File name 'aaa:\a.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long", output.ToString())
+            Assert.Contains("error BC2032: File name 'aaa:\a.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -4741,7 +4741,7 @@ End Module
             Dim exitCode = vbc.Run(output, Nothing)
 
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2006: option 'out' requires ':<file>'", output.ToString())
+            Assert.Contains("error BC2006: option 'out' requires ':<file>'", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -5212,28 +5212,28 @@ End Module
             Dim output As New StringWriter()
             Dim exitCode = vbc.Run(output, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC42024: Unused local variable: 'x'.", output.ToString())
+            Assert.Contains("error BC42024: Unused local variable: 'x'.", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the base case with /noconfig (expect to see warning, instead of error)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "/noconfig"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString())
+            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the base case with /NOCONFIG (expect to see warning, instead of error)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "/NOCONFIG"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString())
+            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the base case with -noconfig (expect to see warning, instead of error)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "-noconfig"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString())
+            Assert.Contains("warning BC42024: Unused local variable: 'x'.", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(source)
             CleanupAllGeneratedFiles(rsp)
@@ -5260,14 +5260,14 @@ End Module
             Dim output As New StringWriter()
             Dim exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the case with /noconfig inside the response file as along with /nowarn (expect to see warning)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "/nowarn"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(source)
             CleanupAllGeneratedFiles(rsp)
@@ -5294,14 +5294,14 @@ End Module
             Dim output As New StringWriter()
             Dim exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the case with /NOCONFIG inside the response file as along with /nowarn (expect to see warning)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "/nowarn"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(source)
             CleanupAllGeneratedFiles(rsp)
@@ -5328,14 +5328,14 @@ End Module
             Dim output As New StringWriter()
             Dim exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             ' Checks the case with -noconfig inside the response file as along with /nowarn (expect to see warning)
             vbc = New MockVisualBasicCompiler(rsp, _baseDirectory, {source, "/preferreduilang:en", "/nowarn"})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString())
+            Assert.Contains("warning BC2025: ignoring /noconfig option because it was specified in a response file", output.ToString(), StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(source)
             CleanupAllGeneratedFiles(rsp)
@@ -5515,8 +5515,8 @@ Imports System
                                               End Sub
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
             Dim result = comp.Run(outWriter, Nothing)
-            Assert.Contains("BC30138", outWriter.ToString())
-            Assert.Contains("Ronnie James Dio", outWriter.ToString())
+            Assert.Contains("BC30138", outWriter.ToString(), StringComparison.Ordinal)
+            Assert.Contains("Ronnie James Dio", outWriter.ToString(), StringComparison.Ordinal)
         End Sub
 
 
@@ -5691,7 +5691,7 @@ End Module
             Assert.NotEqual(0, exitCode)
 
             ' error BC2032: File name '' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
-            Assert.Contains("BC2032", outWriter.ToString())
+            Assert.Contains("BC2032", outWriter.ToString(), StringComparison.Ordinal)
         End Sub
 
         <WorkItem(1119609, "DevDiv")>
@@ -5700,37 +5700,37 @@ End Module
             Dim outWriter As New StringWriter(CultureInfo.InvariantCulture)
             Dim exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("BC2006", outWriter.ToString())
+            Assert.Contains("BC2006", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("BC2006", outWriter.ToString())
+            Assert.Contains("BC2006", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:zz"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("BC2038", outWriter.ToString())
+            Assert.Contains("BC2038", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:en-zz"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("BC2038", outWriter.ToString())
+            Assert.Contains("BC2038", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:en-US"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.DoesNotContain("BC2038", outWriter.ToString())
+            Assert.DoesNotContain("BC2038", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:de"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.DoesNotContain("BC2038", outWriter.ToString())
+            Assert.DoesNotContain("BC2038", outWriter.ToString(), StringComparison.Ordinal)
 
             outWriter = New StringWriter(CultureInfo.InvariantCulture)
             exitCode = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/preferreduilang:de-AT"}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.DoesNotContain("BC2038", outWriter.ToString())
+            Assert.DoesNotContain("BC2038", outWriter.ToString(), StringComparison.Ordinal)
         End Sub
 
         <Fact, WorkItem(650083, "DevDiv")>
@@ -5759,32 +5759,32 @@ Module Module1
     End Sub
 End Module
 </text>.Value).Path
-            ' Make sure these reversed device names don't affect compiler
+            ' Make sure these reserved device names don't affect compiler
             Dim vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/r:.\com3.dll", "/preferreduilang:en", source})
             Dim output = New StringWriter()
             Dim exitCode = vbc.Run(output, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2017: could not find library '.\com3.dll'", output.ToString().Trim())
+            Assert.Contains("error BC2017: could not find library '.\com3.dll'", output.ToString(), StringComparison.Ordinal)
 
             vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/nologo", "/preferreduilang:en", "/link:prn.dll", source})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2017: could not find library 'prn.dll'", output.ToString().Trim())
+            Assert.Contains("error BC2017: could not find library 'prn.dll'", output.ToString(), StringComparison.Ordinal)
 
             vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"@aux.rsp", "/preferreduilang:en", source})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(1, exitCode)
             Dim errMessage = output.ToString().Trim()
-            Assert.Contains("error BC2011: unable to open response file", errMessage)
-            Assert.Contains("aux.rsp", errMessage)
+            Assert.Contains("error BC2011: unable to open response file", errMessage, StringComparison.Ordinal)
+            Assert.Contains("aux.rsp", errMessage, StringComparison.Ordinal)
 
             vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/nologo", "/preferreduilang:en", "/vbruntime:..\con.dll", source})
             output = New StringWriter()
             exitCode = vbc.Run(output, Nothing)
             Assert.Equal(1, exitCode)
-            Assert.Contains("error BC2017: could not find library '..\con.dll'", output.ToString().Trim())
+            Assert.Contains("error BC2017: could not find library '..\con.dll'", output.ToString(), StringComparison.Ordinal)
 
             ' Native VB compiler also ignore invalid lib pathes
             vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/LibPath:lpt1,Lpt2,LPT9", source})
@@ -6088,22 +6088,22 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
             Assert.True(expectedExitCode = exitCode,
                         String.Format("Expected exit code to be '{0}' was '{1}'.{2}Output:{3}{4}", expectedExitCode, exitCode, Environment.NewLine, Environment.NewLine, output))
 
-            Assert.DoesNotContain(" : hidden", output)
+            Assert.DoesNotContain(" : hidden", output, StringComparison.Ordinal)
 
             If expectedInfoCount = 0 Then
-                Assert.DoesNotContain(" : info", output)
+                Assert.DoesNotContain(" : info", output, StringComparison.Ordinal)
             Else
                 Assert.Equal(expectedInfoCount, OccurrenceCount(output, " : info"))
             End If
 
             If expectedWarningCount = 0 Then
-                Assert.DoesNotContain(" : warning", output)
+                Assert.DoesNotContain(" : warning", output, StringComparison.Ordinal)
             Else
                 Assert.Equal(expectedWarningCount, OccurrenceCount(output, " : warning"))
             End If
 
             If expectedErrorCount = 0 Then
-                Assert.DoesNotContain(" : error", output)
+                Assert.DoesNotContain(" : error", output, StringComparison.Ordinal)
             Else
                 Assert.Equal(expectedErrorCount, OccurrenceCount(output, " : error"))
             End If
@@ -6122,7 +6122,7 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
             file.WriteAllText(source)
 
             Dim output = VerifyOutput(dir, file, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42376 can be suppressed via /nowarn.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn"})
@@ -6132,11 +6132,11 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
 
             ' TEST: Verify that compiler warning BC42376 can be promoted to an error via /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42376 can be individually promoted to an error via /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:42376"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -6155,60 +6155,60 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
             file.WriteAllText(source)
 
             Dim output = VerifyOutput(dir, file, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn"})
 
             ' TEST: Verify that /nowarn: has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /warnaserror+ has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/nowarn:42376"})
 
             ' TEST: Verify that /warnaserror- has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /warnaserror: promotes custom hidden diagnostic Hidden01 to an error.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:hidden01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /warnaserror-: has no impact on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:Hidden01", "/nowarn:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:hidden01", "/warnaserror:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Hidden01", "/nowarn:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:hidden01", "/warnaserror-:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn doesn't override /warnaserror: in the case of custom hidden diagnostics.
             ' Although the compiler normally suppresses printing of hidden diagnostics in the compiler output, they are never really suppressed
             ' because in the IDE features that rely on hidden diagnostics to display light bulb need to continue to work even when users have global
             ' suppression (/nowarn) specified in their project. In other words, /nowarn flag is a no-op for hidden diagnostics.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn", "/warnaserror:Hidden01"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn doesn't override /warnaserror: in the case of custom hidden diagnostics.
             ' Although the compiler normally suppresses printing of hidden diagnostics in the compiler output, they are never really suppressed
             ' because in the IDE features that rely on hidden diagnostics to display light bulb need to continue to work even when users have global
             ' suppression (/nowarn) specified in their project. In other words, /nowarn flag is a no-op for hidden diagnostics.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:HIDDen01", "/nowarn"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn and /warnaserror-: have no impact  on custom hidden diagnostic Hidden01.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Hidden01", "/nowarn"})
@@ -6224,45 +6224,45 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:Hidden01", "/warnaserror-:hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Hidden01", "/warnaserror+:hidden01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-", "/warnaserror+:hidden01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:hiddEn01", "/warnaserror+", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:HiDden01", "/warnaserror-"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/warnaserror-:Hidden01", "/nowarn:42376"})
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-", "/warnaserror-:Hidden01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Hidden01", "/warnaserror-"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:HiDden01", "/warnaserror+", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/warnaserror+:HiDden01", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output)
+            Assert.Contains("a.vb(2) : error Hidden01: Throwing a diagnostic for #ExternalSource", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -6278,50 +6278,50 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
             Dim name = "a.vb"
 
             Dim output = GetOutput(name, source, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom info diagnostic Info01 can be suppressed via /nowarn.
             output = GetOutput(name, source, additionalFlags:={"/nowarn"})
 
             ' TEST: Verify that custom info diagnostic Info01 can be individually suppressed via /nowarn:.
             output = GetOutput(name, source, additionalFlags:={"/nowarn:Info01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom info diagnostic Info01 can never be promoted to an error via /warnaserror+.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+", "/nowarn:42376"}, expectedInfoCount:=1)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom info diagnostic Info01 is still reported as an info when /warnaserror- is used.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-"}, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom info diagnostic Info01 can be individually promoted to an error via /warnaserror:.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror:info01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom info diagnostic Info01 is still reported as an info when passed to /warnaserror-:.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-:info01"}, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror:.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror:Info01", "/nowarn:info01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror:.
             output = GetOutput(name, source, additionalFlags:={"/nowarn:INFO01", "/warnaserror:Info01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror-:.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-:Info01", "/nowarn:info01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn: overrides /warnaserror-:.
             output = GetOutput(name, source, additionalFlags:={"/nowarn:INFO01", "/warnaserror-:Info01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify /nowarn overrides /warnaserror:.
             output = GetOutput(name, source, additionalFlags:={"/nowarn", "/warnaserror:Info01"})
@@ -6343,49 +6343,49 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+:Info01", "/warnaserror-:info01"}, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-:Info01", "/warnaserror+:INfo01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-", "/warnaserror+:info01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+:InFo01", "/warnaserror+", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+:InfO01", "/warnaserror-"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+", "/warnaserror-:INfo01", "/nowarn:42376"}, expectedInfoCount:=1)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-", "/warnaserror-:INfo01"}, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror-:Info01", "/warnaserror-"}, expectedWarningCount:=1, expectedInfoCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : info Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+", "/warnaserror+:Info01", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = GetOutput(name, source, additionalFlags:={"/warnaserror+:InFO01", "/warnaserror+", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output)
+            Assert.Contains("a.vb(2) : error Info01: Throwing a diagnostic for #Enable", output, StringComparison.Ordinal)
         End Sub
 
         Private Function GetOutput(name As String,
@@ -6422,10 +6422,10 @@ End Module"
             file.WriteAllText(source)
 
             Dim output = VerifyOutput(dir, file, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42024 as well as custom warning diagnostics Warning01 and Warning03 can be suppressed via /nowarn.
             ' This doesn't work for BC42376 currently (Bug 899050).
@@ -6433,50 +6433,50 @@ End Module"
 
             ' TEST: Verify that compiler warning BC42024 as well as custom warning diagnostics Warning01 and Warning03 can be individually suppressed via /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42024 as well as custom warning diagnostics Warning01 and Warning03 can be promoted to errors via /warnaserror.
             ' Promoting compiler warning BC42024 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42024 as well as custom warning diagnostics Warning01 and Warning03 can be promoted to errors via /warnaserror+.
             ' This doesn't work currently - promoting compiler warning BC42024 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /warnaserror- keeps compiler warning BC42024 as well as custom warning diagnostics Warning01 and Warning03 as warnings.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom warning diagnostics Warning01 and Warning03 can be individually promoted to errors via /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:warning01,Something,warning03"}, expectedWarningCount:=2, expectedErrorCount:=2)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler warning BC42024 can be individually promoted to an error via /warnaserror+:.
             ' This doesn't work correctly currently - promoting compiler warning BC42024 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:bc42024"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom warning diagnostics Warning01 and Warning03 as well as compiler warning BC42024 can be individually promoted to errors via /warnaserror:.
             ' This doesn't work currently - promoting compiler warning BC42024 to an error causes us to no longer report any custom warning diagnostics as errors (Bug 998069).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that last flag on command line wins between /nowarn and /warnaserror.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror", "/nowarn"})
 
             ' TEST: Verify that last flag on command line wins between /nowarn and /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn", "/warnaserror+"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn overrides /warnaserror-.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn", "/warnaserror-"})
@@ -6486,19 +6486,19 @@ End Module"
 
             ' TEST: Verify that /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:Something,042024,Warning01,Warning03", "/nowarn:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:warning01,Warning03,bc42024,58000", "/warnaserror:Something,042024,Warning01,Warning03"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Something,042024,Warning01,Warning03", "/nowarn:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:warning01,Warning03,bc42024,58000", "/warnaserror-:Something,042024,Warning01,Warning03"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/nowarn:warning01,Warning03,bc42024,58000,42376"})
@@ -6514,11 +6514,11 @@ End Module"
 
             ' TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:warning01,Warning03,bc42024,58000", "/nowarn:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror-:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:warning01,Warning03,bc42024,58000", "/warnaserror-:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn overrides /warnaserror:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn", "/warnaserror:Something,042024,Warning01,Warning03,42376"})
@@ -6540,7 +6540,7 @@ End Module"
 
             ' TEST: Verify that last /warnaserror[+/-] flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-", "/warnaserror+"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' Note: Old native compiler behaved strangely for the below case.
             ' When /warnaserror+ and /warnaserror- appeared on the same command line, natvie compiler would allow /warnaserror+ to win always
@@ -6551,72 +6551,72 @@ End Module"
 
             ' TEST: Verify that last /warnaserror[+/-] flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/warnaserror-"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:warning01,Warning03", "/warnaserror+:Warning01,Warning03"}, expectedWarningCount:=2, expectedErrorCount:=2)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that last /warnaserror[+/-]: flag on command line wins.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:Warning01,Warning03", "/warnaserror-:warning01,Warning03"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:warning01,Warning03,bc42024,58000,42376", "/warnaserror+"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:warning01,Warning03,58000", "/warnaserror-"}, expectedWarningCount:=2, expectedErrorCount:=2)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-", "/warnaserror+:warning01,Warning03,bc42024,58000"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : error BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/warnaserror-:warning01,Warning03,bc42024,58000,42376"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/warnaserror+:warning01,Warning03,bc42024,58000,42376"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:warning01,Warning03,bc42024,58000,42376", "/warnaserror"}, expectedErrorCount:=1)
-            Assert.Contains("error BC42376", output)
+            Assert.Contains("error BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-", "/warnaserror-:warning01,Warning03,bc42024,58000,42376"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that specific promotions and suppressions (via /warnaserror[+/-]:) override general ones (i.e. /warnaserror[+/-]).
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:warning01,Warning03,bc42024,58000,42376", "/warnaserror-"}, expectedWarningCount:=4)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output)
-            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning01: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : warning Warning03: Throwing a diagnostic for types declared", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(4) : warning BC42024: Unused local variable: 'x'.", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -6637,15 +6637,15 @@ End Module"
 
             ' TEST: Verify that custom error diagnostic Error01 can't be suppressed via /nowarn.
             Dim output = VerifyOutput(dir, file, additionalFlags:={"/nowarn"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom error diagnostic Error01 can be suppressed via /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:Error01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that custom error diagnostic Error01 can be suppressed via /nowarn:.
             output = VerifyOutput(dir, file, additionalFlags:={"/nowarn:ERROR01"}, expectedWarningCount:=1)
-            Assert.Contains("warning BC42376", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
 
             ' TEST: Verify that /nowarn: overrides /warnaserror+.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/nowarn:ERROR01,42376"})
@@ -6673,27 +6673,27 @@ End Module"
 
             ' TEST: Verify that nothing bad happens when using /warnaserror[+/-] when custom error diagnostic Error01 is present.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+", "/nowarn:42376"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             ' TEST: Verify that nothing bad happens if someone passes custom error diagnostic Error01 to /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror:Error01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror+:ERROR01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, additionalFlags:={"/warnaserror-:Error01"}, expectedWarningCount:=1, expectedErrorCount:=1)
-            Assert.Contains("warning BC42376", output)
-            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output)
+            Assert.Contains("warning BC42376", output, StringComparison.Ordinal)
+            Assert.Contains("a.vb(2) : error Error01: Throwing a diagnostic for #Disable", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -6712,50 +6712,50 @@ End Module"
             file.WriteAllText(source)
 
             Dim output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler error BC30311 can't be suppressed via /nowarn.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/nowarn"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that compiler error BC30311 can't be suppressed via /nowarn:.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/nowarn:30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/nowarn:BC30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/nowarn:bc30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that nothing bad happens when using /warnaserror[+/-] when compiler error BC30311 is present.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror+"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror-"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             ' TEST: Verify that nothing bad happens if someone passes BC30311 to /warnaserror[+/-]:.
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror:30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror+:BC30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror+:bc30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror-:30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror-:BC30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             output = VerifyOutput(dir, file, includeCurrentAssemblyAsAnalyzerReferecne:=False, additionalFlags:={"/warnaserror-:bc30311"}, expectedErrorCount:=1)
-            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output)
+            Assert.Contains("a.vb(4) : error BC30311: Value of type 'Exception' cannot be converted to 'Integer'.", output, StringComparison.Ordinal)
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1573,7 +1573,7 @@ End Class]]></file>
             Dim comp = CreateCompilationWithReferences(source, {MscorlibRef_v4_0_30316_17626}, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             Dim verifier = Me.CompileAndVerify(comp)
             Dim il = verifier.VisualizeIL("Program.VB$StateMachine_1_Foo.GetEnumerator()")
-            Assert.Contains("System.Environment.get_CurrentManagedThreadId()", il)
+            Assert.Contains("System.Environment.get_CurrentManagedThreadId()", il, StringComparison.Ordinal)
         End Sub
 
         <WorkItem(835430, "DevDiv")>

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
@@ -52,7 +52,7 @@ End Class
             Assert.NotNull(MyTemplate)
 
             Dim text = MyTemplate.GetText.ToString
-            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text)
+            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text, StringComparison.Ordinal)
 
         End Sub
 
@@ -77,7 +77,7 @@ End Class
             Dim MyTemplate = GetMyTemplateTree(compilation)
 
             Dim text = MyTemplate.GetText.ToString
-            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text)
+            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text, StringComparison.Ordinal)
         End Sub
 
         <Fact()>
@@ -101,7 +101,7 @@ End Class
             Dim MyTemplate = GetMyTemplateTree(compilation)
 
             Dim text = MyTemplate.GetText.ToString
-            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text)
+            Assert.Contains("Private ReadOnly m_Context As New Global.Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)", text, StringComparison.Ordinal)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UseSiteErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UseSiteErrorTests.vb
@@ -510,7 +510,7 @@ BC30002: Type 'System.Int32' is not defined.
 
             ' the important bit here is, that there is no complaint about a missing CompilerGeneratedAttribute..ctor.
             For Each diag In compilation1.GetDiagnostics()
-                Assert.DoesNotContain("System.Runtime.CompilerServices.CompilerGeneratedAttribute", diag.GetMessage)
+                Assert.DoesNotContain("System.Runtime.CompilerServices.CompilerGeneratedAttribute", diag.GetMessage, StringComparison.Ordinal)
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/XmlDocComments.vb
@@ -70,8 +70,8 @@ Public Class ParseXmlDocComments
 
         Dim struct = DirectCast(comments(2).GetStructure, DocumentationCommentTriviaSyntax)
 
-        Assert.DoesNotContain(vbCr, struct.GetInteriorXml())
-        Assert.DoesNotContain(vbLf, struct.GetInteriorXml())
+        Assert.DoesNotContain(vbCr, struct.GetInteriorXml(), StringComparison.Ordinal)
+        Assert.DoesNotContain(vbLf, struct.GetInteriorXml(), StringComparison.Ordinal)
         Assert.Equal(" hello doc comments! hello doc comments!", struct.GetInteriorXml)
     End Sub
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -115,8 +116,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 Assert.True(preview is IWpfDifferenceViewer);
                 diffView = preview as IWpfDifferenceViewer;
                 text = diffView.RightView.TextBuffer.AsTextContainer().CurrentText.ToString();
-                Assert.Contains(AddedDocumentName, text);
-                Assert.Contains(AddedDocumentText, text);
+                Assert.Contains(AddedDocumentName, text, StringComparison.Ordinal);
+                Assert.Contains(AddedDocumentText, text, StringComparison.Ordinal);
                 diffView.Close();
 
                 // Then comes the removed metadata reference.
@@ -124,14 +125,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 Assert.NotNull(preview);
                 Assert.True(preview is string);
                 text = preview as string;
-                Assert.Contains(s_removedMetadataReferenceDisplayName, text);
+                Assert.Contains(s_removedMetadataReferenceDisplayName, text, StringComparison.Ordinal);
 
                 // And finally the added project.
                 preview = previews.TakeNextPreview();
                 Assert.NotNull(preview);
                 Assert.True(preview is string);
                 text = preview as string;
-                Assert.Contains(AddedProjectName, text);
+                Assert.Contains(AddedProjectName, text, StringComparison.Ordinal);
 
                 // There are no more previews.
                 preview = previews.TakeNextPreview();
@@ -155,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 Assert.NotNull(preview);
                 Assert.True(preview is string);
                 var text = preview as string;
-                Assert.Contains(AddedProjectName, text);
+                Assert.Contains(AddedProjectName, text, StringComparison.Ordinal);
 
                 // Should return preview that matches the preferred (changed) document.
                 preview = previews.TakeNextPreview(preferredDocumentId: document.Id);
@@ -172,8 +173,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 Assert.True(preview is IWpfDifferenceViewer);
                 diffView = preview as IWpfDifferenceViewer;
                 text = diffView.RightView.TextBuffer.AsTextContainer().CurrentText.ToString();
-                Assert.Contains(AddedDocumentName, text);
-                Assert.Contains(AddedDocumentText, text);
+                Assert.Contains(AddedDocumentName, text, StringComparison.Ordinal);
+                Assert.Contains(AddedDocumentText, text, StringComparison.Ordinal);
                 diffView.Close();
 
                 // There is no longer a preview for the  preferred document. Should return the first remaining preview.
@@ -181,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 Assert.NotNull(preview);
                 Assert.True(preview is string);
                 text = preview as string;
-                Assert.Contains(s_removedMetadataReferenceDisplayName, text);
+                Assert.Contains(s_removedMetadataReferenceDisplayName, text, StringComparison.Ordinal);
 
                 // There are no more previews.
                 preview = previews.TakeNextPreview();

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 Assert.Equal(expectedItem.IsCaseSensitive, actualItem.IsCaseSensitive);
                 if (!string.IsNullOrEmpty(expectedItem.SecondarySort))
                 {
-                    Assert.Contains(expectedItem.SecondarySort, actualItem.SecondarySort);
+                    Assert.Contains(expectedItem.SecondarySort, actualItem.SecondarySort, StringComparison.Ordinal);
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -855,7 +855,7 @@ class D
                 Assert.Equal(expectedItem.IsCaseSensitive, actualItem.IsCaseSensitive);
                 if (!string.IsNullOrEmpty(expectedItem.SecondarySort))
                 {
-                    Assert.Contains(expectedItem.SecondarySort, actualItem.SecondarySort);
+                    Assert.Contains(expectedItem.SecondarySort, actualItem.SecondarySort, StringComparison.Ordinal);
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
@@ -75,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
 
             var firstSpan = spans.First();
             Assert.Equal(PredefinedErrorTypeNames.SyntaxError, firstSpan.Tag.ErrorType);
-            Assert.Contains("Bar", (string)firstSpan.Tag.ToolTipContent);
+            Assert.Contains("Bar", (string)firstSpan.Tag.ToolTipContent, StringComparison.Ordinal);
         }
 
         private static IEnumerable<ITagSpan<IErrorTag>> GetErrorSpans(params string[] content)

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -461,11 +461,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
                     if (expectedSymbols == 1)
                     {
-                        Assert.DoesNotContain("+", description.GetFullText());
+                        Assert.DoesNotContain("+", description.GetFullText(), StringComparison.Ordinal);
                     }
                     else
                     {
-                        Assert.Contains(GetExpectedOverloadSubstring(expectedSymbols), description.GetFullText());
+                        Assert.Contains(GetExpectedOverloadSubstring(expectedSymbols), description.GetFullText(), StringComparison.Ordinal);
                     }
                 }
                 else

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -435,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Assert.Equal(1, diagnostics.Count())
                 Dim diagnostic = diagnostics.First()
                 Assert.True(AnalyzerExecutor.IsAnalyzerExceptionDiagnostic(diagnostic.ToDiagnostic(document.GetSyntaxTreeAsync().Result)))
-                Assert.Contains("CodeBlockStartedAnalyzer", diagnostic.Message)
+                Assert.Contains("CodeBlockStartedAnalyzer", diagnostic.Message, StringComparison.Ordinal)
             End Using
         End Sub
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 state.AssertSelectedCompletionItem(displayText:="Net", isSoftSelected:=True)
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains("using System.Net", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using System.Net", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 state.SendTypeChars("us")
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains("using", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
                 state.SendTypeChars("u")
                 state.AssertNoCompletionSession()
-                Assert.Contains("using", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -209,7 +209,7 @@ class C
                 state.SendBackspace()
                 state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
                 state.SendTab()
-                Assert.Contains("new List<int>", state.GetLineTextFromCaretPosition())
+                Assert.Contains("new List<int>", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -271,7 +271,7 @@ class @return
                 state.SendTypeChars("r")
                 state.AssertSelectedCompletionItem(displayText:="@return", isHardSelected:=True)
                 state.SendTab()
-                Assert.Contains("@return", state.GetLineTextFromCaretPosition())
+                Assert.Contains("@return", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -292,7 +292,7 @@ class Program
 
                 state.SendCommitUniqueCompletionListItem()
                 state.AssertNoCompletionSession()
-                Assert.Contains("WriteLine()", state.GetLineTextFromCaretPosition())
+                Assert.Contains("WriteLine()", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -327,7 +327,7 @@ class Program
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars("(")
                 state.AssertNoCompletionSession()
-                Assert.Contains("using Sys(", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -342,7 +342,7 @@ class Program
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars(".")
                 state.AssertCompletionSession()
-                Assert.Contains("using System.", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -357,7 +357,7 @@ class Program
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars(";")
                 state.AssertNoCompletionSession()
-                Assert.Contains("using System;", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using System;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -372,7 +372,7 @@ class Program
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars(" ")
                 state.AssertNoCompletionSession()
-                Assert.Contains("using Sys ", state.GetLineTextFromCaretPosition())
+                Assert.Contains("using Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -481,7 +481,7 @@ class Foo
                 </Document>)
 
                 state.SendTypeChars("Nu.")
-                Assert.Contains("Numeros num = Numeros.", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Numeros num = Numeros.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -510,7 +510,7 @@ class Foo
                 state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
                 state.SendTypeChars(c.ToString())
                 state.AssertNoCompletionSession()
-                Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition())
+                Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -589,7 +589,7 @@ class Program
 
                 state.SendTypeChars("(")
                 state.SendTab()
-                Assert.Contains("Environment.SpecialFolder", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Environment.SpecialFolder", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -608,7 +608,7 @@ public class @event
 
                 state.SendTypeChars("public ")
                 state.AssertNoCompletionSession()
-                Assert.Contains("public @event", state.GetLineTextFromCaretPosition())
+                Assert.Contains("public @event", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -634,7 +634,7 @@ class Program
                 state.SendTypeChars("can")
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains("Foo(cancellationToken)", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Foo(cancellationToken)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -747,7 +747,7 @@ class D : C
                 state.SendTypeChars(" Foo")
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains("public override void Foo<S>(S x = default(S))", state.SubjectBuffer.CurrentSnapshot.GetText())
+                Assert.Contains("public override void Foo<S>(S x = default(S))", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -774,7 +774,7 @@ class C : B
                 state.SendTypeChars(" Foo")
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains("    public override void Foo(int x = 0, int[] y = null)", state.SubjectBuffer.CurrentSnapshot.GetText())
+                Assert.Contains("    public override void Foo(int x = 0, int[] y = null)", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
             End Using
         End Sub
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Projections.vb
@@ -28,7 +28,7 @@ public override void Execute() {
                 state.SendTypeChars(".Curr")
                 state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
                 state.SendTab()
-                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition())
+                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpIntelliSenseCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpIntelliSenseCommandHandlerTests.vb
@@ -28,7 +28,7 @@ class C
                 state.AssertNoCompletionSession()
                 state.AssertSignatureHelpSession()
                 state.AssertSelectedSignatureHelpItem(displayText:="void C.Foo()")
-                Assert.Contains("Foo(", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Foo(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -99,7 +99,7 @@ End Module
                 state.SendTypeChars("Fog(")
                 state.AssertCompletionSession()
 
-                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition())
+                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -151,7 +151,7 @@ End Module
                 state.SendTypeChars("Fog(")
                 state.AssertCompletionSession()
 
-                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition())
+                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -191,7 +191,7 @@ End Module
                 Dim caretPos = state.GetCaretPoint().BufferPosition.Position
                 state.SendReturn()
                 state.Workspace.Documents.First().GetTextView().Caret.MoveTo(New SnapshotPoint(state.Workspace.Documents.First().TextBuffer.CurrentSnapshot, caretPos))
-                Assert.Contains("Program." + vbCrLf, state.GetLineFromCurrentCaretPosition().GetTextIncludingLineBreak())
+                Assert.Contains("Program." + vbCrLf, state.GetLineFromCurrentCaretPosition().GetTextIncludingLineBreak(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -212,7 +212,7 @@ End Module
                 state.SendTab()
                 state.AssertNoCompletionSession()
 
-                Assert.Contains("    FogBar", state.GetLineTextFromCaretPosition())
+                Assert.Contains("    FogBar", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -229,7 +229,7 @@ End Module
                 state.SendTypeChars("Progra.")
                 state.AssertCompletionSession()
                 state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True)
-                Assert.Contains("Program.", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Program.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -250,7 +250,7 @@ End Class
     Sub Main(args As String())
         Program
 
-    End Sub</text>.NormalizedValue, state.GetDocumentText())
+    End Sub</text>.NormalizedValue, state.GetDocumentText(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -467,9 +467,9 @@ End Class
                 state.AssertNoCompletionSession()
                 state.SendTypeChars(".Ma(")
                 state.AssertCompletionSession()
-                Assert.Contains(".Main(", state.GetLineTextFromCaretPosition())
+                Assert.Contains(".Main(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendUndo()
-                Assert.Contains(".Ma(", state.GetLineTextFromCaretPosition())
+                Assert.Contains(".Ma(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -497,7 +497,7 @@ End Class
                 state.SendDownKey()
                 state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True)
                 state.SendTab()
-                Assert.Contains(".B", state.GetLineTextFromCaretPosition())
+                Assert.Contains(".B", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -525,7 +525,7 @@ End Class
                 state.SendSelectCompletionItemThroughPresenterSession(state.CurrentCompletionPresenterSession.CompletionItems.First(
                                                            Function(i) i.DisplayText = "B"))
                 state.SendTab()
-                Assert.Contains(".B", state.GetLineTextFromCaretPosition())
+                Assert.Contains(".B", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -609,7 +609,7 @@ End Module]]></Document>)
                 state.SendBackspace()
                 state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
                 state.SendTab()
-                Assert.Contains("New List(Of Integer)", state.GetLineTextFromCaretPosition())
+                Assert.Contains("New List(Of Integer)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -790,7 +790,7 @@ end class
                 state.SendTypeChars("Fo(")
                 state.AssertCompletionSession()
                 Assert.Equal("        Foo(", state.GetLineTextFromCaretPosition())
-                Assert.DoesNotContain("Foo(Of", state.GetLineTextFromCaretPosition())
+                Assert.DoesNotContain("Foo(Of", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -822,7 +822,7 @@ end class
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars("(")
                 state.AssertNoCompletionSession()
-                Assert.Contains("Imports Sys(", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Imports Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -837,7 +837,7 @@ end class
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars(".")
                 state.AssertCompletionSession()
-                Assert.Contains("Imports System.", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Imports System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -852,7 +852,7 @@ end class
                 state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
                 state.SendTypeChars(" ")
                 state.AssertNoCompletionSession()
-                Assert.Contains("Imports Sys ", state.GetLineTextFromCaretPosition())
+                Assert.Contains("Imports Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -873,7 +873,7 @@ end class
 
                 state.SendTypeChars("x:")
                 state.AssertNoCompletionSession()
-                Assert.DoesNotContain(":=", state.GetLineTextFromCaretPosition())
+                Assert.DoesNotContain(":=", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -895,7 +895,7 @@ end class
                 state.SendTypeChars("x")
                 state.SendTab()
                 state.AssertNoCompletionSession()
-                Assert.Contains(":=", state.GetLineTextFromCaretPosition())
+                Assert.Contains(":=", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 
@@ -1227,7 +1227,7 @@ Module Program
         Dim bbb = 234
         Console.WriteLine(bbb
     End Sub
-End Module          </text>.NormalizedValue, state.GetDocumentText())
+End Module          </text>.NormalizedValue, state.GetDocumentText(), StringComparison.Ordinal)
 
             End Using
         End Sub

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Projections.vb
@@ -36,7 +36,7 @@ End Namespace
                 state.SendTypeChars("Curr")
                 state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
                 state.SendTab()
-                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition())
+                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
@@ -97,8 +97,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
                 Assert.True(TypeOf preview Is IWpfDifferenceViewer)
                 diffView = DirectCast(preview, IWpfDifferenceViewer)
                 text = diffView.RightView.TextBuffer.AsTextContainer().CurrentText.ToString()
-                Assert.Contains(AddedDocumentName, text)
-                Assert.Contains(AddedDocumentText, text)
+                Assert.Contains(AddedDocumentName, text, StringComparison.Ordinal)
+                Assert.Contains(AddedDocumentText, text, StringComparison.Ordinal)
                 diffView.Close()
 
                 ' Then comes the removed metadata reference.
@@ -106,14 +106,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
                 Assert.NotNull(preview)
                 Assert.True(TypeOf preview Is String)
                 text = DirectCast(preview, String)
-                Assert.Contains(removedMetadataReferenceDisplayName, text)
+                Assert.Contains(removedMetadataReferenceDisplayName, text, StringComparison.Ordinal)
 
                 ' And finally the added project.
                 preview = previews.TakeNextPreview()
                 Assert.NotNull(preview)
                 Assert.True(TypeOf preview Is String)
                 text = DirectCast(preview, String)
-                Assert.Contains(AddedProjectName, text)
+                Assert.Contains(AddedProjectName, text, StringComparison.Ordinal)
 
                 ' There are no more previews.
                 preview = previews.TakeNextPreview()
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
                 Assert.NotNull(preview)
                 Assert.True(TypeOf preview Is String)
                 Dim text = DirectCast(preview, String)
-                Assert.Contains(AddedProjectName, text)
+                Assert.Contains(AddedProjectName, text, StringComparison.Ordinal)
 
                 ' Should return preview that matches the preferred (changed) document.
                 preview = previews.TakeNextPreview(preferredDocumentId:=document.Id)
@@ -152,8 +152,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
                 Assert.True(TypeOf preview Is IWpfDifferenceViewer)
                 diffView = DirectCast(preview, IWpfDifferenceViewer)
                 text = diffView.RightView.TextBuffer.AsTextContainer().CurrentText.ToString()
-                Assert.Contains(AddedDocumentName, text)
-                Assert.Contains(AddedDocumentText, text)
+                Assert.Contains(AddedDocumentName, text, StringComparison.Ordinal)
+                Assert.Contains(AddedDocumentText, text, StringComparison.Ordinal)
                 diffView.Close()
 
                 ' There is no longer a preview for the  preferred document. Should return the first remaining preview.
@@ -161,7 +161,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
                 Assert.NotNull(preview)
                 Assert.True(TypeOf preview Is String)
                 text = DirectCast(preview, String)
-                Assert.Contains(removedMetadataReferenceDisplayName, text)
+                Assert.Contains(removedMetadataReferenceDisplayName, text, StringComparison.Ordinal)
 
                 ' There are no more previews.
                 preview = previews.TakeNextPreview()

--- a/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
 
             Dim firstSpan = spans.First()
             Assert.Equal(PredefinedErrorTypeNames.SyntaxError, firstSpan.Tag.ErrorType)
-            Assert.Contains("Bar", DirectCast(firstSpan.Tag.ToolTipContent, String))
+            Assert.Contains("Bar", DirectCast(firstSpan.Tag.ToolTipContent, String), StringComparison.Ordinal)
         End Sub
     End Class
 End Namespace

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -373,8 +373,8 @@ while(true) {}
             Assert.False(task.Result.Success);
 
             var errorOut = ReadErrorOutputToEnd().Trim();
-            Assert.Contains("Specified file not found.", errorOut);
-            Assert.Contains("Searched in directories:", errorOut);
+            Assert.Contains("Specified file not found.", errorOut, StringComparison.Ordinal);
+            Assert.Contains("Searched in directories:", errorOut, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/src/Test/Utilities/AssertEx.cs
+++ b/src/Test/Utilities/AssertEx.cs
@@ -401,7 +401,7 @@ namespace Roslyn.Test.Utilities
         {
             expectedSubString = NormalizeWhitespace(expectedSubString);
             actualString = NormalizeWhitespace(actualString);
-            Assert.Contains(expectedSubString, actualString);
+            Assert.Contains(expectedSubString, actualString, StringComparison.Ordinal);
         }
 
         internal static string NormalizeWhitespace(string input)

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -895,7 +895,7 @@ End Class
 
                 fileCodeModel.EndBatch()
 
-                Assert.Contains("Class C", buffer.CurrentSnapshot.GetText())
+                Assert.Contains("Class C", buffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
             End Using
 
         End Sub

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim diagnostic As DiagnosticData = e.Diagnostics.First()
                 Assert.Equal("BC42378", diagnostic.Id)
                 Assert.Equal(ServicesVSResources.WRN_UnableToLoadAnalyzer, diagnostic.MessageFormat)
-                Assert.Contains(File, diagnostic.Message)
+                Assert.Contains(File, diagnostic.Message, StringComparison.Ordinal)
             End Sub
 
             Public Sub DiagnosticRemovedTest(o As Object, e As DiagnosticsUpdatedArgs)

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -1903,7 +1903,7 @@ class C1
                     Assert.Equal(1, proj.AdditionalDocuments.Count());
                     var doc = proj.AdditionalDocuments.First();
                     Assert.Equal("XamlFile.xaml", doc.Name);
-                    Assert.Contains("Window", doc.GetTextAsync().WaitAndGetResult(CancellationToken.None).ToString());
+                    Assert.Contains("Window", doc.GetTextAsync().WaitAndGetResult(CancellationToken.None).ToString(), StringComparison.Ordinal);
                 }
             }
 #endif


### PR DESCRIPTION
__MAIN CHANGES:__
* Fix #1108. Provide explicit `StringComparison.Ordinal` in invocations of Xunit methods `Assert.Contains` and `Assert.DoesNotContain`
* Unskip test `CommandLineTests.PreferredUILang`

__ALSO:__
* Fix a typo in a comment: "reversed" -> "reserved"
* Remove unnecessary `string.Trim()` invocations
* Remove unnecessary `using` directives

See the explanation of these changes in #1108.