### PR TITLE
Catch exceptions from user code

### DIFF
--- a/src/Features/Core/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -70,5 +70,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <returns>A mapping from analyzer name to the diagnostics produced by that analyzer</returns>
         ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptors(Project projectOpt);
+
+        /// <summary>
+        /// Gets a list of the diagnostics provided by the given <see cref="DiagnosticAnalyzer"/>.
+        /// </summary>
+        /// <returns>A list of the diagnostics produced by the given analyzer</returns>
+        ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer);
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
@@ -15,11 +16,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         [Import(typeof(AnalyzersCommandHandler))]
         private IAnalyzersCommandHandler _commandHandler = null;
 
+        [Import]
+        private IDiagnosticAnalyzerService _diagnosticAnalyzerService = null;
+
         protected override IAttachedCollectionSource CreateCollectionSource(AnalyzerItem item, string relationshipName)
         {
             if (relationshipName == KnownRelationships.Contains)
             {
-                return new DiagnosticItemSource(item, _commandHandler);
+                return new DiagnosticItemSource(item, _commandHandler, (DiagnosticAnalyzerService)_diagnosticAnalyzerService);
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             if (relationshipName == KnownRelationships.Contains)
             {
-                return new DiagnosticItemSource(item, _commandHandler, (DiagnosticAnalyzerService)_diagnosticAnalyzerService);
+                return new DiagnosticItemSource(item, _commandHandler, _diagnosticAnalyzerService);
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
 {
@@ -19,16 +20,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         private readonly AnalyzerItem _item;
         private readonly IAnalyzersCommandHandler _commandHandler;
+        private readonly DiagnosticAnalyzerService _diagnosticAnalyzerService;
         private BulkObservableCollection<DiagnosticItem> _diagnosticItems;
         private Workspace _workspace;
         private ProjectId _projectId;
         private ReportDiagnostic _generalDiagnosticOption;
         private ImmutableDictionary<string, ReportDiagnostic> _specificDiagnosticOptions;
 
-        public DiagnosticItemSource(AnalyzerItem item, IAnalyzersCommandHandler commandHandler)
+        public DiagnosticItemSource(AnalyzerItem item, IAnalyzersCommandHandler commandHandler, DiagnosticAnalyzerService diagnosticAnalyzerService)
         {
             _item = item;
             _commandHandler = commandHandler;
+            _diagnosticAnalyzerService = diagnosticAnalyzerService;
         }
 
         public object SourceItem
@@ -90,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             // one.
 
             return _item.AnalyzerReference.GetAnalyzers(language)
-                .SelectMany(a => a.SupportedDiagnostics)
+                .SelectMany(a => _diagnosticAnalyzerService.GetDiagnosticDescriptors(a))
                 .GroupBy(d => d.Id)
                 .OrderBy(g => g.Key, StringComparer.CurrentCulture)
                 .Select(g =>

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
@@ -20,14 +20,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         private readonly AnalyzerItem _item;
         private readonly IAnalyzersCommandHandler _commandHandler;
-        private readonly DiagnosticAnalyzerService _diagnosticAnalyzerService;
+        private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
         private BulkObservableCollection<DiagnosticItem> _diagnosticItems;
         private Workspace _workspace;
         private ProjectId _projectId;
         private ReportDiagnostic _generalDiagnosticOption;
         private ImmutableDictionary<string, ReportDiagnostic> _specificDiagnosticOptions;
 
-        public DiagnosticItemSource(AnalyzerItem item, IAnalyzersCommandHandler commandHandler, DiagnosticAnalyzerService diagnosticAnalyzerService)
+        public DiagnosticItemSource(AnalyzerItem item, IAnalyzersCommandHandler commandHandler, IDiagnosticAnalyzerService diagnosticAnalyzerService)
         {
             _item = item;
             _commandHandler = commandHandler;

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -185,6 +185,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Function GetProjectDiagnosticsForIdsAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional diagnosticIds As ImmutableHashSet(Of String) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetProjectDiagnosticsForIdsAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
             End Function
+
+            Public Function GetDiagnosticDescriptors(analyzer As DiagnosticAnalyzer) As ImmutableArray(Of DiagnosticDescriptor) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors
+                Return ImmutableArray(Of DiagnosticDescriptor).Empty
+            End Function
         End Class
     End Class
 End Namespace


### PR DESCRIPTION
The Solution Explorer calls `DiagnosticAnalyzer.SupportedDiagnostics` to
determine the list of items to show. This property is implemented by a
3rd-party (the analyzer author) and could potentially throw.

Here we move to using the `DiagnosticAnalyzerService` to obtain this
data; it will catch any exceptions and handle reporting them to the user
as appropriate.

Fixes #898.