### PR TITLE
Reduce the size of PEMethodSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
@@ -40,20 +40,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             _additionalLocations = additionalLocations;
         }
 
-        public override IReadOnlyList<Location> AdditionalLocations
-        {
-            get
-            {
-                return _additionalLocations;
-            }
-        }
+        public override IReadOnlyList<Location> AdditionalLocations => _additionalLocations;
 
-        internal new ErrorCode Code
-        {
-            get
-            {
-                return (ErrorCode)base.Code;
-            }
-        }
+        internal new ErrorCode Code => (ErrorCode)base.Code;
+
+        public static bool IsEmpty(DiagnosticInfo info) => (object)info == EmptyErrorInfo;
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
@@ -44,6 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal new ErrorCode Code => (ErrorCode)base.Code;
 
-        public static bool IsEmpty(DiagnosticInfo info) => (object)info == EmptyErrorInfo;
+        internal static bool IsEmpty(DiagnosticInfo info) => (object)info == EmptyErrorInfo;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             // We currently pack everything into a 32-bit int with the following layout:
             //
-            // |                    |g|f|e|d|c|b|aaaaa|
+            // |            m|l|k|j|i|h|g|f|e|d|c|b|aaaaa|
             // 
             // a = method kind. 5 bits.
             // b = method kind populated. 1 bit.
@@ -48,8 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // e = isExplicitFinalizerOverride. 1 bit.
             // f = isExplicitClassOverride. 1 bit.
             // g = isExplicitFinalizerOverride and isExplicitClassOverride populated. 1 bit.
-            //
-            // 22 bits remain for future purposes.
+            // h = isObsoleteAttribute populated. 1 bit
+            // i = isCustomAttributesPopulated. 1 bit
+            // j = isUseSiteDiagnostic populated. 1 bit
+            // k = isConditional populated. 1 bit
+            // l = isOverriddenOrHiddenMembers populated. 1 bit
+            // 16 bits remain for future purposes.
 
             private const int MethodKindOffset = 0;
 
@@ -61,6 +65,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             private const int IsExplicitFinalizerOverrideBit = 0x1 << 8;
             private const int IsExplicitClassOverrideBit = 0x1 << 9;
             private const int IsExplicitOverrideIsPopulatedBit = 0x1 << 10;
+            private const int IsObsoleteAttributePopulatedBit = 0x1 << 11;
+            private const int IsCustomAttributesPopulatedBit = 0x1 << 12;
+            private const int IsUseSiteDiagnosticPopulatedBit = 0x1 << 13;
+            private const int IsConditionalPopulatedBit = 0x1 << 14;
+            private const int IsOverriddenOrHiddenMembersPopulatedBit = 0x1 << 15;
 
             private int _bits;
 
@@ -78,35 +87,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            public bool MethodKindIsPopulated
-            {
-                get { return (_bits & MethodKindIsPopulatedBit) != 0; }
-            }
-
-            public bool IsExtensionMethod
-            {
-                get { return (_bits & IsExtensionMethodBit) != 0; }
-            }
-
-            public bool IsExtensionMethodIsPopulated
-            {
-                get { return (_bits & IsExtensionMethodIsPopulatedBit) != 0; }
-            }
-
-            public bool IsExplicitFinalizerOverride
-            {
-                get { return (_bits & IsExplicitFinalizerOverrideBit) != 0; }
-            }
-
-            public bool IsExplicitClassOverride
-            {
-                get { return (_bits & IsExplicitClassOverrideBit) != 0; }
-            }
-
-            public bool IsExplicitOverrideIsPopulated
-            {
-                get { return (_bits & IsExplicitOverrideIsPopulatedBit) != 0; }
-            }
+            public bool MethodKindIsPopulated => (_bits & MethodKindIsPopulatedBit) != 0;
+            public bool IsExtensionMethod => (_bits & IsExtensionMethodBit) != 0;
+            public bool IsExtensionMethodIsPopulated => (_bits & IsExtensionMethodIsPopulatedBit) != 0;
+            public bool IsExplicitFinalizerOverride => (_bits & IsExplicitFinalizerOverrideBit) != 0;
+            public bool IsExplicitClassOverride => (_bits & IsExplicitClassOverrideBit) != 0;
+            public bool IsExplicitOverrideIsPopulated => (_bits & IsExplicitOverrideIsPopulatedBit) != 0;
+            public bool IsObsoleteAttributePopulated => (_bits & IsObsoleteAttributePopulatedBit) != 0;
+            public bool IsCustomAttributesPopulated => (_bits & IsCustomAttributesPopulatedBit) != 0;
+            public bool IsUseSiteDiagnosticPopulated => (_bits & IsUseSiteDiagnosticPopulatedBit) != 0;
+            public bool IsConditionalPopulated => (_bits & IsConditionalPopulatedBit) != 0;
+            public bool IsOverriddenOrHiddenMembersPopulated => (_bits & IsOverriddenOrHiddenMembersPopulatedBit) != 0;
 
 #if DEBUG
             static PackedFlags()
@@ -151,32 +142,104 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 Debug.Assert(BitsAreUnsetOrSame(_bits, bitsToSet));
                 ThreadSafeFlagOperations.Set(ref _bits, bitsToSet);
             }
+
+            public void InitializeIsObsoleteAttributePopulated()
+            {
+                ThreadSafeFlagOperations.Set(ref _bits, IsObsoleteAttributePopulatedBit);
+            }
+
+            public void InitializeIsCustomAttributesPopulated()
+            {
+                ThreadSafeFlagOperations.Set(ref _bits, IsCustomAttributesPopulatedBit);
+            }
+
+            public void InitializeIsUseSiteDiagnosticPopulated()
+            {
+                ThreadSafeFlagOperations.Set(ref _bits, IsUseSiteDiagnosticPopulatedBit);
+            }
+
+            public void InitializeIsConditionalAttributePopulated()
+            {
+                ThreadSafeFlagOperations.Set(ref _bits, IsConditionalPopulatedBit);
+            }
+
+            public void InitializeIsOverriddenOrHiddenMembersPopulated()
+            {
+                ThreadSafeFlagOperations.Set(ref _bits, IsOverriddenOrHiddenMembersPopulatedBit);
+            }
+        }
+
+        /// <summary>
+        /// Holds infrequently accessed fields. See <seealso cref="_uncommonFields"/> for an explanation.
+        /// </summary>
+        private sealed class UncommonFields
+        {
+            public ParameterSymbol _lazyThisParameter;
+            public Tuple<CultureInfo, string> _lazyDocComment;
+            public OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembersResult;
+            public ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
+            public ImmutableArray<string> _lazyConditionalAttributeSymbols;
+            public ObsoleteAttributeData _lazyObsoleteAttributeData;
+            public DiagnosticInfo _lazyUseSiteDiagnostic;
+        }
+
+        private UncommonFields CreateUncommonFields()
+        {
+            var retVal = new UncommonFields();
+            if (!_packedFlags.IsObsoleteAttributePopulated)
+            {
+                retVal._lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
+            }
+
+            if (!_packedFlags.IsUseSiteDiagnosticPopulated)
+            {
+                retVal._lazyUseSiteDiagnostic = CSDiagnosticInfo.EmptyErrorInfo; // Indicates unknown state.
+            }
+
+            if (_packedFlags.IsCustomAttributesPopulated)
+            {
+                retVal._lazyCustomAttributes = ImmutableArray<CSharpAttributeData>.Empty;
+            }
+
+            if (_packedFlags.IsConditionalPopulated)
+            {
+                retVal._lazyConditionalAttributeSymbols = ImmutableArray<string>.Empty;
+            }
+
+            if (_packedFlags.IsOverriddenOrHiddenMembersPopulated)
+            {
+                retVal._lazyOverriddenOrHiddenMembersResult = OverriddenOrHiddenMembersResult.Empty;
+            }
+
+            return retVal;
+        }
+
+        private UncommonFields AccessUncommonFields()
+        {
+            var retVal = _uncommonFields;
+            return retVal ?? InterlockedOperations.Initialize(ref _uncommonFields, CreateUncommonFields());
         }
 
         private readonly MethodDefinitionHandle _handle;
         private readonly string _name;
-        private readonly MethodImplAttributes _implFlags;
-        private readonly MethodAttributes _flags;
         private readonly PENamedTypeSymbol _containingType;
-
         private Symbol _associatedPropertyOrEventOpt;
-
         private PackedFlags _packedFlags;
-
+        private readonly ushort _flags;     // MethodAttributes
+        private readonly ushort _implFlags; // MethoImplAttributes
         private ImmutableArray<TypeParameterSymbol> _lazyTypeParameters;
-        private ParameterSymbol _lazyThisParameter;
         private SignatureData _lazySignature;
-
-        // CONSIDER: Should we use a CustomAttributeBag for PE symbols?
-        private ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
-        private ImmutableArray<string> _lazyConditionalAttributeSymbols;
-        private ObsoleteAttributeData _lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
-
-        private Tuple<CultureInfo, string> _lazyDocComment;
-
         private ImmutableArray<MethodSymbol> _lazyExplicitMethodImplementations;
-        private DiagnosticInfo _lazyUseSiteDiagnostic = CSDiagnosticInfo.EmptyErrorInfo; // Indicates unknown state.
-        private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembersResult;
+
+        /// <summary>
+        /// A single field to hold optional auxiliary data.
+        /// In many scenarios it is possible to avoid allocating this, thus saving total space in <see cref="PEModuleSymbol"/>.
+        /// Even for lazily-computed values, it may be possible to avoid allocating <see cref="_uncommonFields"/> if
+        /// the computed value is a well-known "empty" value. In this case, bits in <see cref="_packedFlags"/> are used
+        /// to indicate that the lazy values have been computed and, if <see cref="_uncommonFields"/> is null, then
+        /// the "empty" value should be inferred.
+        /// </summary>
+        private UncommonFields _uncommonFields;
 
         internal PEMethodSymbol(
             PEModuleSymbol moduleSymbol,
@@ -195,7 +258,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             try
             {
                 int rva;
-                moduleSymbol.Module.GetMethodDefPropsOrThrow(methodDef, out _name, out _implFlags, out localflags, out rva);
+                MethodImplAttributes implFlags;
+                moduleSymbol.Module.GetMethodDefPropsOrThrow(methodDef, out _name, out implFlags, out localflags, out rva);
+                Debug.Assert((uint)implFlags <= ushort.MaxValue);
+                _implFlags = (ushort)implFlags;
             }
             catch (BadImageFormatException)
             {
@@ -204,140 +270,58 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     _name = string.Empty;
                 }
 
-                _lazyUseSiteDiagnostic = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
+                InitializeUseSiteDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this));
             }
 
