### PR TITLE
Start a global operation during project disconnect

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Notification;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
@@ -755,42 +756,45 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public virtual void Disconnect()
         {
-            // Unsubscribe IVsHierarchyEvents
-            DisconnectHierarchyEvents();
-
-            // The project is going away, so let's remove ourselves from the host. First, we
-            // close and dispose of any remaining documents
-            foreach (var document in this.GetCurrentDocuments())
+            using (_visualStudioWorkspaceOpt?.Services.GetService<IGlobalOperationNotificationService>()?.Start("Disconnect Project"))
             {
-                UninitializeDocument(document);
+                // Unsubscribe IVsHierarchyEvents
+                DisconnectHierarchyEvents();
+
+                // The project is going away, so let's remove ourselves from the host. First, we
+                // close and dispose of any remaining documents
+                foreach (var document in this.GetCurrentDocuments())
+                {
+                    UninitializeDocument(document);
+                }
+
+                // Dispose metadata references.
+                foreach (var reference in _metadataReferences)
+                {
+                    reference.Dispose();
+                }
+
+                foreach (var analyzer in _analyzers.Values)
+                {
+                    analyzer.Dispose();
+                }
+
+                // Make sure we clear out any external errors left when closing the project.
+                if (_externalErrorReporter != null)
+                {
+                    _externalErrorReporter.ClearAllErrors();
+                }
+
+                // Make sure we clear out any host errors left when closing the project.
+                if (_hostDiagnosticUpdateSourceOpt != null)
+                {
+                    _hostDiagnosticUpdateSourceOpt.ClearAllDiagnosticsForProject(this.Id);
+                }
+
+                ClearAnalyzerRuleSet();
+
+                this.ProjectTracker.RemoveProject(this);
             }
-
-            // Dispose metadata references.
-            foreach (var reference in _metadataReferences)
-            {
-                reference.Dispose();
-            }
-
-            foreach (var analyzer in _analyzers.Values)
-            {
-                analyzer.Dispose();
-            }
-
-            // Make sure we clear out any external errors left when closing the project.
-            if (_externalErrorReporter != null)
-            {
-                _externalErrorReporter.ClearAllErrors();
-            }
-
-            // Make sure we clear out any host errors left when closing the project.
-            if (_hostDiagnosticUpdateSourceOpt != null)
-            {
-                _hostDiagnosticUpdateSourceOpt.ClearAllDiagnosticsForProject(this.Id);
-            }
-
-            ClearAnalyzerRuleSet();
-
-            this.ProjectTracker.RemoveProject(this);
         }
 
         internal void TryProjectConversionForIntroducedOutputPath(string binPath, AbstractProject projectToReference)


### PR DESCRIPTION
Even with the other project reload changes, there was still some solution crawler activity during project unload. With this change there is none. Unloading CSharpCodeAnalysis goes from 90 seconds to 30 seconds, with all the time spent in the project system.  Should fix #1294 