### PR TITLE
change the way build and live diagnostics are merged

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
@@ -36,6 +36,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.CSharp
                         // We don't support configuring WRN_ALinkWarn. See comments in method "CSharpDiagnosticFilter.Filter" for more details.
                         continue;
 
+                    case (int)ErrorCode.WRN_UnreferencedField:
+                        // unused field. current live error doesn't support this.
+                        continue;
+
                     default:
                         builder.Add(errorCode);
                         break;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 c.RegisterSyntaxTreeAction(analyzer.AnalyzeSyntaxTree);
                 c.RegisterSemanticModelAction(CompilationAnalyzer.AnalyzeSemanticModel);
             });
-
-            context.RegisterCompilationAction(CompilationAnalyzer.AnalyzeCompilation);
         }
     }
 }

--- a/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
@@ -166,6 +166,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public abstract Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, CancellationToken cancellationToken);
         #endregion
 
+        #region build error synchronization
+        /// <summary>
+        /// Callback from build listener.
+        /// 
+        /// Given diagnostics are errors host got from explicit build.
+        /// It is up to each incremental analyzer how they will merge this information with live diagnostic info.
+        /// 
+        /// this API doesn't have cancellationToken since it can't be cancelled.
+        /// 
+        /// given diagnostics are project wide diagnsotics that doesn't contain a source location.
+        /// </summary>
+        public abstract Task SynchronizeWithBuildAsync(Project project, ImmutableArray<DiagnosticData> diagnostics);
+
+        /// <summary>
+        /// Callback from build listener.
+        /// 
+        /// Given diagnostics are errors host got from explicit build.
+        /// It is up to each incremental analyzer how they will merge this information with live diagnostic info
+        /// 
+        /// this API doesn't have cancellationToken since it can't be cancelled.
+        /// 
+        /// given diagnostics are ones that has a source location.
+        /// </summary>
+        public abstract Task SynchronizeWithBuildAsync(Document document, ImmutableArray<DiagnosticData> diagnostics);
+        #endregion
+
         internal DiagnosticAnalyzerService Owner { get; }
         internal Workspace Workspace { get; }
         internal AbstractHostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }

--- a/src/Features/Core/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticAnalyzerService.cs
@@ -169,6 +169,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();
         }
 
+        public bool IsCompilerDiagnostic(string language, DiagnosticData diagnostic)
+        {
+            return _hostAnalyzerManager.IsCompilerDiagnostic(language, diagnostic);
+        }
+
         // virtual for testing purposes.
         internal virtual Action<Exception, DiagnosticAnalyzer, Diagnostic> GetOnAnalyzerException(ProjectId projectId, DiagnosticLogAggregator diagnosticLogAggregator)
         {

--- a/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal partial class DiagnosticAnalyzerService
+    {
+        /// <summary>
+        /// Synchronize build errors with live error.
+        /// 
+        /// no cancellationToken since this can't be cancelled
+        /// </summary>
+        public Task SynchronizeWithBuildAsync(Project project, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            BaseDiagnosticIncrementalAnalyzer analyzer;
+            if (_map.TryGetValue(project.Solution.Workspace, out analyzer))
+            {
+                return analyzer.SynchronizeWithBuildAsync(project, diagnostics);
+            }
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        /// <summary>
+        /// Synchronize build errors with live error
+        /// 
+        /// no cancellationToken since this can't be cancelled
+        /// </summary>
+        public Task SynchronizeWithBuildAsync(Document document, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            BaseDiagnosticIncrementalAnalyzer analyzer;
+            if (_map.TryGetValue(document.Project.Solution.Workspace, out analyzer))
+            {
+                return analyzer.SynchronizeWithBuildAsync(document, diagnostics);
+            }
+
+            return SpecializedTasks.EmptyTask;
+        }
+    }
+}

--- a/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
@@ -167,6 +165,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public override Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, CancellationToken cancellationToken)
             {
                 return Analyzer.GetDiagnosticsForSpanAsync(document, range, cancellationToken);
+            }
+            #endregion
+
+            #region build synchronization
+            public override Task SynchronizeWithBuildAsync(Project project, ImmutableArray<DiagnosticData> diagnostics)
+            {
+                return Analyzer.SynchronizeWithBuildAsync(project, diagnostics);
+            }
+
+            public override Task SynchronizeWithBuildAsync(Document document, ImmutableArray<DiagnosticData> diagnostics)
+            {
+                return Analyzer.SynchronizeWithBuildAsync(document, diagnostics);
             }
             #endregion
 

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
@@ -188,7 +188,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return null;
                 }
 
-                Contract.Requires(textVersion != VersionStamp.Default);
                 return new AnalysisData(textVersion, dataVersion, builder.ToImmutable());
             }
 

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var textVersion = VersionStamp.ReadFrom(reader);
                         var dataVersion = VersionStamp.ReadFrom(reader);
 
