### PR TITLE
Introduce a new AbstractEncProject for CSharpProject and VisualBasicProject to extend.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProject.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProject.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
     /// are in a separate files. Methods that are shared across multiple interfaces (which are
     /// effectively methods that just QI from one interface to another), are implemented here.
     /// </remarks>
-    internal partial class CSharpProject : AbstractProject
+    internal partial class CSharpProject : AbstractEncProject
     {
         private static readonly CSharpCompilationOptions s_defaultCompilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
         private static readonly CSharpParseOptions s_defaultParseOptions = new CSharpParseOptions();

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`3.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             foreach (var documentId in vsWorkspace.GetRelatedDocumentIds(container))
             {
                 var hostProject = vsWorkspace.GetHostProject(documentId.ProjectId) as AbstractEncProject;
-                if (hostProject != null && hostProject.EditAndContinueImplOpt != null)
+                if (hostProject?.EditAndContinueImplOpt != null)
                 {
                     if (hostProject.EditAndContinueImplOpt.OnEdit(documentId))
                     {

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`3.cs
@@ -110,8 +110,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             foreach (var documentId in vsWorkspace.GetRelatedDocumentIds(container))
             {
-                var hostProject = (AbstractProject)vsWorkspace.GetHostProject(documentId.ProjectId);
-                if (hostProject.EditAndContinueImplOpt != null)
+                var hostProject = vsWorkspace.GetHostProject(documentId.ProjectId) as AbstractEncProject;
+                if (hostProject != null && hostProject.EditAndContinueImplOpt != null)
                 {
                     if (hostProject.EditAndContinueImplOpt.OnEdit(documentId))
                     {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             }
 
             var hostProject = _vsProject.VisualStudioWorkspace.GetHostProject(documentId.ProjectId) as AbstractEncProject;
-            if (hostProject != null && hostProject.EditAndContinueImplOpt._metadata != null)
+            if (hostProject?.EditAndContinueImplOpt?._metadata != null)
             {
                 var projectHierarchy = _vsProject.VisualStudioWorkspace.GetHierarchy(documentId.ProjectId);
                 _debugEncNotify.NotifyEncEditDisallowedByProject(projectHierarchy);

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -150,9 +150,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 return;
             }
 
-            var hostProject = (AbstractProject)_vsProject.VisualStudioWorkspace.GetHostProject(documentId.ProjectId);
-
-            if (hostProject.EditAndContinueImplOpt._metadata != null)
+            var hostProject = _vsProject.VisualStudioWorkspace.GetHostProject(documentId.ProjectId) as AbstractEncProject;
+            if (hostProject != null && hostProject.EditAndContinueImplOpt._metadata != null)
             {
                 var projectHierarchy = _vsProject.VisualStudioWorkspace.GetHierarchy(documentId.ProjectId);
                 _debugEncNotify.NotifyEncEditDisallowedByProject(projectHierarchy);

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Roslyn.Utilities;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 {
@@ -80,9 +81,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 
         private void SetReadOnly(Document document)
         {
-            SessionReadOnlyReason sessionReason;
-            ProjectReadOnlyReason projectReason;
-            SetReadOnly(document.Id, _encService.IsProjectReadOnly(document.Project.Name, out sessionReason, out projectReason));
+            // Only set documents read-only if they're part of a project that supports Enc.
+            var workspace = document.Project.Solution.Workspace as VisualStudioWorkspaceImpl;
+            var project = workspace?.ProjectTracker?.GetProject(document.Project.Id) as AbstractEncProject;
+
+            if (project != null)
+            {
+                SessionReadOnlyReason sessionReason;
+                ProjectReadOnlyReason projectReason;
+                SetReadOnly(document.Id, _encService.IsProjectReadOnly(document.Project.Name, out sessionReason, out projectReason));
+            }
         }
 
         private void SetReadOnly(DocumentId documentId, bool value)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
+using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+{
+    internal abstract partial class AbstractEncProject : AbstractProject
+    {
+        internal readonly VsENCRebuildableProjectImpl EditAndContinueImplOpt;
+
+        public AbstractEncProject(
+            VisualStudioProjectTracker projectTracker,
+            Func<ProjectId, IVsReportExternalErrors> reportExternalErrorCreatorOpt,
+            string projectSystemName,
+            IVsHierarchy hierarchy,
+            string language,
+            IServiceProvider serviceProvider,
+            MiscellaneousFilesWorkspace miscellaneousFilesWorkspaceOpt,
+            VisualStudioWorkspaceImpl visualStudioWorkspaceOpt,
+            HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt) 
+            : base(projectTracker, reportExternalErrorCreatorOpt, projectSystemName, hierarchy, language, serviceProvider, miscellaneousFilesWorkspaceOpt, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt)
+        {
+            if (visualStudioWorkspaceOpt != null)
+            {
+                this.EditAndContinueImplOpt = new VsENCRebuildableProjectImpl(this);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject_IVsENCRebuildableProjectCfg.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject_IVsENCRebuildableProjectCfg.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     // Dev11 implementation: csharp\radmanaged\Features\EditAndContinue\EncProject.cs
 
-    internal partial class AbstractProject : EncInterop.IVsENCRebuildableProjectCfg2, EncInterop.IVsENCRebuildableProjectCfg4
+    internal partial class AbstractEncProject : EncInterop.IVsENCRebuildableProjectCfg2, EncInterop.IVsENCRebuildableProjectCfg4
     {
         public int HasCustomMetadataEmitter(out bool value)
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -88,8 +88,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private static readonly EventHandler<bool> s_additionalDocumentClosingEventHandler = OnAdditionalDocumentClosing;
         private static readonly EventHandler s_additionalDocumentUpdatedOnDiskEventHandler = OnAdditionalDocumentUpdatedOnDisk;
 
-        internal readonly VsENCRebuildableProjectImpl EditAndContinueImplOpt;
-
         public AbstractProject(
             VisualStudioProjectTracker projectTracker,
             Func<ProjectId, IVsReportExternalErrors> reportExternalErrorCreatorOpt,
@@ -134,11 +132,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (reportExternalErrorCreatorOpt != null)
             {
                 _externalErrorReporter = reportExternalErrorCreatorOpt(_id);
-            }
-
-            if (visualStudioWorkspaceOpt != null)
-            {
-                this.EditAndContinueImplOpt = new VsENCRebuildableProjectImpl(this);
             }
 
             ConnectHierarchyEvents();

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Implementation\Preview\ReferenceChange.AnalyzerReferenceChange.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.ProjectReferenceChange.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.cs" />
+    <Compile Include="Implementation\ProjectSystem\AbstractEncProject.cs" />
     <Compile Include="Implementation\ProjectSystem\IVisualStudioWorkingFolder.cs" />
     <Compile Include="Implementation\ProjectSystem\RuleSets\RuleSetEventHandler.cs" />
     <Compile Include="Implementation\ProjectSystem\VisualStudioProjectTracker_IVsSolutionWorkingFoldersEvents.cs" />
@@ -499,7 +500,7 @@
     <Compile Include="Implementation\ProjectSystem\AbstractEntryPointFinder.cs" />
     <Compile Include="Implementation\ProjectSystem\AbstractProject.cs" />
     <Compile Include="Implementation\ProjectSystem\AbstractProject_IAnalyzerHost.cs" />
-    <Compile Include="Implementation\ProjectSystem\AbstractProject_IVsENCRebuildableProjectCfg.cs" />
+    <Compile Include="Implementation\ProjectSystem\AbstractEncProject_IVsENCRebuildableProjectCfg.cs" />
     <Compile Include="Implementation\ProjectSystem\AbstractProject_IVsReportExternalErrors.cs" />
     <Compile Include="Implementation\ProjectSystem\ComEventSink.cs" />
     <Compile Include="Implementation\ProjectSystem\DocumentKey.cs" />

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -16,7 +16,7 @@ Imports Microsoft.VisualStudio.TextManager.Interop
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
     Partial Friend MustInherit Class VisualBasicProject
-        Inherits AbstractProject
+        Inherits AbstractEncProject
         Implements IVbCompilerProject
         Implements IVisualStudioHostProject
 


### PR DESCRIPTION
This project does the appropriate Enc hookup, and implements the interfaces that the debugger
QIs for to do Enc interaction.

For C# and VB, nothing will change.  For TypeScript, we will continue subclassing AbstractProject.
By doing this, we will not interact with the Enc system at all.  This will help avoid undesirable
behavior (like having our files become read-only when entering debugging).