-            _flags = localflags;
+            Debug.Assert((uint)localflags <= ushort.MaxValue);
+            _flags = (ushort)localflags;
         }
 
         internal override bool TryGetThisParameter(out ParameterSymbol thisParameter)
         {
-            thisParameter = _lazyThisParameter;
-            if ((object)thisParameter != null || IsStatic)
-            {
-                return true;
-            }
-
-            Interlocked.CompareExchange(ref _lazyThisParameter, new ThisParameterSymbol(this), null);
-            thisParameter = _lazyThisParameter;
+            thisParameter = IsStatic ? null :
+                           _uncommonFields?._lazyThisParameter ?? InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyThisParameter, new ThisParameterSymbol(this));
             return true;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override Symbol ContainingSymbol => _containingType;
 
-        public override NamedTypeSymbol ContainingType
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override NamedTypeSymbol ContainingType => _containingType;
 
-        public override string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public override string Name => _name;
 
-        internal override bool HasSpecialName
+        private bool HasFlag(MethodAttributes flag)
         {
-            get
-            {
-                return (_flags & MethodAttributes.SpecialName) != 0;
-            }
-        }
-
-        internal override bool HasRuntimeSpecialName
-        {
-            get
-            {
-                return (_flags & MethodAttributes.RTSpecialName) != 0;
-            }
-        }
-
-        internal override MethodImplAttributes ImplementationAttributes
-        {
-            get
-            {
-                return _implFlags;
-            }
+            // flag must be exactly one bit
+            Debug.Assert(flag != 0 && ((ushort)flag & ((ushort)flag - 1)) == 0);
+            return ((ushort)flag & _flags) != 0;
         }
 
         // Exposed for testing purposes only
-        internal MethodAttributes Flags
-        {
-            get
-            {
-                return _flags;
-            }
-        }
+        internal MethodAttributes Flags => (MethodAttributes)_flags;
 
-        internal override bool RequiresSecurityObject
-        {
-            get
-            {
-                return (_flags & MethodAttributes.RequireSecObject) != 0;
-            }
-        }
+        internal override bool HasSpecialName => HasFlag(MethodAttributes.SpecialName);
 
-        public override DllImportData GetDllImportData()
-        {
-            if ((_flags & MethodAttributes.PinvokeImpl) == 0)
-            {
-                return null;
-            }
+        internal override bool HasRuntimeSpecialName => HasFlag(MethodAttributes.RTSpecialName);
 
-            // do not cache the result, the compiler doesn't use this (it's only exposed thru public API):
-            return _containingType.ContainingPEModule.Module.GetDllImportData(_handle);
-        }
+        internal override MethodImplAttributes ImplementationAttributes => (MethodImplAttributes)_implFlags;
 
-        internal override bool ReturnValueIsMarshalledExplicitly
-        {
-            get
-            {
-                return ReturnTypeParameter.IsMarshalledExplicitly;
-            }
-        }
+        internal override bool RequiresSecurityObject => HasFlag(MethodAttributes.RequireSecObject);
 
-        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
-        {
-            get
-            {
-                return ReturnTypeParameter.MarshallingInformation;
-            }
-        }
+        // do not cache the result, the compiler doesn't use this (it's only exposed thru public API):
+        public override DllImportData GetDllImportData() => HasFlag(MethodAttributes.PinvokeImpl)
+            ? _containingType.ContainingPEModule.Module.GetDllImportData(_handle)
+            : null;
 
-        internal override ImmutableArray<byte> ReturnValueMarshallingDescriptor
-        {
-            get
-            {
-                return ReturnTypeParameter.MarshallingDescriptor;
-            }
-        }
+        internal override bool ReturnValueIsMarshalledExplicitly => ReturnTypeParameter.IsMarshalledExplicitly;
 
-        internal override bool IsAccessCheckedOnOverride
-        {
-            get
-            {
-                return (_flags & MethodAttributes.CheckAccessOnOverride) != 0;
-            }
-        }
+        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation => ReturnTypeParameter.MarshallingInformation;
 
-        internal override bool HasDeclarativeSecurity
-        {
-            get
-            {
-                return (_flags & MethodAttributes.HasSecurity) != 0;
-            }
-        }
+        internal override ImmutableArray<byte> ReturnValueMarshallingDescriptor => ReturnTypeParameter.MarshallingDescriptor;
+
+        internal override bool IsAccessCheckedOnOverride => HasFlag(MethodAttributes.CheckAccessOnOverride);
+
+        internal override bool HasDeclarativeSecurity => HasFlag(MethodAttributes.HasSecurity);
 
         internal override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
         {
@@ -348,7 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                switch (_flags & MethodAttributes.MemberAccessMask)
+                switch (Flags & MethodAttributes.MemberAccessMask)
                 {
                     case MethodAttributes.Assembly:
                         return Accessibility.Internal;
@@ -375,46 +359,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override bool IsExtern
-        {
-            get
-            {
-                return (_flags & MethodAttributes.PinvokeImpl) != 0;
-            }
-        }
+        public override bool IsExtern => HasFlag(MethodAttributes.PinvokeImpl);
 
-        internal override bool IsExternal
-        {
-            get
-            {
-                return IsExtern || (_implFlags & MethodImplAttributes.Runtime) != 0;
-            }
-        }
+        internal override bool IsExternal => IsExtern || (ImplementationAttributes & MethodImplAttributes.Runtime) != 0;
 
-        public override bool IsVararg
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return _lazySignature.Header.CallingConvention == SignatureCallingConvention.VarArgs;
-            }
-        }
+        public override bool IsVararg => Signature.Header.CallingConvention == SignatureCallingConvention.VarArgs;
 
-        public override bool IsGenericMethod
-        {
-            get
-            {
-                return Arity > 0;
-            }
-        }
+        public override bool IsGenericMethod => Arity > 0;
 
-        public override bool IsAsync
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsAsync => false;
 
         public override int Arity
         {
@@ -439,104 +392,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal MethodDefinitionHandle Handle
-        {
-            get
-            {
-                return _handle;
-            }
-        }
+        internal MethodDefinitionHandle Handle => _handle;
 
-        public override bool IsAbstract
-        {
-            get
-            {
-                // Has to have the abstract flag.
-                // NOTE: dev10 treats the method as abstract (i.e. requiring an impl in subtypes) event if it is not metadata virtual.
-                return (_flags & MethodAttributes.Abstract) != 0;
-            }
-        }
+        // Has to have the abstract flag.
+        // NOTE: dev10 treats the method as abstract (i.e. requiring an impl in subtypes) event if it is not metadata virtual.
+        public override bool IsAbstract => HasFlag(MethodAttributes.Abstract);
 
-        public override bool IsSealed
-        {
-            get
-            {
-                // NOTE: abstract final methods are a bit strange.  First, they don't
-                // PEVerify - there's a specific error message for that combination of modifiers.
-                // Second, if dev10 sees an abstract final method in a base class, it will report
-                // an error (CS0534) if it is not overridden.  Third, dev10 does not report an
-                // error if it is overridden - it emits a virtual method without the newslot
-                // modifier as for a normal override.  It is not clear how the runtime rules
-                // interpret this overriding method since the overridden method is invalid.
-                return this.IsMetadataFinal && !this.IsAbstract && this.IsOverride; //slowest check last
-            }
-        }
+        // NOTE: abstract final methods are a bit strange.  First, they don't
+        // PEVerify - there's a specific error message for that combination of modifiers.
+        // Second, if dev10 sees an abstract final method in a base class, it will report
+        // an error (CS0534) if it is not overridden.  Third, dev10 does not report an
+        // error if it is overridden - it emits a virtual method without the newslot
+        // modifier as for a normal override.  It is not clear how the runtime rules
+        // interpret this overriding method since the overridden method is invalid.
+        public override bool IsSealed => this.IsMetadataFinal && !this.IsAbstract && this.IsOverride; //slowest check last
 
-        public override bool HidesBaseMethodsByName
-        {
-            get
-            {
-                return (_flags & MethodAttributes.HideBySig) == 0;
-            }
-        }
+        public override bool HidesBaseMethodsByName => !HasFlag(MethodAttributes.HideBySig);
 
-        public override bool IsVirtual
-        {
-            get
-            {
-                // Has to be metadata virtual and cannot be a destructor.  Cannot be either abstract or override.
-                // Final is a little special - if a method has the virtual, newslot, and final attr
-                // (and is not an explicit override) then we treat it as non-virtual for C# purposes.
-                return this.IsMetadataVirtual() && !this.IsDestructor && !this.IsMetadataFinal && !this.IsAbstract && !this.IsOverride;
-            }
-        }
+        // Has to be metadata virtual and cannot be a destructor.  Cannot be either abstract or override.
+        // Final is a little special - if a method has the virtual, newslot, and final attr
+        // (and is not an explicit override) then we treat it as non-virtual for C# purposes.
+        public override bool IsVirtual => this.IsMetadataVirtual() && !this.IsDestructor && !this.IsMetadataFinal && !this.IsAbstract && !this.IsOverride;
 
-        public override bool IsOverride
-        {
-            get
-            {
-                // Has to be metadata virtual and cannot be a destructor.  
-                // Must either lack the newslot flag or be an explicit override (i.e. via the MethodImpl table).
-                // The IsExplicitClassOverride case is based on LangImporter::DefineMethodImplementations in the native compiler.
-
-                // ECMA-335 
-                // 10.3.1 Introducing a virtual method
-                // If the definition is not marked newslot, the definition creates a new virtual method only 
-                // if there is not virtual method of the same name and signature inherited from a base class.
-                //
-                // This means that a virtual method without NewSlot flag in a type that doesn't have a base
-                // is a new virtual method and doesn't override anything.
-
-                return this.IsMetadataVirtual() && !this.IsDestructor &&
+        // Has to be metadata virtual and cannot be a destructor.  
+        // Must either lack the newslot flag or be an explicit override (i.e. via the MethodImpl table).
+        //
+        // The IsExplicitClassOverride case is based on LangImporter::DefineMethodImplementations in the native compiler.
+        // ECMA-335 
+        // 10.3.1 Introducing a virtual method
+        // If the definition is not marked newslot, the definition creates a new virtual method only 
+        // if there is not virtual method of the same name and signature inherited from a base class.
+        //
+        // This means that a virtual method without NewSlot flag in a type that doesn't have a base
+        // is a new virtual method and doesn't override anything.
+        public override bool IsOverride =>
+            this.IsMetadataVirtual() && !this.IsDestructor &&
                        ((!this.IsMetadataNewSlot() && (object)_containingType.BaseTypeNoUseSiteDiagnostics != null) || this.IsExplicitClassOverride);
-            }
-        }
 
-        public override bool IsStatic
-        {
-            get
-            {
-                return (_flags & MethodAttributes.Static) != 0;
-            }
-        }
+        public override bool IsStatic => HasFlag(MethodAttributes.Static);
 
-        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
-        {
-            return (_flags & MethodAttributes.Virtual) != 0;
-        }
+        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => HasFlag(MethodAttributes.Virtual);
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
-        {
-            return (_flags & MethodAttributes.NewSlot) != 0;
-        }
+        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => HasFlag(MethodAttributes.NewSlot);
 
-        internal override bool IsMetadataFinal
-        {
-            get
-            {
-                return (_flags & MethodAttributes.Final) != 0;
-            }
-        }
+        internal override bool IsMetadataFinal => HasFlag(MethodAttributes.Final);
 
         private bool IsExplicitFinalizerOverride
         {
@@ -564,18 +463,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        private bool IsDestructor
-        {
-            get { return this.MethodKind == MethodKind.Destructor; }
-        }
+        private bool IsDestructor => this.MethodKind == MethodKind.Destructor;
 
-        public override bool ReturnsVoid
-        {
-            get
-            {
-                return this.ReturnType.SpecialType == SpecialType.System_Void;
-            }
-        }
+        public override bool ReturnsVoid => this.ReturnType.SpecialType == SpecialType.System_Void;
 
         internal override int ParameterCount
         {
@@ -601,41 +491,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override ImmutableArray<ParameterSymbol> Parameters
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return _lazySignature.Parameters;
-            }
-        }
+        public override ImmutableArray<ParameterSymbol> Parameters => Signature.Parameters;
 
-        internal PEParameterSymbol ReturnTypeParameter
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return _lazySignature.ReturnParam;
-            }
-        }
+        internal PEParameterSymbol ReturnTypeParameter => Signature.ReturnParam;
 
