### PR TITLE
Load analyzer satellite assemblies

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -210,6 +210,30 @@ Delta: Gamma: Beta: Test B
             Assert.Equal(AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToCreateAnalyzer, errors.First().ErrorCode);
         }
 
+        [Fact]
+        public void AssemblyPathHelper_NeutralCultureAssembly()
+        {
+            string directoryPath = @"C:\Alpha\Beta";
+            AssemblyIdentity assemblyIdentity = new AssemblyIdentity("Gamma");
+
+            string expected = @"C:\Alpha\Beta\Gamma.dll";
+            string actual = AnalyzerFileReference.AssemblyPathHelper.GetCandidatePath(directoryPath, assemblyIdentity);
+
+            Assert.Equal(expected, actual, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void AssemblyPathHelper_AssemblyWithCulture()
+        {
+            string directoryPath = @"C:\Alpha\Beta";
+            AssemblyIdentity assemblyIdentity = new AssemblyIdentity(name: "Gamma", cultureName: "fr-FR");
+
+            string expected = @"C:\Alpha\Beta\fr-FR\Gamma.dll";
+            string actual = AnalyzerFileReference.AssemblyPathHelper.GetCandidatePath(directoryPath, assemblyIdentity);
+
+            Assert.Equal(expected, actual, StringComparer.OrdinalIgnoreCase);
+        }
+
         [DiagnosticAnalyzer(LanguageNames.CSharp, new string[] { LanguageNames.VisualBasic })]
         public class TestAnalyzer : DiagnosticAnalyzer
         {

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.AssemblyPathHelper.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.AssemblyPathHelper.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    public partial class AnalyzerFileReference
+    {
+        internal static class AssemblyPathHelper
+        {
+            internal static string GetCandidatePath(string baseDirectory, AssemblyIdentity assemblyIdentity)
+            {
+                if (!string.IsNullOrEmpty(assemblyIdentity.CultureName))
+                {
+                    baseDirectory = Path.Combine(baseDirectory, assemblyIdentity.CultureName);
+                }
+
+                return Path.Combine(baseDirectory, assemblyIdentity.Name + ".dll");
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
@@ -202,6 +202,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     foreach (string loadedAssemblyFullPath in s_assembliesFromFiles.Keys)
                     {
                         string directoryPath = Path.GetDirectoryName(loadedAssemblyFullPath);
+
+                        if (!string.IsNullOrEmpty(requestedAssemblyIdentity.CultureName))
+                        {
+                            directoryPath = Path.Combine(directoryPath, requestedAssemblyIdentity.CultureName);
+                        }
+
                         string candidateAssemblyFullPath = Path.Combine(directoryPath, requestedAssemblyIdentity.Name + ".dll");
 
                         AssemblyIdentity candidateAssemblyIdentity = TryGetAssemblyIdentity(candidateAssemblyFullPath);
@@ -258,6 +264,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
 
                     string directoryPath = Path.GetDirectoryName(requestingAssemblyFullPath);
+
+                    if (!string.IsNullOrEmpty(assemblyIdentity.CultureName))
+                    {
+                        directoryPath = Path.Combine(directoryPath, assemblyIdentity.CultureName);
+                    }
+
                     string assemblyFullPath = Path.Combine(directoryPath, assemblyIdentity.Name + ".dll");
                     if (!File.Exists(assemblyFullPath))
                     {

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.InMemoryAssemblyLoader.cs
@@ -203,12 +203,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         string directoryPath = Path.GetDirectoryName(loadedAssemblyFullPath);
 
-                        if (!string.IsNullOrEmpty(requestedAssemblyIdentity.CultureName))
-                        {
-                            directoryPath = Path.Combine(directoryPath, requestedAssemblyIdentity.CultureName);
-                        }
-
-                        string candidateAssemblyFullPath = Path.Combine(directoryPath, requestedAssemblyIdentity.Name + ".dll");
+                        string candidateAssemblyFullPath = AssemblyPathHelper.GetCandidatePath(directoryPath, requestedAssemblyIdentity);
 
                         AssemblyIdentity candidateAssemblyIdentity = TryGetAssemblyIdentity(candidateAssemblyFullPath);
 
@@ -264,13 +259,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
 
                     string directoryPath = Path.GetDirectoryName(requestingAssemblyFullPath);
-
-                    if (!string.IsNullOrEmpty(assemblyIdentity.CultureName))
-                    {
-                        directoryPath = Path.Combine(directoryPath, assemblyIdentity.CultureName);
-                    }
-
-                    string assemblyFullPath = Path.Combine(directoryPath, assemblyIdentity.Name + ".dll");
+                    string assemblyFullPath = AssemblyPathHelper.GetCandidatePath(directoryPath, assemblyIdentity);
                     if (!File.Exists(assemblyFullPath))
                     {
                         return null;

--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -49,6 +49,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AdditionalTextFile.cs" />
+    <Compile Include="AnalyzerFileReference.AssemblyPathHelper.cs" />
     <Compile Include="AnalyzerLoadFailureEventArgs.cs" />
     <Compile Include="AssemblyReferenceResolver.cs" />
     <Compile Include="CodeAnalysisDesktopResources.Designer.cs">


### PR DESCRIPTION
Analyzers support localized strings for titles, messages, descriptions,
etc. through the `LocalizableString` types. The localized strings will
generally end up in a set of "satellite" assemblies ending in
.resources.dll, one per culture. For example, if your analyzer is in an
assembly "MyAnalyzer" and you provided localized strings for French
(e.g., the fr-FR culture) then the build will typically produce
bin\Debug\MyAnalyzer.dll and bin\Debug\fr-FR\MyAnalyzer.resources.dll.

However, we currently have no way to find these satellite assemblies
when the CLR asks for them via the `AppDomain.AssemblyResolve` event, so
we never actually output localized strings from analyzers. The fix is to
simply look for the assemblies in culture-specific directories next to
the analyzer.