### PR TITLE
Bootstrap build on Linux

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Run the compilation.  Can pass additional build arguments as parameters
+docompile()
+{
+    xbuild /v:m /p:SignAssembly=false /p:DebugSymbols=false /p:DefineConstants=COMPILERCORE,DEBUG $1 src/Compilers/CSharp/csc/csc.csproj
+}
+
 echo Changing mono snapshot
 . mono-snapshot mono/20150316155603
 if [ $? -ne 0 ]; then
@@ -14,7 +20,36 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-cd src/Compilers/CSharp/csc
+echo Compiling using toolset compiler 
+docompile
+if [ $? -ne 0 ]; then
+    echo Compilation failed
+    exit 1
+fi
 
-echo Compiling
-xbuild /p:SignAssembly=false /p:DebugSymbols=false /p:DefineConstants=COMPILERCORE,DEBUG csc.csproj
+compiler_binaries=(
+    csc.exe
+    Microsoft.CodeAnalysis.dll
+    Microsoft.CodeAnalysis.Desktop.dll
+    Microsoft.CodeAnalysis.CSharp.dll
+    Microsoft.CodeAnalysis.CSharp.Desktop.dll
+    System.Collections.Immutable.dll
+    System.Reflection.Metadata.dll)
+
+mkdir Binaries/Bootstrap
+for i in ${compiler_binaries[@]}; do
+    cp Binaries/Debug/${i} Binaries/Bootstrap/${i}
+    if [ $? -ne 0 ]; then
+        echo Compilation failed
+        exit 1
+    fi
+done
+rm -rf Binaries/Debug
+
+echo Compiling using bootstrap compiler 
+docompile /p:BootstrapBuild="$(pwd)/Binaries/Bootstrap"
+if [ $? -ne 0 ]; then
+    echo Compilation failed
+    exit 1
+fi
+


### PR DESCRIPTION
This adds a bootstrap build step to our Linux verification process.  The
CI test will now build csc and then use that result to rebuild csc.
This will give us verification that we can fully bootstrap our compiler
(on Linux!).