-        public override TypeSymbol ReturnType
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return _lazySignature.ReturnParam.Type;
-            }
-        }
+        public override TypeSymbol ReturnType => Signature.ReturnParam.Type;
 
-        public override ImmutableArray<CustomModifier> ReturnTypeCustomModifiers
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return _lazySignature.ReturnParam.CustomModifiers;
-            }
-        }
+        public override ImmutableArray<CustomModifier> ReturnTypeCustomModifiers => Signature.ReturnParam.CustomModifiers;
 
         /// <summary>
         /// Associate the method with a particular property. Returns
@@ -681,15 +543,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return false;
         }
 
-        private void EnsureSignatureIsLoaded()
-        {
-            if (_lazySignature == null)
-            {
-                LoadSignature();
-            }
-        }
+        private SignatureData Signature => _lazySignature ?? LoadSignature();
 
-        private void LoadSignature()
+        private SignatureData LoadSignature()
         {
             var moduleSymbol = _containingType.ContainingPEModule;
 
@@ -702,8 +558,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             if (!signatureHeader.IsGeneric &&
                 _lazyTypeParameters.IsDefault)
             {
-                ImmutableInterlocked.InterlockedCompareExchange(ref _lazyTypeParameters,
-                    ImmutableArray<TypeParameterSymbol>.Empty, default(ImmutableArray<TypeParameterSymbol>));
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameters,
+                    ImmutableArray<TypeParameterSymbol>.Empty);
             }
 
             int count = paramInfo.Length - 1;
@@ -740,82 +596,72 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             if (makeBad || isBadParameter)
             {
-                var old = Interlocked.CompareExchange(ref _lazyUseSiteDiagnostic, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
-                Debug.Assert((object)old == (object)CSDiagnosticInfo.EmptyErrorInfo ||
-                             ((object)old != null && old.Code == (int)ErrorCode.ERR_BindToBogus && old.Arguments.Length == 1 && old.Arguments[0] == (object)this));
+                InitializeUseSiteDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this));
             }
 
             var signature = new SignatureData(signatureHeader, @params, returnParam);
 
-            Interlocked.CompareExchange(ref _lazySignature, signature, null);
+            return InterlockedOperations.Initialize(ref _lazySignature, signature);
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters
         {
             get
             {
-                EnsureTypeParametersAreLoaded();
-                return _lazyTypeParameters;
+                DiagnosticInfo diagnosticInfo = null;
+                var typeParams = EnsureTypeParametersAreLoaded(ref diagnosticInfo);
+                if (diagnosticInfo != null)
+                {
+                    InitializeUseSiteDiagnostic(diagnosticInfo);
+                }
+
+                return typeParams;
             }
         }
 
-        public override ImmutableArray<TypeSymbol> TypeArguments
+        private ImmutableArray<TypeParameterSymbol> EnsureTypeParametersAreLoaded(ref DiagnosticInfo diagnosticInfo)
         {
-            get
+            var typeParams = _lazyTypeParameters;
+            if (!typeParams.IsDefault)
             {
-                if (IsGenericMethod)
-                {
-                    return this.TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>();
-                }
-
-                return ImmutableArray<TypeSymbol>.Empty;
+                return typeParams;
             }
+
+            return InterlockedOperations.Initialize(ref _lazyTypeParameters, LoadTypeParameters(ref diagnosticInfo));
         }
 
-        private void EnsureTypeParametersAreLoaded()
+        private ImmutableArray<TypeParameterSymbol> LoadTypeParameters(ref DiagnosticInfo diagnosticInfo)
         {
-            if (_lazyTypeParameters.IsDefault)
+            try
             {
-                ImmutableArray<TypeParameterSymbol> typeParams;
+                var moduleSymbol = _containingType.ContainingPEModule;
+                var gpHandles = moduleSymbol.Module.GetGenericParametersForMethodOrThrow(_handle);
 
-                try
+                if (gpHandles.Count == 0)
                 {
-                    var moduleSymbol = _containingType.ContainingPEModule;
-                    var gpHandles = moduleSymbol.Module.GetGenericParametersForMethodOrThrow(_handle);
-
-                    if (gpHandles.Count == 0)
-                    {
-                        typeParams = ImmutableArray<TypeParameterSymbol>.Empty;
-                    }
-                    else
-                    {
-                        TypeParameterSymbol[] ownedParams = new PETypeParameterSymbol[gpHandles.Count];
-
-                        for (int i = 0; i < ownedParams.Length; i++)
-                        {
-                            ownedParams[i] = new PETypeParameterSymbol(moduleSymbol, this, (ushort)i, gpHandles[i]);
-                        }
-
-                        typeParams = ImmutableArray.Create(ownedParams);
-                    }
+                    return ImmutableArray<TypeParameterSymbol>.Empty;
                 }
-                catch (BadImageFormatException)
+                else
                 {
-                    var old = Interlocked.CompareExchange(ref _lazyUseSiteDiagnostic, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
-                    Debug.Assert((object)old == (object)CSDiagnosticInfo.EmptyErrorInfo ||
-                                    ((object)old != null && old.Code == (int)ErrorCode.ERR_BindToBogus && old.Arguments.Length == 1 && old.Arguments[0] == (object)this));
+                    var ownedParams = ImmutableArray.CreateBuilder<TypeParameterSymbol>(gpHandles.Count);
+                    for (int i = 0; i < gpHandles.Count; i++)
+                    {
+                        ownedParams.Add(new PETypeParameterSymbol(moduleSymbol, this, (ushort)i, gpHandles[i]));
+                    }
 
-                    typeParams = ImmutableArray<TypeParameterSymbol>.Empty;
+                    return ownedParams.ToImmutable();
                 }
-
-                ImmutableInterlocked.InterlockedCompareExchange(ref _lazyTypeParameters, typeParams, default(ImmutableArray<TypeParameterSymbol>));
+            }
+            catch (BadImageFormatException)
+            {
+                diagnosticInfo = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
+                return ImmutableArray<TypeParameterSymbol>.Empty;
             }
         }
 
-        public override Symbol AssociatedSymbol
-        {
-            get { return _associatedPropertyOrEventOpt; }
-        }
+        public override ImmutableArray<TypeSymbol> TypeArguments => IsGenericMethod ? TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>() : ImmutableArray<TypeSymbol>.Empty;
+
+        public override Symbol AssociatedSymbol => _associatedPropertyOrEventOpt;
 
         public override bool IsExtensionMethod
         {
@@ -839,26 +685,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override ImmutableArray<Location> Locations
-        {
-            get
-            {
-                return _containingType.ContainingPEModule.MetadataLocation.Cast<MetadataLocation, Location>();
-            }
-        }
+        public override ImmutableArray<Location> Locations => _containingType.ContainingPEModule.MetadataLocation.Cast<MetadataLocation, Location>();
 
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-        {
-            get
-            {
-                return ImmutableArray<SyntaxReference>.Empty;
-            }
-        }
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
 
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
-            if (_lazyCustomAttributes.IsDefault)
+            if (!_packedFlags.IsCustomAttributesPopulated)
             {
+                // Compute the value
+                var attributeData = default(ImmutableArray<CSharpAttributeData>);
                 var containingPEModuleSymbol = _containingType.ContainingPEModule;
 
                 // Could this possibly be an extension method?
@@ -873,33 +709,49 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if (checkForExtension)
                 {
                     containingPEModuleSymbol.LoadCustomAttributesFilterExtensions(_handle,
-                        ref _lazyCustomAttributes,
+                        ref attributeData,
                         out isExtensionMethod);
                 }
                 else
                 {
                     containingPEModuleSymbol.LoadCustomAttributes(_handle,
-                        ref _lazyCustomAttributes);
+                        ref attributeData);
                 }
 
                 if (!alreadySet)
                 {
                     _packedFlags.InitializeIsExtensionMethod(isExtensionMethod);
                 }
+
+                // Store the result in uncommon fields only if it's not empty.
+                Debug.Assert(!attributeData.IsDefault);
+                if (!attributeData.IsEmpty)
+                {
+                    attributeData = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyCustomAttributes, attributeData);
+                }
+
+                _packedFlags.InitializeIsCustomAttributesPopulated();
+                return attributeData;
             }
