### PR TITLE
Add a new export to RoslynVisualStudioWorkspace

### DIFF
--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 {
     [Export(typeof(VisualStudioWorkspace))]
     [Export(typeof(VisualStudioWorkspaceImpl))]
+    [Export("Microsoft.VisualStudio.LanguageServices.VisualStudioWorkspace", typeof(Workspace))]
     internal class RoslynVisualStudioWorkspace : VisualStudioWorkspaceImpl
     {
         private readonly IEnumerable<Lazy<INavigableItemsPresenter>> _navigableItemsPresenters;


### PR DESCRIPTION
The new export allows consumers to get at the Visual Studio workspace without referencing Microsoft.VisualStudio.LanguageServices.dll