### PR TITLE
Create props file in the System.Runtime.Analyzers with CodeAnalysisOverr...

### DIFF
--- a/src/Diagnostics/FxCop/CSharp/Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.props
+++ b/src/Diagnostics/FxCop/CSharp/Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.props
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>$(CodeAnalysisRuleSetOverrides);
       -Microsoft.Design#CA1003;
-      -Microsoft.Design#CA1019;
       -Microsoft.Design#CA1024;
       -Microsoft.Design#CA1027;
 

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
@@ -69,6 +69,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="System.Runtime.CSharp.Analyzers.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.props
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.props
@@ -1,5 +1,4 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <!-- 
     This file contains the rules that have been implemented in this package and therefore should be disabled for the binary FxCop.
     When a new rule is implemented in this package, make sure to add an entry below to disable that rule in FxCop to avoid duplicate 
@@ -8,25 +7,7 @@
   -->
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>$(CodeAnalysisRuleSetOverrides);
-      -Microsoft.Design#CA1008;
-      -Microsoft.Design#CA1012;
-      -Microsoft.Design#CA1018;
-      -Microsoft.Design#CA1052;
-      -Microsoft.Design#CA1053;
-      -Microsoft.Design#CA1060;
-
-      -Microsoft.Interoperability#CA1401;
-
-      -Microsoft.Globalization#CA2101;
-
-      -Microsoft.Naming#CA1708;
-      -Microsoft.Naming#CA1715;
-
-      -Microsoft.Performance#CA1813;
-
-      -Microsoft.Usage#CA2229;
-      -Microsoft.Usage#CA2235;
-      -Microsoft.Usage#CA2237;
+      -Microsoft.Design#CA1019;
     </CodeAnalysisRuleSetOverrides>
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.Common.props
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.Common.props
@@ -8,25 +8,13 @@
   -->
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>$(CodeAnalysisRuleSetOverrides);
-      -Microsoft.Design#CA1008;
-      -Microsoft.Design#CA1012;
-      -Microsoft.Design#CA1018;
-      -Microsoft.Design#CA1052;
-      -Microsoft.Design#CA1053;
-      -Microsoft.Design#CA1060;
-
-      -Microsoft.Interoperability#CA1401;
-
-      -Microsoft.Globalization#CA2101;
-
-      -Microsoft.Naming#CA1708;
-      -Microsoft.Naming#CA1715;
-
-      -Microsoft.Performance#CA1813;
-
-      -Microsoft.Usage#CA2229;
-      -Microsoft.Usage#CA2235;
-      -Microsoft.Usage#CA2237;
+      -Microsoft.Design#CA1001;
+      -Microsoft.Design#CA1014;
+      -Microsoft.Design#CA1016;
+      -Microsoft.Design#CA1017;
+      -Microsoft.Design#CA1036;
+      
+      -Microsoft.Usage#CA2231;
     </CodeAnalysisRuleSetOverrides>
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.csproj
@@ -50,6 +50,10 @@
     <InternalsVisibleToTest Include="System.Runtime.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="System.Runtime.Analyzers.Common.props">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
@@ -68,6 +68,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="System.Runtime.VisualBasic.Analyzers.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.props
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.props
@@ -1,5 +1,4 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <!-- 
     This file contains the rules that have been implemented in this package and therefore should be disabled for the binary FxCop.
     When a new rule is implemented in this package, make sure to add an entry below to disable that rule in FxCop to avoid duplicate 
@@ -8,25 +7,7 @@
   -->
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>$(CodeAnalysisRuleSetOverrides);
-      -Microsoft.Design#CA1008;
-      -Microsoft.Design#CA1012;
-      -Microsoft.Design#CA1018;
-      -Microsoft.Design#CA1052;
-      -Microsoft.Design#CA1053;
-      -Microsoft.Design#CA1060;
-
-      -Microsoft.Interoperability#CA1401;
-
-      -Microsoft.Globalization#CA2101;
-
-      -Microsoft.Naming#CA1708;
-      -Microsoft.Naming#CA1715;
-
-      -Microsoft.Performance#CA1813;
-
-      -Microsoft.Usage#CA2229;
-      -Microsoft.Usage#CA2235;
-      -Microsoft.Usage#CA2237;
+      -Microsoft.Design#CA1019;
     </CodeAnalysisRuleSetOverrides>
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/FxCop/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.props
+++ b/src/Diagnostics/FxCop/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.props
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>$(CodeAnalysisRuleSetOverrides);
       -Microsoft.Design#CA1003;
-      -Microsoft.Design#CA1019;
       -Microsoft.Design#CA1024;
       -Microsoft.Design#CA1027;
 


### PR DESCRIPTION
...ides so that the rules implemented by these analyzers are not run when FxCop runs for the project.