### PR TITLE
Update Code Model to support ReadOnly and WriteOnly VB auto-properties

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -737,23 +737,47 @@ End Class
             TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
         End Sub
 
-        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Sub ReadWrite4()
-            Dim code =
+		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+		Public Sub ReadWrite4()
+			Dim code =
 <Code>
 Class C
     Public Property $$P As Integer
 End Class
 </Code>
 
-            TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
-        End Sub
+			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+		End Sub
+
+		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+		Public Sub ReadWrite5()
+			Dim code =
+<Code>
+Class C
+    Public ReadOnly Property $$P As Integer
+End Class
+</Code>
+
+			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+		End Sub
+
+		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+		Public Sub ReadWrite6()
+			Dim code =
+<Code>
+Class C
+    Public WriteOnly Property $$P As Integer
+End Class
+</Code>
+
+			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
+		End Sub
 
 #End Region
 
 #Region "Setter tests"
 
-        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub SetterIsNothingForAutoProp()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -737,47 +737,47 @@ End Class
             TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
         End Sub
 
-		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-		Public Sub ReadWrite4()
-			Dim code =
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ReadWrite4()
+            Dim code =
 <Code>
 Class C
     Public Property $$P As Integer
 End Class
 </Code>
 
-			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
-		End Sub
+            TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+        End Sub
 
-		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-		Public Sub ReadWrite5()
-			Dim code =
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ReadWrite5()
+            Dim code =
 <Code>
 Class C
     Public ReadOnly Property $$P As Integer
 End Class
 </Code>
 
-			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
-		End Sub
+            TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Sub
 
-		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-		Public Sub ReadWrite6()
-			Dim code =
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ReadWrite6()
+            Dim code =
 <Code>
 Class C
     Public WriteOnly Property $$P As Integer
 End Class
 </Code>
 
-			TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
-		End Sub
+            TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
+        End Sub
 
 #End Region
 
 #Region "Setter tests"
 
-		<ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub SetterIsNothingForAutoProp()
             Dim code =
 <Code>

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -2823,26 +2823,26 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
             Debug.Assert(TypeOf memberNode Is PropertyBlockSyntax OrElse
                          TypeOf memberNode Is PropertyStatementSyntax)
 
-            Dim propertyStatement = TryCast(memberNode, PropertyStatementSyntax)
-            If propertyStatement IsNot Nothing Then
-                Debug.Assert(Not propertyStatement.IsParentKind(SyntaxKind.PropertyBlock))
+			Dim propertyStatement = TryCast(memberNode, PropertyStatementSyntax)
 
-                ' Auto property
-                Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite
-            End If
+			If propertyStatement Is Nothing Then
+				Dim propertyBlock = TryCast(memberNode, PropertyBlockSyntax)
+				If propertyBlock IsNot Nothing Then
+					propertyStatement = propertyBlock.PropertyStatement
+				End If
+			End If
 
-            Dim propertyBlock = TryCast(memberNode, PropertyBlockSyntax)
-            If propertyBlock IsNot Nothing Then
-                If propertyBlock.PropertyStatement.Modifiers.Any(SyntaxKind.WriteOnlyKeyword) Then
-                    Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly
-                ElseIf propertyBlock.PropertyStatement.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) Then
-                    Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly
-                Else
-                    Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite
-                End If
-            End If
+			If propertyStatement IsNot Nothing Then
+				If propertyStatement.Modifiers.Any(SyntaxKind.WriteOnlyKeyword) Then
+					Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly
+				ElseIf propertyStatement.Modifiers.Any(SyntaxKind.ReadOnlyKeyword)
+					Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly
+				Else
+					Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite
+				End If
+			End If
 
-            Throw Exceptions.ThrowEUnexpected()
+			Throw Exceptions.ThrowEUnexpected()
         End Function
 
         Private Function SetDelegateType(delegateStatement As DelegateStatementSyntax, typeSymbol As ITypeSymbol) As DelegateStatementSyntax


### PR DESCRIPTION
VB 14 supports ReadOnly and WriteOnly auto-properties. Code Model's
CodeProperty2.ReadWrite should return the correct value for them. Fixes issue #851.