### PR TITLE
Tweak Find All References display to reduce some noise

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
@@ -20,13 +20,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
         {
             get
             {
-                return false;
+                return this.Children == null || this.Children.Count == 0; 
             }
         }
 
         protected static readonly SymbolDisplayFormat definitionDisplayFormat =
             new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 parameterOptions: SymbolDisplayParameterOptions.IncludeType,
                 propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                 kindOptions: SymbolDisplayKindOptions.IncludeMemberKeyword | SymbolDisplayKindOptions.IncludeNamespaceKeyword | SymbolDisplayKindOptions.IncludeTypeKeyword,
                 localOptions: SymbolDisplayLocalOptions.IncludeType,
                 memberOptions:
-                    SymbolDisplayMemberOptions.IncludeAccessibility |
                     SymbolDisplayMemberOptions.IncludeContainingType |
                     SymbolDisplayMemberOptions.IncludeExplicitInterface |
                     SymbolDisplayMemberOptions.IncludeModifiers |

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
@@ -14,14 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
         private readonly Workspace _workspace;
         private readonly ProjectId _referencingProjectId;
 
-        public override bool UseGrayText
-        {
-            get
-            {
-                return true;
-            }
-        }
-
         public MetadataDefinitionTreeItem(Workspace workspace, ISymbol definition, ProjectId referencingProjectId, ushort glyphIndex)
             : base(glyphIndex)
         {
@@ -50,14 +42,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         public void SetReferenceCount(int referenceCount)
         {
-            if (referenceCount > 0)
-            {
-                var referenceCountDisplay = referenceCount == 1
-                    ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)
-                    : string.Format(ServicesVSResources.ReferenceCountPlural, referenceCount);
+            var referenceCountDisplay = referenceCount == 1
+                ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)
+                : string.Format(ServicesVSResources.ReferenceCountPlural, referenceCount);
 
-                this.DisplayText = $"[{_assemblyName}] {_symbolDefinition} ({referenceCountDisplay})";
-            }
+            this.DisplayText = $"[{_assemblyName}] {_symbolDefinition} ({referenceCountDisplay})";
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -20,14 +19,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         public void SetReferenceCount(int referenceCount)
         {
-            if (referenceCount > 0)
-            {
-                var referenceCountDisplay = referenceCount == 1
-                    ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)
-                    : string.Format(ServicesVSResources.ReferenceCountPlural, referenceCount);
+            var referenceCountDisplay = referenceCount == 1
+                ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)
+                : string.Format(ServicesVSResources.ReferenceCountPlural, referenceCount);
 
-                this.DisplayText = $"[{_projectName}] {_symbolDisplay} ({referenceCountDisplay})";
-            }
+            this.DisplayText = $"[{_projectName}] {_symbolDisplay} ({referenceCountDisplay})";
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
@@ -31,6 +31,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                 projectNameDisambiguator: string.Empty);
         }
 
+        public override bool UseGrayText
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public void AddProjectNameDisambiguator()
         {
             SetDisplayProperties(


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/116161/6560338/8abfd11e-c646-11e4-9a52-ee5635b15cb2.png)

* Display logical path rather than full file path. I.e.
<ProjectName>\<Folders>\<FileName>
* Use gray text to indicate definitions that have no references rather
than definitions defined in metadata.
* Show "(0 references)" when there aren't any found.
* Don't fully-qualify definitions.