### PR TITLE
log when VS has hit low memory barrier

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -4,6 +4,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -50,8 +51,13 @@ namespace Microsoft.VisualStudio.LanguageServices
             {
                 case VSConstants.VSM_VIRTUALMEMORYLOW:
                 case VSConstants.VSM_VIRTUALMEMORYCRITICAL:
-                    _workspaceCacheService.FlushCaches();
-                    break;
+                    {
+                        // record that we had hit critical memory barrier
+                        Logger.Log(FunctionId.VirtualMemory_MemoryLow, KeyValueLogMessage.Create(m => m["Memory"] = msg));
+
+                        _workspaceCacheService.FlushCaches();
+                        break;
+                    }
             }
 
             return VSConstants.S_OK;

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -297,6 +297,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Tagger_Diagnostics_Updated,
         SuggestedActions_HasSuggestedActionsAsync,
         SuggestedActions_GetSuggestedActions,
-        AnalyzerDependencyCheckingService_CheckForConflictsAsync
+        AnalyzerDependencyCheckingService_CheckForConflictsAsync,
+        VirtualMemory_MemoryLow
     }
 }


### PR DESCRIPTION
we have a safe switch where we flush all internal caches when VS hits certain low memory barrier. this let us to see how often we hit that barrier