### PR TITLE
Handle null AccessorList in expression bodied properties

### DIFF
--- a/src/EditorFeatures/CSharp/Completion/CompletionProviders/OverrideCompletionProvider.cs
+++ b/src/EditorFeatures/CSharp/Completion/CompletionProviders/OverrideCompletionProvider.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
 {
@@ -217,27 +218,24 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
                     return lastStatement.GetLocation().SourceSpan.End;
                 }
             }
-            else if (caretTarget is PropertyDeclarationSyntax)
+            else if (caretTarget is BasePropertyDeclarationSyntax)
             {
-                // property: no accesors; move to the end of the declaration
-                var propertyDeclaration = (PropertyDeclarationSyntax)caretTarget;
-                if (!propertyDeclaration.AccessorList.Accessors.Any())
-                {
-                    return propertyDeclaration.GetLocation().SourceSpan.End;
-                }
-                else
+                // property: no accessors; move to the end of the declaration
+                var propertyDeclaration = (BasePropertyDeclarationSyntax)caretTarget;
+                if (propertyDeclaration.AccessorList != null && propertyDeclaration.AccessorList.Accessors.Any())
                 {
                     // move to the end of the last statement of the first accessor
                     var firstAccessorStatement = propertyDeclaration.AccessorList.Accessors.First().Body.Statements.Last();
                     return firstAccessorStatement.GetLocation().SourceSpan.End;
                 }
+                else
+                {
+                    return propertyDeclaration.GetLocation().SourceSpan.End;
+                }
             }
             else
             {
-                // indexer: move to the end of the last statement
-                var indexerDeclaration = (IndexerDeclarationSyntax)caretTarget;
-                var firstAccessorStatement = indexerDeclaration.AccessorList.Accessors.First().Body.Statements.Last();
-                return firstAccessorStatement.GetLocation().SourceSpan.End;
+                throw ExceptionUtilities.Unreachable;
             }
         }
     }

--- a/src/EditorFeatures/CSharp/LineSeparators/CSharpLineSeparatorService.cs
+++ b/src/EditorFeatures/CSharp/LineSeparators/CSharpLineSeparatorService.cs
@@ -148,47 +148,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LineSeparator
 
         private static bool IsBadProperty(SyntaxNode node)
         {
-            var propDecl = node as PropertyDeclarationSyntax;
-            if (propDecl != null)
-            {
-                if (propDecl.AccessorList.OpenBraceToken.IsMissing ||
-                    propDecl.AccessorList.CloseBraceToken.IsMissing)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return IsBadAccessorList(node as PropertyDeclarationSyntax);
         }
 
         private static bool IsBadEvent(SyntaxNode node)
         {
-            var eventDecl = node as EventDeclarationSyntax;
-            if (eventDecl != null)
-            {
-                if (eventDecl.AccessorList.OpenBraceToken.IsMissing ||
-                    eventDecl.AccessorList.CloseBraceToken.IsMissing)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return IsBadAccessorList(node as EventDeclarationSyntax);
         }
 
         private static bool IsBadIndexer(SyntaxNode node)
         {
-            var indexerDecl = node as IndexerDeclarationSyntax;
-            if (indexerDecl != null)
+            return IsBadAccessorList(node as IndexerDeclarationSyntax);
+        }
+
+        private static bool IsBadAccessorList(BasePropertyDeclarationSyntax baseProperty)
+        {
+            if (baseProperty?.AccessorList == null)
             {
-                if (indexerDecl.AccessorList.OpenBraceToken.IsMissing ||
-                    indexerDecl.AccessorList.CloseBraceToken.IsMissing)
-                {
-                    return true;
-                }
+                return false;
             }
 
-            return false;
+            return baseProperty.AccessorList.OpenBraceToken.IsMissing ||
+                baseProperty.AccessorList.CloseBraceToken.IsMissing;
         }
 
         private static bool IsBadConstructor(SyntaxNode node)

--- a/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
@@ -414,6 +414,50 @@ class Program
             AssertTagsOnBracesOrSemicolons(file, 2, 4);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)]
+        [WorkItem(1297, "https://github.com/dotnet/roslyn/issues/1297")]
+        public void ExpressionBodiedProperty()
+        {
+            AssertTagsOnBracesOrSemicolons(@"class C
+{
+    int Prop => 3;
+
+    void M()
+    {
+    }
+}", 0, 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)]
+        [WorkItem(1297, "https://github.com/dotnet/roslyn/issues/1297")]
+        public void ExpressionBodiedIndexer()
+        {
+            AssertTagsOnBracesOrSemicolons(@"class C
+{
+    int this[int i] => 3;
+
+    void M()
+    {
+    }
+}", 0, 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)]
+        [WorkItem(1297, "https://github.com/dotnet/roslyn/issues/1297")]
+        public void ExpressionBodiedEvent()
+        {
+            // This is not valid code, and parses all wrong, but just in case a user writes it.  Note
+            // the 3 is because there is a skipped } in the event declaration.
+            AssertTagsOnBracesOrSemicolons(@"class C
+{
+    event EventHandler MyEvent => 3;
+
+    void M()
+    {
+    }
+}", 3);
+        }
+
         #region Negative (incomplete) tests
 
         [Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)]

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             var property = node as BasePropertyDeclarationSyntax;
-            if (property != null)
+            if (property != null && property.AccessorList != null)
             {
                 return property.AccessorList.Accessors.Select(a => a.Body).WhereNotNull();
             }


### PR DESCRIPTION
Fixes #1297 which is a crash in line separators.  I also took a look around for
other places where we access BasePropertyDeclarationSyntax and tried
to tighten them up too.