### PR TITLE
Fix cibuild.cmd

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,6 +1,14 @@
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 msbuild /v:m /m BuildAndTest.proj /p:CIBuild=true
+if ERRORLEVEL 1 (
+    echo Build failed
+    exit /b 1
+)
 
 REM Kill any instances of VBCSCompiler.exe to release locked files;
 REM otherwise future CI runs may fail while trying to delete those files.
 taskkill /F /IM vbcscompiler.exe
+
+REM It is okay and expected for taskkill to fail (it's a cleanup routine).  Ensure
+REM caller sees successful exit.
+exit /b 0

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,6 +1,7 @@
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 msbuild /v:m /m BuildAndTest.proj /p:CIBuild=true
 if ERRORLEVEL 1 (
+    taskkill /F /IM vbcscompiler.exe
     echo Build failed
     exit /b 1
 )


### PR DESCRIPTION
Make sure the error checking is done properly.

- msbuild needs to be checked for failure
- taskkill failure shouldn't matter