### PR TITLE
only try to do inline rename on documents that support it (e.g., not venus)

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 foreach (var buffer in openBuffers)
                 {
-                    TryCreateOpenTextBufferManagerForBuffer(buffer, buffer.AsTextContainer().GetRelatedDocuments());
+                    TryPopulateOpenTextBufferManagerForBuffer(buffer, buffer.AsTextContainer().GetRelatedDocuments());
                 }
             }
 
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
         }
 
-        private bool TryCreateOpenTextBufferManagerForBuffer(ITextBuffer buffer, IEnumerable<Document> documents)
+        private bool TryPopulateOpenTextBufferManagerForBuffer(ITextBuffer buffer, IEnumerable<Document> documents)
         {
             AssertIsForeground();
             VerifyNotDismissed();
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 if (buffer.GetWorkspace() == _workspace)
                 {
                     var documents = buffer.AsTextContainer().GetRelatedDocuments();
-                    if (TryCreateOpenTextBufferManagerForBuffer(buffer, documents))
+                    if (TryPopulateOpenTextBufferManagerForBuffer(buffer, documents))
                     {
                         _openTextBuffers[buffer].ConnectToView(e.TextView);
                     }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.SuggestionSupport;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -144,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 foreach (var buffer in openBuffers)
                 {
-                    CreateOpenTextBufferManagerForBuffer(buffer, buffer.AsTextContainer().GetRelatedDocuments());
+                    TryCreateOpenTextBufferManagerForBuffer(buffer, buffer.AsTextContainer().GetRelatedDocuments());
                 }
             }
 
@@ -166,15 +167,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
         }
 
-        private void CreateOpenTextBufferManagerForBuffer(ITextBuffer buffer, IEnumerable<Document> documents)
+        private bool TryCreateOpenTextBufferManagerForBuffer(ITextBuffer buffer, IEnumerable<Document> documents)
         {
             AssertIsForeground();
             VerifyNotDismissed();
 
-            if (!_openTextBuffers.ContainsKey(buffer))
+            var documentSupportsRefactoringService = _workspace.Services.GetService<IDocumentSupportsSuggestionService>();
+
+            if (!_openTextBuffers.ContainsKey(buffer) && documents.All(d => documentSupportsRefactoringService.SupportsRename(d)))
             {
                 _openTextBuffers[buffer] = new OpenTextBufferManager(this, buffer, _workspace, documents, _textBufferFactoryService);
+                return true;
             }
+
+            return _openTextBuffers.ContainsKey(buffer);
         }
 
         private void OnSubjectBuffersConnected(object sender, SubjectBuffersConnectedEventArgs e)
@@ -185,9 +191,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 if (buffer.GetWorkspace() == _workspace)
                 {
                     var documents = buffer.AsTextContainer().GetRelatedDocuments();
-                    CreateOpenTextBufferManagerForBuffer(buffer, documents);
-
-                    _openTextBuffers[buffer].ConnectToView(e.TextView);
+                    if (TryCreateOpenTextBufferManagerForBuffer(buffer, documents))
+                    {
+                        _openTextBuffers[buffer].ConnectToView(e.TextView);
+                    }
                 }
             }
         }


### PR DESCRIPTION
We were incorrectly trying to do an inline rename in a Venus editor (which is not supported because they don't project all of their spans appropriately) and this was causing a crash when trying to update the tracking span.  The fix is to only track spans in documents that actually support renaming (like we used to do in the past) and then manually notify Venus of the rename (like we currently do in `ContainedLanguageRefactorNotifyService::TryOnAfterGlobalSymbolRenamed()`).  With these changes the behavior is consistent with Dev12.  There is an accompanying test in our private sources.