### PR TITLE
Do not allocate too much for Guid stream

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -166,8 +166,8 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.String] + _previousGeneration.StringStreamLengthAdded,
                 // UserString stream is concatenated aligned.
                 userStringStreamLengthAdded: metadataSizes.GetAlignedHeapSize(HeapIndex.UserString) + _previousGeneration.UserStringStreamLengthAdded,
-                // Guid stream is always aligned (the size if a multiple of 16 = sizeof(Guid))
-                guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid] + _previousGeneration.GuidStreamLengthAdded,
+                // Guid stream accumulates on the GUID heap unlike other heaps, so the previous generations are already included.
+                guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid],
                 anonymousTypeMap: ((IPEDeltaAssemblyBuilder)moduleBuilder).GetAnonymousTypeMap(),
                 synthesizedMembers: synthesizedMembers,
                 addedOrChangedMethods: AddRange(addedOrChangedMethodsByIndex, _previousGeneration.AddedOrChangedMethods, replace: true),


### PR DESCRIPTION
When computing delta during EnC, we allocated too much heap for Guid stream, which caused OutofMemory exception. The heap size should be a multiple of sizeof(Guid).