### PR TITLE
Qualify member accesses with type name in nameof

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -2901,5 +2901,107 @@ internal abstract partial class AbstractReferenceFinder<TSymbol> : IReferenceFin
                 result.AssertLabeledSpansAre("unresolved2", type:=RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub
+
+        <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MemberQualificationInNameOfUsesTypeName_StaticReferencingInstance()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class C
+{
+    static void F(int [|$$z|])
+    {
+        string x = nameof({|ref:zoo|});
+    }
+
+    int zoo;
+}
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="zoo")
+
+                result.AssertLabeledSpansAre("ref", "string x = nameof(C.zoo);", RelatedLocationType.ResolvedNonReferenceConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingStatic()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class C
+{
+    void F(int [|$$z|])
+    {
+        string x = nameof({|ref:zoo|});
+    }
+
+    static int zoo;
+}
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="zoo")
+
+                result.AssertLabeledSpansAre("ref", "string x = nameof(C.zoo);", RelatedLocationType.ResolvedNonReferenceConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class C
+{
+    void F(int [|$$z|])
+    {
+        string x = nameof({|ref:zoo|});
+    }
+
+    int zoo;
+}
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="zoo")
+
+                result.AssertLabeledSpansAre("ref", "string x = nameof(C.zoo);", RelatedLocationType.ResolvedNonReferenceConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MemberQualificationInNameOfMethodInvocationUsesThisDot()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class C
+{
+    int zoo;
+
+    void F(int [|$$z|])
+    {
+        string x = nameof({|ref:zoo|});
+    }
+
+    void nameof(int x) { }
+}
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="zoo")
+
+                result.AssertLabeledSpansAre("ref", "string x = nameof(this.zoo);", RelatedLocationType.ResolvedNonReferenceConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2805,6 +2805,72 @@ End Class
                     AssertTokenRenamable(workspace)
                 End Using
             End Sub
+
+            <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub MemberQualificationInNameOfUsesTypeName_StaticReferencingInstance()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C
+    Shared Sub F([|$$z|] As Integer)
+        Dim x = NameOf({|ref:zoo|})
+    End Sub
+
+    Dim zoo As Integer
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="zoo")
+
+                    result.AssertLabeledSpansAre("ref", "Dim x = NameOf(C.zoo)", RelatedLocationType.ResolvedNonReferenceConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingStatic()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C
+    Sub F([|$$z|] As Integer)
+        Dim x = NameOf({|ref:zoo|})
+    End Sub
+
+    Shared zoo As Integer
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="zoo")
+
+                    result.AssertLabeledSpansAre("ref", "Dim x = NameOf(C.zoo)", RelatedLocationType.ResolvedNonReferenceConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
+                            <Document>
+Class C
+    Sub F([|$$z|] As Integer)
+        Dim x = NameOf({|ref:zoo|})
+    End Sub
+
+    Dim zoo As Integer
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="zoo")
+
+                    result.AssertLabeledSpansAre("ref", "Dim x = NameOf(C.zoo)", RelatedLocationType.ResolvedNonReferenceConflict)
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -2723,7 +2723,7 @@ End Class
 
         <WorkItem(866094)>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub Bug866094_DaveTest()
+        Public Sub Bug866094()
             Using result = RenameEngineResult.Create(
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Rename;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -507,7 +508,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     symbol.Kind == SymbolKind.Field ||
                     symbol.Kind == SymbolKind.Property)
                 {
-                    if (symbol.IsStatic || originalSimpleName.IsParentKind(SyntaxKind.NameMemberCref))
+                    if (symbol.IsStatic ||
+                        originalSimpleName.IsParentKind(SyntaxKind.NameMemberCref) ||
+                        _semanticModel.SyntaxTree.IsNameOfContext(originalSimpleName.SpanStart, _semanticModel, _cancellationToken))
                     {
                         newNode = FullyQualifyIdentifierName(
                             symbol,

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Rename
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
     Partial Friend Class VisualBasicSimplificationService
@@ -554,7 +555,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                    symbol.Kind = SymbolKind.Field OrElse
                    symbol.Kind = SymbolKind.Property Then
 
-                    If symbol.IsStatic OrElse (TypeOf (parent) Is CrefReferenceSyntax) Then
+                    If symbol.IsStatic OrElse
+                       (TypeOf (parent) Is CrefReferenceSyntax) OrElse
+                       _semanticModel.SyntaxTree.IsNameOfContext(originalSimpleName.SpanStart, _cancellationToken) Then
+
                         newNode = FullyQualifyIdentifierName(
                             symbol,
                             newNode,


### PR DESCRIPTION
Fixes #1193

During expansion, directly accessed members need to be qualified with
"this." or "TypeName.". Prior to this change, we always qualified
instance members with "this." and static members with "TypeName.", but
this technique fails in nameof contexts where an instance member can be
referenced from a static method, resulting in an improper "this."
qualification. We can only legally use "this." when both the member
being accessed and the context from which we are accessing it are
non-static. However, this change updates the expanders to always use
"TypeName." qualification in nameof contexts regardless of the
staticness of either member because it is always legal and feels more
natural in nameof expressions (where no actual value is being accessed).