### PR TITLE
Fix build warnings

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
@@ -3200,10 +3200,10 @@ Unify Enum declarations with other block type declarations.
       <description>
         Represents a multi-line "If ... Then ... ElseIf ... Then ... Else ... End If" block.
       </description>
-      <spec-section>10.8.1</spec-section>
-      <grammar>IfStatement</grammar>
       <lm-equiv name="IfNode">A MultiLineIfBlock corresponds to an IfNode -- the If statement and its following body.</lm-equiv>
       <native-equiv name="IfStatement">A MultiLineIfBlock corresponds to an IfStatement -- the If statement and its following body.</native-equiv>
+      <spec-section>10.8.1</spec-section>
+      <grammar>IfStatement</grammar>
 
       <node-kind name="MultiLineIfBlock" />
 

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
@@ -42,7 +42,7 @@
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor.Interop.dll">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsft.VisualStudio.Platform.VSEditor.Interop.dll</HintPath>
+      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Platform.VSEditor.Interop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Program.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Program.vb
@@ -33,31 +33,37 @@ Module Program
             Dim outputFile = paths(1)
 
             If Not File.Exists(inputFile) Then
-                WriteLine("Input file not found - ""{0}""", inputFile)
+                Console.Error.WriteLine("Input file not found - ""{0}""", inputFile)
 
                 Return exitWithErrors
             End If
 
-            Dim definition = ReadDefinition(inputFile)
+            Dim definition As ParseTree = Nothing
+            If Not TryReadDefinition(inputFile, definition) Then
+                Return exitWithErrors
+            End If
+
             Dim outputKind = If(switches.Any(), switches(0).ToLowerInvariant(), Nothing)
             WriteOutput(outputFile, definition, outputKind)
 
             Return exitWithoutErrors
         Catch ex As Exception
-            WriteLine("FATAL ERROR: {0}", ex.Message)
-            WriteLine(ex.StackTrace)
+            Console.Error.WriteLine("FATAL ERROR: {0}", ex.Message)
+            Console.Error.WriteLine(ex.StackTrace)
 
             Return exitWithErrors
         End Try
 
     End Function
 
-    Function ReadDefinition(inputFile As String) As ParseTree
-        Dim definition = ReadTheTree(inputFile)
+    Function TryReadDefinition(inputFile As String, ByRef definition As ParseTree) As Boolean
+        If Not TryReadTheTree(inputFile, definition) Then
+            Return False
+        End If
 
         ValidateTree(definition)
 
-        Return definition
+        Return True
     End Function
 
     Sub WriteOutput(outputFile As String, definition As ParseTree, outputKind As String)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Program.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Program.vb
@@ -2,6 +2,7 @@
 
 Imports System.IO
 Imports System.Console
+Imports System.Runtime.InteropServices
 
 ''' <summary>
 ''' Contains the startup code, command line argument processing, and driving the execution of the tool.
@@ -56,7 +57,7 @@ Module Program
 
     End Function
 
-    Function TryReadDefinition(inputFile As String, ByRef definition As ParseTree) As Boolean
+    Function TryReadDefinition(inputFile As String, <Out> ByRef definition As ParseTree) As Boolean
         If Not TryReadTheTree(inputFile, definition) Then
             Return False
         End If

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ReadTree.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ReadTree.vb
@@ -15,14 +15,17 @@ Public Module ReadTree
     Dim currentFile As String
 
     ' Read an XML file and return the resulting ParseTree object.
-    Public Function ReadTheTree(fileName As String, Optional ByRef xDoc As XDocument = Nothing) As ParseTree
+    Public Function TryReadTheTree(fileName As String, ByRef tree As ParseTree) As Boolean
 
         Console.WriteLine("Reading input file ""{0}""...", fileName)
 
-        xDoc = GetXDocument(fileName)
+        Dim validationError As Boolean = False
+        Dim xDoc = GetXDocument(fileName, validationError)
+        If validationError Then
+            Return False
+        End If
 
-        Dim tree As New ParseTree
-
+        tree = New ParseTree
         Dim x = xDoc.<define-parse-tree>
 
         tree.FileName = fileName
