### PR TITLE
Handle pseudo-variables with pointer types

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private MethodSymbol GetSpecialTypeMethod(CSharpSyntaxNode syntax, SpecialMember specialMember)
         {
             MethodSymbol method;
-            if (TryGetSpecialTypeMember<MethodSymbol>(syntax, specialMember, out method))
+            if (Binder.TryGetSpecialTypeMember(_compilation, specialMember, syntax, _diagnostics, out method))
             {
                 return method;
             }
@@ -249,27 +249,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbol returnType = new ExtendedErrorTypeSymbol(compilation: _compilation, name: descriptor.Name, errorInfo: null, arity: descriptor.Arity);
                 return new ErrorMethodSymbol(container, returnType, "Missing");
             }
-        }
-
-        private bool TryGetSpecialTypeMember<TSymbol>(CSharpSyntaxNode syntax, SpecialMember specialMember, out TSymbol symbol) where TSymbol : Symbol
-        {
-            symbol = (TSymbol)_compilation.Assembly.GetSpecialTypeMember(specialMember);
-            if ((object)symbol == null)
-            {
-                MemberDescriptor descriptor = SpecialMembers.GetDescriptor(specialMember);
-                _diagnostics.Add(ErrorCode.ERR_MissingPredefinedMember, syntax.Location, descriptor.DeclaringTypeMetadataName, descriptor.Name);
-                return false;
-            }
-            else
-            {
-                var useSiteDiagnostic = symbol.GetUseSiteDiagnosticForSymbolOrContainingType();
-                if (useSiteDiagnostic != null)
-                {
-                    Symbol.ReportUseSiteDiagnostic(useSiteDiagnostic, _diagnostics, new SourceLocation(syntax));
-                }
-            }
-
-            return true;
         }
 
         public override BoundNode VisitTypeOfOperator(BoundTypeOfOperator node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement result;
 
             MethodSymbol disposeMethod;
-            if (enumeratorInfo.NeedsDisposeMethod && TryGetSpecialTypeMember(forEachSyntax, SpecialMember.System_IDisposable__Dispose, out disposeMethod))
+            if (enumeratorInfo.NeedsDisposeMethod && Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, forEachSyntax, _diagnostics, out disposeMethod))
             {
                 Binder.ReportDiagnosticsIfObsolete(_diagnostics, disposeMethod, forEachSyntax,
                                                    hasBaseReceiver: false,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression disposeCall;
 
             MethodSymbol disposeMethodSymbol;
-            if (TryGetSpecialTypeMember(syntax, SpecialMember.System_IDisposable__Dispose, out disposeMethodSymbol))
+            if (Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, syntax, _diagnostics, out disposeMethodSymbol))
             {
                 disposeCall = BoundCall.Synthesized(syntax, disposedExpression, disposeMethodSymbol);
             }

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
@@ -48,17 +48,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         private struct TypeNameConfig
         {
-            public int nestingLevel;
-            public TypeNameConfig[] genericParamsConfig;
-            public ArrayKind arrayKind;
-            public bool assemblyQualified;
+            public int NestingLevel;
+            public TypeNameConfig[] GenericParamsConfig;
+            public ArrayKind ArrayKind;
+            public bool AssemblyQualified;
 
             public TypeNameConfig(int nestingLevel, TypeNameConfig[] genericParamsConfig, ArrayKind arrayKind, bool assemblyQualified)
             {
-                this.nestingLevel = nestingLevel;
-                this.genericParamsConfig = genericParamsConfig;
-                this.arrayKind = arrayKind;
-                this.assemblyQualified = assemblyQualified;
+                this.NestingLevel = nestingLevel;
+                this.GenericParamsConfig = genericParamsConfig;
+                this.ArrayKind = arrayKind;
+                this.AssemblyQualified = assemblyQualified;
             }
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         private static string[] GenerateTypeNamesToDecode(TypeNameConfig[] typeNameConfigs, out MetadataHelpers.AssemblyQualifiedTypeName[] expectedDecodeNames)
         {
             var pooledStrBuilder = PooledStringBuilder.GetInstance();
-            StringBuilder typeNamebuilder = pooledStrBuilder.Builder;
+            StringBuilder typeNameBuilder = pooledStrBuilder.Builder;
 
             var typeNamesToDecode = new string[typeNameConfigs.Length];
             expectedDecodeNames = new MetadataHelpers.AssemblyQualifiedTypeName[typeNameConfigs.Length];
@@ -101,97 +101,97 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 TypeNameConfig typeNameConfig = typeNameConfigs[index];
 
                 string expectedTopLevelTypeName = "X";
-                typeNamebuilder.Append("X");
+                typeNameBuilder.Append("X");
 
                 string[] expectedNestedTypes = null;
-                if (typeNameConfig.nestingLevel > 0)
+                if (typeNameConfig.NestingLevel > 0)
                 {
-                    expectedNestedTypes = new string[typeNameConfig.nestingLevel];
-                    for (int i = 0; i < typeNameConfig.nestingLevel; i++)
+                    expectedNestedTypes = new string[typeNameConfig.NestingLevel];
+                    for (int i = 0; i < typeNameConfig.NestingLevel; i++)
                     {
                         expectedNestedTypes[i] = "Y" + i;
-                        typeNamebuilder.Append("+" + expectedNestedTypes[i]);
+                        typeNameBuilder.Append("+" + expectedNestedTypes[i]);
                     }
                 }
 
                 MetadataHelpers.AssemblyQualifiedTypeName[] expectedTypeArguments;
-                if (typeNameConfig.genericParamsConfig == null)
+                if (typeNameConfig.GenericParamsConfig == null)
                 {
                     expectedTypeArguments = null;
                 }
                 else
                 {
-                    string[] genericParamsToDecode = GenerateTypeNamesToDecode(typeNameConfig.genericParamsConfig, out expectedTypeArguments);
+                    string[] genericParamsToDecode = GenerateTypeNamesToDecode(typeNameConfig.GenericParamsConfig, out expectedTypeArguments);
 
                     var genericArityStr = "`" + genericParamsToDecode.Length.ToString();
-                    typeNamebuilder.Append(genericArityStr);
-                    if (typeNameConfig.nestingLevel == 0)
+                    typeNameBuilder.Append(genericArityStr);
+                    if (typeNameConfig.NestingLevel == 0)
                     {
                         expectedTopLevelTypeName += genericArityStr;
                     }
                     else
                     {
-                        expectedNestedTypes[typeNameConfig.nestingLevel - 1] += genericArityStr;
+                        expectedNestedTypes[typeNameConfig.NestingLevel - 1] += genericArityStr;
                     }
 
-                    typeNamebuilder.Append("[");
+                    typeNameBuilder.Append("[");
 
                     for (int i = 0; i < genericParamsToDecode.Length; i++)
                     {
                         if (i > 0)
                         {
-                            typeNamebuilder.Append(", ");
+                            typeNameBuilder.Append(", ");
                         }
 
-                        if (typeNameConfig.genericParamsConfig[i].assemblyQualified)
+                        if (typeNameConfig.GenericParamsConfig[i].AssemblyQualified)
                         {
-                            typeNamebuilder.Append("[");
-                            typeNamebuilder.Append(genericParamsToDecode[i]);
-                            typeNamebuilder.Append("]");
+                            typeNameBuilder.Append("[");
+                            typeNameBuilder.Append(genericParamsToDecode[i]);
+                            typeNameBuilder.Append("]");
                         }
                         else
                         {
-                            typeNamebuilder.Append(genericParamsToDecode[i]);
+                            typeNameBuilder.Append(genericParamsToDecode[i]);
                         }
                     }
 
-                    typeNamebuilder.Append("]");
+                    typeNameBuilder.Append("]");
                 }
 
                 int[] expectedArrayRanks = null;
-                switch (typeNameConfig.arrayKind)
+                switch (typeNameConfig.ArrayKind)
                 {
                     case ArrayKind.SingleDimensional:
-                        typeNamebuilder.Append("[]");
+                        typeNameBuilder.Append("[]");
                         expectedArrayRanks = new[] { 1 };
                         break;
 
                     case ArrayKind.MultiDimensional:
-                        typeNamebuilder.Append("[,]");
+                        typeNameBuilder.Append("[,]");
                         expectedArrayRanks = new[] { 2 };
                         break;
 
                     case ArrayKind.Jagged:
-                        typeNamebuilder.Append("[,][]");
+                        typeNameBuilder.Append("[,][]");
                         expectedArrayRanks = new[] { 1, 2 };
                         break;
                 }
 
                 string expectedAssemblyName;
-                if (typeNameConfig.assemblyQualified)
+                if (typeNameConfig.AssemblyQualified)
                 {
                     expectedAssemblyName = "Assembly, Version=0.0.0.0, Culture=neutral, null";
-                    typeNamebuilder.Append(", " + expectedAssemblyName);
+                    typeNameBuilder.Append(", " + expectedAssemblyName);
                 }
                 else
                 {
                     expectedAssemblyName = null;
                 }
 
-                typeNamesToDecode[index] = typeNamebuilder.ToString();
+                typeNamesToDecode[index] = typeNameBuilder.ToString();
                 expectedDecodeNames[index] = new MetadataHelpers.AssemblyQualifiedTypeName(expectedTopLevelTypeName, expectedNestedTypes, expectedTypeArguments, expectedArrayRanks, expectedAssemblyName);
 
-                typeNamebuilder.Clear();
+                typeNameBuilder.Clear();
             }
 
             pooledStrBuilder.Free();

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
                     case ArrayKind.Jagged:
                         typeNameBuilder.Append("[,][]");
-                        expectedArrayRanks = new[] { 1, 2 };
+                        expectedArrayRanks = new[] { 2, 1 };
                         break;
                 }
 
@@ -224,6 +224,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                         expectedTypeArgument.NestedTypes, expectedTypeArgument.TypeArguments, expectedTypeArgument.ArrayRanks);
                 }
             }