-                        if (textVersion == VersionStamp.Default || dataVersion == VersionStamp.Default)
+                        if (dataVersion == VersionStamp.Default)
                         {
                             return null;
                         }

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
+{
+    internal partial class DiagnosticIncrementalAnalyzer
+    {
+        public override async Task SynchronizeWithBuildAsync(Project project, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            if (!PreferBuildErrors(project.Solution.Workspace))
+            {
+                // prefer live errors over build errors
+                return;
+            }
+
+            using (var poolObject = SharedPools.Default<HashSet<string>>().GetPooledObject())
+            {
+                var lookup = CreateDiagnosticIdLookup(diagnostics);
+
+                foreach (var stateSet in _stateManger.GetStateSets(project))
+                {
+                    var descriptors = HostAnalyzerManager.GetDiagnosticDescriptors(stateSet.Analyzer);
+                    var liveDiagnostics = ConvertToLiveDiagnostics(lookup, descriptors, poolObject.Object);
+
+                    // we are using Default so that things like LB can't use cached information
+                    var projectTextVersion = VersionStamp.Default;
+                    var semanticVersion = await project.GetDependentSemanticVersionAsync(CancellationToken.None).ConfigureAwait(false);
+
+                    var state = stateSet.GetState(StateType.Project);
+                    var existingDiagnostics = await state.TryGetExistingDataAsync(project, CancellationToken.None).ConfigureAwait(false);
+
+                    var mergedDiagnostics = MergeDiagnostics(liveDiagnostics, GetExistingDiagnostics(existingDiagnostics));
+                    await state.PersistAsync(project, new AnalysisData(projectTextVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
+                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet.Analyzer, new SolutionArgument(project), mergedDiagnostics);
+                }
+            }
+        }
+
+        public override async Task SynchronizeWithBuildAsync(Document document, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            if (!PreferBuildErrors(document.Project.Solution.Workspace))
+            {
+                // prefer live errors over build errors
+                return;
+            }
+
+            using (var poolObject = SharedPools.Default<HashSet<string>>().GetPooledObject())
+            {
+                var lookup = CreateDiagnosticIdLookup(diagnostics);
+
+                foreach (var stateSet in _stateManger.GetStateSets(document.Project))
+                {
+                    // we are using Default so that things like LB can't use cached information
+                    var textVersion = VersionStamp.Default;
+                    var semanticVersion = await document.Project.GetDependentSemanticVersionAsync(CancellationToken.None).ConfigureAwait(false);
+
+                    // clear document and project live errors
+                    await PersistAndReportAsync(stateSet, StateType.Project, document, textVersion, semanticVersion, ImmutableArray<DiagnosticData>.Empty).ConfigureAwait(false);
+                    await PersistAndReportAsync(stateSet, StateType.Syntax, document, textVersion, semanticVersion, ImmutableArray<DiagnosticData>.Empty).ConfigureAwait(false);
+
+                    var descriptors = HostAnalyzerManager.GetDiagnosticDescriptors(stateSet.Analyzer);
+                    var liveDiagnostics = ConvertToLiveDiagnostics(lookup, descriptors, poolObject.Object);
+
+                    // REVIEW: for now, we are putting build error in document state rather than creating its own state.
+                    //         reason is so that live error can take over it as soon as possible
+                    //         this also means there can be slight race where it will clean up eventually. if live analysis runs for syntax but didn't run
+                    //         for document yet, then we can have duplicated entries in the error list until live analysis catch.
+                    await PersistAndReportAsync(stateSet, StateType.Document, document, textVersion, semanticVersion, liveDiagnostics).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private bool PreferBuildErrors(Workspace workspace)
+        {
+            return workspace.Options.GetOption(InternalDiagnosticsOptions.BuildErrorIsTheGod) || workspace.Options.GetOption(InternalDiagnosticsOptions.BuildErrorWinLiveError);
+        }
+
+        private async Task PersistAndReportAsync(
+            StateSet stateSet, StateType stateType, Document document, VersionStamp textVersion, VersionStamp semanticVersion, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            var state = stateSet.GetState(stateType);
+            var existingDiagnostics = await state.TryGetExistingDataAsync(document, CancellationToken.None).ConfigureAwait(false);
+
+            var mergedDiagnostics = MergeDiagnostics(diagnostics, GetExistingDiagnostics(existingDiagnostics));
+            await state.PersistAsync(document, new AnalysisData(textVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
+            RaiseDiagnosticsUpdated(stateType, document.Id, stateSet.Analyzer, new SolutionArgument(document), mergedDiagnostics);
+        }
+
+        private static ImmutableArray<DiagnosticData> GetExistingDiagnostics(AnalysisData analysisData)
+        {
+            if (analysisData == null)
+            {
+                return ImmutableArray<DiagnosticData>.Empty;
+            }
+
+            return analysisData.Items;
+        }
+
+        private ImmutableArray<DiagnosticData> MergeDiagnostics(ImmutableArray<DiagnosticData> liveDiagnostics, ImmutableArray<DiagnosticData> existingDiagnostics)
+        {
+            ImmutableArray<DiagnosticData>.Builder builder = null;
+
+            if (liveDiagnostics.Length > 0)
+            {
+                builder = ImmutableArray.CreateBuilder<DiagnosticData>();
+                builder.AddRange(liveDiagnostics);
+            }
+
+            if (existingDiagnostics.Length > 0)
+            {
+                builder = builder ?? ImmutableArray.CreateBuilder<DiagnosticData>();
+                builder.AddRange(existingDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Hidden));
+            }
+
+            return builder == null ? ImmutableArray<DiagnosticData>.Empty : builder.ToImmutable();
+        }
+
+        private static ILookup<string, DiagnosticData> CreateDiagnosticIdLookup(ImmutableArray<DiagnosticData> diagnostics)
+        {
+            if (diagnostics.Length == 0)
+            {
+                return null;
+            }
+
+            return diagnostics.ToLookup(d => d.Id);
+        }
+
+        private ImmutableArray<DiagnosticData> ConvertToLiveDiagnostics(
+            ILookup<string, DiagnosticData> lookup, ImmutableArray<DiagnosticDescriptor> descriptors, HashSet<string> seen)
+        {
+            if (lookup == null)
+            {
+                return ImmutableArray<DiagnosticData>.Empty;
+            }
+
+            ImmutableArray<DiagnosticData>.Builder builder = null;
+            foreach (var descriptor in descriptors)
+            {
+                // make sure we don't report same id to multiple different analyzers
+                if (!seen.Add(descriptor.Id))
+                {
+                    // TODO: once we have information where diagnostic came from, we probably doesnt need this.
+                    continue;
+                }
+
+                var items = lookup[descriptor.Id];
+                if (items == null)
+                {
+                    continue;
+                }
+
+                builder = builder ?? ImmutableArray.CreateBuilder<DiagnosticData>();
+                builder.AddRange(items.Select(d => CreateLiveDiagnostic(descriptor, d)));
+            }
+
+            return builder == null ? ImmutableArray<DiagnosticData>.Empty : builder.ToImmutable();
+        }
+
+        private static DiagnosticData CreateLiveDiagnostic(DiagnosticDescriptor descriptor, DiagnosticData diagnostic)
+        {
+            return new DiagnosticData(
+                descriptor.Id,
+                descriptor.Category,
+                diagnostic.Message,
+                descriptor.MessageFormat.ToString(DiagnosticData.USCultureInfo),
+                diagnostic.Severity,
+                descriptor.DefaultSeverity,
+                descriptor.IsEnabledByDefault,
+                diagnostic.WarningLevel,
+                descriptor.CustomTags.ToImmutableArray(),
+                diagnostic.Properties,
+                diagnostic.Workspace,
+                diagnostic.ProjectId,
+                diagnostic.DocumentId,
+                diagnostic.HasTextSpan ? diagnostic.TextSpan : (TextSpan?)null,
+                diagnostic.MappedFilePath, diagnostic.MappedStartLine, diagnostic.MappedStartColumn, diagnostic.MappedEndLine, diagnostic.MappedEndColumn,
+                diagnostic.OriginalFilePath, diagnostic.OriginalStartLine, diagnostic.OriginalStartColumn, diagnostic.OriginalEndLine, diagnostic.OriginalEndColumn,
+                descriptor.Title.ToString(CultureInfo.CurrentUICulture),
+                descriptor.Description.ToString(CultureInfo.CurrentUICulture),
+                descriptor.HelpLinkUri);
+        }
+    }
+}

--- a/src/Features/Core/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     internal class DiagnosticIncrementalAnalyzer : BaseDiagnosticIncrementalAnalyzer
     {
         private readonly int _correlationId;
-        
+
         public DiagnosticIncrementalAnalyzer(DiagnosticAnalyzerService owner, int correlationId, Workspace workspace, HostAnalyzerManager hostAnalyzerManager, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource)
             : base(owner, workspace, hostAnalyzerManager, hostDiagnosticUpdateSource)
         {
@@ -179,6 +179,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 yield return DiagnosticData.Create(document, diagnostic);
             }
+        }
+
+        public override Task SynchronizeWithBuildAsync(Project project, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            // V2 engine doesn't do anything. 
+            // it means live error always win over build errors. build errors that can't be reported by live analyzer
+            // are already taken cared by engine
+            return SpecializedTasks.EmptyTask;
+        }
+
+        public override Task SynchronizeWithBuildAsync(Document document, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            // V2 engine doesn't do anything. 
+            // it means live error always win over build errors. build errors that can't be reported by live analyzer
+            // are already taken cared by engine
+            return SpecializedTasks.EmptyTask;
         }
 
         private void RaiseEvents(Project project, ImmutableArray<DiagnosticData> diagnostics)

--- a/src/Features/Core/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -76,5 +76,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <returns>A list of the diagnostics produced by the given analyzer</returns>
         ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer);
+
+        /// <summary>
+        /// Check whether given diagnostic is compiler diagnostic or not
+        /// </summary>
+        bool IsCompilerDiagnostic(string language, DiagnosticData diagnostic);
     }
 }

--- a/src/Features/Core/Diagnostics/InternalDiagnosticsOptions.cs
+++ b/src/Features/Core/Diagnostics/InternalDiagnosticsOptions.cs
@@ -19,5 +19,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [ExportOption]
         public static readonly Option<bool> UseCompilationEndCodeFixHeuristic = new Option<bool>(OptionName, "Enable Compilation End Code Fix With Heuristic", defaultValue: true);
+
+        [ExportOption]
+        public static readonly Option<bool> BuildErrorIsTheGod = new Option<bool>(OptionName, "Make build errors to take over everything", defaultValue: false);
+
+        [ExportOption]
+        public static readonly Option<bool> BuildErrorWinLiveError = new Option<bool>(OptionName, "Errors from build will win live errors from same analyzer", defaultValue: true);
     }
 }

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -179,11 +179,13 @@
     <Compile Include="Diagnostics\AnalyzerDriverResources.cs" />
     <Compile Include="Diagnostics\AnalyzerHelper.cs" />
     <Compile Include="Diagnostics\AbstractHostDiagnosticUpdateSource.cs" />
