### PR TITLE
Use TryGetValue when looking up cached SyntaxContexts

### DIFF
--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -297,9 +297,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             lock (s_cacheGate)
             {
-                if (s_cachedDocuments[document] != null)
+                Task<AbstractSyntaxContext> cachedContext;
+                if (s_cachedDocuments.TryGetValue(document, out cachedContext) && cachedContext != null)
                 {
-                    return s_cachedDocuments[document];
+                    return cachedContext;
                 }
             }
 


### PR DESCRIPTION
A Document might not already be present as a key which will of course throw KeyNotFound