### PR TITLE
Rename methods referenced in nameof expressions

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public bool HasOverloads { get { return false; } }
 
+            public bool ForceRenameOverloads { get { return false; } }
+
             public string LocalizedErrorMessage { get; }
 
             public TextSpan TriggerSpan { get { return default(TextSpan); } }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 _renameInfo = renameInfo;
                 _renameLocationSet = renameLocationSet;
-                this.Locations = renameLocationSet.Locations.Where(l => !l.IsCandidateLocation).Select(ConvertLocation).ToList();
+                this.Locations = renameLocationSet.Locations.Where(l => !l.IsCandidateLocation || l.IsMethodGroupReference).Select(ConvertLocation).ToList();
             }
 
             private InlineRenameLocation ConvertLocation(RenameLocation location)

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -45,9 +45,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             public TextSpan TriggerSpan { get; }
             public ISymbol RenameSymbol { get; }
             public bool HasOverloads { get; }
+            public bool ForceRenameOverloads { get; }
 
             public SymbolInlineRenameInfo(
-                IEnumerable<IRefactorNotifyService> refactorNotifyServices, Document document, TextSpan triggerSpan, ISymbol renameSymbol, CancellationToken cancellationToken)
+                IEnumerable<IRefactorNotifyService> refactorNotifyServices, 
+                Document document, 
+                TextSpan triggerSpan, 
+                ISymbol renameSymbol, 
+                bool forceRenameOverloads, 
+                CancellationToken cancellationToken)
             {
                 this.CanRename = true;
 
@@ -56,6 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.RenameSymbol = renameSymbol;
 
                 this.HasOverloads = RenameLocationSet.GetOverloadedSymbols(this.RenameSymbol).Any();
+                this.ForceRenameOverloads = forceRenameOverloads;
 
                 _isRenamingAttributePrefix = CanRenameAttributePrefix(document, triggerSpan, cancellationToken);
                 this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
@@ -181,7 +181,7 @@
                 </StackPanel>
 
                 <CheckBox Content="{Binding ElementName=dashboard, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}" Cursor="Arrow"
-                      Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}"/>
+                      Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=dashboard, Path=IsRenameOverloadsEditable}" />
                 <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" Cursor="Arrow" />
                 <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" Cursor="Arrow" />
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -213,6 +213,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         public string RenameOverloads { get { return EditorFeaturesResources.RenameOverloads; } }
         public Visibility RenameOverloadsVisibility { get { return _model.RenameOverloadsVisibility; } }
+        public bool IsRenameOverloadsEditable { get { return _model.IsRenameOverloadsEditable; } }
         public string SearchInComments { get { return EditorFeaturesResources.SearchInComments; } }
         public string SearchInStrings { get { return EditorFeaturesResources.SearchInStrings; } }
         public string ApplyRename { get { return EditorFeaturesResources.ApplyRename; } }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private int _unresolvableConflictCount;
         private string _errorText;
         private bool _defaultRenameOverloadFlag;
+        private readonly bool _isRenameOverloadsEditable;
         private bool _defaultRenameInStringsFlag;
         private bool _defaultRenameInCommentsFlag;
         private bool _defaultPreviewChangesFlag;
@@ -36,7 +37,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _searchText = "Searching...";
 
             _renameOverloadsVisibility = session.HasRenameOverloads ? Visibility.Visible : Visibility.Collapsed;
-            _defaultRenameOverloadFlag = session.OptionSet.GetOption(RenameOptions.RenameOverloads);
+            _isRenameOverloadsEditable = !session.ForceRenameOverloads;
+
+            _defaultRenameOverloadFlag = session.OptionSet.GetOption(RenameOptions.RenameOverloads) || session.ForceRenameOverloads;
             _defaultRenameInStringsFlag = session.OptionSet.GetOption(RenameOptions.RenameInStrings);
             _defaultRenameInCommentsFlag = session.OptionSet.GetOption(RenameOptions.RenameInComments);
             _defaultPreviewChangesFlag = session.OptionSet.GetOption(RenameOptions.PreviewChanges);
@@ -206,6 +209,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             get { return _renameOverloadsVisibility; }
         }
 
