### PR TITLE
Dont disturb whitespace preceding comments

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
@@ -77,7 +77,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                 {
                     new KeyValuePair<string, IOption>(GetStorageKeyForOption(CompletionOptions.IncludeKeywords), CompletionOptions.IncludeKeywords),
                     new KeyValuePair<string, IOption>(GetStorageKeyForOption(CompletionOptions.TriggerOnTypingLetters), CompletionOptions.TriggerOnTypingLetters),
-                    new KeyValuePair<string, IOption>(GetStorageKeyForOption(FormattingOptions.UseTabOnlyForIndentation), FormattingOptions.UseTabOnlyForIndentation)
                 });
 
             Type[] types = new[]

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5832,9 +5832,10 @@ class C
             AssertFormat(expected, code);
         }
 
-        [WorkItem(961559)]
+        [WorkItem(1041787)]
+        [WorkItem(1151, "https://github.com/dotnet/roslyn/issues/1151")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public void ReconstructWhitespaceStringUsingTabs()
+        public void ReconstructWhitespaceStringUsingTabs_SingleLineComment()
         {
             var optionSet = new Dictionary<OptionKey, object> { { new OptionKey(FormattingOptions.UseTabs, LanguageNames.CSharp), true } };
             AssertFormat(@"using System;
@@ -5843,7 +5844,7 @@ class Program
 {
 	static void Main(string[] args)
 	{
-		Console.WriteLine(""""); // FooBar
+		Console.WriteLine("""");        // FooBar
 	}
 }", @"using System;
 
@@ -5851,7 +5852,33 @@ class Program
 {
     static void Main(string[] args)
     {
-        Console.WriteLine(""""); // FooBar
+        Console.WriteLine("""");        // FooBar
+    }
+}", false, optionSet);
+        }
+
+        [WorkItem(961559)]
+        [WorkItem(1041787)]
+        [WorkItem(1151, "https://github.com/dotnet/roslyn/issues/1151")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ReconstructWhitespaceStringUsingTabs_MultiLineComment()
+        {
+            var optionSet = new Dictionary<OptionKey, object> { { new OptionKey(FormattingOptions.UseTabs, LanguageNames.CSharp), true } };
+            AssertFormat(@"using System;
+
+class Program
+{
+	static void Main(string[] args)
+	{
+		Console.WriteLine("""");        /* FooBar */
+	}
+}", @"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("""");        /* FooBar */
     }
 }", false, optionSet);
         }

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
@@ -18,8 +18,6 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public static readonly PerLanguageOption<IndentStyle> SmartIndent = new PerLanguageOption<IndentStyle>(FormattingFeatureName, "SmartIndent", defaultValue: IndentStyle.Smart);
 
-        public static readonly PerLanguageOption<bool> UseTabOnlyForIndentation = new PerLanguageOption<bool>(InternalTabFeatureName, "UseTabOnlyForIndentation", defaultValue: false);
-
         public static readonly PerLanguageOption<string> NewLine = new PerLanguageOption<string>(FormattingFeatureName, "NewLine", defaultValue: "\r\n");
 
         internal static readonly PerLanguageOption<bool> DebugMode = new PerLanguageOption<bool>(FormattingFeatureName, "DebugMode", defaultValue: false);

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -789,7 +789,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             var useTabOnlyForIndentation = this.OptionSet.GetOption(FormattingOptions.UseTabOnlyForIndentation, this.Language);
 
             // space indicates space between two noisy trivia or tokens
-            changes.Add(CreateWhitespace(GetSpacesOrTabs(lineColumn.Column, delta.Spaces, useTabs && !useTabOnlyForIndentation, tabSize)));
+            changes.Add(CreateWhitespace(GetSpacesOrTabs(delta.Spaces)));
         }
 
         private string GetWhitespaceString(LineColumn lineColumn, LineColumnDelta delta)
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             var useTabOnlyForIndentation = this.OptionSet.GetOption(FormattingOptions.UseTabOnlyForIndentation, this.Language);
 
             // space indicates space between two noisy trivia or tokens
-            sb.Append(GetSpacesOrTabs(lineColumn.Column, delta.Spaces, useTabs && !useTabOnlyForIndentation, tabSize));
+            sb.Append(GetSpacesOrTabs(delta.Spaces));
             return StringBuilderPool.ReturnAndFree(sb);
         }
 
@@ -948,20 +948,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             return this.InitialLineColumn.With(delta).Column;
         }
 
-        private static string GetSpacesOrTabs(int initialColumn, int space, bool useTab, int tabSize)
+        private static string GetSpacesOrTabs(int space)
         {
-            if (useTab)
-            {
-                var preceedingTabs = initialColumn / tabSize;
-                var preceedingSpace = initialColumn % tabSize;
-
-                var column = initialColumn + space;
-                var numberOfTabs = column / tabSize;
-                var numberOfSpaces = column % tabSize;
-                var numberOfTabsToIntroduce = numberOfTabs - preceedingTabs;
-                return new string('\t', numberOfTabsToIntroduce) + new string(' ', numberOfTabsToIntroduce == 0 ? numberOfSpaces - preceedingSpace : numberOfSpaces);
-            }
-
             if (space >= 0 && space < 20)
             {
                 return s_spaceCache[space];

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -786,10 +786,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return;
             }
 
-            var useTabOnlyForIndentation = this.OptionSet.GetOption(FormattingOptions.UseTabOnlyForIndentation, this.Language);
-
             // space indicates space between two noisy trivia or tokens
-            changes.Add(CreateWhitespace(GetSpacesOrTabs(delta.Spaces)));
+            changes.Add(CreateWhitespace(GetSpaces(delta.Spaces)));
         }
 
         private string GetWhitespaceString(LineColumn lineColumn, LineColumnDelta delta)
@@ -815,10 +813,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return StringBuilderPool.ReturnAndFree(sb);
             }
 
-            var useTabOnlyForIndentation = this.OptionSet.GetOption(FormattingOptions.UseTabOnlyForIndentation, this.Language);
-
             // space indicates space between two noisy trivia or tokens
-            sb.Append(GetSpacesOrTabs(delta.Spaces));
+            sb.Append(GetSpaces(delta.Spaces));
             return StringBuilderPool.ReturnAndFree(sb);
         }
 
@@ -948,7 +944,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             return this.InitialLineColumn.With(delta).Column;
         }
 
-        private static string GetSpacesOrTabs(int space)
+        private static string GetSpaces(int space)
         {
             if (space >= 0 && space < 20)
             {

--- a/src/Workspaces/Core/Portable/PublicAPI.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.txt
@@ -1215,7 +1215,6 @@ static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationS
 static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine
 static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent
 static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabOnlyForIndentation
 static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs
 static readonly Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.FilterOutOfScopeLocals
 static readonly Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.HideAdvancedMembers

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -1677,8 +1677,7 @@ End Class</Code>
             {
                 {New OptionKey(FormattingOptions.UseTabs, LanguageNames.VisualBasic), True},
                 {New OptionKey(FormattingOptions.TabSize, LanguageNames.VisualBasic), 4},
-                {New OptionKey(FormattingOptions.IndentationSize, LanguageNames.VisualBasic), 4},
-                {New OptionKey(FormattingOptions.UseTabOnlyForIndentation, LanguageNames.VisualBasic), True}
+                {New OptionKey(FormattingOptions.IndentationSize, LanguageNames.VisualBasic), 4}
             }
 
             AssertFormat(code, expected, changedOptionSet:=optionSet)
@@ -1697,7 +1696,7 @@ End Class</Code>
 
             Dim expected =
                 "Class SomeClass" + vbCrLf +
-                vbTab + "Sub Foo()			' Comment" + vbCrLf +
+                vbTab + "Sub Foo()           ' Comment" + vbCrLf +
                 vbTab + vbTab + "Foo()" + vbCrLf +
                 vbTab + "End Sub" + vbCrLf +
                 "End Class"
@@ -1933,7 +1932,7 @@ End Class</Code>
 End Class</Code>
 
             Dim expected = <Code>Class Foo
-	Sub Foo()			' Comment
+	Sub Foo()           ' Comment
 		Foo()
 	End Sub
 End Class</Code>


### PR DESCRIPTION
Fix #1151 : Dont disturb the whitespaces preceding the comments which
are also not part of indentation to be converted to tabs if 'Keep Tabs'
option is set.