### PR TITLE
Trim the filepaths in FindRefs to avoid displaying so much redundant information.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Navigation;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
@@ -10,24 +13,93 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 {
     internal partial class LibraryManager
     {
-        private IList<AbstractTreeItem> CreateGoToDefinitionItems(IEnumerable<INavigableItem> items)
+        private IList<AbstractTreeItem> CreateNavigableItemTreeItems(IEnumerable<INavigableItem> items)
+        {
+            var itemsList = items.ToList();
+            if (itemsList.Count == 0)
+            {
+                return new List<AbstractTreeItem>();
+            }
+
+            // Find out how many different projects are referenced by these items.  If it's more than
+            // one, then we should present results that disambiguate the projects.  If it's only one,
+            // then we don't have to present the information.
+            var documents = new HashSet<Document>();
+            CollectDocuments(itemsList, documents);
+
+            var commonPathElements = CountCommonPathElements(documents);
+
+            return CreateNavigableItemTreeItems(itemsList, commonPathElements);
+        }
+
+        private int CountCommonPathElements(HashSet<Document> documents)
+        {
+            Debug.Assert(documents.Count > 0);
+            var commonPathElements = 0;
+            for (var index = 0; ; index++)
+            {
+                var pathPortion = GetPathPortion(documents.First(), index);
+                if (pathPortion == null)
+                {
+                    return commonPathElements;
+                }
+
+                foreach (var document in documents)
+                {
+                    if (GetPathPortion(document, index) != pathPortion)
+                    {
+                        return commonPathElements;
+                    }
+                }
+
+                commonPathElements++;
+            }
+        }
+
+        private string GetPathPortion(Document document, int index)
+        {
+            if (index == 0)
+            {
+                return document.Project.Name;
+            }
+
+            index--;
+            if (index < document.Folders.Count)
+            {
+                return document.Folders[index];
+            }
+
+            return null;
+        }
+
+        private void CollectDocuments(IEnumerable<INavigableItem> items, HashSet<Document> documents)
+        {
+            foreach (var item in items)
+            {
+                documents.Add(item.Document);
+
+                CollectDocuments(item.ChildItems, documents);
+            }
+        }
+
+        private IList<AbstractTreeItem> CreateNavigableItemTreeItems(IEnumerable<INavigableItem> items, int commonPathElements)
         {
             var sourceListItems =
                 from item in items
                 where IsValidSourceLocation(item.Document, item.SourceSpan)
-                select CreateTreeItem(item);
+                select CreateTreeItem(item, commonPathElements);
 
             return sourceListItems.ToList();
         }
 
-        private AbstractTreeItem CreateTreeItem(INavigableItem item)
+        private AbstractTreeItem CreateTreeItem(INavigableItem item, int commonPathElements)
         {
             var displayText = !item.ChildItems.IsEmpty ? item.DisplayName : null;
-            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex(), displayText);
+            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex(), commonPathElements, displayText);
 
             if (!item.ChildItems.IsEmpty)
             {
-                var childItems = CreateGoToDefinitionItems(item.ChildItems);
+                var childItems = CreateNavigableItemTreeItems(item.ChildItems, commonPathElements);
                 result.Children.AddRange(childItems);
                 result.SetReferenceCount(childItems.Count);
             }
@@ -37,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         public void PresentNavigableItems(string title, IEnumerable<INavigableItem> items)
         {
-            PresentObjectList(title, new ObjectList(CreateGoToDefinitionItems(items), this));
+            PresentObjectList(title, new ObjectList(CreateNavigableItemTreeItems(items), this));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
@@ -21,9 +21,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                 return new List<AbstractTreeItem>();
             }
 
-            // Find out how many different projects are referenced by these items.  If it's more than
-            // one, then we should present results that disambiguate the projects.  If it's only one,
-            // then we don't have to present the information.
+            // Collect all the documents in the list of items we're presenting.  Then determine
+            // what number of common path elements they have in common.  We can avoid showing
+            // these common locations, thus presenting a much cleaner result view to the user.
             var documents = new HashSet<Document>();
             CollectDocuments(itemsList, documents);
 

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -8,8 +9,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 {
     internal class SourceReferenceTreeItem : AbstractSourceTreeItem, IComparable<SourceReferenceTreeItem>
     {
-        public SourceReferenceTreeItem(Document document, TextSpan sourceSpan, ushort glyphIndex, string displayText = null)
-            : base(document, sourceSpan, glyphIndex)
+        public SourceReferenceTreeItem(Document document, TextSpan sourceSpan, ushort glyphIndex, int commonPathElements = 0, string displayText = null)
+            : base(document, sourceSpan, glyphIndex, commonPathElements)
         {
             if (displayText != null)
             {


### PR DESCRIPTION
So, instead of showing something like:

```
(local) int i
ServicesVisualStudio\Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs - (75, 21) : ...
ServicesVisualStudio\Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs - (88, 21) : ...
ServicesVisualStudio\Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs - (92, 21) : ...
ServicesVisualStudio\Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs - (133, 21) : ...
```

You'll instead just get:
```
(local) int i
AbstractSourceTreeItem.cs - (75, 21) : ...
AbstractSourceTreeItem.cs - (88, 21) : ...
AbstractSourceTreeItem.cs - (92, 21) : ...
AbstractSourceTreeItem.cs - (133, 21) : ...
```

Basically, we trim off all path sub portions that all the results share in common.   This is also nice in TS so we don't preface all results with:

"TypeScript Virtual Projects\Project #1 Miscellaneous"