### PR TITLE
Added suppression attributes for FxCop CA2001:AvoidCallingProblematicMet...

### DIFF
--- a/src/Compilers/Core/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Core/VBCSCompiler/NamedPipeClientConnection.cs
@@ -18,25 +18,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         // This is a value used for logging only, do not depend on this value
         private readonly string _loggingIdentifier;
+        private static int _lastLoggingIdentifier;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", 
-            MessageId = "System.Runtime.InteropServices.DangerousGetHandle", 
-            Justification = "We are using DangerousGetHandle for logging only.")]
         internal NamedPipeClientConnection(NamedPipeServerStream pipeStream)
         {
             _pipeStream = pipeStream;
-
-            try
-            {
-                _loggingIdentifier = _pipeStream.SafePipeHandle.DangerousGetHandle().ToInt32().ToString();
-            }
-            catch (Exception e)
-            {
-                // We shouldn't fail just because we don't have a good logging identifier
-                _loggingIdentifier = new Random().Next().ToString();
-                var msg = string.Format("Pipe {0}: Exception setting logging identifier.", _loggingIdentifier);
-                CompilerServerLogger.LogException(e, msg);
-            }
+            _loggingIdentifier = Interlocked.Increment(ref _lastLoggingIdentifier).ToString();
         }
 
         public string LoggingIdentifier

--- a/src/Compilers/Core/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Core/VBCSCompiler/NamedPipeClientConnection.cs
@@ -19,6 +19,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         // This is a value used for logging only, do not depend on this value
         private readonly string _loggingIdentifier;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", 
+            MessageId = "System.Runtime.InteropServices.DangerousGetHandle", 
+            Justification = "We are using DangerousGetHandle for logging only.")]
         internal NamedPipeClientConnection(NamedPipeServerStream pipeStream)
         {
             _pipeStream = pipeStream;

--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -144,6 +144,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// test framework.  The code hooks <see cref="AppDomain.AssemblyResolve"/> in a way
         /// that prevents xUnit from running correctly and hence must be disabled. 
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", 
+            MessageId = "System.GC.Collect", 
+            Justification ="We intentionally call GC.Collect when anticipate long period on inactivity.")]
         public void ListenAndDispatchConnections(string pipeName, TimeSpan? keepAlive, bool watchAnalyzerFiles, CancellationToken cancellationToken = default(CancellationToken))
         {
             Debug.Assert(SynchronizationContext.Current == null);


### PR DESCRIPTION
...hods warnings

FxCop flagged our use of GC.Collect and System.Runtime.InteropServices.DangerousGetHandle.
The cases seems to be justified uses.

We use GC.Collect when we expect long periods of inactivity. This is the rare case where we might know better than GC that it is a good time to trim garbage.

We use System.Runtime.InteropServices.DangerousGetHandle for logging purposes. Nothing is dependent on the actual value returned.