### PR TITLE
Make FileBasedXmlDocumentProvider not process DTDs

### DIFF
--- a/src/Workspaces/Core/Desktop/Utilities/Documentation/FileBasedXmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/Documentation/FileBasedXmlDocumentationProvider.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
+using System.IO;
 using Roslyn.Utilities;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -22,9 +18,9 @@ namespace Microsoft.CodeAnalysis
             _filePath = filePath;
         }
 
-        protected override XDocument GetXDocument()
+        protected override Stream GetSourceStream(CancellationToken cancellationToken)
         {
-            return XDocument.Load(_filePath);
+            return new FileStream(_filePath, FileMode.Open, FileAccess.Read);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Fix #1371 :  Make FileBasedXmlDocumentProvider not process DTD by
setting the correct DTDProcessing value in the XmlReaderSetting

Also fix XmlDocumentProvicer to return the string with the Tags and
Newlines when called GetDocumentForSymbol