### PR TITLE
Disable Array.Empty params array optimization in expression lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -615,7 +615,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var paramArrayType = parameters[paramsParam].Type;
             var arrayArgs = paramArray.ToImmutableAndFree();
 
-            if (arrayArgs.Length == 0) // if this is a zero-length array, rather than using "new T[0]", optimize with "Array.Empty<T>()" if it's available
+            // If this is a zero-length array, rather than using "new T[0]", optimize with "Array.Empty<T>()" 
+            // if it's available.  However, we also disable the optimization if we're in an expression lambda, the 
+            // point of which is just to represent the semantics of an operation, and we don't know that all consumers
+            // of expression lambdas will appropriately understand Array.Empty<T>().
+            if (arrayArgs.Length == 0 && !_inExpressionLambda)
             {
                 ArrayTypeSymbol ats = paramArrayType as ArrayTypeSymbol;
                 if (ats != null) // could be null if there's a semantic error, e.g. the params parameter type isn't an array

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -2275,7 +2275,7 @@ public class Test
                 new[] { ExpressionAssemblyRef }, expectedOutput: TrimExpectedOutput(expectedOutput));
 
             // Also verify with the assemblies on which the tests are running, as there's a higher
-            // liklihood that they have Array.Empty, and we want to verify that Array.Empty is not used
+            // likelihood that they have Array.Empty, and we want to verify that Array.Empty is not used
             // in expression lambdas.  This can be changed to use the mscorlib 4.6 metadata once it's
             // available in the Roslyn tests.
             CompileAndVerify(CreateCompilation(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -2273,6 +2273,19 @@ public class Test
             CompileAndVerify(
                 text,
                 new[] { ExpressionAssemblyRef }, expectedOutput: TrimExpectedOutput(expectedOutput));
+
+            // Also verify with the assemblies on which the tests are running, as there's a higher
+            // liklihood that they have Array.Empty, and we want to verify that Array.Empty is not used
+            // in expression lambdas.  This can be changed to use the mscorlib 4.6 metadata once it's
+            // available in the Roslyn tests.
+            CompileAndVerify(CreateCompilation(
+                text,
+                references: new[] {
+                    MetadataReference.CreateFromAssembly(typeof(object).Assembly),
+                    MetadataReference.CreateFromAssembly(typeof(System.Linq.Enumerable).Assembly)
+                },
+                options: TestOptions.ReleaseExe),
+                expectedOutput: TrimExpectedOutput(expectedOutput));
         }
 
         [WorkItem(544270, "DevDiv")]


### PR DESCRIPTION
Fixes #1103.  Or more specifically, #1103 represents two issues: that we do the Array.Empty optimization for params arrays in the expression lambda, and that this optimization does not kick in when compiling expression lambdas... this fix addresses the former but not the latter.

The actual fix is a one-line trivial change.  In terms of tests, there's actually already a test for this case, but as it compiles against an earlier mscorlib that lacks Array.Empty, it passes even before the fix.  I augmented the test to also try to run it on a newer mscorlib, but since the Roslyn test suite doesn't yet contain the metadata for mscorlib 4.6, I use the mscorlib on which the test is running as a substitute (thanks to @jaredpar for the suggestion); worst case is the test isn't running on 4.6 and it passes but doesn't verify what we wanted it to.  I did verify that on 4.6 the test fails before the product fix and passes after it.