-            return _lazyCustomAttributes;
+
+            // Retrieve cached or inferred value.
+            var uncommonFields = _uncommonFields;
+            if (uncommonFields == null)
+            {
+                return ImmutableArray<CSharpAttributeData>.Empty;
+            }
+            else
+            {
+                var attributeData = uncommonFields._lazyCustomAttributes;
+                return attributeData.IsDefault
+                    ? InterlockedOperations.Initialize(ref uncommonFields._lazyCustomAttributes, ImmutableArray<CSharpAttributeData>.Empty)
+                    : attributeData;
+            }
         }
 
-        internal override IEnumerable<CSharpAttributeData> GetCustomAttributesToEmit(ModuleCompilationState compilationState)
-        {
-            return GetAttributes();
-        }
+        internal override IEnumerable<CSharpAttributeData> GetCustomAttributesToEmit(ModuleCompilationState compilationState) => GetAttributes();
 
-        public override ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes()
-        {
-            EnsureSignatureIsLoaded();
-            return _lazySignature.ReturnParam.GetAttributes();
-        }
+        public override ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes() => Signature.ReturnParam.GetAttributes();
 
         public override MethodKind MethodKind
         {
@@ -930,16 +782,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return (parameter.RefKind == RefKind.None) && !parameter.IsParams;
         }
 
-        private bool IsValidUserDefinedOperatorSignature(int parameterCount)
-        {
-            return
+        private bool IsValidUserDefinedOperatorSignature(int parameterCount) =>
                 !this.ReturnsVoid &&
                 !this.IsGenericMethod &&
                 !this.IsVararg &&
                 this.ParameterCount == parameterCount &&
                 this.ParameterRefKinds.IsDefault && // No 'ref' or 'out'
                 !this.IsParams();
-        }
 
         private MethodKind ComputeMethodKind()
         {
@@ -957,7 +806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     // This method shall be static, take no parameters, return no value,
                     // be marked with rtspecialname and specialname (§15.4.2.6), and be named .cctor.
 
-                    if ((_flags & (MethodAttributes.RTSpecialName | MethodAttributes.Virtual)) == MethodAttributes.RTSpecialName &&
+                    if ((Flags & (MethodAttributes.RTSpecialName | MethodAttributes.Virtual)) == MethodAttributes.RTSpecialName &&
                         _name.Equals(this.IsStatic ? WellKnownMemberNames.StaticConstructorName : WellKnownMemberNames.InstanceConstructorName) &&
                         this.ReturnsVoid && this.Arity == 0)
                     {
@@ -1052,107 +901,141 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return MethodKind.Ordinary;
         }
 
-        internal override Cci.CallingConvention CallingConvention
-        {
-            get
-            {
-                EnsureSignatureIsLoaded();
-                return (Cci.CallingConvention)_lazySignature.Header.RawValue;
-            }
-        }
+        internal override Cci.CallingConvention CallingConvention => (Cci.CallingConvention)Signature.Header.RawValue;
 
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
         {
             get
             {
-                if (_lazyExplicitMethodImplementations.IsDefault)
+                var explicitInterfaceImplementations = _lazyExplicitMethodImplementations;
+                if (!explicitInterfaceImplementations.IsDefault)
                 {
-                    var moduleSymbol = _containingType.ContainingPEModule;
+                    return explicitInterfaceImplementations;
+                }
 
-                    // Context: we need the containing type of this method as context so that we can substitute appropriately into
-                    // any generic interfaces that we might be explicitly implementing.  There is no reason to pass in the method
-                    // context, however, because any method type parameters will belong to the implemented (i.e. interface) method,
-                    // which we do not yet know.
-                    var explicitlyOverriddenMethods = new MetadataDecoder(moduleSymbol, _containingType).GetExplicitlyOverriddenMethods(_containingType.Handle, _handle, this.ContainingType);
+                var moduleSymbol = _containingType.ContainingPEModule;
 
-                    //avoid allocating a builder in the common case
-                    var anyToRemove = false;
-                    var sawObjectFinalize = false;
+                // Context: we need the containing type of this method as context so that we can substitute appropriately into
+                // any generic interfaces that we might be explicitly implementing.  There is no reason to pass in the method
+                // context, however, because any method type parameters will belong to the implemented (i.e. interface) method,
+                // which we do not yet know.
+                var explicitlyOverriddenMethods = new MetadataDecoder(moduleSymbol, _containingType).GetExplicitlyOverriddenMethods(_containingType.Handle, _handle, this.ContainingType);
+
+                //avoid allocating a builder in the common case
+                var anyToRemove = false;
+                var sawObjectFinalize = false;
+                foreach (var method in explicitlyOverriddenMethods)
+                {
+                    if (!method.ContainingType.IsInterface)
+                    {
+                        anyToRemove = true;
+                        sawObjectFinalize =
+                            (method.ContainingType.SpecialType == SpecialType.System_Object &&
+                             method.Name == WellKnownMemberNames.DestructorName && // Cheaper than MethodKind.
+                             method.MethodKind == MethodKind.Destructor);
+                    }
+
+                    if (anyToRemove && sawObjectFinalize)
+                    {
+                        break;
+                    }
+                }
+
+                // CONSIDER: could assert that we're writing the existing value if it's already there
+                // CONSIDER: what we'd really like to do is set this bit only in cases where the explicitly
+                // overridden method matches the method that will be returned by MethodSymbol.OverriddenMethod.
+                // Unfortunately, this MethodSymbol will not be sufficiently constructed (need IsOverride and MethodKind,
+                // which depend on this property) to determine which method OverriddenMethod will return.
+                _packedFlags.InitializeIsExplicitOverride(isExplicitFinalizerOverride: sawObjectFinalize, isExplicitClassOverride: anyToRemove);
+
+                explicitInterfaceImplementations = explicitlyOverriddenMethods;
+
+                if (anyToRemove)
+                {
+                    var explicitInterfaceImplementationsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
                     foreach (var method in explicitlyOverriddenMethods)
                     {
-                        if (!method.ContainingType.IsInterface)
+                        if (method.ContainingType.IsInterface)
                         {
-                            anyToRemove = true;
-                            sawObjectFinalize = 
-                                (method.ContainingType.SpecialType == SpecialType.System_Object &&
-                                 method.Name == WellKnownMemberNames.DestructorName && // Cheaper than MethodKind.
-                                 method.MethodKind == MethodKind.Destructor);
-                        }
-
-                        if (anyToRemove && sawObjectFinalize)
-                        {
-                            break;
+                            explicitInterfaceImplementationsBuilder.Add(method);
                         }
                     }
 
-                    // CONSIDER: could assert that we're writing the existing value if it's already there
-                    // CONSIDER: what we'd really like to do is set this bit only in cases where the explicitly
-                    // overridden method matches the method that will be returned by MethodSymbol.OverriddenMethod.
-                    // Unfortunately, this MethodSymbol will not be sufficiently constructed (need IsOverride and MethodKind,
-                    // which depend on this property) to determine which method OverriddenMethod will return.
-                    _packedFlags.InitializeIsExplicitOverride(isExplicitFinalizerOverride: sawObjectFinalize, isExplicitClassOverride: anyToRemove);
-
-                    var explicitInterfaceImplementations = explicitlyOverriddenMethods;
-
-                    if (anyToRemove)
-                    {
-                        var explicitInterfaceImplementationsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
-                        foreach (var method in explicitlyOverriddenMethods)
-                        {
-                            if (method.ContainingType.IsInterface)
-                            {
-                                explicitInterfaceImplementationsBuilder.Add(method);
-                            }
-                        }
-
-                        explicitInterfaceImplementations = explicitInterfaceImplementationsBuilder.ToImmutableAndFree();
-                    }
-
-                    ImmutableInterlocked.InterlockedCompareExchange(ref _lazyExplicitMethodImplementations, explicitInterfaceImplementations, default(ImmutableArray<MethodSymbol>));
+                    explicitInterfaceImplementations = explicitInterfaceImplementationsBuilder.ToImmutableAndFree();
                 }
-                return _lazyExplicitMethodImplementations;
+
+                return InterlockedOperations.Initialize(ref _lazyExplicitMethodImplementations, explicitInterfaceImplementations);
             }
         }
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PEDocumentationCommentUtils.GetDocumentationComment(this, _containingType.ContainingPEModule, preferredCulture, cancellationToken, ref _lazyDocComment);
+            return PEDocumentationCommentUtils.GetDocumentationComment(this, _containingType.ContainingPEModule, preferredCulture, cancellationToken, ref AccessUncommonFields()._lazyDocComment);
         }
 
         internal override DiagnosticInfo GetUseSiteDiagnostic()
         {
-            if ((object)_lazyUseSiteDiagnostic == (object)CSDiagnosticInfo.EmptyErrorInfo)
+            if (!_packedFlags.IsUseSiteDiagnosticPopulated)
             {
                 DiagnosticInfo result = null;
                 CalculateUseSiteDiagnostic(ref result);
-                EnsureTypeParametersAreLoaded();
-                Interlocked.CompareExchange(ref _lazyUseSiteDiagnostic, result, CSDiagnosticInfo.EmptyErrorInfo);
+                EnsureTypeParametersAreLoaded(ref result);
+                return InitializeUseSiteDiagnostic(result);
             }
 
-            return _lazyUseSiteDiagnostic;
+            var uncommonFields = _uncommonFields;
+            if (uncommonFields == null)
+            {
+                return null;
+            }
+            else
+            {
+                var result = uncommonFields._lazyUseSiteDiagnostic;
+                return CSDiagnosticInfo.IsEmpty(result)
+                       ? InterlockedOperations.Initialize(ref uncommonFields._lazyUseSiteDiagnostic, null, CSDiagnosticInfo.EmptyErrorInfo)
+                       : result;
+            }
+        }
+
+        private DiagnosticInfo InitializeUseSiteDiagnostic(DiagnosticInfo diagnostic)
+        {
+            Debug.Assert(!CSDiagnosticInfo.IsEmpty(diagnostic));
+            if (diagnostic != null)
+            {
+                diagnostic = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyUseSiteDiagnostic, diagnostic, CSDiagnosticInfo.EmptyErrorInfo);
+            }
+
+            _packedFlags.InitializeIsUseSiteDiagnosticPopulated();
+            return diagnostic;
         }
 
         internal override ImmutableArray<string> GetAppliedConditionalSymbols()
         {
-            if (_lazyConditionalAttributeSymbols.IsDefault)
+            if (!_packedFlags.IsConditionalPopulated)
             {
-                var moduleSymbol = _containingType.ContainingPEModule;
-                ImmutableArray<string> conditionalSymbols = moduleSymbol.Module.GetConditionalAttributeValues(_handle);
-                Debug.Assert(!conditionalSymbols.IsDefault);
-                ImmutableInterlocked.InterlockedCompareExchange(ref _lazyConditionalAttributeSymbols, conditionalSymbols, default(ImmutableArray<string>));
+                var result = _containingType.ContainingPEModule.Module.GetConditionalAttributeValues(_handle);
+                Debug.Assert(!result.IsDefault);
+                if (!result.IsEmpty)
+                {
+                    result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyConditionalAttributeSymbols, result);
+                }
+
+                _packedFlags.InitializeIsConditionalAttributePopulated();
+                return result;
             }
 