+    <Compile Include="Diagnostics\DiagnosticAnalyzerService_BuildSynchronization.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.ProjectAnalyzerReferenceChangedEventArgs.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.StateManager.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.StateSet.cs" />
+    <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer_BuildSynchronization.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer_GetLatestDiagnosticsForSpan.cs" />
     <Compile Include="Diagnostics\HostAnalyzerManager.cs" />
     <Compile Include="Diagnostics\Analyzers\IDEDiagnosticIds.cs" />

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -22,16 +24,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
     internal class ExternalErrorDiagnosticUpdateSource : IDiagnosticUpdateSource
     {
         private readonly Workspace _workspace;
-        private readonly IDiagnosticUpdateSource _diagnosticService;
+        private readonly IDiagnosticAnalyzerService _diagnosticService;
 
         private readonly SimpleTaskQueue _taskQueue;
         private readonly IAsynchronousOperationListener _listener;
 
-        private readonly object _gate = new object();
-
-        // errors reported by build that is not reported by live errors
-        private readonly Dictionary<ProjectId, HashSet<DiagnosticData>> _projectToDiagnosticsMap = new Dictionary<ProjectId, HashSet<DiagnosticData>>();
-        private readonly Dictionary<DocumentId, HashSet<DiagnosticData>> _documentToDiagnosticsMap = new Dictionary<DocumentId, HashSet<DiagnosticData>>();
+        private InprogressState _state = null;
 
         [ImportingConstructor]
         public ExternalErrorDiagnosticUpdateSource(
@@ -45,9 +43,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         }
 
         /// <summary>
-        /// Test Only
+        /// internal for testing
         /// </summary>
-        public ExternalErrorDiagnosticUpdateSource(
+        internal ExternalErrorDiagnosticUpdateSource(
             Workspace workspace,
             IDiagnosticAnalyzerService diagnosticService,
             IAsynchronousOperationListener listener)
@@ -59,107 +57,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             _workspace = workspace;
             _workspace.WorkspaceChanged += OnWorkspaceChanged;
 
-            _diagnosticService = (IDiagnosticUpdateSource)diagnosticService;
-            _diagnosticService.DiagnosticsUpdated += OnDiagnosticUpdated;
+            _diagnosticService = diagnosticService;
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-
-        public bool SupportGetDiagnostics { get { return true; } }
-
-        public ImmutableArray<DiagnosticData> GetDiagnostics(
-            Workspace workspace, ProjectId projectId, DocumentId documentId, object id, CancellationToken cancellationToken)
-        {
-            if (workspace != _workspace)
-            {
-                return ImmutableArray<DiagnosticData>.Empty;
-            }
-
-            if (id != null)
-            {
-                return GetSpecificDiagnostics(projectId, documentId, id);
-            }
-
-            if (documentId != null)
-            {
-                return GetSpecificDiagnostics(_documentToDiagnosticsMap, documentId);
-            }
-
-            if (projectId != null)
-            {
-                return GetProjectDiagnostics(projectId, cancellationToken);
-            }
-
-            return GetSolutionDiagnostics(workspace.CurrentSolution, cancellationToken);
-        }
-
-        private ImmutableArray<DiagnosticData> GetSolutionDiagnostics(Solution solution, CancellationToken cancellationToken)
-        {
-            var builder = ImmutableArray.CreateBuilder<DiagnosticData>();
-            foreach (var projectId in solution.ProjectIds)
-            {
-                builder.AddRange(GetProjectDiagnostics(projectId, cancellationToken));
-            }
-
-            return builder.ToImmutable();
-        }
-
-        private ImmutableArray<DiagnosticData> GetProjectDiagnostics(ProjectId projectId, CancellationToken cancellationToken)
-        {
-            List<DocumentId> documentIds;
-            lock (_gate)
-            {
-                documentIds = _documentToDiagnosticsMap.Keys.Where(d => d.ProjectId == projectId).ToList();
-            }
-
-            var builder = ImmutableArray.CreateBuilder<DiagnosticData>(documentIds.Count + 1);
-            builder.AddRange(GetSpecificDiagnostics(_projectToDiagnosticsMap, projectId));
-
-            foreach (var documentId in documentIds)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                builder.AddRange(GetSpecificDiagnostics(_documentToDiagnosticsMap, documentId));
-            }
-
-            return builder.ToImmutable();
-        }
-
-        private ImmutableArray<DiagnosticData> GetSpecificDiagnostics(ProjectId projectId, DocumentId documentId, object id)
-        {
-            var key = id as ArgumentKey;
-            if (key == null)
-            {
-                return ImmutableArray<DiagnosticData>.Empty;
-            }
-
-            Contract.Requires(documentId == key.DocumentId);
-            if (documentId != null)
-            {
-                return GetSpecificDiagnostics(_documentToDiagnosticsMap, documentId);
-            }
-
-            Contract.Requires(projectId == key.ProjectId);
-            if (projectId != null)
-            {
-                return GetSpecificDiagnostics(_projectToDiagnosticsMap, projectId);
-            }
-
-            return Contract.FailWithReturn<ImmutableArray<DiagnosticData>>("shouldn't reach here");
-        }
-
-        private ImmutableArray<DiagnosticData> GetSpecificDiagnostics<T>(Dictionary<T, HashSet<DiagnosticData>> map, T key)
-        {
-            lock (_gate)
-            {
-                HashSet<DiagnosticData> data;
-                if (map.TryGetValue(key, out data))
-                {
-                    return data.ToImmutableArrayOrEmpty();
-                }
-
-                return ImmutableArray<DiagnosticData>.Empty;
-            }
-        }
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
         {
@@ -171,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 case WorkspaceChangeKind.SolutionReloaded:
                     {
                         var asyncToken = _listener.BeginAsyncOperation("OnSolutionChanged");
-                        _taskQueue.ScheduleTask(() => e.OldSolution.ProjectIds.Do(p => ClearProjectErrors(p))).CompletesAsyncOperation(asyncToken);
+                        _taskQueue.ScheduleTask(() => e.OldSolution.ProjectIds.Do(p => ClearProjectErrors(p, e.OldSolution))).CompletesAsyncOperation(asyncToken);
                         break;
                     }
 
@@ -179,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 case WorkspaceChangeKind.ProjectReloaded:
                     {
                         var asyncToken = _listener.BeginAsyncOperation("OnProjectChanged");
-                        _taskQueue.ScheduleTask(() => ClearProjectErrors(e.ProjectId)).CompletesAsyncOperation(asyncToken);
+                        _taskQueue.ScheduleTask(() => ClearProjectErrors(e.ProjectId, e.OldSolution)).CompletesAsyncOperation(asyncToken);
                         break;
                     }
 
@@ -215,109 +116,151 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             }
 
             var asyncToken = _listener.BeginAsyncOperation("OnSolutionBuild");
-            _taskQueue.ScheduleTask(() =>
+            _taskQueue.ScheduleTask(async () =>
             {
-                // build is done, remove live error and report errors
-                IDictionary<ProjectId, IList<DiagnosticData>> liveProjectErrors;
-                IDictionary<DocumentId, IList<DiagnosticData>> liveDocumentErrors;
-                GetLiveProjectAndDocumentErrors(out liveProjectErrors, out liveDocumentErrors);
-
-                using (var documentIds = SharedPools.Default<List<DocumentId>>().GetPooledObject())
-                using (var projectIds = SharedPools.Default<List<ProjectId>>().GetPooledObject())
+                // nothing to do
+                if (_state == null)
                 {
-                    lock (_gate)
-                    {
-                        documentIds.Object.AddRange(_documentToDiagnosticsMap.Keys);
-                        projectIds.Object.AddRange(_projectToDiagnosticsMap.Keys);
-                    }
+                    return;
+                }
 
-                    foreach (var documentId in documentIds.Object)
-                    {
-                        var errors = liveDocumentErrors.GetValueOrDefault(documentId);
-                        RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(documentId.ProjectId, documentId, errors, reportOnlyIfChanged: false);
-                    }
+                // we are about to update live analyzer data using one from build.
+                // pause live analyzer
+                var service = _workspace.Services.GetService<IGlobalOperationNotificationService>();
+                using (var operation = service.Start("BuildDone"))
+                {
+                    // we will have a race here since we can't track version of solution the out of proc build actually used.
+                    // result of the race will be us dropping some diagnostics from the build to the floor.
+                    var solution = _workspace.CurrentSolution;
 
-                    foreach (var projectId in projectIds.Object)
+                    await CleanupAllLiveErrorsIfNeededAsync(solution).ConfigureAwait(false);
+
+                    var supportedIdMap = GetSupportedLiveDiagnosticId(solution, _state);
+                    Func<DiagnosticData, bool> liveDiagnosticChecker = d =>
                     {
-                        var errors = liveProjectErrors.GetValueOrDefault(projectId);
-                        RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(projectId, null, errors, reportOnlyIfChanged: false);
-                    }
+                        // REVIEW: we probably need a better design on de-duplicating live and build errors. or don't de-dup at all.
+                        //         for now, we are special casing compiler error case.
+                        var project = solution.GetProject(d.ProjectId);
+                        if (project == null)
+                        {
+                            // project doesn't exist
+                            return false;
+                        }
+
+                        // REVIEW: current design is that we special case compiler analyzer case and we accept only document level
+                        //         diagnostic as live. otherwise, we let them be build errors. we changed compiler analyzer accordingly as well
+                        //         so that it doesn't report project level diagnostic as live errors.
+                        if (_diagnosticService.IsCompilerDiagnostic(project.Language, d) && d.DocumentId == null)
+                        {
+                            // compiler error but project level error
+                            return false;
+                        }
+
+                        HashSet<string> set;
+                        if (supportedIdMap.TryGetValue(d.ProjectId, out set) && set.Contains(d.Id))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    };
+
+                    await SyncBuildErrorsAndReportAsync(solution, liveDiagnosticChecker, _state.GetDocumentAndErrors(solution)).ConfigureAwait(false);
+                    await SyncBuildErrorsAndReportAsync(solution, liveDiagnosticChecker, _state.GetProjectAndErrors(solution)).ConfigureAwait(false);
+
+                    // we are done. set inprogress state to null
+                    _state = null;
                 }
             }).CompletesAsyncOperation(asyncToken);
         }
 
