### PR TITLE
Allow INavigableItems to have child items.

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Navigation
@@ -11,5 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
 
         Document Document { get; }
         TextSpan SourceSpan { get; }
+
+        ImmutableArray<INavigableItem> ChildItems { get; }
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -20,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             public Glyph Glyph => _lazySymbol.Value?.GetGlyph() ?? Glyph.Error;
             public TextSpan SourceSpan => _declaredSymbolInfo.Span;
             public ISymbol Symbol => _lazySymbol.Value;
+            public ImmutableArray<INavigableItem> ChildItems => ImmutableArray<INavigableItem>.Empty;
 
             private readonly DeclaredSymbolInfo _declaredSymbolInfo;
             private readonly Lazy<string> _lazyDisplayName;

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -76,6 +77,8 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                     return _location.SourceSpan;
                 }
             }
+
+            public ImmutableArray<INavigableItem> ChildItems => ImmutableArray<INavigableItem>.Empty;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_FindReferences.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_FindReferences.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                         definitions.Add(definitionItem);
                         var referenceItems = CreateReferenceItems(solution, uniqueLocations, referencedSymbol.Locations.Select(loc => loc.Location), Glyph.Reference);
                         definitionItem.Children.AddRange(referenceItems);
-                        (definitionItem as ITreeItemWithReferenceCount)?.SetReferenceCount(referenceItems.Count);
+                        definitionItem.SetReferenceCount(referenceItems.Count);
                     }
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
@@ -22,7 +22,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         private AbstractTreeItem CreateTreeItem(INavigableItem item)
         {
-            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex());
+            var displayText = !item.ChildItems.IsEmpty ? item.DisplayName : null;
+            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex(), displayText);
+
             if (!item.ChildItems.IsEmpty)
             {
                 var childItems = CreateGoToDefinitionItems(item.ChildItems);

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
@@ -2,10 +2,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Navigation;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindResults
 {
@@ -16,9 +15,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             var sourceListItems =
                 from item in items
                 where IsValidSourceLocation(item.Document, item.SourceSpan)
-                select (AbstractTreeItem)new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex());
+                select CreateTreeItem(item);
 
             return sourceListItems.ToList();
+        }
+
+        private AbstractTreeItem CreateTreeItem(INavigableItem item)
+        {
+            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex());
+            if (!item.ChildItems.IsEmpty)
+            {
+                var childItems = CreateGoToDefinitionItems(item.ChildItems);
+                result.Children.AddRange(childItems);
+                result.SetReferenceCount(childItems.Count);
+            }
+
+            return result;
         }
 
         public void PresentNavigableItems(string title, IEnumerable<INavigableItem> items)

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
@@ -96,5 +96,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
             return string.Empty;
         }
+
+        internal virtual void SetReferenceCount(int referenceCount)
+        {
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/ITreeItemWithReferenceCount.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/ITreeItemWithReferenceCount.cs
@@ -1,9 +1,0 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindResults
-{
-    internal interface ITreeItemWithReferenceCount
-    {
-        void SetReferenceCount(int referenceCount);
-    }
-}

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Navigation;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindResults
 {
-    internal class MetadataDefinitionTreeItem : AbstractTreeItem, ITreeItemWithReferenceCount
+    internal class MetadataDefinitionTreeItem : AbstractTreeItem
     {
         private readonly string _assemblyName;
         private readonly string _symbolDefinition;
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             return VSConstants.E_FAIL;
         }
 
-        public void SetReferenceCount(int referenceCount)
+        internal override void SetReferenceCount(int referenceCount)
         {
             var referenceCountDisplay = referenceCount == 1
                 ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindResults
 {
-    internal class SourceDefinitionTreeItem : AbstractSourceTreeItem, ITreeItemWithReferenceCount
+    internal class SourceDefinitionTreeItem : AbstractSourceTreeItem
     {
         private readonly string _symbolDisplay;
 
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             this.DisplayText = $"[{document.Project.Name}] {_symbolDisplay}";
         }
 
-        public void SetReferenceCount(int referenceCount)
+        internal override void SetReferenceCount(int referenceCount)
         {
             var referenceCountDisplay = referenceCount == 1
                 ? string.Format(ServicesVSResources.ReferenceCountSingular, referenceCount)

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
@@ -8,27 +8,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 {
     internal class SourceReferenceTreeItem : AbstractSourceTreeItem, IComparable<SourceReferenceTreeItem>
     {
-        public SourceReferenceTreeItem(Location location, Solution solution, ushort glyphIndex)
-            : this(solution.GetDocument(location.SourceTree), location.SourceSpan, glyphIndex)
-        {
-        }
-
-        public SourceReferenceTreeItem(Document document, TextSpan sourceSpan, ushort glyphIndex)
-            : this(document, sourceSpan, glyphIndex, includeProjectNameDisambiguator: false)
-        {
-        }
-
-        public SourceReferenceTreeItem(Document document, TextSpan sourceSpan, ushort glyphIndex, bool includeProjectNameDisambiguator)
+        public SourceReferenceTreeItem(Document document, TextSpan sourceSpan, ushort glyphIndex, string displayText = null)
             : base(document, sourceSpan, glyphIndex)
         {
-            SetDisplayProperties(
-                _filePath,
-                _mappedLineNumber,
-                _mappedOffset,
-                _offset,
-                _textLineString,
-                sourceSpan.Length,
-                projectNameDisambiguator: string.Empty);
+            if (displayText != null)
+            {
+                this.DisplayText = displayText;
+            }
+            else
+            {
+                SetDisplayProperties(
+                    _filePath,
+                    _mappedLineNumber,
+                    _mappedOffset,
+                    _offset,
+                    _textLineString,
+                    sourceSpan.Length,
+                    projectNameDisambiguator: string.Empty);
+            }
         }
 
         public override bool UseGrayText

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -24,7 +24,6 @@
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs" />
-    <Compile Include="Implementation\Library\FindResults\TreeItems\ITreeItemWithReferenceCount.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\MetadataDefinitionTreeItem.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\SourceDefinitionTreeItem.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.MetadataReferenceChange.cs" />


### PR DESCRIPTION
This will be used by TypeScript so it can display FindRefernces result in a
tree form similar to how C#/VB does it.  i.e. it can show results like:

Decl1
|--Ref1
|--Ref2
Decl2
|--Ref3
|--Ref4