### PR TITLE
Fix customer build / test scenario

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -11,7 +11,7 @@
        use a 2013 compatible solution. -->
   <PropertyGroup>
     <RoslynSolution>$(MSBuildThisFileDirectory)\Src\Roslyn.sln</RoslynSolution>
-    <RoslynSolution Condition="'$(CIBuild)' == 'true'">$(MSBuildThisFileDirectory)\Src\RoslynLight.sln</RoslynSolution>
+    <RoslynSolution Condition="'$(PublicBuild)' == 'true'">$(MSBuildThisFileDirectory)\Src\RoslynLight.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <RunTestArgs></RunTestArgs>
     <RunTestArgs Condition="'$(Test64)' == 'true'">-test64</RunTestArgs>
@@ -48,17 +48,26 @@
 
   <Target Name="Test">
 
-    <ItemGroup Condition="'$(CIBuild)' == ''">
+    <ItemGroup Condition="'$(PublicBuild)' == ''">
       <TestAssemblies 
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
         Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll" />
     </ItemGroup>
 
     <!-- The Microsoft.CodeAnalysis.Scripting.UnitTests.dll is disabled due to https://github.com/dotnet/roslyn/issues/860 -->
-    <ItemGroup Condition="'$(CIBuild)' == 'true'">
+    <ItemGroup Condition="'$(PublicBuild)' == 'true'">
       <TestAssemblies 
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
-        Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;Binaries\$(Configuration)\*ResultProvider*.UnitTests.dll;Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll" />
+        Exclude="
+        Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;
+        Binaries\$(Configuration)\*ResultProvider*.UnitTests.dll;
+        Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.Services.Editor.UnitTests2.dll;
+        Binaries\$(Configuration)\Roslyn.Services.Editor.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.Services.Editor.VisualBasic.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.Services.Editor.CSharp.UnitTests.dll;" />
     </ItemGroup>
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(RunTestArgs) @(TestAssemblies, ' ')" />

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -11,7 +11,7 @@
        use a 2013 compatible solution. -->
   <PropertyGroup>
     <RoslynSolution>$(MSBuildThisFileDirectory)\Src\Roslyn.sln</RoslynSolution>
-    <RoslynSolution Condition="'$(PublicBuild)' == 'true'">$(MSBuildThisFileDirectory)\Src\RoslynLight.sln</RoslynSolution>
+    <RoslynSolution Condition="'$(PublicBuild)' == 'true' OR '$(CIBuild)' == 'true'">$(MSBuildThisFileDirectory)\Src\RoslynLight.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <RunTestArgs></RunTestArgs>
     <RunTestArgs Condition="'$(Test64)' == 'true'">-test64</RunTestArgs>

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -48,14 +48,25 @@
 
   <Target Name="Test">
 
-    <ItemGroup Condition="'$(PublicBuild)' == ''">
+    <ItemGroup Condition="'$(PublicBuild)' == '' AND '$(CIBuild)' == ''">
       <TestAssemblies 
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
         Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(PublicBuild)' == '' AND '$(CIBuild)' == 'true'">
+      <TestAssemblies 
+        Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
+        Exclude="
+        Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;
+        Binaries\$(Configuration)\*ResultProvider*.UnitTests.dll;
+        Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests.dll;
+        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests.dll;" />
+    </ItemGroup>
+
     <!-- The Microsoft.CodeAnalysis.Scripting.UnitTests.dll is disabled due to https://github.com/dotnet/roslyn/issues/860 -->
-    <ItemGroup Condition="'$(PublicBuild)' == 'true'">
+    <ItemGroup Condition="'$(PublicBuild)' == 'true' AND '$(CIBuild)' == ''">
       <TestAssemblies 
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
         Exclude="


### PR DESCRIPTION
This fixes the build and test scenario for customers who are running
CTP6.  Previously Jenkins had only been running CTPs but recently we
moved it to a newer drop.  Our code was updated at the same time to take
advantage of this drop and hence tests no longer fully ran on CTP6.

This change fixes by adding the new build flag PublicBuild.  This build
flag is intended to track the latest public available version of Visual
Studio meaning customers can verify their changes by running:

> msbuild /v:m /m BuildAndTest.proj /p:PublicBuild=true

The CIBuild flag remains to ensure we generate XML output files on
failure.  This format can be consumed by Jenkins to produce better
output and diagnostics.

closes #1275