### PR TITLE
More linux work

### DIFF
--- a/build/VSL.Imports.Closed.targets
+++ b/build/VSL.Imports.Closed.targets
@@ -98,7 +98,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="SignVsixInputs" Condition="'$(ProducingSignedVsix)' == 'true'" DependsOnTargets="GetVsixSourceItems" BeforeTargets="CopyFilesToOutputDirectory">
+  <Target Name="SignVsixInputs" Condition="'$(ProducingSignedVsix)' == 'true'" DependsOnTargets="GetVsixSourceItems" BeforeTargets="AfterCompile">
     <!-- Ensure the build tasks project is already built -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\Closed\Setup\BuildTasks\BuildTasks.vbproj" Condition="!Exists('$(OutDir)\Roslyn.Setup.BuildTasks.dll') AND '$(RunningInMicroBuild)' != 'true'" />
     

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -13,10 +13,19 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# NuGet on mono crashes about every 5th time we run it.  This is causing
+# Linux runs to fail frequently enough that we need to employee a 
+# temporary work around.  
 echo Restoring NuGet packages
-mono src/.nuget/NuGet.exe restore src/Roslyn.sln
+i=5
+while [ $i -gt 0 ]; do
+    mono src/.nuget/NuGet.exe restore src/Roslyn.sln
+    if [ $? -eq 0 ]; then
+        i=0
+    fi
+done
 if [ $? -ne 0 ]; then
-    echo Failed restoring NuGet packages
+    echo NuGet Failed
     exit 1
 fi
 

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -14,7 +14,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # NuGet on mono crashes about every 5th time we run it.  This is causing
-# Linux runs to fail frequently enough that we need to employee a 
+# Linux runs to fail frequently enough that we need to employ a 
 # temporary work around.  
 echo Restoring NuGet packages
 i=5


### PR DESCRIPTION
This PR addresses the following issues:

- Retry NuGet only failure to work around the random crash we've seen in Jenkins.
- Remove warnings during build due to a missing target. 