### PR TITLE
Enable bootstrap builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.sln.docstates
 
 # Build results
-
+[Bb]inaries/
 [Dd]ebug/
 [Rr]elease/
 x64/

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -58,16 +58,26 @@
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackagesPath)\Microsoft.Net.RoslynDiagnostics.1.0.0-rc2-20150313-01\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
   </PropertyGroup>
-  <ImportGroup Label="GlobalNuGets">
+
+  <!-- Import the props files from the toolset NuGet packages if we're not in a bootstrap build -->
+  <ImportGroup Label="GlobalNuGets" Condition="'$(BootstrapBuild)' == ''">
     <Import Project="$(ToolsetCompilerPropsFilePath)"
             Condition="Exists('$(ToolsetCompilerPropsFilePath)')" />
     <Import Project="$(RoslynDiagnosticsPropsFilePath)"
             Condition="Exists('$(RoslynDiagnosticsPropsFilePath)') And ('$(UseRoslynAnalyzers)' == 'true')" />
   </ImportGroup>
-  <Target Name="EnsureGlobalNuGets">
+
+  <Target Name="EnsureGlobalNuGets" Condition="'$(BootstrapBuild)' == ''">
     <Error Condition="!$(CscToolPath.Contains('$(ToolsetCompilerPackageName)'))"
            Text="This project requires the $(ToolsetCompilerPackageName) NuGet package to build. Use NuGet Package Restore to download the required files (&quot;powershell .nuget\NuGetRestore.ps1&quot;). The missing file is &quot;$(ToolsetCompilerPropsFilePath)&quot;." />
   </Target>
+
+  <PropertyGroup Condition="'$(BootstrapBuild)' != ''">
+    <CscToolPath>$(BootstrapBuild)</CscToolPath>
+    <CscToolExe>csc.exe</CscToolExe>
+    <VbcToolPath>$(BootstrapBuild)</VbcToolPath>
+    <VbcToolExe>vbc.exe</VbcToolExe>
+  </PropertyGroup>
 
   <!-- Common project settings -->
   <PropertyGroup>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -60,22 +60,22 @@
   </PropertyGroup>
 
   <!-- Import the props files from the toolset NuGet packages if we're not in a bootstrap build -->
-  <ImportGroup Label="GlobalNuGets" Condition="'$(BootstrapBuild)' == ''">
+  <ImportGroup Label="GlobalNuGets" Condition="'$(BootstrapBuildPath)' == ''">
     <Import Project="$(ToolsetCompilerPropsFilePath)"
             Condition="Exists('$(ToolsetCompilerPropsFilePath)')" />
     <Import Project="$(RoslynDiagnosticsPropsFilePath)"
             Condition="Exists('$(RoslynDiagnosticsPropsFilePath)') And ('$(UseRoslynAnalyzers)' == 'true')" />
   </ImportGroup>
 
-  <Target Name="EnsureGlobalNuGets" Condition="'$(BootstrapBuild)' == ''">
+  <Target Name="EnsureGlobalNuGets" Condition="'$(BootstrapBuildPath)' == ''">
     <Error Condition="!$(CscToolPath.Contains('$(ToolsetCompilerPackageName)'))"
            Text="This project requires the $(ToolsetCompilerPackageName) NuGet package to build. Use NuGet Package Restore to download the required files (&quot;powershell .nuget\NuGetRestore.ps1&quot;). The missing file is &quot;$(ToolsetCompilerPropsFilePath)&quot;." />
   </Target>
 
-  <PropertyGroup Condition="'$(BootstrapBuild)' != ''">
-    <CscToolPath>$(BootstrapBuild)</CscToolPath>
+  <PropertyGroup Condition="'$(BootstrapBuildPath)' != ''">
+    <CscToolPath>$(BootstrapBuildPath)</CscToolPath>
     <CscToolExe>csc.exe</CscToolExe>
-    <VbcToolPath>$(BootstrapBuild)</VbcToolPath>
+    <VbcToolPath>$(BootstrapBuildPath)</VbcToolPath>
     <VbcToolExe>vbc.exe</VbcToolExe>
   </PropertyGroup>
 


### PR DESCRIPTION
This adds a new supported MSBuild property BootstrapBuild.  The value of
this must point to a directory containing a functional version of csc
and vbc.  When specified these executables will be used to build the
product instead of the versions provided in NuGet.

This provides us a very simple way of enabling bootstrap builds.