+        public bool IsRenameOverloadsEditable
+        {
+            get { return _isRenameOverloadsEditable; }
+        }
+
         public bool DefaultRenameOverloadFlag
         {
             get
@@ -215,8 +223,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             set
             {
-                _defaultRenameOverloadFlag = value;
-                _session.RefreshRenameSessionWithOptionsChanged(RenameOptions.RenameOverloads, value);
+                if (IsRenameOverloadsEditable)
+                {
+                    _defaultRenameOverloadFlag = value;
+                    _session.RefreshRenameSessionWithOptionsChanged(RenameOptions.RenameOverloads, value);
+                }
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -149,6 +149,11 @@ namespace Microsoft.CodeAnalysis.Editor
         bool HasOverloads { get; }
 
         /// <summary>
+        /// Whether the Rename Overloads option should be forced to true. Used if rename is invoked from within a nameof expression.
+        /// </summary>
+        bool ForceRenameOverloads { get; }
+
+        /// <summary>
         /// The short name of the symbol being renamed, for use in displaying information to the user.
         /// </summary>
         string DisplayName { get; }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -108,7 +108,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _triggerView = textBufferAssociatedViewService.GetAssociatedTextViews(triggerSpan.Snapshot.TextBuffer).FirstOrDefault(v => v.HasAggregateFocus) ??
                 textBufferAssociatedViewService.GetAssociatedTextViews(triggerSpan.Snapshot.TextBuffer).First();
 
-            _optionSet = workspace.Options;
+            _optionSet = renameInfo.ForceRenameOverloads
+                ? workspace.Options.WithChangedOption(RenameOptions.RenameOverloads, true)
+                : workspace.Options;
 
             this.ReplacementText = triggerSpan.GetText();
 
@@ -208,6 +210,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public Workspace Workspace { get { return _workspace; } }
         public OptionSet OptionSet { get { return _optionSet; } }
         public bool HasRenameOverloads { get { return _renameInfo.HasOverloads; } }
+        public bool ForceRenameOverloads { get { return _renameInfo.ForceRenameOverloads; } }
+
         public IInlineRenameUndoManager UndoManager { get; private set; }
 
         public event EventHandler<IList<InlineRenameLocation>> ReferenceLocationsChanged;

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
@@ -42,8 +44,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             public string OriginalName { get { return _originalName; } }
 
             private readonly ITrackingSpan _trackingSpan;
-
             public ITrackingSpan TrackingSpan { get { return _trackingSpan; } }
+
+            private bool _forceRenameOverloads;
+            public bool ForceRenameOverloads { get { return _forceRenameOverloads; } }
 
             public TrackingSession(StateMachine stateMachine, SnapshotSpan snapshotSpan, IAsynchronousOperationListener asyncListener)
             {
@@ -152,24 +156,58 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                         var semanticModel = await document.GetSemanticModelForNodeAsync(token.Parent, _cancellationToken).ConfigureAwait(false);
                         var semanticFacts = document.GetLanguageService<ISemanticFactsService>();
 
-                        var symbol = semanticFacts.GetDeclaredSymbol(semanticModel, token, _cancellationToken);
-                        symbol = symbol ?? semanticModel.GetSymbolInfo(token, _cancellationToken).Symbol;
-
-                        if (symbol != null)
+                        var renameSymbolInfo = RenameUtilities.GetTokenRenameInfo(semanticFacts, semanticModel, token, _cancellationToken);
+                        if (!renameSymbolInfo.HasSymbols)
                         {
-                            // Get the source symbol if possible
-                            symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
+                            return TriggerIdentifierKind.NotRenamable;
+                        }
 
-                            return symbol.Locations.All(loc => loc.IsInSource)
-                                ? symbol.Locations.Any(loc => loc == token.GetLocation())
-                                    ? TriggerIdentifierKind.RenamableDeclaration
-                                    : TriggerIdentifierKind.RenamableReference
-                                : TriggerIdentifierKind.NotRenamable;
+                        if (renameSymbolInfo.IsMemberGroup)
+                        {
+                            // This is a reference from a nameof expression. Allow the rename but set the RenameOverloads option
+                            _forceRenameOverloads = true;
+
+                            return await DetermineIfRenamableSymbolsAsync(renameSymbolInfo.Symbols, document, token).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            return await DetermineIfRenamableSymbolAsync(renameSymbolInfo.Symbols.Single(), document, token).ConfigureAwait(false);
                         }
                     }
                 }
 
                 return TriggerIdentifierKind.NotRenamable;
+            }
+
+            private async Task<TriggerIdentifierKind> DetermineIfRenamableSymbolsAsync(IEnumerable<ISymbol> symbols, Document document, SyntaxToken token)
+            {
+                foreach (var symbol in symbols)
+                {
+                    // Get the source symbol if possible
+                    var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
+
+                    if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
+                    {
+                        return TriggerIdentifierKind.NotRenamable;
+                    }
+                }
+
+                return TriggerIdentifierKind.RenamableReference;
+            }
+
+            private async Task<TriggerIdentifierKind> DetermineIfRenamableSymbolAsync(ISymbol symbol, Document document, SyntaxToken token)
+            {
+                // Get the source symbol if possible
+                var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
+
+                if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
+                {
+                    return TriggerIdentifierKind.NotRenamable;
+                }
+
+                return sourceSymbol.Locations.Any(loc => loc == token.GetLocation())
+                        ? TriggerIdentifierKind.RenamableDeclaration
+                        : TriggerIdentifierKind.RenamableReference;
             }
 
             internal bool CanInvokeRename(ISyntaxFactsService syntaxFactsService, bool isSmartTagCheck, bool waitForResult, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -987,5 +987,136 @@ class C$$
                 Assert.Empty(state.GetDocumentDiagnostics());
             }
         }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_Nameof_FromMethodGroupReference()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        nameof(M$$).ToString();
