### PR TITLE
Indent VB Comments for empty case blocks

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
@@ -148,9 +148,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             End If
 
             Dim caseBlock = TryCast(node, CaseBlockSyntax)
-            If caseBlock IsNot Nothing AndAlso pair.Item2.GetNextToken().IsKind(SyntaxKind.CaseKeyword) Then
-                AddIndentBlockOperation(operations, pair.Item1, pair.Item2, dontIncludeNextTokenTrailingTrivia:=True)
-                Return
+            If caseBlock IsNot Nothing Then
+                Dim nextTokenAfterCase = pair.Item2.GetNextToken()
+                If nextTokenAfterCase.IsKind(SyntaxKind.CaseKeyword) Then
+                    ' Make sure the comments in the empty case block are indented
+                    If caseBlock.Statements.Count = 0 Then
+                        Dim caseBlockLastToken = caseBlock.GetLastToken()
+                        operations.Add(FormattingOperations.CreateIndentBlockOperation(caseBlockLastToken, nextTokenAfterCase, TextSpan.FromBounds(caseBlockLastToken.Span.End, nextTokenAfterCase.SpanStart), 1, IndentBlockOption.RelativePosition))
+                        Return
+                    End If
+
+                    AddIndentBlockOperation(operations, pair.Item1, pair.Item2, dontIncludeNextTokenTrailingTrivia:=True)
+                    Return
+                End If
             End If
 
             AddIndentBlockOperation(operations, pair.Item1, pair.Item2)

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4203,5 +4203,42 @@ End Class
             AssertFormatLf2CrLf(text.Value, expected.Value)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
+        Public Sub EmptyCaseBlockCommentGetsIndented()
+            Dim text = <Code>
+Class Program
+    Sub Main(args As String())
+        Dim s = 0
+        Select Case s
+            Case 0
+            ' Comment should be indented
+            Case 2
+                ' comment
+                Console.WriteLine(s)
+            Case 4
+        End Select
+    End Sub
+End Class
+</Code>
+
+            Dim expected = <Code>
+Class Program
+    Sub Main(args As String())
+        Dim s = 0
+        Select Case s
+            Case 0
+                ' Comment should be indented
+            Case 2
+                ' comment
+                Console.WriteLine(s)
+            Case 4
+        End Select
+    End Sub
+End Class
+</Code>
+
+            AssertFormatLf2CrLf(text.Value, expected.Value)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fix #1177: Indent VB Comments for empty case blocks