### PR TITLE
Convert FakeSign to a NuGet reference

### DIFF
--- a/build/VSL.Imports.Closed.targets
+++ b/build/VSL.Imports.Closed.targets
@@ -70,7 +70,6 @@
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
     
-    <Message Text="Fake Sign Assembly" />
     <Exec Command="$(FakeSignToolPath) &quot;@(IntermediateAssembly)&quot;" />
     
   </Target>

--- a/build/VSL.Imports.Closed.targets
+++ b/build/VSL.Imports.Closed.targets
@@ -70,7 +70,8 @@
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
     
-    <Exec Command="$(VSLOutDir)\FakeSign.exe &quot;@(IntermediateAssembly)&quot;" />
+    <Message Text="Fake Sign Assembly" />
+    <Exec Command="$(FakeSignToolPath) &quot;@(IntermediateAssembly)&quot;" />
     
   </Target>
 

--- a/build/VSL.Settings.Closed.targets
+++ b/build/VSL.Settings.Closed.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <CopyVSReferencesToOutput>True</CopyVSReferencesToOutput>
     <AuthenticodeCertificateName>MicrosoftSHA1</AuthenticodeCertificateName>
+    <FakeSignToolPath>$(MSBuildThisFileDirectory)..\packages\FakeSign.0.9.2\tools\FakeSign.exe</FakeSignToolPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DevEnvDir)' == ''">

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -3,4 +3,5 @@
 <packages>
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc2-20150313-01" targetFramework="net45" />
   <package id="Microsoft.Net.RoslynDiagnostics" version="1.0.0-rc2-20150313-01" targetFramework="net45" />
+  <package id="FakeSign" version="0.9.2" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Source/Concord/Concord.csproj
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Concord.csproj
@@ -44,7 +44,7 @@
           Inputs="@(ConcordAssemblies->'$(ConcordDir)%(Identity).NetFX20.il')"
           Outputs="$(OutDir)%(Identity).dll">
     <Exec Command="$(MSBuildFrameworkToolsPath)ilasm.exe /dll /quiet /mdv:v2.0.50727 &quot;/output:$(OutDir)@(ConcordAssemblies).dll&quot; $(ConcordDir)@(ConcordAssemblies).NetFX20.il" />
-    <Exec Command="$(VSLOutDir)\FakeSign.exe &quot;$(OutDir)@(ConcordAssemblies).dll&quot;" />
+    <Exec Command="$(FakeSignToolPath) &quot;$(OutDir)@(ConcordAssemblies).dll&quot;" />
   </Target>
   <Target Name="IlasmPortable" 
           AfterTargets="CoreCompile"
@@ -52,7 +52,7 @@
           Outputs="$(OutDir)Phone\%(Identity).dll">
     <MakeDir Directories="$(OutDir)Phone" />
     <Exec Command="$(MSBuildFrameworkToolsPath)ilasm.exe /dll /quiet &quot;/output:$(OutDir)Phone\@(ConcordAssemblies).dll&quot; $(ConcordDir)@(ConcordAssemblies).Portable.il" />
-    <Exec Command="$(VSLOutDir)\FakeSign.exe &quot;$(OutDir)Phone\@(ConcordAssemblies).dll&quot;" />
+    <Exec Command="$(FakeSignToolPath) &quot;$(OutDir)Phone\@(ConcordAssemblies).dll&quot;" />
   </Target>
   <Target Name="CleanIlasmOutputs" AfterTargets="Clean">
     <Delete Files="@(ConcordAssemblies->'$(OutDir)%(Identity).dll')" />

--- a/src/Tools/Source/FakeSign/FakeSign.nuspec
+++ b/src/Tools/Source/FakeSign/FakeSign.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>FakeSign</id>
+    <version>0.9.2</version>
+    <title>FakeSign</title>
+    <authors>Roslyn</authors>
+    <owners>Roslyn</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>https://github.com/dotnet/roslyn/tree/master/src/Tools/Source/FakeSign</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A tool for OSS / fake signing .NET binaries</description>
+  </metadata>
+  <files>
+    <file src="FakeSign.exe" target="tools" />
+    <file src="System.Collections.Immutable.dll" target="tools" />
+    <file src="System.Reflection.Metadata.dll" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
Lately our developer builds have gotten a bit flaky due to the
dependency on FakeSign.  This is both a tool we create and consume
during build.  In order to do this properly every tool which depends on
FakeSign should list it as a dependency.  This ensures it will be built
before the project which consumes it.

Unfortunately this is not the case.  Virtually nothing lists it as a
dependency and hence we are often broken during build due to ordering
issues.  This fixes the problem by hosting FakeSign as a NuGet package.

Note: the long term plan is to have the compiler support oss signing
directly from the command line.  At that point the majority of our
projects will employ fake / oss signing via a command line switch.  The
FakeSign tool will still be necessary for IL projects like Concord
though hence this is not wasted work.