+
+            AssertEx.Equal(expectedArrayRanks, decodedName.ArrayRanks);
         }
 
         private static void DecodeTypeNameAndVerify(

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(!isTypeArgumentWithAssemblyName || isTypeArgument);
 
                 string topLevelType = null;
-                ArrayBuilder<string> nestedTypesbuilder = null;
+                ArrayBuilder<string> nestedTypesBuilder = null;
                 AssemblyQualifiedTypeName[] typeArguments = null;
                 ArrayBuilder<int> arrayRanksBuilder = null;
                 string assemblyName = null;
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis
                 bool isGenericTypeName = false;
 
                 var pooledStrBuilder = PooledStringBuilder.GetInstance();
-                StringBuilder typeNamebuilder = pooledStrBuilder.Builder;
+                StringBuilder typeNameBuilder = pooledStrBuilder.Builder;
 
                 while (!EndOfInput)
                 {
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis
 
                         // Type name is generic if the decoded name of the top level type OR any of the outer types of a nested type had the '`' character.
                         isGenericTypeName = isGenericTypeName || decodedString.IndexOf(GenericTypeNameManglingChar) >= 0;
-                        typeNamebuilder.Append(decodedString);
+                        typeNameBuilder.Append(decodedString);
 
                         switch (c)
                         {
@@ -157,13 +157,13 @@ namespace Microsoft.CodeAnalysis
                                 {
                                     // Error case, array shape must be specified at the end of the type name.
                                     // Process as a regular character and continue.
-                                    typeNamebuilder.Append('+');
+                                    typeNameBuilder.Append('+');
                                 }
                                 else
                                 {
                                     // Type followed by nested type. Handle nested class separator and collect the nested types.
-                                    HandleDecodedTypeName(typeNamebuilder.ToString(), decodingTopLevelType, ref topLevelType, ref nestedTypesbuilder);
-                                    typeNamebuilder.Clear();
+                                    HandleDecodedTypeName(typeNameBuilder.ToString(), decodingTopLevelType, ref topLevelType, ref nestedTypesBuilder);
+                                    typeNameBuilder.Clear();
                                     decodingTopLevelType = false;
                                 }
 
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis
                                     {
                                         // Error case, array shape must be specified at the end of the type name.
                                         // Process as a regular character and continue.
-                                        typeNamebuilder.Append('[');
+                                        typeNameBuilder.Append('[');
                                     }
                                     else
                                     {
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis
                                 else
                                 {
                                     // Decode array shape.
-                                    DecodeArrayShape(typeNamebuilder, ref arrayRanksBuilder);
+                                    DecodeArrayShape(typeNameBuilder, ref arrayRanksBuilder);
                                 }
 
                                 break;
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis
                                 else
                                 {
                                     // Error case, process as a regular character and continue.
-                                    typeNamebuilder.Append(']');
+                                    typeNameBuilder.Append(']');
                                     Advance();
                                     break;
                                 }
@@ -233,24 +233,24 @@ namespace Microsoft.CodeAnalysis
                     }
                     else
                     {
-                        typeNamebuilder.Append(DecodeGenericName(_input.Length));
+                        typeNameBuilder.Append(DecodeGenericName(_input.Length));
                         goto ExitDecodeTypeName;
                     }
                 }
 
             ExitDecodeTypeName:
-                HandleDecodedTypeName(typeNamebuilder.ToString(), decodingTopLevelType, ref topLevelType, ref nestedTypesbuilder);
+                HandleDecodedTypeName(typeNameBuilder.ToString(), decodingTopLevelType, ref topLevelType, ref nestedTypesBuilder);
                 pooledStrBuilder.Free();
 
                 return new AssemblyQualifiedTypeName(
                     topLevelType,
-                    nestedTypesbuilder?.ToArrayAndFree(),
+                    nestedTypesBuilder?.ToArrayAndFree(),
                     typeArguments,
                     arrayRanksBuilder?.ToArrayAndFree(),
                     assemblyName);
             }
 
-            private static void HandleDecodedTypeName(string decodedTypeName, bool decodingTopLevelType, ref string topLevelType, ref ArrayBuilder<string> nestedTypesbuilder)
+            private static void HandleDecodedTypeName(string decodedTypeName, bool decodingTopLevelType, ref string topLevelType, ref ArrayBuilder<string> nestedTypesBuilder)
             {
                 if (decodedTypeName.Length != 0)
                 {
@@ -261,12 +261,12 @@ namespace Microsoft.CodeAnalysis
                     }
                     else
                     {
-                        if (nestedTypesbuilder == null)
+                        if (nestedTypesBuilder == null)
                         {
-                            nestedTypesbuilder = ArrayBuilder<string>.GetInstance();
+                            nestedTypesBuilder = ArrayBuilder<string>.GetInstance();
                         }
 
-                        nestedTypesbuilder.Add(decodedTypeName);
+                        nestedTypesBuilder.Add(decodedTypeName);
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -191,6 +191,11 @@ namespace Microsoft.CodeAnalysis
                 container = SubstituteWithUnboundIfGeneric(container);
             }
 
+            for (int i = 0; i < fullName.PointerCount; i++)
+            {
+                container = MakePointerTypeSymbol(container, ImmutableArray<ModifierInfo<TypeSymbol>>.Empty);
+            }
+
             // Process any array type ranks
             if (fullName.ArrayRanks != null)
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -57,16 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 var method = GetIntrinsicMethod(_compilation, ExpressionCompilerConstants.GetVariableValueMethodName);
                 var local = variable.LocalSymbol;
                 var expr = InvokeGetMethod(method, variable.Syntax, local.Name);
-                var localType = local.Type;
-                if (localType.IsPointerType())
-                {
-                    var temp = ConvertToLocalType(_compilation, expr, _compilation.GetSpecialType(SpecialType.System_IntPtr), diagnostics);
-                    return ConvertToLocalType(_compilation, temp, localType, diagnostics);
-                }
-                else
-                {
-                    return ConvertToLocalType(_compilation, expr, localType, diagnostics);
-                }
+                return ConvertToLocalType(_compilation, expr, local.Type, diagnostics);
             }
 
             internal override BoundExpression GetAddress(BoundPseudoVariable variable)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -57,7 +57,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 var method = GetIntrinsicMethod(_compilation, ExpressionCompilerConstants.GetVariableValueMethodName);
                 var local = variable.LocalSymbol;
                 var expr = InvokeGetMethod(method, variable.Syntax, local.Name);
-                return ConvertToLocalType(_compilation, expr, local.Type, diagnostics);
+                var localType = local.Type;
+                if (localType.IsPointerType())
+                {
+                    var temp = ConvertToLocalType(_compilation, expr, _compilation.GetSpecialType(SpecialType.System_IntPtr), diagnostics);
+                    return ConvertToLocalType(_compilation, temp, localType, diagnostics);
+                }
+                else
+                {
+                    return ConvertToLocalType(_compilation, expr, localType, diagnostics);
+                }
             }
 
             internal override BoundExpression GetAddress(BoundPseudoVariable variable)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -88,6 +88,37 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal static BoundExpression ConvertToLocalType(CSharpCompilation compilation, BoundExpression expr, TypeSymbol type, DiagnosticBag diagnostics)
         {
+            if (type.IsPointerType())
+            {
+                var syntax = expr.Syntax;
+                var intPtrType = compilation.GetSpecialType(SpecialType.System_IntPtr);
+                Binder.ReportUseSiteDiagnostics(intPtrType, diagnostics, syntax);
+                MethodSymbol conversionMethod;
+                if (Binder.TryGetSpecialTypeMember(compilation, SpecialMember.System_IntPtr__op_Explicit_ToPointer, syntax, diagnostics, out conversionMethod))
+                {
+                    var temp = ConvertToLocalTypeHelper(compilation, expr, intPtrType, diagnostics);
+                    expr = BoundCall.Synthesized(
+                        syntax,
+                        receiverOpt: null,
+                        method: conversionMethod,
+                        arg0: temp);
+                }
+                else
+                {
+                    return new BoundBadExpression(
+                        syntax,
+                        LookupResultKind.Empty,
+                        ImmutableArray<Symbol>.Empty,
+                        ImmutableArray.Create<BoundNode>(expr),
+                        type);
+                }
+            }
+
+            return ConvertToLocalTypeHelper(compilation, expr, type, diagnostics);
+        }
+
+        private static BoundExpression ConvertToLocalTypeHelper(CSharpCompilation compilation, BoundExpression expr, TypeSymbol type, DiagnosticBag diagnostics)
+        {
             // NOTE: This conversion can fail if some of the types involved are from not-yet-loaded modules.
             // For example, if System.Exception hasn't been loaded, then this call will fail for $stowedexception.
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             var conversion = compilation.Conversions.ClassifyConversionFromExpression(expr, type, ref useSiteDiagnostics);
             diagnostics.Add(expr.Syntax, useSiteDiagnostics);
+            Debug.Assert(conversion.IsValid || diagnostics.HasAnyErrors());
 
             return BoundConversion.Synthesized(
                 expr.Syntax,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1195,6 +1196,94 @@ class B
   IL_0010:  ret
 }");
             }