-            return _lazyConditionalAttributeSymbols;
+            var uncommonFields = _uncommonFields;
+            if (uncommonFields == null)
+            {
+                return ImmutableArray<string>.Empty;
+            }
+            else
+            {
+                var result = uncommonFields._lazyConditionalAttributeSymbols;
+                return result.IsDefault
+                    ? InterlockedOperations.Initialize(ref uncommonFields._lazyConditionalAttributeSymbols, ImmutableArray<string>.Empty)
+                    : result;
+            }
         }
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
@@ -1164,50 +1047,69 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(ref _lazyObsoleteAttributeData, _handle, (PEModuleSymbol)(this.ContainingModule));
-                return _lazyObsoleteAttributeData;
+                if (!_packedFlags.IsObsoleteAttributePopulated)
+                {
+                    var result = ObsoleteAttributeHelpers.GetObsoleteDataFromMetadata(_handle, (PEModuleSymbol)ContainingModule);
+                    if (result != null)
+                    {
+                        result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyObsoleteAttributeData, result, ObsoleteAttributeData.Uninitialized);
+                    }
+
+                    _packedFlags.InitializeIsObsoleteAttributePopulated();
+                    return result;
+                }
+
+                var uncommonFields = _uncommonFields;
+                if (uncommonFields == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    var result = uncommonFields._lazyObsoleteAttributeData;
+                    return ReferenceEquals(result, ObsoleteAttributeData.Uninitialized)
+                        ? InterlockedOperations.Initialize(ref uncommonFields._lazyObsoleteAttributeData, null, ObsoleteAttributeData.Uninitialized)
+                        : result;
+                }
             }
         }
 
-        internal override bool GenerateDebugInfo
-        {
-            get { return false; }
-        }
+        internal override bool GenerateDebugInfo => false;
 
         internal override OverriddenOrHiddenMembersResult OverriddenOrHiddenMembers
         {
             get
             {
-                if ((object)_lazyOverriddenOrHiddenMembersResult == null)
+                if (!_packedFlags.IsOverriddenOrHiddenMembersPopulated)
                 {
-                    Interlocked.CompareExchange(ref _lazyOverriddenOrHiddenMembersResult, base.OverriddenOrHiddenMembers, null);
+                    var result = base.OverriddenOrHiddenMembers;
+                    Debug.Assert(result != null);
+                    if (result != OverriddenOrHiddenMembersResult.Empty)
+                    {
+                        result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyOverriddenOrHiddenMembersResult, result);
+                    }
+
+                    _packedFlags.InitializeIsOverriddenOrHiddenMembersPopulated();
+                    return result;
                 }
 
-                return _lazyOverriddenOrHiddenMembersResult;
+                var uncommonFields = _uncommonFields;
+                if (uncommonFields == null)
+                {
+                    return OverriddenOrHiddenMembersResult.Empty;
+                }
+
+                return uncommonFields._lazyOverriddenOrHiddenMembersResult ?? InterlockedOperations.Initialize(ref uncommonFields._lazyOverriddenOrHiddenMembersResult, OverriddenOrHiddenMembersResult.Empty);
             }
         }
 
-        internal override CSharpCompilation DeclaringCompilation // perf, not correctness
-        {
-            get { return null; }
-        }
-
-        // Internal for unit test
-        internal bool TestIsExtensionBitSet
-        {
-            get
-            {
-                return _packedFlags.IsExtensionMethodIsPopulated;
-            }
-        }
+        // perf, not correctness
+        internal override CSharpCompilation DeclaringCompilation => null;
 
         // Internal for unit test
-        internal bool TestIsExtensionBitTrue
-        {
-            get
-            {
-                return _packedFlags.IsExtensionMethod;
-            }
-        }
+        internal bool TestIsExtensionBitSet => _packedFlags.IsExtensionMethodIsPopulated;
+
+        // Internal for unit test
+        internal bool TestIsExtensionBitTrue => _packedFlags.IsExtensionMethod;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -143,27 +143,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ThreadSafeFlagOperations.Set(ref _bits, bitsToSet);
             }
 
-            public void InitializeIsObsoleteAttributePopulated()
+            public void SetIsObsoleteAttributePopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsObsoleteAttributePopulatedBit);
             }
 
-            public void InitializeIsCustomAttributesPopulated()
+            public void SetIsCustomAttributesPopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsCustomAttributesPopulatedBit);
             }
 
-            public void InitializeIsUseSiteDiagnosticPopulated()
+            public void SetIsUseSiteDiagnosticPopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsUseSiteDiagnosticPopulatedBit);
             }
 
-            public void InitializeIsConditionalAttributePopulated()
+            public void SetIsConditionalAttributePopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsConditionalPopulatedBit);
             }
 
-            public void InitializeIsOverriddenOrHiddenMembersPopulated()
+            public void SetIsOverriddenOrHiddenMembersPopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsOverriddenOrHiddenMembersPopulatedBit);
             }
@@ -568,18 +568,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             if (count > 0)
             {
-                ParameterSymbol[] parameterCreation = new ParameterSymbol[count];
-
+                var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    parameterCreation[i] = new PEParameterSymbol(moduleSymbol, this, i, paramInfo[i + 1], out isBadParameter);
+                    builder.Add(new PEParameterSymbol(moduleSymbol, this, i, paramInfo[i + 1], out isBadParameter));
                     if (isBadParameter)
                     {
                         makeBad = true;
                     }
                 }
 
-                @params = parameterCreation.AsImmutableOrNull();
+                @params = builder.ToImmutable();
             }
             else
             {
@@ -730,7 +729,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     attributeData = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyCustomAttributes, attributeData);
                 }
 
-                _packedFlags.InitializeIsCustomAttributesPopulated();
+                _packedFlags.SetIsCustomAttributesPopulated();
                 return attributeData;
             }
 
@@ -1005,7 +1004,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 diagnostic = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyUseSiteDiagnostic, diagnostic, CSDiagnosticInfo.EmptyErrorInfo);
             }
 
-            _packedFlags.InitializeIsUseSiteDiagnosticPopulated();
+            _packedFlags.SetIsUseSiteDiagnosticPopulated();
             return diagnostic;
         }
 
@@ -1020,7 +1019,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyConditionalAttributeSymbols, result);
                 }
 
-                _packedFlags.InitializeIsConditionalAttributePopulated();
+                _packedFlags.SetIsConditionalAttributePopulated();
                 return result;
             }
 
@@ -1055,7 +1054,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyObsoleteAttributeData, result, ObsoleteAttributeData.Uninitialized);
                     }
 
-                    _packedFlags.InitializeIsObsoleteAttributePopulated();
+                    _packedFlags.SetIsObsoleteAttributePopulated();
                     return result;
                 }
 
@@ -1089,7 +1088,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyOverriddenOrHiddenMembersResult, result);
                     }
 
-                    _packedFlags.InitializeIsOverriddenOrHiddenMembersPopulated();
+                    _packedFlags.SetIsOverriddenOrHiddenMembersPopulated();
                     return result;
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
@@ -17,12 +17,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (ReferenceEquals(data, ObsoleteAttributeData.Uninitialized))
             {
-                ObsoleteAttributeData obsoleteAttributeData;
-                bool isObsolete = containingModule.Module.HasDeprecatedOrObsoleteAttribute(token, out obsoleteAttributeData);
-                Debug.Assert(isObsolete == (obsoleteAttributeData != null));
-                Debug.Assert(obsoleteAttributeData == null || !obsoleteAttributeData.IsUninitialized);
+                ObsoleteAttributeData obsoleteAttributeData = GetObsoleteDataFromMetadata(token, containingModule);
                 Interlocked.CompareExchange(ref data, obsoleteAttributeData, ObsoleteAttributeData.Uninitialized);
             }