+    }
+
+    void M(int x)
+    {
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("at");
+
+                state.AssertTag("M", "Mat", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void Mat()
+    {
+        nameof(Mat).ToString();
+    }
+
+    void Mat(int x)
+    {
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                state.AssertNoTag();
+            }
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_Nameof_FromMethodDefinition_NoOverloads()
+        {
+            var code = @"
+class C
+{
+    void M$$()
+    {
+        nameof(M).ToString();
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("at");
+
+                state.AssertTag("M", "Mat", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void Mat()
+    {
+        nameof(Mat).ToString();
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                state.AssertNoTag();
+            }
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_Nameof_FromMethodDefinition_WithOverloads()
+        {
+            var code = @"
+class C
+{
+    void M$$()
+    {
+        nameof(M).ToString();
+    }
+
+    void M(int x)
+    {
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("at");
+
+                state.AssertTag("M", "Mat", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void Mat()
+    {
+        nameof(M).ToString();
+    }
+
+    void M(int x)
+    {
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                state.AssertNoTag();
+            }
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_Nameof_FromReferenceToMetadata_NoTag()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        var x = nameof(ToString$$);
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("z");
+                state.AssertNoTag();
+            }
+        }
     }
 }

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1069,5 +1069,161 @@ class C
                 VerifyTagsAreCorrect(workspace, "xyzq")
             End Using
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_FromDefinition_NoOverloads()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void [|M$$|]()
+    {
+        nameof([|M|]).ToString();
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.First(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.First().TextBuffer
+
+                textBuffer.Insert(caretPosition, "a")
+                WaitForRename(workspace)
+                VerifyTagsAreCorrect(workspace, "Ma")
+
+                session.Commit()
+                VerifyTagsAreCorrect(workspace, "Ma")
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_FromReference_NoOverloads()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void [|M|]()
+    {
+        nameof([|M$$|]).ToString();
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.First(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.First().TextBuffer
+
+                textBuffer.Insert(caretPosition, "a")
+                WaitForRename(workspace)
+                VerifyTagsAreCorrect(workspace, "Ma")
+
+                session.Commit()
+                VerifyTagsAreCorrect(workspace, "Ma")
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_FromDefinition_WithOverloads()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void [|M$$|]()
+    {
+        nameof(M).ToString();
+    }
+
+    void M(int x) { }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.First(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.First().TextBuffer
+
+                textBuffer.Insert(caretPosition, "a")
+                WaitForRename(workspace)
+                VerifyTagsAreCorrect(workspace, "Ma")
+
+                session.Commit()
+                VerifyTagsAreCorrect(workspace, "Ma")
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_FromReference_WithOverloads()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void [|M|]()
+    {
+        nameof([|M$$|]).ToString();
+    }
+
+    void [|M|](int x) { }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.First(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.First().TextBuffer
+
+                textBuffer.Insert(caretPosition, "a")
+                WaitForRename(workspace)
+                VerifyTagsAreCorrect(workspace, "Ma")
+
+                session.Commit()
+                VerifyTagsAreCorrect(workspace, "Ma")
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_FromDefinition_WithOverloads_WithRenameOverloadsOption()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void [|$$M|]()
+    {
+        nameof([|M|]).ToString();
+    }
+
+    void [|M|](int x) { }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                VerifyRenameOptionChangedSessionCommit(workspace, "M", "Sa", renameOverloads:=True)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -6692,6 +6692,85 @@ class {|Conflict:foo|}
                 result.AssertLabeledSpansInStringsAndCommentsAre("RenameInComment", "// foo BAR! foo!")
             End Using
         End Sub
+
 #End Region
+
+#Region "Rename In NameOf"
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_NoOverloads_CSharp()
+            Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
+                            <Document><![CDATA[
+class C
+{
+    void [|$$M|]()
+    {
+        nameof([|M|]).ToString();
+    }
+}
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Mo")
+
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_WithOverloads_CSharp()
+            Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
+                            <Document><![CDATA[
+class C
+{
+    void [|$$M|]()
+    {
+        nameof(M).ToString();
+    }
+
+    void M(int x)
+    {
+    }
+}
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Mo")
+
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameMethodWithNameof_WithOverloads_WithRenameOverloadsOption_CSharp()
+            Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
+            renamingOptions.Add(RenameOptions.RenameOverloads, True)
+            Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
+                            <Document><![CDATA[
+class C
+{
+    void [|$$M|]()
+    {
+        nameof([|M|]).ToString();
+    }
+
+    void [|M|](int x)
+    {
+    }
+}
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Mo", changedOptionSet:=renamingOptions)
+
+            End Using
+        End Sub
+
+#End Region
+
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -625,7 +625,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     // Get all rename locations for the current document.
                     var allTextSpansInSingleSourceTree = renameLocations
-                        .Where(l => l.DocumentId == documentId && !l.IsRenameInStringOrComment && (renameLocations.Count() == 1 || !l.IsCandidateLocation))
+                        .Where(l => l.DocumentId == documentId && !l.IsRenameInStringOrComment && (renameLocations.Count() == 1 || !l.IsCandidateLocation || l.IsMethodGroupReference))
                         .ToDictionary(l => l.Location.SourceSpan);
 
                     // All textspan in the document documentId, that requires rename in String or Comment

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -364,7 +364,12 @@ namespace Microsoft.CodeAnalysis.Rename
                     else
                     {
                         // The simple case, so just the single location and we're done
-                        results.Add(new RenameLocation(location.Location, location.Document.Id, isCandidateLocation: location.IsCandidateLocation, isRenamableAccessor: await IsPropertyAccessorOrAnOverride(referencedSymbol, solution, cancellationToken).ConfigureAwait(false)));
+                        results.Add(new RenameLocation(
+                            location.Location, 
+                            location.Document.Id, 
+                            isCandidateLocation: location.IsCandidateLocation, 
+                            isMethodGroupReference: location.IsCandidateLocation && location.CandidateReason == CandidateReason.MemberGroup, 
+                            isRenamableAccessor: await IsPropertyAccessorOrAnOverride(referencedSymbol, solution, cancellationToken).ConfigureAwait(false)));
                     }
                 }
 

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.cs
@@ -17,10 +17,13 @@ namespace Microsoft.CodeAnalysis.Rename
 
         public bool IsRenameInStringOrComment { get { return ContainingLocationForStringOrComment != default(TextSpan); } }
 
+        public bool IsMethodGroupReference { get; private set; }
+
         public RenameLocation(
             Location location,
             DocumentId documentId,
             bool isCandidateLocation = false,
+            bool isMethodGroupReference = false,
             bool isRenamableAliasUsage = false,
             bool isRenamableAccessor = false,
             TextSpan containingLocationForStringOrComment = default(TextSpan))
@@ -28,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Rename
             this.Location = location;
             this.DocumentId = documentId;
             this.IsCandidateLocation = isCandidateLocation;
+            this.IsMethodGroupReference = isMethodGroupReference;
             this.IsRenamableAliasUsage = isRenamableAliasUsage;
             this.IsRenamableAccessor = isRenamableAccessor;
             this.ContainingLocationForStringOrComment = containingLocationForStringOrComment;
@@ -37,7 +41,8 @@ namespace Microsoft.CodeAnalysis.Rename
         {
             this.Location = referenceLocation.Location;
             this.DocumentId = documentId;
-            this.IsCandidateLocation = referenceLocation.IsCandidateLocation && !(referenceLocation.CandidateReason == CandidateReason.LateBound);
+            this.IsCandidateLocation = referenceLocation.IsCandidateLocation && referenceLocation.CandidateReason != CandidateReason.LateBound;
+            this.IsMethodGroupReference = referenceLocation.IsCandidateLocation && referenceLocation.CandidateReason == CandidateReason.MemberGroup;
             this.IsRenamableAliasUsage = false;
             this.IsRenamableAccessor = false;
             this.ContainingLocationForStringOrComment = default(TextSpan);

--- a/src/Workspaces/Core/Portable/Rename/RenameLocationSet.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocationSet.cs
@@ -76,10 +76,14 @@ namespace Microsoft.CodeAnalysis.Rename
                 mergedLocations.AddRange(commentsResult);
             }
 
+            var renameMethodGroupReferences = optionSet.GetOption(RenameOptions.RenameOverloads) || !GetOverloadedSymbols(symbol).Any();
             var overloadsToMerge = (optionSet.GetOption(RenameOptions.RenameOverloads) ? overloadsResult : null) ?? SpecializedCollections.EmptyEnumerable<SearchResult>();
             foreach (var result in overloadsToMerge.Concat(originalSymbolResult))
             {
-                mergedLocations.AddRange(result.Locations);
+                mergedLocations.AddRange(renameMethodGroupReferences 
+                    ? result.Locations
+                    : result.Locations.Where(x => !x.IsMethodGroupReference));
+
                 mergedImplicitLocations.AddRange(result.ImplicitLocations);
                 mergedReferencedSymbols.AddRange(result.ReferencedSymbols);
             }

--- a/src/Workspaces/Core/Portable/Rename/TokenRenameInfo.cs
+++ b/src/Workspaces/Core/Portable/Rename/TokenRenameInfo.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Rename
+{
+    internal sealed class TokenRenameInfo
+    {
+        public bool HasSymbols { get; private set; }
+        public IEnumerable<ISymbol> Symbols { get; private set; }
+        public bool IsMemberGroup { get; private set; }
+
+        public static TokenRenameInfo CreateMemberGroupTokenInfo(IEnumerable<ISymbol> symbols)
+        {
+            return new TokenRenameInfo
+            {
+                HasSymbols = true,
+                IsMemberGroup = true,
+                Symbols = symbols
+            };
+        }
+
+        public static TokenRenameInfo CreateSingleSymbolTokenInfo(ISymbol symbol)
+        {
+            return new TokenRenameInfo
+            {
+                HasSymbols = true,
+                IsMemberGroup = false,
+                Symbols = SpecializedCollections.SingletonEnumerable(symbol)
+            };
+        }
+
+        public static TokenRenameInfo NoSymbolsTokenInfo = new TokenRenameInfo
+        {
+            HasSymbols = false,
+            IsMemberGroup = false,
+            Symbols = SpecializedCollections.EmptyEnumerable<ISymbol>()
+        };
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -378,6 +378,7 @@
     <Compile Include="Log\LogAggregator.cs" />
     <Compile Include="Log\Logger.LogBlock.cs" />
     <Compile Include="Log\LogMessage.cs" />
+    <Compile Include="Rename\TokenRenameInfo.cs" />
     <Compile Include="Serialization\AssemblySerializationInfoService.cs" />
     <Compile Include="Serialization\IAssemblySerializationInfoService.cs" />
     <Compile Include="Shared\Extensions\TextDocumentExtensions.cs" />


### PR DESCRIPTION
This change adds support for renaming methods that are referenced in nameof expressions during Inline Rename, Rename Tracking, and RenameSymbolAsync. For all of these features, there are three primary cases:

- Rename invoked from a method declaration with no overloads: Any nameof expressions that reference the method are unambiguous and are therefore updated to the new name.
- Rename invoked from a method declaration with overloads: In this case, any references in nameof expressions are renamed only if the RenameOverloads option is set to true (e.g. when the user checks the "Rename overloads" checkbox in Inline Rename).
- Rename invoked from a reference in a nameof expression: We always rename all overloads by automatically setting the RenameOverloads option to true and disabling Inline Rename's "Rename overloads" checkbox.