### PR TITLE
Ignore bit flag AssemblyFlags.PublicKey for assembly definitions

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1650,8 +1650,8 @@ public class C
             }
         }
 
-        [Fact(Skip = "Bug 399")]
-        [WorkItem(399, "GitHub")]
+        [Fact]
+        [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()
         {
             // The referenced assembly Signed.dll from the repro steps

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -1050,8 +1050,8 @@ class C
             context.CompileExpression(
                 // typeof(Exception), typeof(A<B<object>>), typeof(B<A<object>[]>)
                 InspectionContextFactory.Empty.Add("$exception", "System.Exception, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").
-                    Add("1", "A`1[[B`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], 397300B0-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null]], 397300B0-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=null").
-                    Add("2", "B`1[[A`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], 397300B0-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=null]], 397300B0-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null"),
+                    Add("1", "A`1[[B`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], 397300B0-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null]], 397300B0-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=1f8a32457d187bf3").
+                    Add("2", "B`1[[A`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], 397300B0-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=1f8a32457d187bf3]], 397300B0-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null"),
                 "(object)$exception ?? (object)$1 ?? $2",
                 DkmEvaluationFlags.TreatAsExpression,
                 DiagnosticFormatter.Instance,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
@@ -859,8 +859,8 @@ End Class"
             ' GetType(Exception), GetType(A(Of B(Of Object))), GetType(B(Of A(Of Object)()))
             context.CompileExpression(
                 InspectionContextFactory.Empty.Add("$exception", "System.Exception, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").
-                    Add("1", "A`1[[B`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], 397300B1-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null]], 397300B1-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=null").
-                    Add("2", "B`1[[A`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], 397300B1-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=null]], 397300B1-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null"),
+                    Add("1", "A`1[[B`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], 397300B1-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null]], 397300B1-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=1f8a32457d187bf3").
+                    Add("2", "B`1[[A`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], 397300B1-A, Version=2.1.2.1, Culture=neutral, PublicKeyToken=1f8a32457d187bf3]], 397300B1-B, Version=1.2.2.2, Culture=neutral, PublicKeyToken=null"),
                 "If(If($exception, $1), $2)",
                 DkmEvaluationFlags.TreatAsExpression,
                 DiagnosticFormatter.Instance,


### PR DESCRIPTION
Fix #399