### PR TITLE
Delay-load Roslyn services

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemProvider.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
 {
@@ -13,20 +15,40 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     [Order]
     internal sealed class DiagnosticItemProvider : AttachedCollectionSourceProvider<AnalyzerItem>
     {
-        [Import(typeof(AnalyzersCommandHandler))]
-        private IAnalyzersCommandHandler _commandHandler = null;
+        private readonly IAnalyzersCommandHandler _commandHandler;
+        private readonly IServiceProvider _serviceProvider;
 
-        [Import]
-        private IDiagnosticAnalyzerService _diagnosticAnalyzerService = null;
+        private IDiagnosticAnalyzerService _diagnosticAnalyzerService;
+
+        [ImportingConstructor]
+        public DiagnosticItemProvider(
+            [Import(typeof(AnalyzersCommandHandler))]IAnalyzersCommandHandler commandHandler,
+            [Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider)
+        {
+            _commandHandler = commandHandler;
+            _serviceProvider = serviceProvider;
+        }
 
         protected override IAttachedCollectionSource CreateCollectionSource(AnalyzerItem item, string relationshipName)
         {
             if (relationshipName == KnownRelationships.Contains)
             {
-                return new DiagnosticItemSource(item, _commandHandler, _diagnosticAnalyzerService);
+                IDiagnosticAnalyzerService analyzerService = GetAnalyzerService();
+                return new DiagnosticItemSource(item, _commandHandler, analyzerService);
             }
 
             return null;
+        }
+
+        private IDiagnosticAnalyzerService GetAnalyzerService()
+        {
+            if (_diagnosticAnalyzerService == null)
+            {
+                IComponentModel componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
+                _diagnosticAnalyzerService = componentModel.GetService<IDiagnosticAnalyzerService>();
+            }
+
+            return _diagnosticAnalyzerService;
         }
     }
 }


### PR DESCRIPTION
Commit bcb2c8c7 added an `[Import]` of `IDiagnosticAnalyzerService` to
our Solution Explorer code. Unfortunately, this causes us to compose and
load effectively all of Roslyn whenever the Solution Explorer is opened,
even if no C# or VB code is loaded.

The fix is to delay pulling in the `IDiagnosticAnalyzerService` until we
actually need to make use of it, which is guaranteed to be after we have
loaded a C# or VB project (and thus we've already loaded Roslyn).