@@ -59,14 +62,23 @@ Public Module ReadTree
         Next
 
         tree.FinishedReading()
-        Return tree
+        Return True
     End Function
 
     ' Open the input XML file as an XDocument, using the reading options that we want.
     ' We use a schema to validate the input.
-    Private Function GetXDocument(fileName As String) As XDocument
+    Private Function GetXDocument(fileName As String, ByRef validationError As Boolean) As XDocument
         currentFile = fileName
 
+        Dim hadError = False
+        Dim onValidationError =
+            Sub(sender As Object, e As ValidationEventArgs)
+                ' A validation error occurred while reading the document. Tell the user.
+                Console.Error.WriteLine("{0}({1},{2}): Invalid input: {3}", currentFile, e.Exception.LineNumber, e.Exception.LinePosition, e.Exception.Message)
+                hadError = True
+            End Sub
+
+        Dim xDoc As XDocument
         Using schemaReader = XmlReader.Create(Assembly.GetExecutingAssembly().GetManifestResourceStream("VBSyntaxModelSchema.xsd"))
 
             Dim readerSettings As New XmlReaderSettings()
@@ -74,18 +86,16 @@ Public Module ReadTree
             readerSettings.XmlResolver = Nothing
             readerSettings.Schemas.Add(Nothing, schemaReader)
             readerSettings.ValidationType = ValidationType.Schema
-            AddHandler readerSettings.ValidationEventHandler, AddressOf ValidationError
+            AddHandler readerSettings.ValidationEventHandler, onValidationError
 
             Dim fileStream As New FileStream(fileName, FileMode.Open, FileAccess.Read)
             Using reader = XmlReader.Create(fileStream, readerSettings)
-                Return XDocument.Load(reader, LoadOptions.SetLineInfo Or LoadOptions.PreserveWhitespace)
+                xDoc = XDocument.Load(reader, LoadOptions.SetLineInfo Or LoadOptions.PreserveWhitespace)
             End Using
         End Using
-    End Function
 
-    ' A validation error occurred while reading the document. Tell the user.
-    Private Sub ValidationError(sender As Object, e As ValidationEventArgs)
-        Console.WriteLine("{0}({1},{2}): Invalid input: {3}", currentFile, e.Exception.LineNumber, e.Exception.LinePosition, e.Exception.Message)
-    End Sub
+        validationError = hadError
+        Return xDoc
+    End Function
 
 End Module

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ReadTree.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ReadTree.vb
@@ -7,6 +7,7 @@
 
 Imports System.IO
 Imports System.Reflection
+Imports System.Runtime.InteropServices
 Imports System.Xml
 Imports System.Xml.Schema
 Imports <xmlns="http://schemas.microsoft.com/VisualStudio/Roslyn/Compiler">
@@ -15,8 +16,9 @@ Public Module ReadTree
     Dim currentFile As String
 
     ' Read an XML file and return the resulting ParseTree object.
-    Public Function TryReadTheTree(fileName As String, ByRef tree As ParseTree) As Boolean
+    Public Function TryReadTheTree(fileName As String, <Out> ByRef tree As ParseTree) As Boolean
 
+        tree = Nothing
         Console.WriteLine("Reading input file ""{0}""...", fileName)
 
         Dim validationError As Boolean = False
@@ -67,7 +69,7 @@ Public Module ReadTree
 
     ' Open the input XML file as an XDocument, using the reading options that we want.
     ' We use a schema to validate the input.
-    Private Function GetXDocument(fileName As String, ByRef validationError As Boolean) As XDocument
+    Private Function GetXDocument(fileName As String, <Out> ByRef validationError As Boolean) As XDocument
         currentFile = fileName
 
         Dim hadError = False


### PR DESCRIPTION
This fixes a couple of build warnings:

- Bad hint path for MS.VS.Platform.VSEditor.Interop.dll
- Syntax.xml did not conform to the prescribed XML schema

I additionally modified VisualBasicSyntaxGenerator to exit with an error
code in the case the provided XML file did not match the schema.  That
will prevent future regressions on the second warning I fixed.

closes #1356