### PR TITLE
Remove pending notifications from SolutionEventMonitor

### DIFF
--- a/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
@@ -76,6 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             {
                 globalOperation.Done();
                 globalOperation.Dispose();
+                _operations.Remove(operation);
             }
         }
     }


### PR DESCRIPTION
If we do not remove pending notifications when we cancel them, we may
try to cancel them twice.

Fixes #1136.