### PR TITLE
Formatting: lock, typeof, and array initializers

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -68,6 +68,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
 
+            // For spacing in the parenthesis of typeof, treat like a Method Call
+            if (previousKind == SyntaxKind.OpenParenToken && previousParentKind == SyntaxKind.TypeOfExpression)
+            {
+                return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
+            }
+
+            if (currentKind == SyntaxKind.CloseParenToken && currentParentKind == SyntaxKind.TypeOfExpression)
+            {
+                return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
+            }
+
             // For Spacing b/n control flow keyword and paren. Parent check not needed.
             if (currentKind == SyntaxKind.OpenParenToken &&
                 (previousKind == SyntaxKind.IfKeyword || previousKind == SyntaxKind.WhileKeyword || previousKind == SyntaxKind.SwitchKeyword ||
@@ -95,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (previousKind == SyntaxKind.OpenParenToken &&
                 (previousParentKind == SyntaxKind.IfStatement || previousParentKind == SyntaxKind.WhileStatement || previousParentKind == SyntaxKind.SwitchStatement ||
                 previousParentKind == SyntaxKind.ForStatement || previousParentKind == SyntaxKind.ForEachStatement || previousParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement))
+                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.LockStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -103,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.CloseParenToken &&
                 (currentParentKind == SyntaxKind.IfStatement || currentParentKind == SyntaxKind.WhileStatement || currentParentKind == SyntaxKind.SwitchStatement ||
                 currentParentKind == SyntaxKind.ForStatement || currentParentKind == SyntaxKind.ForEachStatement || currentParentKind == SyntaxKind.DoStatement ||
-                currentParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.CatchDeclaration))
+                currentParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement || currentParentKind == SyntaxKind.LockStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -121,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // For spacing empty square braces
-            if (previousKind == SyntaxKind.OpenBracketToken && currentKind == SyntaxKind.OmittedArraySizeExpressionToken && HasFormattableBracketParent(previousToken))
+            if (previousKind == SyntaxKind.OpenBracketToken && (currentKind == SyntaxKind.CloseBracketToken || currentKind == SyntaxKind.OmittedArraySizeExpressionToken) && HasFormattableBracketParent(previousToken))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceBetweenEmptySquareBrackets);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -69,6 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // For spacing in the parenthesis of typeof, treat like a Method Call
+            if (currentKind == SyntaxKind.OpenParenToken && currentParentKind == SyntaxKind.TypeOfExpression)
+            {
+                return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterMethodCallName);
+            }
+
             if (previousKind == SyntaxKind.OpenParenToken && previousParentKind == SyntaxKind.TypeOfExpression)
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6127,19 +6127,26 @@ class Program
     {
         var a = typeof(A);
         var b = M(a);
+        M();
     }
 }";
             const string expected = @"
-[Bar( A = 1, B = 2 )]
+[Bar ( A = 1, B = 2 )]
 class Program
 {
     public void foo()
     {
-        var a = typeof( A );
-        var b = M( a );
+        var a = typeof ( A );
+        var b = M ( a );
+        M ( );
     }
 }";
-            var optionSet = new Dictionary<OptionKey, object> { { CSharpFormattingOptions.SpaceWithinMethodCallParentheses, true } };
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.SpaceWithinMethodCallParentheses, true },
+                { CSharpFormattingOptions.SpaceAfterMethodCallName, true },
+                { CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses, true },
+            };
             AssertFormat(expected, code, changedOptionSet: optionSet);
         }
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4762,7 +4762,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public void TestSpacingOptionAroundControlFlow()
         {
-            var code = @"
+            const string code = @"
 class Program
 {
     public void foo()
@@ -4789,14 +4789,19 @@ class Program
 
         try
         { }
+        catch (System.Exception)
+        { }
         catch (System.Exception e)
         { }
 
         using(somevar)
         { }
+
+        lock(somevar)
+        { }
     }
 }";
-            var expected = @"
+            const string expected = @"
 class Program
 {
     public void foo()
@@ -4823,10 +4828,15 @@ class Program
 
         try
         { }
+        catch ( System.Exception )
+        { }
         catch ( System.Exception e )
         { }
 
         using ( somevar )
+        { }
+
+        lock ( somevar )
         { }
     }
 }";
@@ -5323,6 +5333,29 @@ class Program
 }";
 
             var options = new Dictionary<OptionKey, object>() { { CSharpFormattingOptions.SpaceBetweenEmptySquareBrackets, true } };
+            AssertFormat(expected, code, changedOptionSet: options);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ArrayDeclarationShouldFollowEmptySquareBrackets()
+        {
+            const string code = @"
+class Program
+{
+   var t = new Foo(new[ ] { ""a"", ""b"" });
+}";
+
+            const string expected = @"
+class Program
+{
+    var t = new Foo(new[] { ""a"", ""b"" });
+}";
+
+            var options = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.SpaceWithinSquareBrackets, true },
+                { CSharpFormattingOptions.SpaceBetweenEmptySquareBrackets, false }
+            };
             AssertFormat(expected, code, changedOptionSet: options);
         }
 
@@ -6081,6 +6114,33 @@ class Program
     }
 }";
             AssertFormat(code, code);
+        }
+
+        [Fact]
+        public void SpacingInMethodCallArguments_True()
+        {
+            const string code = @"
+[Bar(A=1,B=2)]
+class Program
+{
+    public void foo()
+    {
+        var a = typeof(A);
+        var b = M(a);
+    }
+}";
+            const string expected = @"
+[Bar( A = 1, B = 2 )]
+class Program
+{
+    public void foo()
+    {
+        var a = typeof( A );
+        var b = M( a );
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object> { { CSharpFormattingOptions.SpaceWithinMethodCallParentheses, true } };
+            AssertFormat(expected, code, changedOptionSet: optionSet);
         }
     }
 }


### PR DESCRIPTION
This fixes a couple spacing issues:

1. `SpaceWithinOtherParentheses` rule now applies to `lock`  
1. Method call spacing options, like `SpaceWithinMethodCallParentheses` now apply to the `typeof` keyword
1. `SpaceBetweenEmptySquareBrackets` rule now applies to array initializers, sometimes was following `SpaceWithinSquareBrackets`
1. The space before closing parenthesis on a catch expression wasn't formatted correctly, looks like a copy/paste error.

I think these changes are consistent with how VS2013 applied these rules.