### PR TITLE
Dont re-add the same source table

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             SVsServiceProvider serviceProvider, MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
             base(serviceProvider, workspace, diagnosticService, Identifier, provider)
         {
-            AddTableSource();
+            ConnectWorkspaceEvents();
         }
 
         /// this is for test only

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         public MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
             base(workspace, todoListProvider, Identifier, provider)
         {
-            AddTableSource();
+            ConnectWorkspaceEvents();
         }
 
         // only for test


### PR DESCRIPTION
Fix #1309 : The call to AddTableSource(), which adds the table to
the manager, happens the first time when calling the base constructor
hence a explicit call to the same method is unnecessary and results
in exception being thrown