-        private void OnDiagnosticUpdated(object sender, DiagnosticsUpdatedArgs args)
+        private async System.Threading.Tasks.Task CleanupAllLiveErrorsIfNeededAsync(Solution solution)
         {
-            if (args.Diagnostics.Length == 0 || _workspace != args.Workspace)
+            if (!_workspace.Options.GetOption(InternalDiagnosticsOptions.BuildErrorIsTheGod))
             {
                 return;
             }
 
-            // live errors win over build errors
-            var asyncToken = _listener.BeginAsyncOperation("OnDiagnosticUpdated");
-            _taskQueue.ScheduleTask(
-                () => RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(args.ProjectId, args.DocumentId, args.Diagnostics, reportOnlyIfChanged: true)).CompletesAsyncOperation(asyncToken);
+            // clear all existing live errors
+            foreach (var project in solution.Projects)
+            {
+                foreach (var document in project.Documents)
+                {
+                    await SynchronizeWithBuildAsync(document, ImmutableArray<DiagnosticData>.Empty).ConfigureAwait(false);
+                }
+
+                await SynchronizeWithBuildAsync(project, ImmutableArray<DiagnosticData>.Empty).ConfigureAwait(false);
+            }
         }
 
-        private void RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(ProjectId projectId, DocumentId documentId, IEnumerable<DiagnosticData> liveErrors, bool reportOnlyIfChanged)
+        private async System.Threading.Tasks.Task SyncBuildErrorsAndReportAsync<T>(
+            Solution solution,
+            Func<DiagnosticData, bool> liveDiagnosticChecker, IEnumerable<KeyValuePair<T, HashSet<DiagnosticData>>> items)
         {
-            if (documentId != null)
+            foreach (var kv in items)
             {
-                RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(_documentToDiagnosticsMap, documentId, projectId, documentId, liveErrors, reportOnlyIfChanged);
-                return;
-            }
+                // get errors that can be reported by live diagnostic analyzer
+                var liveErrors = kv.Value.Where(liveDiagnosticChecker).ToImmutableArray();
 
-            if (projectId != null)
-            {
-                RemoveBuildErrorsDuplicatedByLiveErrorsAndReport(_projectToDiagnosticsMap, projectId, projectId, null, liveErrors, reportOnlyIfChanged);
-                return;
-            }
+                // make those errors live errors
+                await SynchronizeWithBuildAsync(kv.Key, liveErrors).ConfigureAwait(false);
 
-            // diagnostic errors without any associated workspace project/document?
-            Contract.Requires(false, "how can this happen?");
+                // raise events for ones left-out
+                if (liveErrors.Length != kv.Value.Count)
+                {
+                    var buildErrors = kv.Value.Except(liveErrors).ToImmutableArray();
+                    ReportBuildErrors(kv.Key, buildErrors);
+                }
+            }
         }
 
