### PR TITLE
Change CodeModel to not auto-simplify added imports

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host;
@@ -1105,10 +1106,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             // Annotate the member we're inserting so we can get back to it.
             var annotation = new SyntaxAnnotation();
 
-            // REVIEW: how simplifier ever worked for code model? nobody added simplifier.Annotation before?
-            var annotatedNode = node.WithAdditionalAnnotations(annotation, Simplifier.Annotation);
+            var gen = SyntaxGenerator.GetGenerator(document);
+            node = node.WithAdditionalAnnotations(annotation);
 
-            var newContainerNode = insertNodeIntoContainer(insertionIndex, annotatedNode, containerNode);
+            if (gen.GetDeclarationKind(node) != DeclarationKind.NamespaceImport)
+            {
+                // REVIEW: how simplifier ever worked for code model? nobody added simplifier.Annotation before?
+                node = node.WithAdditionalAnnotations(Simplifier.Annotation);
+            }
+
+            var newContainerNode = insertNodeIntoContainer(insertionIndex, node, containerNode);
             var newRoot = root.ReplaceNode(containerNode, newContainerNode);
             document = document.WithSyntaxRoot(newRoot);
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -519,7 +519,7 @@ enum E
 
 #Region "AddImport tests"
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport1()
             Dim code =
 <Code>
@@ -540,7 +540,7 @@ class C
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport2()
             Dim code =
 <Code>
@@ -561,7 +561,7 @@ class C
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System", .Alias = "S"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport3()
             Dim code =
 <Code>
@@ -585,7 +585,7 @@ class C
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport4()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -520,7 +520,7 @@ End Class
 
 #Region "AddImport tests"
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport1()
             Dim code =
 <Code>
@@ -538,7 +538,7 @@ End Class
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport2()
             Dim code =
 <Code>
@@ -556,7 +556,7 @@ End Class
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System", .Alias = "S"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport3()
             Dim code =
 <Code>
@@ -578,7 +578,7 @@ End Class
             TestAddImport(code, expected, New ImportData With {.[Namespace] = "System"})
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="1136356"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddImport4()
             Dim code =
 <Code>


### PR DESCRIPTION
This fixes a problem with code model failing tests that add imports.

@amcasey, @dpoeschl, @tmeschter, @DustinCampbell  please review