### PR TITLE
PERF: MetadataDecoder allocations for PEMethodSymbol.Arity

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     {
                         int parameterCount;
                         int typeParameterCount;
-                        new MetadataDecoder(_containingType.ContainingPEModule, this).GetSignatureCountsOrThrow(_handle, out parameterCount, out typeParameterCount);
+                        MetadataDecoder.GetSignatureCountsOrThrow(_containingType.ContainingPEModule.Module, _handle, out parameterCount, out typeParameterCount);
                         return typeParameterCount;
                     }
                     catch (BadImageFormatException)
@@ -600,7 +600,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     {
                         int parameterCount;
                         int typeParameterCount;
-                        new MetadataDecoder(_containingType.ContainingPEModule, this).GetSignatureCountsOrThrow(_handle, out parameterCount, out typeParameterCount);
+                        MetadataDecoder.GetSignatureCountsOrThrow(_containingType.ContainingPEModule.Module, _handle, out parameterCount, out typeParameterCount);
                         return parameterCount;
                     }
                     catch (BadImageFormatException)

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -898,11 +898,11 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <exception cref="BadImageFormatException">An exception from metadata reader.</exception>
-        internal void GetSignatureCountsOrThrow(MethodDefinitionHandle methodDef, out int parameterCount, out int typeParameterCount)
+        internal static void GetSignatureCountsOrThrow(PEModule module, MethodDefinitionHandle methodDef, out int parameterCount, out int typeParameterCount)
         {
-            BlobHandle signature = Module.GetMethodSignatureOrThrow(methodDef);
+            BlobHandle signature = module.GetMethodSignatureOrThrow(methodDef);
             SignatureHeader signatureHeader;
-            BlobReader signatureReader = DecodeSignatureHeaderOrThrow(signature, out signatureHeader);
+            BlobReader signatureReader = DecodeSignatureHeaderOrThrow(module, signature, out signatureHeader);
 
             GetSignatureCountsOrThrow(ref signatureReader, signatureHeader, out parameterCount, out typeParameterCount);
         }
@@ -1497,7 +1497,13 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="BadImageFormatException">An exception from metadata reader.</exception>
         internal BlobReader DecodeSignatureHeaderOrThrow(BlobHandle signature, out SignatureHeader signatureHeader)
         {
-            BlobReader reader = Module.GetMemoryReaderOrThrow(signature);
+            return DecodeSignatureHeaderOrThrow(Module, signature, out signatureHeader);
+        }
+
+        /// <exception cref="BadImageFormatException">An exception from metadata reader.</exception>
+        internal static BlobReader DecodeSignatureHeaderOrThrow(PEModule module, BlobHandle signature, out SignatureHeader signatureHeader)
+        {
+            BlobReader reader = module.GetMemoryReaderOrThrow(signature);
             signatureHeader = reader.ReadSignatureHeader();
             return reader;
         }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -550,8 +550,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     Try
                         Dim paramCount As Integer = 0
                         Dim typeParamCount As Integer = 0
-                        Dim decoder As New MetadataDecoder(Me.m_ContainingType.ContainingPEModule, Me)
-                        decoder.GetSignatureCountsOrThrow(Me.m_Handle, paramCount, typeParamCount)
+                        MetadataDecoder.GetSignatureCountsOrThrow(Me.m_ContainingType.ContainingPEModule.Module, Me.m_Handle, paramCount, typeParamCount)
                         Return typeParamCount
                     Catch mrEx As BadImageFormatException
                         Return TypeParameters.Length
@@ -673,8 +672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     Try
                         Dim paramCount As Integer = 0
                         Dim typeParamCount As Integer = 0
-                        Dim decoder As New MetadataDecoder(Me.m_ContainingType.ContainingPEModule, Me)
-                        decoder.GetSignatureCountsOrThrow(Me.m_Handle, paramCount, typeParamCount)
+                        MetadataDecoder.GetSignatureCountsOrThrow(Me.m_ContainingType.ContainingPEModule.Module, Me.m_Handle, paramCount, typeParamCount)
                         Return paramCount
                     Catch mrEx As BadImageFormatException
                         Return Parameters.Length


### PR DESCRIPTION
Reduce allocations by making MetadataDecode.GetSignatureCountsOrThrow static.
Thanks to @tmat for the suggestion.