### PR TITLE
Avoid calling .Locations on namespaces

### DIFF
--- a/src/Diagnostics/Roslyn/Core/Maintainability/UnusedDeclarationsAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Maintainability/UnusedDeclarationsAnalyzer.cs
@@ -67,6 +67,11 @@ namespace Roslyn.Diagnostics.Analyzers
                 context.CancellationToken.ThrowIfCancellationRequested();
 
                 var info = context.SemanticModel.GetSymbolInfo(context.Node, context.CancellationToken);
+                if (info.Symbol?.Kind == SymbolKind.Namespace)
+                {
+                    // Avoid getting Locations for namespaces. That can be very expensive.
+                    return;
+                }
 
                 var hasLocations = info.Symbol?.OriginalDefinition?.Locations.Length > 0;
                 if (!hasLocations)


### PR DESCRIPTION
Addresses one performance issue with the UnusedDeclarationsAnalyzer where it would call .Locations on a merged namespace symbol. That can be very expensive.
@heejaechang, @mavasani please review.