-        private void RemoveBuildErrorsDuplicatedByLiveErrorsAndReport<T>(
-            Dictionary<T, HashSet<DiagnosticData>> buildErrorMap, T key,
-            ProjectId projectId, DocumentId documentId, IEnumerable<DiagnosticData> liveErrors, bool reportOnlyIfChanged)
+        private async System.Threading.Tasks.Task SynchronizeWithBuildAsync<T>(T item, ImmutableArray<DiagnosticData> liveErrors)
         {
-            ImmutableArray<DiagnosticData> items;
-
-            lock (_gate)
+            var diagnosticService = _diagnosticService as DiagnosticAnalyzerService;
+            if (diagnosticService == null)
             {
-                HashSet<DiagnosticData> buildErrors;
-                if (!buildErrorMap.TryGetValue(key, out buildErrors))
-                {
-                    return;
-                }
-
-                var originalBuildErrorCount = buildErrors.Count;
-                if (liveErrors != null)
-                {
-                    buildErrors.ExceptWith(liveErrors);
-                }
-
-                if (buildErrors.Count == 0)
-                {
-                    buildErrorMap.Remove(key);
-                }
-
-                // nothing to refresh.
-                if (originalBuildErrorCount == 0)
-                {
-                    return;
-                }
-
-                // if nothing has changed and we are asked to report only when something has changed
-                if (reportOnlyIfChanged && originalBuildErrorCount == buildErrors.Count)
-                {
-                    return;
-                }
-
-                items = buildErrors.ToImmutableArrayOrEmpty();
+                // we don't synchronize if implementation is not DiagnosticService
+                return;
             }
 
-            RaiseDiagnosticsUpdated(key, projectId, documentId, items);
+            var project = item as Project;
+            if (project != null)
+            {
+                await diagnosticService.SynchronizeWithBuildAsync(project, liveErrors).ConfigureAwait(false);
+                return;
+            }
+
+            // must be not null
+            var document = item as Document;
+            await diagnosticService.SynchronizeWithBuildAsync(document, liveErrors).ConfigureAwait(false);
+        }
+
+        private void ReportBuildErrors<T>(T item, ImmutableArray<DiagnosticData> buildErrors)
+        {
+            var project = item as Project;
+            if (project != null)
+            {
+                RaiseDiagnosticsUpdated(project.Id, project.Id, null, buildErrors);
+                return;
+            }
+
+            // must be not null
+            var document = item as Document;
+            RaiseDiagnosticsUpdated(document.Id, document.Project.Id, document.Id, buildErrors);
+        }
+
+        private Dictionary<ProjectId, HashSet<string>> GetSupportedLiveDiagnosticId(Solution solution, InprogressState state)
+        {
+            var map = new Dictionary<ProjectId, HashSet<string>>();
+
+            // here, we don't care about perf that much since build is already expensive work
+            foreach (var project in state.GetProjectsWithErrors(solution))
+            {
+                var descriptorMap = _diagnosticService.GetDiagnosticDescriptors(project);
+                map.Add(project.Id, new HashSet<string>(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id))));
+            }
+
+            return map;
         }
 
         public void ClearErrors(ProjectId projectId)
