### PR TITLE
Changed the default compiler server keepalive to 10 minutes

### DIFF
--- a/src/Compilers/Core/VBCSCompiler/App.config
+++ b/src/Compilers/Core/VBCSCompiler/App.config
@@ -9,6 +9,6 @@
   <appSettings>
     <!-- Number of seconds with no activity before the server times out and closes. 
          Set to -1 to never shut down the server. -->
-    <add key="keepalive" value="300"/>
+    <add key="keepalive" value="600"/>
   </appSettings>
 </configuration>

--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <summary>
         /// Default time the server will stay alive after the last request disconnects.
         /// </summary>
-        private static readonly TimeSpan s_defaultServerKeepAlive = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan s_defaultServerKeepAlive = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// Time to delay after the last connection before initiating a garbage collection


### PR DESCRIPTION
This is to address server expiration during our end-to-end Venus performance scenario.