### PR TITLE
Dont Assume Certain Node Are Always Parented

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -98,8 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return false;
             }
 
-            return node.Parent.Kind() == SyntaxKind.SimpleLambdaExpression ||
-                   node.Parent.Kind() == SyntaxKind.ParenthesizedLambdaExpression;
+            return node.IsParentKind(SyntaxKind.SimpleLambdaExpression) || node.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression);
         }
 
         public static bool IsAnonymousMethodBlock(this SyntaxNode node)
@@ -109,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return false;
             }
 
-            return node.Parent.Kind() == SyntaxKind.AnonymousMethodExpression;
+            return node.IsParentKind(SyntaxKind.AnonymousMethodExpression);
         }
 
         public static bool IsSemicolonInForStatement(this SyntaxToken token)
@@ -502,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             Contract.ThrowIfNull(node);
 
             var blockNode = node as BlockSyntax;
-            if (blockNode == null)
+            if (blockNode == null || blockNode.Parent == null)
             {
                 return false;
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6010,5 +6010,13 @@ class Program
 }";
             AssertFormat(expected, code);
         }
+
+        [WorkItem(1118, "https://github.com/dotnet/roslyn/issues/1118")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DontAssumeCertainNodeAreAlwaysParented()
+        {
+            var block = SyntaxFactory.Block();
+            Formatter.Format(block, new AdhocWorkspace());
+        }
     }
 }


### PR DESCRIPTION
Fix #1118 : Dont assume that some of the nodes are always parented.
Always check if the parent is not null before accessing the parent.