@@ -326,38 +269,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             _taskQueue.ScheduleTask(() => ClearProjectErrors(projectId)).CompletesAsyncOperation(asyncToken);
         }
 
-        private void ClearProjectErrors(ProjectId projectId)
+        private void ClearProjectErrors(ProjectId projectId, Solution solution = null)
         {
-            var clearProjectError = false;
-            using (var pool = SharedPools.Default<List<DocumentId>>().GetPooledObject())
+            // remove all project errors
+            RaiseDiagnosticsUpdated(projectId, projectId, null, ImmutableArray<DiagnosticData>.Empty);
+
+            var project = (solution ?? _workspace.CurrentSolution).GetProject(projectId);
+            if (project == null)
             {
-                lock (_gate)
-                {
-                    clearProjectError = _projectToDiagnosticsMap.Remove(projectId);
-                    pool.Object.AddRange(_documentToDiagnosticsMap.Keys.Where(k => k.ProjectId == projectId));
-                }
+                return;
+            }
 
-                if (clearProjectError)
-                {
-                    // remove all project errors
-                    RaiseDiagnosticsUpdated(projectId, projectId, null, ImmutableArray<DiagnosticData>.Empty);
-                }
-
-                // remove all document errors
-                foreach (var documentId in pool.Object)
-                {
-                    ClearDocumentErrors(projectId, documentId);
-                }
+            // remove all document errors
+            foreach (var documentId in project.DocumentIds)
+            {
+                ClearDocumentErrors(projectId, documentId);
             }
         }
 
         private void ClearDocumentErrors(ProjectId projectId, DocumentId documentId)
         {
-            lock (_gate)
-            {
-                _documentToDiagnosticsMap.Remove(documentId);
-            }
-
             RaiseDiagnosticsUpdated(documentId, projectId, documentId, ImmutableArray<DiagnosticData>.Empty);
         }
 
