### PR TITLE
 Added missing file path parameter in AbstractGenerateTypeService.Editor...

### DIFF
--- a/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -328,7 +328,8 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     documentId,
                     documentName,
                     containers,
-                    sourceCodeKind));
+                    sourceCodeKind,
+                    filePath: Path.Combine (Path.GetDirectoryName (generatingDocument.FilePath), documentName)));
 
                 updatedSolution = updatedSolution.WithDocumentSyntaxRoot(documentId, root, PreservationMode.PreserveIdentity);
 

--- a/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     documentName,
                     containers,
                     sourceCodeKind,
-                    filePath: Path.Combine (Path.GetDirectoryName (generatingDocument.FilePath), documentName)));
+                    filePath: Path.Combine(Path.GetDirectoryName(generatingDocument.FilePath), documentName)));
 
                 updatedSolution = updatedSolution.WithDocumentSyntaxRoot(documentId, root, PreservationMode.PreserveIdentity);
 


### PR DESCRIPTION
....

Without it the workspace implementation doesn't know where to save the newly generated document.