### PR TITLE
Apply Spacing rules around methodcall inside Attributes

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -73,12 +73,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
         public static bool IsOpenParenInArgumentList(this SyntaxToken token)
         {
-            return token.Kind() == SyntaxKind.OpenParenToken && token.Parent.Kind() == SyntaxKind.ArgumentList;
+            return token.Kind() == SyntaxKind.OpenParenToken &&
+                (token.Parent.IsKind(SyntaxKind.ArgumentList) || token.Parent.IsKind(SyntaxKind.AttributeArgumentList));
         }
 
         public static bool IsCloseParenInArgumentList(this SyntaxToken token)
         {
-            return token.Kind() == SyntaxKind.CloseParenToken && token.Parent.Kind() == SyntaxKind.ArgumentList;
+            return token.Kind() == SyntaxKind.CloseParenToken &&
+                (token.Parent.IsKind(SyntaxKind.ArgumentList) || token.Parent.IsKind(SyntaxKind.AttributeArgumentList));
         }
 
         public static bool IsColonInTypeBaseList(this SyntaxToken token)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6045,5 +6045,42 @@ class Program
             var block = SyntaxFactory.Block();
             Formatter.Format(block, new AdhocWorkspace());
         }
+
+        [WorkItem(776, "https://github.com/dotnet/roslyn/issues/776")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void SpacingRulesAroundMethodCallAndParenthesisAppliedInAttributeNonDefault()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.SpaceAfterMethodCallName, true);
+            changingOptions.Add(CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses, true);
+            changingOptions.Add(CSharpFormattingOptions.SpaceWithinMethodCallParentheses, true);
+            AssertFormat(@"[Obsolete ( ""Test"" ), Obsolete ( )]
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}", @"[Obsolete(""Test""), Obsolete()]
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}", false, changingOptions);
+        }
+
+        [WorkItem(776, "https://github.com/dotnet/roslyn/issues/776")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void SpacingRulesAroundMethodCallAndParenthesisAppliedInAttribute()
+        {
+            var code = @"[Obsolete(""Test""), Obsolete()]
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}";
+            AssertFormat(code, code);
+        }
     }
 }


### PR DESCRIPTION
Fix #776 : Apply spacing rules around method call inside attributes as
well