### PR TITLE
Suppess Line Operation Within SingleLined Property AccessorList

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -54,6 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 var tokens = memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
                 AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, tokens.Item2);
+                var propertyDeclNode = node as PropertyDeclarationSyntax;
+                if (propertyDeclNode?.Initializer != null && propertyDeclNode?.AccessorList != null)
+                {
+                    AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, propertyDeclNode.AccessorList.GetLastToken());
+                }
                 return;
             }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6149,5 +6149,35 @@ class Program
             };
             AssertFormat(expected, code, changedOptionSet: optionSet);
         }
+
+        [WorkItem(1298, "https://github.com/dotnet/roslyn/issues/1298")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DontforceAccessorsToNewLineWithPropertyInitializers()
+        {
+            var code = @"using System.Collections.Generic;
+
+class Program
+{
+    public List<ExcludeValidation> ValidationExcludeFilters { get; }
+    = new List<ExcludeValidation>();
+}
+
+public class ExcludeValidation
+{
+}";
+
+            var expected = @"using System.Collections.Generic;
+
+class Program
+{
+    public List<ExcludeValidation> ValidationExcludeFilters { get; }
+    = new List<ExcludeValidation>();
+}
+
+public class ExcludeValidation
+{
+}";
+            AssertFormat(expected, code);
+        }
     }
 }


### PR DESCRIPTION
Fix 1298 Add suppress operation to span of the property including the
Property along with Accessorlist if it contains an initializer in
addition to the supress operation that goes over the whole of the
Property Declaration Statement