@@ -366,66 +297,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             var asyncToken = _listener.BeginAsyncOperation("Document New Errors");
             _taskQueue.ScheduleTask(() =>
             {
-                lock (_gate)
-                {
-                    var errors = _documentToDiagnosticsMap.GetOrAdd(documentId, _ => new HashSet<DiagnosticData>(DiagnosticDataComparer.Instance));
-                    errors.Add(diagnostic);
-                }
+                GetOrCreateInprogressState().AddError(documentId, diagnostic);
             }).CompletesAsyncOperation(asyncToken);
         }
 
         public void AddNewErrors(
-            ProjectId projectId, HashSet<DiagnosticData> projectErrorSet, Dictionary<DocumentId, HashSet<DiagnosticData>> documentErrorMap)
+            ProjectId projectId, HashSet<DiagnosticData> projectErrors, Dictionary<DocumentId, HashSet<DiagnosticData>> documentErrorMap)
         {
             var asyncToken = _listener.BeginAsyncOperation("Project New Errors");
             _taskQueue.ScheduleTask(() =>
             {
-                lock (_gate)
+                var state = GetOrCreateInprogressState();
+                foreach (var kv in documentErrorMap)
                 {
-                    foreach (var kv in documentErrorMap)
-                    {
-                        var documentErrors = _documentToDiagnosticsMap.GetOrAdd(kv.Key, _ => new HashSet<DiagnosticData>(DiagnosticDataComparer.Instance));
-                        documentErrors.UnionWith(kv.Value);
-                    }
-
-                    var projectErrors = _projectToDiagnosticsMap.GetOrAdd(projectId, _ => new HashSet<DiagnosticData>(DiagnosticDataComparer.Instance));
-                    projectErrors.UnionWith(projectErrorSet);
+                    state.AddErrors(kv.Key, kv.Value);
                 }
+
+                state.AddErrors(projectId, projectErrors);
             }).CompletesAsyncOperation(asyncToken);
         }
 
