### PR TITLE
Ensure Razor lines are editable when debugging an MVC5 project

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ReadOnlyDocumentTracker.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ReadOnlyDocumentTracker.cs
@@ -86,12 +86,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
         {
             AssertIsForeground();
 
-            var document = _workspace.CurrentSolution.GetDocument(documentId);
-            Debug.Assert(document != null);
-
             SessionReadOnlyReason sessionReason;
             ProjectReadOnlyReason projectReason;
-            bool isReadOnly = _encService.IsProjectReadOnly(document.Project.Name, out sessionReason, out projectReason);
+            bool isReadOnly = _encService.IsProjectReadOnly(documentId.ProjectId, out sessionReason, out projectReason);
 
             if (isEdit && isReadOnly)
             {

--- a/src/Features/Core/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _debuggingSession = null;
         }
 
-        public bool IsProjectReadOnly(string projectName, out SessionReadOnlyReason sessionReason, out ProjectReadOnlyReason projectReason)
+        public bool IsProjectReadOnly(ProjectId id, out SessionReadOnlyReason sessionReason, out ProjectReadOnlyReason projectReason)
         {
             if (_debuggingSession == null)
             {
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // normal break mode - if the document belongs to a project that hasn't entered the edit session it shall be read-only:
-            if (editSession.TryGetProjectState(projectName, out projectReason))
+            if (editSession.Projects.TryGetValue(id, out projectReason))
             {
                 sessionReason = SessionReadOnlyReason.None;
                 return projectReason != ProjectReadOnlyReason.None;

--- a/src/Features/Core/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/EditAndContinue/EditSession.cs
@@ -136,21 +136,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             get { return _projects; }
         }
 
-        internal bool TryGetProjectState(string projectName, out ProjectReadOnlyReason reason)
-        {
-            // We used to keep track of project ids but Venus may have multiple project ids during debugging sessions,
-            // causing EnC fail to recognize they belong to the same project. Therefore, instead of ids,
-            // their public display name (which is shared between multiple projects in Venus) is compared.
-            foreach (var pair in Projects.Where((p) => _baseSolution.GetProject(p.Key)?.Name == projectName))
-            {
-                reason = pair.Value;
-                return true;
-            }
-
-            reason = ProjectReadOnlyReason.NotLoaded;
-            return false;
-        }
-
         internal bool HasProject(ProjectId id)
         {
             ProjectReadOnlyReason reason;

--- a/src/Features/Core/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
@@ -22,6 +23,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         void EndEditSession();
         void EndDebuggingSession();
 
-        bool IsProjectReadOnly(string projectName, out SessionReadOnlyReason sessionReason, out ProjectReadOnlyReason projectReason);
+        bool IsProjectReadOnly(ProjectId id, out SessionReadOnlyReason sessionReason, out ProjectReadOnlyReason projectReason);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Roslyn.Utilities;
 using Microsoft.VisualStudio.SymReaderInterop;
@@ -225,7 +224,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     _encService.StartDebuggingSession(_vsProject.VisualStudioWorkspace.CurrentSolution);
                     s_encDebuggingSessionInfo = new EncDebuggingSessionInfo();
 
-                    s_readOnlyDocumentTracker = new VsReadOnlyDocumentTracker(_encService, _editorAdaptersFactoryService, AllowsReadOnly);
+                    s_readOnlyDocumentTracker = new VsReadOnlyDocumentTracker(_encService, _editorAdaptersFactoryService, _vsProject);
                 }
 
                 string outputPath = _vsProject.TryGetObjOutputPath();
@@ -286,17 +285,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             {
                 throw ExceptionUtilities.Unreachable;
             }
-        }
-
-        private bool AllowsReadOnly(DocumentId documentId)
-        {
-            // All documents of regular running projects are read-only until the debugger breaks the app.
-            // However, ASP.NET doesn’t want its views (aspx, cshtml, or vbhtml) to be read-only, so they can be editable
-            // while the code is running and get refreshed next time the web page is hit.
-            
-            // Note that Razor-like views are modelled as a ContainedDocument but normal code including code-behind are modelled as a StandradTextDocument.
-            var containedDocument = _vsProject.VisualStudioWorkspace.GetHostDocument(documentId) as ContainedDocument;
-            return containedDocument == null;
         }
 
         public int StopDebuggingPE()

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Roslyn.Utilities;
 using Microsoft.VisualStudio.SymReaderInterop;
@@ -125,12 +126,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
         // called from an edit filter if an edit of a read-only buffer is attempted:
         internal bool OnEdit(DocumentId documentId)
         {
-            var document = _vsProject.Workspace.CurrentSolution.GetDocument(documentId);
-            Debug.Assert(document != null);
-
             SessionReadOnlyReason sessionReason;
             ProjectReadOnlyReason projectReason;
-            if (_encService.IsProjectReadOnly(document.Project.Name, out sessionReason, out projectReason))
+            if (_encService.IsProjectReadOnly(documentId.ProjectId, out sessionReason, out projectReason))
             {
                 OnReadOnlyDocumentEditAttempt(documentId, sessionReason, projectReason);
                 return true;
@@ -227,7 +225,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     _encService.StartDebuggingSession(_vsProject.VisualStudioWorkspace.CurrentSolution);
                     s_encDebuggingSessionInfo = new EncDebuggingSessionInfo();
 
-                    s_readOnlyDocumentTracker = new VsReadOnlyDocumentTracker(_encService, _editorAdaptersFactoryService);
+                    s_readOnlyDocumentTracker = new VsReadOnlyDocumentTracker(_encService, _editorAdaptersFactoryService, AllowsReadOnly);
                 }
 
                 string outputPath = _vsProject.TryGetObjOutputPath();
@@ -288,6 +286,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             {
                 throw ExceptionUtilities.Unreachable;
             }
+        }
+
+        private bool AllowsReadOnly(DocumentId documentId)
+        {
+            // All documents of regular running projects are read-only until the debugger breaks the app.
+            // However, ASP.NET doesn’t want its views (aspx, cshtml, or vbhtml) to be read-only, so they can be editable
+            // while the code is running and get refreshed next time the web page is hit.
+            
+            // Note that Razor-like views are modelled as a ContainedDocument but normal code including code-behind are modelled as a StandradTextDocument.
+            var containedDocument = _vsProject.VisualStudioWorkspace.GetHostDocument(documentId) as ContainedDocument;
+            return containedDocument == null;
         }
 
         public int StopDebuggingPE()

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -1,0 +1,97 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Text
+Imports Roslyn.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
+    Friend Class EditAndContinueTestHelper
+
+        Shared Function CreateTestWorkspace() As TestWorkspace
+            ' create workspace
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document FilePath="Test.cs">
+                                        class Foo { }
+                                    </Document>
+                           </Project>
+                       </Workspace>
+            Return TestWorkspaceFactory.CreateWorkspace(test)
+        End Function
+
+        Public Class TestDiagnosticAnalyzerService
+            Implements IDiagnosticAnalyzerService, IDiagnosticUpdateSource
+
+            Private ReadOnly data As ImmutableArray(Of DiagnosticData)
+
+            Public Sub New()
+            End Sub
+
+            Public Sub New(data As ImmutableArray(Of DiagnosticData))
+                Me.data = data
+            End Sub
+
+            Public ReadOnly Property SupportGetDiagnostics As Boolean Implements IDiagnosticUpdateSource.SupportGetDiagnostics
+                Get
+                    Return True
+                End Get
+            End Property
+
+            Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticUpdateSource.DiagnosticsUpdated
+
+            Public Function GetDiagnostics(workspace As Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, cancellationToken As CancellationToken) As ImmutableArray(Of DiagnosticData) Implements IDiagnosticUpdateSource.GetDiagnostics
+                Return data
+            End Function
+
+            Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing) Implements IDiagnosticAnalyzerService.Reanalyze
+            End Sub
+
+            Public Function GetDiagnosticDescriptors(projectOpt As Project) As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors
+                Return ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)).Empty
+            End Function
+
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+                Return Task.FromResult(SpecializedCollections.EmptyEnumerable(Of DiagnosticData))
+            End Function
+
+            Public Function TryAppendDiagnosticsForSpanAsync(document As Document, range As TextSpan, diagnostics As List(Of DiagnosticData), cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDiagnosticAnalyzerService.TryAppendDiagnosticsForSpanAsync
+                Return Task.FromResult(False)
+            End Function
+
+            Public Function GetSpecificCachedDiagnosticsAsync(workspace As Workspace, id As Object, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetSpecificCachedDiagnosticsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetCachedDiagnosticsAsync(workspace As Workspace, Optional projectId As ProjectId = Nothing, Optional documentId As DocumentId = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetCachedDiagnosticsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetSpecificDiagnosticsAsync(solution As Solution, id As Object, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetSpecificDiagnosticsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetDiagnosticsAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional documentId As DocumentId = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetDiagnosticsForIdsAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional documentId As DocumentId = Nothing, Optional diagnosticIds As ImmutableHashSet(Of String) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForIdsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetProjectDiagnosticsForIdsAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional diagnosticIds As ImmutableHashSet(Of String) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetProjectDiagnosticsForIdsAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
+            End Function
+
+            Public Function GetDiagnosticDescriptors(analyzer As DiagnosticAnalyzer) As ImmutableArray(Of DiagnosticDescriptor) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors
+                Return ImmutableArray(Of DiagnosticDescriptor).Empty
+            End Function
+        End Class
+
+    End Class
+
+End Namespace

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.vb
@@ -1,0 +1,123 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
+Imports Roslyn.Test.Utilities
+Imports Roslyn.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
+    Public Class EditAndContinueWorkspaceServiceTests
+        <Fact>
+        Public Sub ReadOnlyDocumentTest()
+            Dim diagnosticService As IDiagnosticAnalyzerService = New EditAndContinueTestHelper.TestDiagnosticAnalyzerService()
+            Dim encService As IEditAndContinueWorkspaceService = New EditAndContinueWorkspaceService(diagnosticService)
+            Dim workspace = EditAndContinueTestHelper.CreateTestWorkspace()
+            Dim currentSolution = workspace.CurrentSolution
+            Dim project = currentSolution.Projects(0)
+
+            Dim sessionReason As SessionReadOnlyReason
+            Dim projectReason As ProjectReadOnlyReason
+            Dim isReadOnly As Boolean
+
+            ' not yet start
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+
+            Assert.Equal(ProjectReadOnlyReason.None, projectReason)
+            Assert.Equal(SessionReadOnlyReason.None, sessionReason)
+            Assert.Equal(False, isReadOnly)
+
+            ' run mode 
+            encService.StartDebuggingSession(workspace.CurrentSolution)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+
+            Assert.Equal(ProjectReadOnlyReason.None, projectReason)
+            Assert.Equal(SessionReadOnlyReason.Running, sessionReason)
+            Assert.Equal(True, isReadOnly)
+
+            ' edit mode
+            Dim activeStatement = New Dictionary(Of DocumentId, ImmutableArray(Of ActiveStatementSpan))()
+            Dim projectStates = ImmutableArray.Create(Of KeyValuePair(Of ProjectId, ProjectReadOnlyReason))(New KeyValuePair(Of ProjectId, ProjectReadOnlyReason)(project.Id, ProjectReadOnlyReason.None))
+
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            Assert.Equal(ProjectReadOnlyReason.None, projectReason)
+            Assert.Equal(SessionReadOnlyReason.None, sessionReason)
+            Assert.Equal(False, isReadOnly)
+
+            ' end edit session
+            encService.EndEditSession()
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            Assert.Equal(ProjectReadOnlyReason.None, projectReason)
+            Assert.Equal(SessionReadOnlyReason.Running, sessionReason)
+            Assert.Equal(True, isReadOnly)
+
+            ' break mode and stop at exception
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=True)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            Assert.Equal(ProjectReadOnlyReason.None, projectReason)
+            Assert.Equal(SessionReadOnlyReason.StoppedAtException, sessionReason)
+            Assert.Equal(True, isReadOnly)
+        End Sub
+
+        <Fact>
+        Public Sub NotLoadedTest()
+            Dim diagnosticService As IDiagnosticAnalyzerService = New EditAndContinueTestHelper.TestDiagnosticAnalyzerService()
+            Dim encService As IEditAndContinueWorkspaceService = New EditAndContinueWorkspaceService(diagnosticService)
+            Dim workspace = EditAndContinueTestHelper.CreateTestWorkspace()
+            Dim currentSolution = workspace.CurrentSolution
+            Dim project = currentSolution.Projects(0)
+
+            Dim sessionReason As SessionReadOnlyReason
+            Dim projectReason As ProjectReadOnlyReason
+            Dim isReadOnly As Boolean
+
+            ' run mode 
+            encService.StartDebuggingSession(workspace.CurrentSolution)
+
+            ' edit mode
+            Dim activeStatement = New Dictionary(Of DocumentId, ImmutableArray(Of ActiveStatementSpan))()
+            Dim projectStates = ImmutableArray.Create(Of KeyValuePair(Of ProjectId, ProjectReadOnlyReason))(New KeyValuePair(Of ProjectId, ProjectReadOnlyReason)(project.Id, ProjectReadOnlyReason.NotLoaded))
+
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            Assert.Equal(ProjectReadOnlyReason.NotLoaded, projectReason)
+            Assert.Equal(SessionReadOnlyReason.None, sessionReason)
+            Assert.Equal(True, isReadOnly)
+        End Sub
+
+        <Fact>
+        Public Sub MetaDataNotAvailableTest()
+            Dim diagnosticService As IDiagnosticAnalyzerService = New EditAndContinueTestHelper.TestDiagnosticAnalyzerService()
+            Dim encService As IEditAndContinueWorkspaceService = New EditAndContinueWorkspaceService(diagnosticService)
+            Dim workspace = EditAndContinueTestHelper.CreateTestWorkspace()
+            Dim currentSolution = workspace.CurrentSolution
+            Dim project = currentSolution.Projects(0)
+
+            Dim sessionReason As SessionReadOnlyReason
+            Dim projectReason As ProjectReadOnlyReason
+            Dim isReadOnly As Boolean
+
+            ' run mode 
+            encService.StartDebuggingSession(workspace.CurrentSolution)
+
+            ' edit mode with empty project
+            Dim activeStatement = New Dictionary(Of DocumentId, ImmutableArray(Of ActiveStatementSpan))()
+            Dim projectStates = ImmutableDictionary.Create(Of ProjectId, ProjectReadOnlyReason)
+
+            encService.StartEditSession(currentSolution, activeStatement, projectStates, stoppedAtException:=False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            Assert.Equal(ProjectReadOnlyReason.MetadataNotAvailable, projectReason)
+            Assert.Equal(SessionReadOnlyReason.None, sessionReason)
+            Assert.Equal(True, isReadOnly)
+        End Sub
+    End Class
+
+End Namespace

--- a/src/VisualStudio/Core/Test/EditAndContinue/VsReadOnlyDocumentTrackerTests.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/VsReadOnlyDocumentTrackerTests.vb
@@ -1,0 +1,302 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
+Imports Microsoft.VisualStudio.Editor
+Imports Microsoft.VisualStudio.OLE.Interop
+Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.TextManager.Interop
+Imports Microsoft.VisualStudio.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
+
+    Public Class VsReadOnlyDocumentTrackerTests
+        <Fact>
+        Public Sub StandardTextDocumentTest()
+            Dim diagnosticService As IDiagnosticAnalyzerService = New EditAndContinueTestHelper.TestDiagnosticAnalyzerService()
+            Dim encService As IEditAndContinueWorkspaceService = New EditAndContinueWorkspaceService(diagnosticService)
+            Dim workspace = EditAndContinueTestHelper.CreateTestWorkspace()
+            Dim currentSolution = workspace.CurrentSolution
+            Dim project = currentSolution.Projects(0)
+
+            Dim mockVsBuffer = New VsTextBufferMock()
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags)
+
+            Dim mockEditorAdaptersFactoryService = New VsEditorAdaptersFactoryServiceMock(mockVsBuffer)
+            Dim readOnlyDocumentTracker As VsReadOnlyDocumentTracker
+
+            Dim sessionReason As SessionReadOnlyReason
+            Dim projectReason As ProjectReadOnlyReason
+            Dim isReadOnly As Boolean
+
+            ' start debugging
+            encService.StartDebuggingSession(workspace.CurrentSolution)
+            readOnlyDocumentTracker = New VsReadOnlyDocumentTracker(encService, mockEditorAdaptersFactoryService, allowsReadOnly:=Function(documentId) True)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(1, mockVsBuffer._oldFlags) ' Read-Only
+
+            ' edit mode
+            Dim activeStatement = New Dictionary(Of DocumentId, ImmutableArray(Of ActiveStatementSpan))()
+            Dim projectStates = ImmutableArray.Create(Of KeyValuePair(Of ProjectId, ProjectReadOnlyReason))(New KeyValuePair(Of ProjectId, ProjectReadOnlyReason)(project.Id, ProjectReadOnlyReason.None))
+
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
+
+            ' end edit session
+            encService.EndEditSession()
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(1, mockVsBuffer._oldFlags) ' Read-Only
+
+            ' break mode and stop at exception
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=True)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(1, mockVsBuffer._oldFlags) ' Read-Only
+        End Sub
+
+        <Fact>
+        Public Sub ContainedDocumentTest()
+            Dim diagnosticService As IDiagnosticAnalyzerService = New EditAndContinueTestHelper.TestDiagnosticAnalyzerService()
+            Dim encService As IEditAndContinueWorkspaceService = New EditAndContinueWorkspaceService(diagnosticService)
+            Dim workspace = EditAndContinueTestHelper.CreateTestWorkspace()
+            Dim currentSolution = workspace.CurrentSolution
+            Dim project = currentSolution.Projects(0)
+
+            Dim mockVsBuffer = New VsTextBufferMock()
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags)
+
+            Dim mockEditorAdaptersFactoryService = New VsEditorAdaptersFactoryServiceMock(mockVsBuffer)
+            Dim readOnlyDocumentTracker As VsReadOnlyDocumentTracker
+
+            Dim sessionReason As SessionReadOnlyReason
+            Dim projectReason As ProjectReadOnlyReason
+            Dim isReadOnly As Boolean
+
+            ' start debugging
+            encService.StartDebuggingSession(workspace.CurrentSolution)
+            readOnlyDocumentTracker = New VsReadOnlyDocumentTracker(encService, mockEditorAdaptersFactoryService, allowsReadOnly:=Function(documentId) False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
+
+            ' edit mode
+            Dim activeStatement = New Dictionary(Of DocumentId, ImmutableArray(Of ActiveStatementSpan))()
+            Dim projectStates = ImmutableArray.Create(Of KeyValuePair(Of ProjectId, ProjectReadOnlyReason))(New KeyValuePair(Of ProjectId, ProjectReadOnlyReason)(project.Id, ProjectReadOnlyReason.None))
+
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=False)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
+
+            ' end edit session
+            encService.EndEditSession()
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
+
+            ' break mode and stop at exception
+            encService.StartEditSession(currentSolution, activeStatement, projectStates.ToImmutableDictionary(), stoppedAtException:=True)
+            isReadOnly = encService.IsProjectReadOnly(project.Id, sessionReason, projectReason)
+            readOnlyDocumentTracker.SetReadOnly(project.DocumentIds.First(), isReadOnly)
+            Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
+        End Sub
+
+#Region "Helper Methods"
+
+        Public Class VsTextBufferMock
+            Implements IVsTextBuffer
+
+            Public _oldFlags As UInteger = 0
+
+            Public Function GetLanguageServiceID(ByRef pguidLangService As Guid) As Integer Implements IVsTextBuffer.GetLanguageServiceID
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetLastLineIndex(ByRef piLine As Integer, ByRef piIndex As Integer) As Integer Implements IVsTextBuffer.GetLastLineIndex
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetLengthOfLine(iLine As Integer, ByRef piLength As Integer) As Integer Implements IVsTextBuffer.GetLengthOfLine
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetLineCount(ByRef piLineCount As Integer) As Integer Implements IVsTextBuffer.GetLineCount
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetLineIndexOfPosition(iPosition As Integer, ByRef piLine As Integer, ByRef piColumn As Integer) As Integer Implements IVsTextBuffer.GetLineIndexOfPosition
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetPositionOfLine(iLine As Integer, ByRef piPosition As Integer) As Integer Implements IVsTextBuffer.GetPositionOfLine
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetPositionOfLineIndex(iLine As Integer, iIndex As Integer, ByRef piPosition As Integer) As Integer Implements IVsTextBuffer.GetPositionOfLineIndex
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetSize(ByRef piLength As Integer) As Integer Implements IVsTextBuffer.GetSize
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetStateFlags(ByRef pdwReadOnlyFlags As UInteger) As Integer Implements IVsTextBuffer.GetStateFlags
+                pdwReadOnlyFlags = _oldFlags
+                Return 0
+            End Function
+
+            Public Function GetUndoManager(ByRef ppUndoManager As IOleUndoManager) As Integer Implements IVsTextBuffer.GetUndoManager
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function InitializeContent(pszText As String, iLength As Integer) As Integer Implements IVsTextBuffer.InitializeContent
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function LockBuffer() As Integer Implements IVsTextBuffer.LockBuffer
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function LockBufferEx(dwFlags As UInteger) As Integer Implements IVsTextBuffer.LockBufferEx
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reload(fUndoable As Integer) As Integer Implements IVsTextBuffer.Reload
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved1() As Integer Implements IVsTextBuffer.Reserved1
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved10() As Integer Implements IVsTextBuffer.Reserved10
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved2() As Integer Implements IVsTextBuffer.Reserved2
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved3() As Integer Implements IVsTextBuffer.Reserved3
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved4() As Integer Implements IVsTextBuffer.Reserved4
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved5() As Integer Implements IVsTextBuffer.Reserved5
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved6() As Integer Implements IVsTextBuffer.Reserved6
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved7() As Integer Implements IVsTextBuffer.Reserved7
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved8() As Integer Implements IVsTextBuffer.Reserved8
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function Reserved9() As Integer Implements IVsTextBuffer.Reserved9
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function SetLanguageServiceID(ByRef guidLangService As Guid) As Integer Implements IVsTextBuffer.SetLanguageServiceID
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function SetStateFlags(dwReadOnlyFlags As UInteger) As Integer Implements IVsTextBuffer.SetStateFlags
+                _oldFlags = dwReadOnlyFlags
+                Return 0
+            End Function
+
+            Public Function UnlockBuffer() As Integer Implements IVsTextBuffer.UnlockBuffer
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function UnlockBufferEx(dwFlags As UInteger) As Integer Implements IVsTextBuffer.UnlockBufferEx
+                Throw New NotImplementedException()
+            End Function
+        End Class
+
+        Public Class VsEditorAdaptersFactoryServiceMock
+            Implements IVsEditorAdaptersFactoryService
+
+            Dim _buffer As IVsTextBuffer
+            Sub New(buffer As IVsTextBuffer)
+                _buffer = buffer
+            End Sub
+
+            Public Sub SetDataBuffer(bufferAdapter As IVsTextBuffer, dataBuffer As ITextBuffer) Implements IVsEditorAdaptersFactoryService.SetDataBuffer
+                Throw New NotImplementedException()
+            End Sub
+
+            Public Function CreateVsCodeWindowAdapter(serviceProvider As IServiceProvider) As IVsCodeWindow Implements IVsEditorAdaptersFactoryService.CreateVsCodeWindowAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextBufferAdapter(serviceProvider As IServiceProvider) As IVsTextBuffer Implements IVsEditorAdaptersFactoryService.CreateVsTextBufferAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextBufferAdapter(serviceProvider As IServiceProvider, contentType As IContentType) As IVsTextBuffer Implements IVsEditorAdaptersFactoryService.CreateVsTextBufferAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextBufferAdapterForSecondaryBuffer(serviceProvider As IServiceProvider, secondaryBuffer As ITextBuffer) As IVsTextBuffer Implements IVsEditorAdaptersFactoryService.CreateVsTextBufferAdapterForSecondaryBuffer
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextBufferCoordinatorAdapter() As IVsTextBufferCoordinator Implements IVsEditorAdaptersFactoryService.CreateVsTextBufferCoordinatorAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextViewAdapter(serviceProvider As IServiceProvider) As IVsTextView Implements IVsEditorAdaptersFactoryService.CreateVsTextViewAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function CreateVsTextViewAdapter(serviceProvider As IServiceProvider, roles As ITextViewRoleSet) As IVsTextView Implements IVsEditorAdaptersFactoryService.CreateVsTextViewAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetBufferAdapter(textBuffer As ITextBuffer) As IVsTextBuffer Implements IVsEditorAdaptersFactoryService.GetBufferAdapter
+                Return _buffer
+            End Function
+
+            Public Function GetDataBuffer(bufferAdapter As IVsTextBuffer) As ITextBuffer Implements IVsEditorAdaptersFactoryService.GetDataBuffer
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetDocumentBuffer(bufferAdapter As IVsTextBuffer) As ITextBuffer Implements IVsEditorAdaptersFactoryService.GetDocumentBuffer
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetViewAdapter(textView As ITextView) As IVsTextView Implements IVsEditorAdaptersFactoryService.GetViewAdapter
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetWpfTextView(viewAdapter As IVsTextView) As IWpfTextView Implements IVsEditorAdaptersFactoryService.GetWpfTextView
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetWpfTextViewHost(viewAdapter As IVsTextView) As IWpfTextViewHost Implements IVsEditorAdaptersFactoryService.GetWpfTextViewHost
+                Throw New NotImplementedException()
+            End Function
+        End Class
+
+#End Region
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -321,6 +321,9 @@
     <Compile Include="Diagnostics\ExternalDiagnosticUpdateSourceTests.vb" />
     <Compile Include="Diagnostics\TestTableManagerProvider.vb" />
     <Compile Include="Diagnostics\TodoListTableDataSourceTests.vb" />
+    <Compile Include="EditAndContinue\EditAndContinueTestHelper.vb" />
+    <Compile Include="EditAndContinue\EditAndContinueWorkspaceServiceTests.vb" />
+    <Compile Include="EditAndContinue\VsReadOnlyDocumentTrackerTests.vb" />
     <Compile Include="ExtractInterface\ExtractInterfaceViewModelTests.vb" />
     <Compile Include="GenerateType\GenerateTypeViewModelTests.vb" />
     <Compile Include="GoToDefinition\GoToDefinitionApiTests.vb" />


### PR DESCRIPTION
All documents of regular running projects are read-only until the debugger breaks the app. However, Dev12 allows Razor views to be editable while the code is running and get refreshed next time the web page is hit. This PR supports the same behavior as in Dev12 by not setting Razor-like files (cshtml/aspx) read-only.