### PR TITLE
Indent/Format Auto Property Initializers appropriately

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -215,6 +215,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                     case SyntaxKind.CloseBraceToken:
                         {
+                            if (token.Parent.IsKind(SyntaxKind.AccessorList) &&
+                                token.Parent.Parent.IsKind(SyntaxKind.PropertyDeclaration))
+                            {
+                                if (token.GetNextToken().IsEqualsTokenInAutoPropertyInitializers())
+                                {
+                                    return GetDefaultIndentationFromToken(token);
+                                }
+                            }
+
                             return IndentFromStartOfLine(Finder.GetIndentationOfCurrentPosition(Tree, token, position, CancellationToken));
                         }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1252,6 +1252,25 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
+        [Fact]
+        [WorkItem(1339, "https://github.com/dotnet/roslyn/issues/1339")]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void IndentAutoPropertyInitializerAsPartOfTheDeclaration()
+        {
+            var code = @"class Program
+{
+    public int d { get; } 
+= 3;
+    static void Main(string[] args)
+    {
+    }
+}";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 3,
+                expectedIndentation: 8);
+        }
+
         private void AssertIndentUsingSmartTokenFormatter(
             string code,
             char ch,

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -248,6 +248,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return false;
         }
 
+        public static bool IsEqualsTokenInAutoPropertyInitializers(this SyntaxToken token)
+        {
+            return token.IsKind(SyntaxKind.EqualsToken) &&
+                token.Parent.IsKind(SyntaxKind.EqualsValueClause) &&
+                token.Parent.Parent.IsKind(SyntaxKind.PropertyDeclaration);
+        }
+
         public static bool IsCloseParenInStatement(this SyntaxToken token)
         {
             var statement = token.Parent as StatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -60,13 +60,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                     if (!previousToken.IsCloseBraceOfExpression())
                     {
-                        if (currentToken.Kind() != SyntaxKind.SemicolonToken &&
+                        if (!currentToken.IsKind(SyntaxKind.SemicolonToken) &&
                             !currentToken.IsParenInParenthesizedExpression() &&
                             !currentToken.IsCommaInInitializerExpression() &&
                             !currentToken.IsCommaInAnyArgumentsList() &&
                             !currentToken.IsParenInArgumentList() &&
                             !currentToken.IsDotInMemberAccess() &&
-                            !currentToken.IsCloseParenInStatement())
+                            !currentToken.IsCloseParenInStatement() &&
+                            !currentToken.IsEqualsTokenInAutoPropertyInitializers())
                         {
                             return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                         }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6179,5 +6179,20 @@ public class ExcludeValidation
 }";
             AssertFormat(expected, code);
         }
+
+        [WorkItem(1339, "https://github.com/dotnet/roslyn/issues/1339")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DontFormatAutoPropertyInitializerIfNotDifferentLine()
+        {
+            var code = @"class Program
+{
+    public int d { get; }
+            = 3;
+    static void Main(string[] args)
+    {
+    }
+}";
+            AssertFormat(code, code);
+        }
     }
 }


### PR DESCRIPTION
Fix #1339 : Indent the initializer of the Auto Property one less than
the beginning of the statement to signify the initializer is still part
of the Property declaration when issued a <Return> just before Auto
Property Initializer

If the user has selected a custom indentation for the Auto Property
Initializer don't distrub it and preserve the spaces