+        }
+
+        [WorkItem(1140387, "DevDiv")]
+        [Fact]
+        public void ReturnValueOfPointerType()
+        {
+            var source =
+@"class C
+{
+    static void M()
+    {
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
+
+            ResultProperties resultProperties;
+            string error;
+            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+            var testData = new CompilationTestData();
+            var result = context.CompileExpression(
+                InspectionContextFactory.Empty.Add("$ReturnValue", typeof(int*)),
+                "$ReturnValue",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData);
+            Assert.Empty(missingAssemblyIdentities);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            Assert.Equal(SpecialType.System_Int32, ((PointerTypeSymbol)methodData.Method.ReturnType).PointedAtType.SpecialType);
+            methodData.VerifyIL(
+@"{
+  // Code size       17 (0x11)
+  .maxstack  1
+  IL_0000:  ldc.i4.0
+  IL_0001:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(int)""
+  IL_0006:  unbox.any  ""System.IntPtr""
+  IL_000b:  call       ""void* System.IntPtr.op_Explicit(System.IntPtr)""
+  IL_0010:  ret
+}");
+        }
+
+        [WorkItem(1140387, "DevDiv")]
+        [Fact]
+        public void UserVariableOfPointerType()
+        {
+            var source =
+@"class C
+{
+    static void M()
+    {
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
+
+            ResultProperties resultProperties;
+            string error;
+            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+            var testData = new CompilationTestData();
+            var result = context.CompileExpression(
+                InspectionContextFactory.Empty.Add("p", typeof(char*)),
+                "p",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData);
+            Assert.Empty(missingAssemblyIdentities);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            Assert.Equal(SpecialType.System_Char, ((PointerTypeSymbol)methodData.Method.ReturnType).PointedAtType.SpecialType);
+            methodData.VerifyIL(
+@"{
+  // Code size       21 (0x15)
+  .maxstack  1
+  IL_0000:  ldstr      ""p""
+  IL_0005:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetObjectByAlias(string)""
+  IL_000a:  unbox.any  ""System.IntPtr""
+  IL_000f:  call       ""void* System.IntPtr.op_Explicit(System.IntPtr)""
+  IL_0014:  ret
+}");
         }
     }
 }


### PR DESCRIPTION
The intrinsic methods that we call to retrieve the values of pseudo-variables from the debugger return System.Object.  Unfortunately, object cannot be converted (directly) to a pointer type.  Instead, we need to unbox an IntPtr and then call an explicit conversion method to get a pointer.

Caveat: This won't work until the debugger actually returns a boxed IntPtr.