### PR TITLE
Slight tweaks in handling of OperationCanceledExceptions during analy… 

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
@@ -77,8 +77,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var analyzerAndOptions = new AnalyzerAndOptions(analyzer, analyzerExecutor.AnalyzerOptions);
 
-            analyzerExecutor = analyzerExecutor.WithCalleeHandledOperationCanceledException();
-
             try
             {
                 return await GetCompilationAnalysisScopeCoreAsync(analyzerAndOptions, sessionScope, analyzerExecutor).ConfigureAwait(false);
@@ -118,8 +116,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             AnalyzerExecutor analyzerExecutor)
         {
-            analyzerExecutor = analyzerExecutor.WithCalleeHandledOperationCanceledException();
-
             try
             {
                 return await GetSessionAnalysisScopeCoreAsync(analyzer, analyzerExecutor).ConfigureAwait(false);

--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
@@ -77,6 +77,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var analyzerAndOptions = new AnalyzerAndOptions(analyzer, analyzerExecutor.AnalyzerOptions);
 
+            analyzerExecutor = analyzerExecutor.WithCalleeHandledOperationCanceledException();
+
             try
             {
                 return await GetCompilationAnalysisScopeCoreAsync(analyzerAndOptions, sessionScope, analyzerExecutor).ConfigureAwait(false);
@@ -116,6 +118,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             AnalyzerExecutor analyzerExecutor)
         {
+            analyzerExecutor = analyzerExecutor.WithCalleeHandledOperationCanceledException();
+
             try
             {
                 return await GetSessionAnalysisScopeCoreAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
@@ -189,10 +193,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var handler = new EventHandler<Exception>((sender, ex) =>
                     {
                         var diagnostic = AnalyzerExecutor.GetAnalyzerExceptionDiagnostic(analyzer, ex);
-                        if (diagnostic != null)
-                        {
-                            analyzerExecutor.OnAnalyzerException?.Invoke(ex, analyzer, diagnostic);
-                        }
+                        analyzerExecutor.OnAnalyzerException?.Invoke(ex, analyzer, diagnostic);
                     });
 
                 // Subscribe for exceptions from lazily evaluated localizable strings in the descriptors.

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         await documentAnalyzer.AnalyzeSyntaxAsync(_document, diagnostics.Add, _cancellationToken).ConfigureAwait(false);
                         return diagnostics.ToImmutableArrayOrEmpty();
                     }
-                    catch (Exception e) when (!IsCanceled(e, _cancellationToken))
+                    catch (Exception e) when (!AnalyzerExecutor.IsCanceled(e, _cancellationToken))
                     {
                         OnAnalyzerException(e, analyzer, compilation);
                         return ImmutableArray<Diagnostic>.Empty;
@@ -305,11 +305,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             return compilation == null
                 ? diagnostics
                 : CompilationWithAnalyzers.GetEffectiveDiagnostics(diagsFilteredByLocation, compilation);
-        }
-
-        private static bool IsCanceled(Exception ex, CancellationToken cancellationToken)
-        {
-            return (ex as OperationCanceledException)?.CancellationToken == cancellationToken;
         }
 
         internal void OnAnalyzerException(Exception ex, DiagnosticAnalyzer analyzer, Compilation compilation)
@@ -380,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     {
                         await documentAnalyzer.AnalyzeSemanticsAsync(_document, diagnostics.Add, _cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e) when (!IsCanceled(e, _cancellationToken))
+                    catch (Exception e) when (!AnalyzerExecutor.IsCanceled(e, _cancellationToken))
                     {
                         OnAnalyzerException(e, analyzer, compilation);
                         return ImmutableArray<Diagnostic>.Empty;
@@ -456,7 +451,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             {
                 await projectAnalyzer.AnalyzeProjectAsync(_project, diagnostics.Add, _cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (!IsCanceled(e, _cancellationToken))
+            catch (Exception e) when (!AnalyzerExecutor.IsCanceled(e, _cancellationToken))
             {
                 var compilation = await _project.GetCompilationAsync(_cancellationToken).ConfigureAwait(false);
                 OnAnalyzerException(e, analyzer, compilation);


### PR DESCRIPTION
…zer execution:

1. Don't swallow OperationCanceledException fired with our cancellelationToken. These are supposed to be handled up the stack and swallowing them would mean unnecessary computation would be done for result that would eventually be ignored.
2. Analyzer callbacks that register actions need custom handling of all OperationCanceledExceptions in AnalyzerManager. Multiple threads trying to fetch registered analyzer actions might share the same task for computing registered actions, and if cancellation is fired on the source of this task, we want to re-attempt invoking the register callbacks, otherwise the analyzer will never execute.

@JohnHamby @pharring @srivatsn @tmeschter @heejaechang can you please review?