+        }
+
+        /// <summary>
+        /// Get the ObsoleteAttributeData by fetching attributes and decoding ObsoleteAttributeData. This can be 
+        /// done for Metadata symbol easily whereas trying to do this for source symbols could result in cycles.
+        /// </summary>
+        internal static ObsoleteAttributeData GetObsoleteDataFromMetadata(Handle token, PEModuleSymbol containingModule)
+        {
+            ObsoleteAttributeData obsoleteAttributeData;
+            bool isObsolete = containingModule.Module.HasDeprecatedOrObsoleteAttribute(token, out obsoleteAttributeData);
+            Debug.Assert(isObsolete == (obsoleteAttributeData != null));
+            Debug.Assert(obsoleteAttributeData == null || !obsoleteAttributeData.IsUninitialized);
+            return obsoleteAttributeData;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Emit\EditAndContinue\SymbolMatcher.cs" />
     <Compile Include="InternalUtilities\FailFast.cs" />
     <Compile Include="InternalUtilities\FileStreamLightUp.cs" />
+    <Compile Include="InternalUtilities\InterlockedOperations.cs" />
     <Compile Include="InternalUtilities\IReadOnlySet.cs" />
     <Compile Include="Collections\KeyedStack.cs" />
     <Compile Include="Collections\OrderPreservingMultiDictionary.cs" />

--- a/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Roslyn.Utilities
+{
+    internal static class InterlockedOperations
+    {
+        /// <summary>
+        /// Initialize the value referenced by <paramref name="target"/> in a thread-safe manner.
+        /// The value is changed to <paramref name="value"/> only if the current value is null.
+        /// </summary>
+        /// <typeparam name="T">Type of value.</typeparam>
+        /// <param name="target">Referene to the target location.</param>
+        /// <param name="value">The value to use if the target is currently null.</param>
+        /// <returns>The new value referenced by <paramref name="target"/>. Note that this is
+        /// nearly always more useful than the usual return from <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>
+        /// because it saves another read to <paramref name="target"/>.</returns>
+        public static T Initialize<T>(ref T target, T value) where T : class
+        {
+            Debug.Assert((object)value != null);
+            return Interlocked.CompareExchange(ref target, value, null) ?? value;
+        }
+
+        /// <summary>
+        /// Initialize the value referenced by <paramref name="target"/> in a thread-safe manner.
+        /// The value is changed to <paramref name="initializedValue"/> only if the current value
+        /// is <paramref name="uninitializedValue"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of value.</typeparam>
+        /// <param name="target">Referene to the target location.</param>
+        /// <param name="initializedValue">The value to use if the target is currently uninitialized.</param>
+        /// <param name="uninitializedValue">The uninitialized value.</param>
+        /// <returns>The new value referenced by <paramref name="target"/>. Note that this is
+        /// nearly always more useful than the usual return from <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>
+        /// because it saves another read to <paramref name="target"/>.</returns>
+        public static T Initialize<T>(ref T target, T initializedValue, T uninitializedValue) where T : class
+        {
+            Debug.Assert((object)initializedValue != uninitializedValue);
+            T oldValue = Interlocked.CompareExchange(ref target, initializedValue, uninitializedValue);
+            return (object)oldValue == uninitializedValue ? initializedValue : oldValue;
+        }
+
+        /// <summary>
+        /// Initialize the immutable array referenced by <paramref name="target"/> in a thread-safe manner.
+        /// </summary>
+        /// <typeparam name="T">Elemental type of the array.</typeparam>
+        /// <param name="target">Referene to the target location.</param>
+        /// <param name="initializedValue">The value to use if the target is currently uninitialized (default).</param>
+        /// <returns>The new value referenced by <paramref name="target"/>. Note that this is
+        /// nearly always more useful than the usual return from <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>
+        /// because it saves another read to <paramref name="target"/>.</returns>
+        public static ImmutableArray<T> Initialize<T>(ref ImmutableArray<T> target, ImmutableArray<T> initializedValue)
+        {
+            Debug.Assert(!initializedValue.IsDefault);
+            var oldValue = ImmutableInterlocked.InterlockedCompareExchange(ref target, initializedValue, default(ImmutableArray<T>));
+            return oldValue.IsDefault ? initializedValue : oldValue;
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -20,33 +20,178 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
     Friend NotInheritable Class PEMethodSymbol
         Inherits MethodSymbol
 
-        Private Const s_uninitializedMethodKind As Integer = -1
-
         Private ReadOnly _handle As MethodDefinitionHandle
         Private ReadOnly _name As String
-        Private ReadOnly _implFlags As MethodImplAttributes
-        Private ReadOnly _flags As MethodAttributes
+        Private ReadOnly _implFlags As UShort
+        Private ReadOnly _flags As UShort
         Private ReadOnly _containingType As PENamedTypeSymbol
 
         Private _associatedPropertyOrEventOpt As Symbol
 
-        Private _lazyMethodKind As Integer = s_uninitializedMethodKind ' really a MethodKind, but Interlocked.CompareExchange doesn't handle those
+        Private _packedFlags As PackedFlags
 
         Private _lazyTypeParameters As ImmutableArray(Of TypeParameterSymbol)
 
-        Private _lazyDocComment As Tuple(Of CultureInfo, String)
-
         Private _lazyExplicitMethodImplementations As ImmutableArray(Of MethodSymbol)
 
-        Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
-        Private _lazyConditionalAttributeSymbols As ImmutableArray(Of String)
+        ''' <summary>
+        ''' A single field to hold optional auxiliary data.
+        ''' In many scenarios it is possible to avoid allocating this, thus saving total space in <see cref="PEModuleSymbol"/>.
+        ''' Even for lazily-computed values, it may be possible to avoid allocating <see cref="_uncommonFields"/> if
+        ''' the computed value is a well-known "empty" value. In this case, bits in <see cref="_packedFlags"/> are used
+        ''' to indicate that the lazy values have been computed and, if <see cref="_uncommonFields"/> is null, then
+        ''' the "empty" value should be inferred.
+        ''' </summary>
+        Private _uncommonFields As UncommonFields
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private Structure PackedFlags
+            ' Flags are packed into a 32-bit int with the following layout:
+            ' |              h|g|f|e|d|c|b|aaaaa|
+            '
+            ' a = method kind. 5 bits
+            ' b = method kind populated. 1 bit
+            ' c = isExtensionMethod. 1 bit.
+            ' d = isExtensionMethod populated. 1 bit.
+            ' e = obsolete attribute populated. 1 bit
+            ' f = custom attributes populated. 1 bit
+            ' g = use site diagnostic populated. 1 bit
+            ' h = conditional attributes populted. 1 bit
 
-        Private _lazyIsExtensionMethod As Byte = ThreeState.Unknown
-        Private _lazyObsoleteAttributeData As ObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
+            Private _bits As Integer
 
-        Private _lazyMeParameter As ParameterSymbol
+            Private Const MethodKindOffset As Integer = 0
+            Private Const MethodKindMask As Integer = &H1F
+            Private Const MethodKindIsPopulatedBit As Integer = 1 << 5
+            Private Const IsExtensionMethodBit As Integer = 1 << 6
+            Private Const IsExtensionMethodIsPopulatedBit As Integer = 1 << 7
+            Private Const IsObsoleteAttributePopulatedBit As Integer = 1 << 8
+            Private Const IsCustomAttributesPopulatedBit As Integer = 1 << 9
+            Private Const IsUseSiteDiagnosticPopulatedBit As Integer = 1 << 10
+            Private Const IsConditionalAttributePopulatedBit As Integer = 1 << 11
+
+            Public Property MethodKind As MethodKind
+                Get
+                    Return CType((_bits >> MethodKindOffset) And MethodKindMask, MethodKind)
+                End Get
+                Set(value As MethodKind)
+                    Debug.Assert(value = (value And MethodKindMask))
+                    _bits = (_bits And Not (MethodKindMask << MethodKindOffset)) Or (value << MethodKindOffset) Or MethodKindIsPopulatedBit
+                End Set
+            End Property
+
+            Public ReadOnly Property MethodKindIsPopulated As Boolean
+                Get
+                    Return (_bits And MethodKindIsPopulatedBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsExtensionMethod As Boolean
+                Get
+                    Return (_bits And IsExtensionMethodBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsExtensionMethodPopulated As Boolean
+                Get
+                    Return (_bits And IsExtensionMethodIsPopulatedBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsObsoleteAttributePopulated As Boolean
+                Get
+                    Return (_bits And IsObsoleteAttributePopulatedBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsCustomAttributesPopulated As Boolean
+                Get
+                    Return (_bits And IsCustomAttributesPopulatedBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsUseSiteDiagnoticPopulated As Boolean
+                Get
+                    Return (_bits And IsUseSiteDiagnosticPopulatedBit) <> 0
+                End Get
+            End Property
+
+            Public ReadOnly Property IsConditionalPopulated As Boolean
+                Get
+                    Return (_bits And IsConditionalAttributePopulatedBit) <> 0
+                End Get
+            End Property
+
+            Private Shared Function BitsAreUnsetOrSame(bits As Integer, mask As Integer) As Boolean
+                Return (bits And mask) = 0 OrElse (bits And mask) = mask
+            End Function
+
+            Public Sub InitializeMethodKind(methodKind As MethodKind)
+                Debug.Assert(methodKind = (methodKind And MethodKindMask))
+                Dim bitsToSet = ((methodKind And MethodKindMask) << MethodKindOffset) Or MethodKindIsPopulatedBit
+                Debug.Assert(BitsAreUnsetOrSame(_bits, bitsToSet))
+                ThreadSafeFlagOperations.Set(_bits, bitsToSet)
+            End Sub
+
+            Public Sub InitializeIsExtensionMethod(isExtensionMethod As Boolean)
+                Dim bitsToSet = If(isExtensionMethod, IsExtensionMethodBit, 0) Or IsExtensionMethodIsPopulatedBit
+                Debug.Assert(BitsAreUnsetOrSame(_bits, bitsToSet))
+                ThreadSafeFlagOperations.Set(_bits, bitsToSet)
+            End Sub
+
+            Public Sub InitializeIsObsoleteAttributePopulated()
+                ThreadSafeFlagOperations.Set(_bits, IsObsoleteAttributePopulatedBit)
+            End Sub
+
+            Public Sub InitializeIsCustomAttributesPopulated()
+                ThreadSafeFlagOperations.Set(_bits, IsCustomAttributesPopulatedBit)
+            End Sub
+
+            Public Sub InitializeIsUseSiteDiagnosticPopulated()
+                ThreadSafeFlagOperations.Set(_bits, IsUseSiteDiagnosticPopulatedBit)
+            End Sub
+
+            Public Sub InitializeIsConditionalAttributePopulated()
+                ThreadSafeFlagOperations.Set(_bits, IsConditionalAttributePopulatedBit)
+            End Sub
+        End Structure
+
+        ''' <summary>
+        ''' Holds infrequently accessed fields. See <seealso cref="_uncommonFields"/> for an explanation.
+        ''' </summary>
+        Private NotInheritable Class UncommonFields
+            Public _lazyMeParameter As ParameterSymbol
+            Public _lazyDocComment As Tuple(Of CultureInfo, String)
+            Public _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
+            Public _lazyConditionalAttributeSymbols As ImmutableArray(Of String)
+            Public _lazyObsoleteAttributeData As ObsoleteAttributeData
+            Public _lazyUseSiteErrorInfo As DiagnosticInfo
+        End Class
+
+        Private Function CreateUncommonFields() As UncommonFields
+            Dim retVal = New UncommonFields
+
+            If Not _packedFlags.IsObsoleteAttributePopulated Then
+                retVal._lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
+            End If
+
+            If Not _packedFlags.IsUseSiteDiagnoticPopulated Then
+                retVal._lazyUseSiteErrorInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+            End If
+
+            If _packedFlags.IsCustomAttributesPopulated Then
+                retVal._lazyCustomAttributes = ImmutableArray(Of VisualBasicAttributeData).Empty
+            End If
+
+            If _packedFlags.IsConditionalPopulated Then
+                retVal._lazyConditionalAttributeSymbols = ImmutableArray(Of String).Empty
+            End If
+            Return retVal
+        End Function
+
+        Private Function AccessUncommonFields() As UncommonFields
+            Dim retVal = _uncommonFields
+            Return If(retVal, InterlockedOperations.Initialize(_uncommonFields, CreateUncommonFields()))
+        End Function
 
 
 #Region "Signature data"
@@ -78,14 +223,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             _containingType = containingType
 
             Try
+                Dim implFlags As MethodImplAttributes
+                Dim flags As MethodAttributes
                 Dim rva As Integer
-                moduleSymbol.Module.GetMethodDefPropsOrThrow(handle, _name, _implFlags, _flags, rva)
+                moduleSymbol.Module.GetMethodDefPropsOrThrow(handle, _name, implFlags, flags, rva)
+                _implFlags = CType(implFlags, UShort)
+                _flags = CType(flags, UShort)
             Catch mrEx As BadImageFormatException
                 If _name Is Nothing Then
                     _name = String.Empty
                 End If
 
-                _lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                AccessUncommonFields()._lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                _packedFlags.InitializeIsUseSiteDiagnosticPopulated()
             End Try
         End Sub
 
@@ -127,25 +277,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Friend ReadOnly Property MethodImplFlags As MethodImplAttributes
             Get
-                Return _implFlags
+                Return CType(_implFlags, MethodImplAttributes)
             End Get
         End Property
 
         Friend ReadOnly Property MethodFlags As MethodAttributes
             Get
-                Return _flags
+                Return CType(_flags, MethodAttributes)
             End Get
         End Property
 
         Public Overrides ReadOnly Property MethodKind As MethodKind
             Get
-                If _lazyMethodKind = s_uninitializedMethodKind Then
-                    Dim computed As MethodKind = ComputeMethodKind()
-                    Dim oldValue As Integer = Interlocked.CompareExchange(_lazyMethodKind, CType(computed, Integer), s_uninitializedMethodKind)
-                    Debug.Assert(oldValue = s_uninitializedMethodKind OrElse oldValue = computed)
+                If Not _packedFlags.MethodKindIsPopulated Then
+                    _packedFlags.InitializeMethodKind(ComputeMethodKind())
                 End If
 
-                Return CType(_lazyMethodKind, MethodKind)
+                Return _packedFlags.MethodKind
             End Get
 
         End Property
@@ -211,8 +359,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Friend Overrides Function IsParameterlessConstructor() As Boolean
-            If _lazyMethodKind <> s_uninitializedMethodKind Then
-                Return _lazyMethodKind = MethodKind.Constructor AndAlso ParameterCount = 0
+            If _packedFlags.MethodKindIsPopulated Then
+                Return _packedFlags.MethodKind = MethodKind.Constructor AndAlso ParameterCount = 0
             End If
 
             ' 10.5.1 Instance constructor
@@ -227,9 +375,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                ParameterCount = 0 AndAlso
                IsSub AndAlso Arity = 0 Then
 
-                Dim oldValue As Integer = Interlocked.CompareExchange(_lazyMethodKind, MethodKind.Constructor, s_uninitializedMethodKind)
-                Debug.Assert(oldValue = s_uninitializedMethodKind OrElse oldValue = MethodKind.Constructor)
-
+                _packedFlags.MethodKind = MethodKind.Constructor
                 Return True
             End If
 
@@ -342,18 +488,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                         Continue For
                     End If
 
-                    Select Case contender._lazyMethodKind
-                        Case s_uninitializedMethodKind, MethodKind.Ordinary
-                        ' Need to check against our method
-                        Case potentialMethodKind
-                            If i = 0 OrElse adjustContendersOfAdditionalName Then
-                                ' Contender was already cleared, so it cannot conflict with this operator.
+                    If contender._packedFlags.MethodKindIsPopulated Then
+                        Select Case contender._packedFlags.MethodKind
+                            Case MethodKind.Ordinary
+                            ' Need to check against our method
+                            Case potentialMethodKind
+                                If i = 0 OrElse adjustContendersOfAdditionalName Then
+                                    ' Contender was already cleared, so it cannot conflict with this operator.
+                                    Continue For
+                                End If
+                            Case Else
+                                ' Cannot be an operator of the target kind.
                                 Continue For
-                            End If
-                        Case Else
-                            ' Cannot be an operator of the target kind.
-                            Continue For
-                    End Select
+                        End Select
+                    End If
 
                     If potentialMethodKind = MethodKind.Conversion AndAlso Not outputType.IsSameTypeIgnoringCustomModifiers(contender.ReturnType) Then
                         Continue For
@@ -375,8 +523,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
                     ' Mark the contender too.
                     If i = 0 OrElse adjustContendersOfAdditionalName Then
-                        Dim oldValue As Integer = Interlocked.CompareExchange(contender._lazyMethodKind, MethodKind.Ordinary, s_uninitializedMethodKind)
-                        Debug.Assert(oldValue = s_uninitializedMethodKind OrElse oldValue = MethodKind.Ordinary)
+                        contender._packedFlags.InitializeMethodKind(MethodKind.Ordinary)
                     End If
                 Next
             Next
@@ -424,11 +571,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Property
 
         Public Overloads Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)
-            If _lazyCustomAttributes.IsDefault Then
+            If Not _packedFlags.IsCustomAttributesPopulated Then
+                Dim attributeData As ImmutableArray(Of VisualBasicAttributeData) = Nothing
                 Dim containingPEModuleSymbol = DirectCast(ContainingModule(), PEModuleSymbol)
-                containingPEModuleSymbol.LoadCustomAttributes(Me.Handle, _lazyCustomAttributes)
+                containingPEModuleSymbol.LoadCustomAttributes(Me.Handle, attributeData)
+                Debug.Assert(Not attributeData.IsDefault)
+                If Not attributeData.IsEmpty Then
+                    attributeData = InterlockedOperations.Initialize(AccessUncommonFields()._lazyCustomAttributes, attributeData)
+                End If
+
+                _packedFlags.InitializeIsCustomAttributesPopulated()
+                Return attributeData
             End If
-            Return _lazyCustomAttributes
+
+            Dim uncommonFields = _uncommonFields
+            If uncommonFields Is Nothing Then
+                Return ImmutableArray(Of VisualBasicAttributeData).Empty
+            Else
+                Dim attributeData = uncommonFields._lazyCustomAttributes
+                Return If(attributeData.IsDefault,
+                    InterlockedOperations.Initialize(uncommonFields._lazyCustomAttributes, ImmutableArray(Of VisualBasicAttributeData).Empty),
+                    attributeData)
+            End If
         End Function
 
         Friend Overrides Function GetCustomAttributesToEmit(compilationState As ModuleCompilationState) As IEnumerable(Of VisualBasicAttributeData)
@@ -437,7 +601,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Public Overrides ReadOnly Property IsExtensionMethod As Boolean
             Get
-                If _lazyIsExtensionMethod = ThreeState.Unknown Then
+                If Not _packedFlags.IsExtensionMethodPopulated Then
 
                     Dim result As Boolean = False
 
@@ -453,14 +617,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                         result = Not (firstParam.IsOptional OrElse firstParam.IsParamArray)
                     End If
 
-                    If result Then
-                        _lazyIsExtensionMethod = ThreeState.True
-                    Else
-                        _lazyIsExtensionMethod = ThreeState.False
-                    End If
+                    _packedFlags.InitializeIsExtensionMethod(result)
                 End If
 
-                Return _lazyIsExtensionMethod = ThreeState.True
+                Return _packedFlags.IsExtensionMethod
             End Get
         End Property
 
@@ -604,11 +764,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Public Overrides ReadOnly Property IsOverridable As Boolean
             Get
-                Dim flagsToCheck As MethodAttributes = (_flags And
-                                                        (MethodAttributes.Virtual Or
-                                                         MethodAttributes.Final Or
-                                                         MethodAttributes.Abstract Or
-                                                         MethodAttributes.NewSlot))
+                Dim flagsToCheck = (_flags And
+                                    (MethodAttributes.Virtual Or
+                                     MethodAttributes.Final Or
+                                     MethodAttributes.Abstract Or
+                                     MethodAttributes.NewSlot))
 
                 Return flagsToCheck = (MethodAttributes.Virtual Or MethodAttributes.NewSlot) OrElse
                        (flagsToCheck = MethodAttributes.Virtual AndAlso _containingType.BaseTypeNoUseSiteDiagnostics Is Nothing)
@@ -738,7 +898,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             If Me._associatedPropertyOrEventOpt Is Nothing Then
                 Debug.Assert(propertyOrEventSymbol.ContainingType = Me.ContainingType)
                 Me._associatedPropertyOrEventOpt = propertyOrEventSymbol
-                _lazyMethodKind = CType(methodKind, Integer)
+                _packedFlags.MethodKind = methodKind
                 Return True
             End If
 
@@ -788,11 +948,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Dim returnParam = New PEParameterSymbol(moduleSymbol, Me, 0, paramInfo(0), isBad)
 
                 If mrEx IsNot Nothing OrElse hasBadParameter OrElse isBad Then
-                    Dim old = Interlocked.CompareExchange(_lazyUseSiteErrorInfo,
+                    Dim old = Interlocked.CompareExchange(AccessUncommonFields()._lazyUseSiteErrorInfo,
                                                           ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me)),
                                                           ErrorFactory.EmptyErrorInfo)
                     Debug.Assert(old Is ErrorFactory.EmptyErrorInfo OrElse
                                  (old IsNot Nothing AndAlso old.Code = ERRID.ERR_UnsupportedMethod1))
+                    _packedFlags.InitializeIsUseSiteDiagnosticPopulated()
                 End If
 
                 Dim signature As New SignatureData(signatureHeader, params, returnParam)
@@ -802,8 +963,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Public Overrides ReadOnly Property TypeParameters As ImmutableArray(Of TypeParameterSymbol)
             Get
-                EnsureTypeParametersAreLoaded()
-                Return _lazyTypeParameters
+                Dim errorInfo As DiagnosticInfo = Nothing
+                EnsureTypeParametersAreLoaded(errorInfo)
+                Dim typeParams = EnsureTypeParametersAreLoaded(errorInfo)
+                If errorInfo IsNot Nothing Then
+                    InitializeUseSiteErrorInfo(errorInfo)
+                End If
+                Return typeParams
             End Get
         End Property
 
@@ -817,42 +983,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        Private Sub EnsureTypeParametersAreLoaded()
-
-            If _lazyTypeParameters.IsDefault Then
-
-                Dim typeParams As ImmutableArray(Of TypeParameterSymbol)
-
-                Try
-                    Dim moduleSymbol = _containingType.ContainingPEModule
-                    Dim gpHandles = moduleSymbol.Module.GetGenericParametersForMethodOrThrow(_handle)
-
-
-                    If gpHandles.Count = 0 Then
-                        typeParams = ImmutableArray(Of TypeParameterSymbol).Empty
-                    Else
-                        Dim ownedParams(gpHandles.Count - 1) As PETypeParameterSymbol
-
-                        For i = 0 To ownedParams.Length - 1
-                            ownedParams(i) = New PETypeParameterSymbol(moduleSymbol, Me, CUShort(i), gpHandles(i))
-                        Next
-
-                        typeParams = StaticCast(Of TypeParameterSymbol).From(ownedParams.AsImmutableOrNull)
-                    End If
-                Catch mrEx As BadImageFormatException
-                    Dim old = Interlocked.CompareExchange(_lazyUseSiteErrorInfo,
-                                                          ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me)),
-                                                          ErrorFactory.EmptyErrorInfo)
-                    Debug.Assert(old Is ErrorFactory.EmptyErrorInfo OrElse
-                                 (old IsNot Nothing AndAlso old.Code = ERRID.ERR_UnsupportedMethod1))
-
-                    typeParams = ImmutableArray(Of TypeParameterSymbol).Empty
-                End Try
-
-                ImmutableInterlocked.InterlockedCompareExchange(_lazyTypeParameters, typeParams, Nothing)
+        Private Function EnsureTypeParametersAreLoaded(ByRef errorInfo As DiagnosticInfo) As ImmutableArray(Of TypeParameterSymbol)
+            Dim typeParams = _lazyTypeParameters
+            If Not typeParams.IsDefault Then
+                Return typeParams
             End If
 
-        End Sub
+            Return InterlockedOperations.Initialize(_lazyTypeParameters, LoadTypeParameters(errorInfo))
+        End Function
+
+        Private Function LoadTypeParameters(ByRef errorInfo As DiagnosticInfo) As ImmutableArray(Of TypeParameterSymbol)
+
+            Try
+                Dim moduleSymbol = _containingType.ContainingPEModule
+                Dim gpHandles = moduleSymbol.Module.GetGenericParametersForMethodOrThrow(_handle)
+
+
+                If gpHandles.Count = 0 Then
+                    Return ImmutableArray(Of TypeParameterSymbol).Empty
+                Else
+                    Dim ownedParams = ImmutableArray.CreateBuilder(Of TypeParameterSymbol)(gpHandles.Count)
+                    For i = 0 To gpHandles.Count - 1
+                        ownedParams.Add(New PETypeParameterSymbol(moduleSymbol, Me, CUShort(i), gpHandles(i)))
+                    Next
+
+                    Return ownedParams.ToImmutable()
+                End If
+            Catch mrEx As BadImageFormatException
+                errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                Return ImmutableArray(Of TypeParameterSymbol).Empty
+            End Try
+
+        End Function
 
         Friend Overrides ReadOnly Property CallingConvention As Microsoft.Cci.CallingConvention
             Get
@@ -909,7 +1071,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Public Overrides Function GetDocumentationCommentXml(Optional preferredCulture As CultureInfo = Nothing, Optional expandIncludes As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As String
             ' Note: m_lazyDocComment is passed ByRef
             Return PEDocumentationCommentUtils.GetDocumentationComment(
-                Me, _containingType.ContainingPEModule, preferredCulture, cancellationToken, _lazyDocComment)
+                Me, _containingType.ContainingPEModule, preferredCulture, cancellationToken, AccessUncommonFields()._lazyDocComment)
         End Function
 
         Friend Overrides ReadOnly Property Syntax As VisualBasicSyntaxNode
@@ -919,31 +1081,79 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Property
 
         Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
+            If Not _packedFlags.IsUseSiteDiagnoticPopulated Then
                 Dim errorInfo As DiagnosticInfo = CalculateUseSiteErrorInfo()
-                EnsureTypeParametersAreLoaded()
-                Interlocked.CompareExchange(_lazyUseSiteErrorInfo, errorInfo, ErrorFactory.EmptyErrorInfo)
+                EnsureTypeParametersAreLoaded(errorInfo)
+                Return InitializeUseSiteErrorInfo(errorInfo)
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Dim uncommonFields = _uncommonFields
+            If uncommonFields Is Nothing Then
+                Return Nothing
+            Else
+                Dim result = uncommonFields._lazyUseSiteErrorInfo
+                Return If(result Is ErrorFactory.EmptyErrorInfo,
+                    InterlockedOperations.Initialize(uncommonFields._lazyUseSiteErrorInfo, Nothing, ErrorFactory.EmptyErrorInfo),
+                    result)
+            End If
+        End Function
+
+        Private Function InitializeUseSiteErrorInfo(errorInfo As DiagnosticInfo) As DiagnosticInfo
+            Debug.Assert(errorInfo IsNot ErrorFactory.EmptyErrorInfo)
+            If errorInfo IsNot Nothing Then
+                errorInfo = InterlockedOperations.Initialize(AccessUncommonFields()._lazyUseSiteErrorInfo, errorInfo, ErrorFactory.EmptyErrorInfo)
+            End If
+
+            _packedFlags.InitializeIsUseSiteDiagnosticPopulated()
+            Return errorInfo
         End Function
 
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
-                ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(_lazyObsoleteAttributeData, _handle, DirectCast(ContainingModule, PEModuleSymbol))
-                Return _lazyObsoleteAttributeData
+                If Not _packedFlags.IsObsoleteAttributePopulated Then
+                    Dim result = ObsoleteAttributeHelpers.GetObsoleteDataFromMetadata(_handle, DirectCast(ContainingModule, PEModuleSymbol))
+                    If result IsNot Nothing Then
+                        result = InterlockedOperations.Initialize(AccessUncommonFields()._lazyObsoleteAttributeData, result, ObsoleteAttributeData.Uninitialized)
+                    End If
+
+                    _packedFlags.InitializeIsObsoleteAttributePopulated()
+                    Return result
+                End If
+
+                Dim uncommonFields = _uncommonFields
+                If uncommonFields Is Nothing Then
+                    Return Nothing
+                Else
+                    Dim result = uncommonFields._lazyObsoleteAttributeData
+                    Return If(result Is ObsoleteAttributeData.Uninitialized,
+                              InterlockedOperations.Initialize(uncommonFields._lazyObsoleteAttributeData, Nothing, ObsoleteAttributeData.Uninitialized),
+                              result)
+                End If
             End Get
         End Property
 
         Friend Overrides Function GetAppliedConditionalSymbols() As ImmutableArray(Of String)
-            If Me._lazyConditionalAttributeSymbols.IsDefaultOrEmpty Then
+            If Not _packedFlags.IsConditionalPopulated Then
                 Dim moduleSymbol As PEModuleSymbol = _containingType.ContainingPEModule
                 Dim conditionalSymbols As ImmutableArray(Of String) = moduleSymbol.Module.GetConditionalAttributeValues(_handle)
                 Debug.Assert(Not conditionalSymbols.IsDefault)
-                ImmutableInterlocked.InterlockedCompareExchange(_lazyConditionalAttributeSymbols, conditionalSymbols, Nothing)
+                If Not conditionalSymbols.IsEmpty Then
+                    conditionalSymbols = InterlockedOperations.Initialize(AccessUncommonFields()._lazyConditionalAttributeSymbols, conditionalSymbols)
+                End If
+
+                _packedFlags.InitializeIsConditionalAttributePopulated()
+                Return conditionalSymbols
             End If
 
-            Return Me._lazyConditionalAttributeSymbols
+            Dim uncommonFields = _uncommonFields
+            If uncommonFields Is Nothing Then
+                Return ImmutableArray(Of String).Empty
+            Else
+                Dim result = uncommonFields._lazyConditionalAttributeSymbols
+                Return If(result.IsDefault,
+                    InterlockedOperations.Initialize(uncommonFields._lazyConditionalAttributeSymbols, ImmutableArray(Of String).Empty),
+                    result)
+            End If
         End Function
 
         ''' <remarks>
@@ -956,13 +1166,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Property
 
         Friend Overrides Function TryGetMeParameter(<Out> ByRef meParameter As ParameterSymbol) As Boolean
-            meParameter = _lazyMeParameter
-            If meParameter IsNot Nothing OrElse Me.IsShared Then
-                Return True
+            If IsShared Then
+                meParameter = Nothing
+            Else
+                meParameter = If(_uncommonFields?._lazyMeParameter, InterlockedOperations.Initialize(AccessUncommonFields()._lazyMeParameter, New MeParameterSymbol(Me)))
             End If
-
-            Interlocked.CompareExchange(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
-            meParameter = _lazyMeParameter
             Return True
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -18,13 +18,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend Shared Sub InitializeObsoleteDataFromMetadata(ByRef data As ObsoleteAttributeData, token As Handle, containingModule As PEModuleSymbol)
             If data Is ObsoleteAttributeData.Uninitialized Then
-                Dim obsoleteAttributeData As ObsoleteAttributeData = Nothing
-                Dim isObsolete As Boolean = containingModule.Module.HasDeprecatedOrObsoleteAttribute(token, obsoleteAttributeData)
-                Debug.Assert(isObsolete = (obsoleteAttributeData IsNot Nothing))
-                Debug.Assert(obsoleteAttributeData Is Nothing OrElse Not obsoleteAttributeData.IsUninitialized)
+                Dim obsoleteAttributeData As ObsoleteAttributeData = GetObsoleteDataFromMetadata(token, containingModule)
                 Interlocked.CompareExchange(data, obsoleteAttributeData, obsoleteAttributeData.Uninitialized)
             End If
         End Sub
+
+        Friend Shared Function GetObsoleteDataFromMetadata(token As Handle, containingModule As PEModuleSymbol) As ObsoleteAttributeData
+            Dim obsoleteAttributeData As ObsoleteAttributeData = Nothing
+            Dim isObsolete As Boolean = containingModule.Module.HasDeprecatedOrObsoleteAttribute(token, obsoleteAttributeData)
+            Debug.Assert(isObsolete = (obsoleteAttributeData IsNot Nothing))
+            Debug.Assert(obsoleteAttributeData Is Nothing OrElse Not obsoleteAttributeData.IsUninitialized)
+            Return obsoleteAttributeData
+        End Function
 
         ''' <summary>
         ''' This method checks to see if the given symbol is Obsolete or if any symbol in the parent hierarchy is Obsolete.


### PR DESCRIPTION
PEMethodSymbol is the most frequent symbol allocation during compilation. This change reduces PEMethodSymbol's size by moving some rarely used fields into an auxiliary "UncommonFields" class. UncommonFields are allocated only when necessary. In addition to being purely 'lazy', if the computed values are well-known 'common' values we can further avoid creating UncommonFields by using bits in a _packedFlags field. When a lazily computed value is resolved, a bit is set in _packedFlags but we allocate an UncommonFields instance to store the result only if it's "uncommon". On subsequent accesses, if the bit is set, but _uncommonFields is still null, then we infer the "common" value.