### PR TITLE
Support VSHPROPID_ActiveIntellisenseProjectContext

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -495,11 +495,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             uint itemid;
             RunningDocumentTable.GetDocumentHierarchyItem(docCookie, out hierarchy, out itemid);
 
-            // If it belongs to a Shared Code project, then the current context is determined 
-            // by the SharedItemContextHierarchy.
-            var hierarchyOwningDocument = LinkedFileUtilities.GetSharedItemContextHierarchy(hierarchy) ?? hierarchy;
+            // If it belongs to a Shared Code or ASP.NET 5 project, then find the correct host project
+            var hostProject = LinkedFileUtilities.GetContextHostProject(hierarchy, _projectContainer);
 
-            return documentKey.HostProject.Hierarchy == hierarchyOwningDocument;
+            return documentKey.HostProject == hostProject;
         }
 
         public IDisposable ProvideDocumentIdHint(string filePath, DocumentId documentId)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/HierarchyEventsSink.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/HierarchyEventsSink.cs
@@ -24,9 +24,10 @@ namespace Roslyn.VisualStudio.ProjectSystem
 
         public int OnPropertyChanged(uint itemid, int propid, uint flags)
         {
-            if (propid == (int)__VSHPROPID7.VSHPROPID_SharedItemContextHierarchy)
+            if (propid == (int)__VSHPROPID7.VSHPROPID_SharedItemContextHierarchy ||
+                propid == (int)__VSHPROPID8.VSHPROPID_ActiveIntellisenseProjectContext)
             {
-                _workspace.UpdateContextHierarchyIfContainsDocument(_sharedHierarchy, _documentId);
+                _workspace.UpdateDocumentContextIfContainsDocument(_sharedHierarchy, _documentId);
                 return VSConstants.S_OK;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         string Language { get; }
         IVsHierarchy Hierarchy { get; }
         Workspace Workspace { get; }
+        string ProjectSystemName { get; }
 
         IVisualStudioHostDocument GetDocumentOrAdditionalDocument(DocumentId id);
         IVisualStudioHostDocument GetCurrentDocumentFromPath(string filePath);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.HostProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.HostProject.cs
@@ -71,6 +71,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 get { return _workspace; }
             }
 
+            public string ProjectSystemName
+            {
+                get { return "MiscellaneousFiles"; }
+            }
+
             public IVisualStudioHostDocument GetDocumentOrAdditionalDocument(DocumentId id)
             {
                 if (id == this.Document.Id)


### PR DESCRIPTION
ASP.NET 5 supports switching between target platforms in the IDE via a new hierarchy property, "VSHPROPID_ActiveIntellisenseProjectContext". We now consider this property when determining or setting the active document context and also listen to its hierarchy event.

Fixes #164