-        private void GetLiveProjectAndDocumentErrors(
-            out IDictionary<ProjectId, IList<DiagnosticData>> projectErrors,
-            out IDictionary<DocumentId, IList<DiagnosticData>> documentErrors)
+        private InprogressState GetOrCreateInprogressState()
         {
-            projectErrors = null;
-            documentErrors = null;
-
-            foreach (var diagnostic in _diagnosticService.GetDiagnostics(_workspace, id: null, projectId: null, documentId: null, cancellationToken: CancellationToken.None))
+            if (_state == null)
             {
-                if (diagnostic.DocumentId != null)
-                {
-                    documentErrors = documentErrors ?? new Dictionary<DocumentId, IList<DiagnosticData>>();
-
-                    var errors = documentErrors.GetOrAdd(diagnostic.DocumentId, _ => new List<DiagnosticData>());
-                    errors.Add(diagnostic);
-                    continue;
-                }
-
-                if (diagnostic.ProjectId != null)
-                {
-                    projectErrors = projectErrors ?? new Dictionary<ProjectId, IList<DiagnosticData>>();
-
-                    var errors = projectErrors.GetOrAdd(diagnostic.ProjectId, _ => new List<DiagnosticData>());
-                    errors.Add(diagnostic);
-                    continue;
-                }
-
-                Contract.Requires(false, "shouldn't happen");
+                _state = new InprogressState();
             }
 
-            projectErrors = projectErrors ?? SpecializedCollections.EmptyDictionary<ProjectId, IList<DiagnosticData>>();
-            documentErrors = documentErrors ?? SpecializedCollections.EmptyDictionary<DocumentId, IList<DiagnosticData>>();
+            return _state;
         }
 
         private void RaiseDiagnosticsUpdated(object id, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
@@ -435,6 +334,96 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             {
                 diagnosticsUpdated(this, new DiagnosticsUpdatedArgs(
                    new ArgumentKey(id), _workspace, _workspace.CurrentSolution, projectId, documentId, items));
+            }
+        }
+
+        #region not supported
+        public bool SupportGetDiagnostics { get { return false; } }
+
+        public ImmutableArray<DiagnosticData> GetDiagnostics(
+            Workspace workspace, ProjectId projectId, DocumentId documentId, object id, CancellationToken cancellationToken)
+        {
+            return ImmutableArray<DiagnosticData>.Empty;
+        }
+        #endregion
+
+        private class InprogressState
+        {
+            private readonly Dictionary<ProjectId, HashSet<DiagnosticData>> _projectMap = new Dictionary<ProjectId, HashSet<DiagnosticData>>();
+            private readonly Dictionary<DocumentId, HashSet<DiagnosticData>> _documentMap = new Dictionary<DocumentId, HashSet<DiagnosticData>>();
+
+            public IEnumerable<Project> GetProjectsWithErrors(Solution solution)
+            {
+                foreach (var projectId in _documentMap.Keys.Select(k => k.ProjectId).Concat(_projectMap.Keys).Distinct())
+                {
+                    var project = solution.GetProject(projectId);
+                    if (project == null)
+                    {
+                        continue;
+                    }
+
+                    yield return project;
+                }
+            }
+
+            public IEnumerable<KeyValuePair<Document, HashSet<DiagnosticData>>> GetDocumentAndErrors(Solution solution)
+            {
+                foreach (var kv in _documentMap)
+                {
+                    var document = solution.GetDocument(kv.Key);
+                    if (document == null)
+                    {
+                        continue;
+                    }
+
+                    yield return KeyValuePair.Create(document, kv.Value);
+                }
+            }
+
+            public IEnumerable<KeyValuePair<Project, HashSet<DiagnosticData>>> GetProjectAndErrors(Solution solution)
+            {
+                foreach (var kv in _projectMap)
+                {
+                    var project = solution.GetProject(kv.Key);
+                    if (project == null)
+                    {
+                        continue;
+                    }
+
+                    yield return KeyValuePair.Create(project, kv.Value);
+                }
+            }
+
+            public void AddErrors(DocumentId key, HashSet<DiagnosticData> diagnostics)
+            {
+                AddErrors(_documentMap, key, diagnostics);
+            }
+
+            public void AddErrors(ProjectId key, HashSet<DiagnosticData> diagnostics)
+            {
+                AddErrors(_projectMap, key, diagnostics);
+            }
+
+            public void AddError(DocumentId key, DiagnosticData diagnostic)
+            {
+                AddError(_documentMap, key, diagnostic);
+            }
+
+            private void AddErrors<T>(Dictionary<T, HashSet<DiagnosticData>> map, T key, HashSet<DiagnosticData> diagnostics)
+            {
+                var errors = GetErrors(map, key);
+                errors.UnionWith(diagnostics);
+            }
+
+            private void AddError<T>(Dictionary<T, HashSet<DiagnosticData>> map, T key, DiagnosticData diagnostic)
+            {
+                var errors = GetErrors(map, key);
+                errors.Add(diagnostic);
+            }
+
+            private HashSet<DiagnosticData> GetErrors<T>(Dictionary<T, HashSet<DiagnosticData>> map, T key)
+            {
+                return map.GetOrAdd(key, _ => new HashSet<DiagnosticData>(DiagnosticDataComparer.Instance));
             }
         }
 

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -90,6 +90,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             Public Function GetDiagnosticDescriptors(analyzer As DiagnosticAnalyzer) As ImmutableArray(Of DiagnosticDescriptor) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors
                 Return ImmutableArray(Of DiagnosticDescriptor).Empty
             End Function
+
+            Public Function IsCompilerDiagnostic(language As String, diagnostic As DiagnosticData) As Boolean Implements IDiagnosticAnalyzerService.IsCompilerDiagnostic
+                Return False
+            End Function
         End Class
 
     End Class


### PR DESCRIPTION
previously we made system to prefer live diagnostic over build diagnostic.
also when we merge those two, we used very detail info to find out build and live diagnostics are same or not. 

but the issue was diagnostics from build didn't have all information live one has, also diagnostics from build is static when live one is changing as user type in IDE. which lead to race where build diagnostic might be already out-dated on arrival.

new system is that we prefer diagnostic from build over live. and don't distinguish them by detail info but whether live can produce same diagnostics build produced. as user change file, we will replace build diagnostics in affected files to live diagnostics.

this should remove chance where build diagnostic got stuck in the system until next build. and as user change files, live diagnostic over take build diagnostics.

Fixes #1554