### PR TITLE
Fix issues around NotConfigurable diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -28,10 +28,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>A diagnostic updated to reflect the options, or null if it has been filtered out</returns>
         public static Diagnostic Filter(Diagnostic d, int warningLevelOption, ReportDiagnostic generalDiagnosticOption, IDictionary<string, ReportDiagnostic> specificDiagnosticOptions)
         {
-            // If diagnostic is not configurable, keep it as it is.
-            if (d == null || d.IsNotConfigurable())
+            if (d == null)
             {
                 return d;
+            }
+            else if (d.IsNotConfigurable())
+            {
+                if (d.IsEnabledByDefault)
+                {
+                    // Enabled NotConfigurable should always be reported as it is.
+                    return d;
+                }
+                else
+                {
+                    // Disabled NotConfigurable should never be reported.
+                    return null;
+                }
             }
             else if (d.Severity == InternalDiagnosticSeverity.Void)
             {

--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
@@ -301,6 +301,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             foreach (var diag in supportedDiagnostics)
             {
+                if (HasNotConfigurableTag(diag.CustomTags))
+                {
+                    if (diag.IsEnabledByDefault)
+                    {
+                        // Diagnostic descriptor is not configurable, so the diagnostics created through it cannot be suppressed.
+                        return false;
+                    }
+                    else
+                    {
+                        // NotConfigurable disabled diagnostic can be ignored as it is never reported.
+                        continue;
+                    }
+                }
+
                 // Is this diagnostic suppressed by default (as written by the rule author)
                 var isSuppressed = !diag.IsEnabledByDefault;
 

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -396,15 +396,15 @@ Public MustInherit Class BasicTestBaseBase
                                          errorCodeType:=GetType(ERRID))
     End Function
 
-    Friend Shared Function AnalyzerDiagnostic(code As String, squiggledText As XCData, Optional arguments As Object() = Nothing, Optional startLocation As LinePosition? = Nothing, Optional syntaxNodePredicate As Func(Of VisualBasicSyntaxNode, Boolean) = Nothing, Optional argumentOrderDoesNotMatter As Boolean = False) As DiagnosticDescription
+    Friend Shared Function AnalyzerDiagnostic(code As String, Optional squiggledText As XCData = Nothing, Optional arguments As Object() = Nothing, Optional startLocation As LinePosition? = Nothing, Optional syntaxNodePredicate As Func(Of VisualBasicSyntaxNode, Boolean) = Nothing, Optional argumentOrderDoesNotMatter As Boolean = False) As DiagnosticDescription
         'Additional Overload taking XCData which needs to call NormalizeDiagnosticString to ensure that differences in end of line characters are normalized
         Return New DiagnosticDescription(code:=code,
-                                         squiggledText:=NormalizeDiagnosticString(squiggledText.Value),
+                                         squiggledText:=If(squiggledText IsNot Nothing, NormalizeDiagnosticString(squiggledText.Value), Nothing),
                                          arguments:=arguments,
                                          startLocation:=startLocation,
                                          syntaxNodePredicate:=DirectCast(syntaxNodePredicate, Func(Of SyntaxNode, Boolean)),
                                          argumentOrderDoesNotMatter:=argumentOrderDoesNotMatter,
-                                         errorCodeType:=GetType(ERRID))
+                                         errorCodeType:=GetType(String))
     End Function
     Friend Shared Function Diagnostic(code As ERRID, squiggledText As XCData, Optional arguments As Object() = Nothing, Optional startLocation As LinePosition? = Nothing, Optional syntaxNodePredicate As Func(Of VisualBasicSyntaxNode, Boolean) = Nothing, Optional argumentOrderDoesNotMatter As Boolean = False) As DiagnosticDescription
         'Additional Overload taking XCData which needs to call NormalizeDiagnosticString to ensure that differences in end of line characters are normalized

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -35,7 +35,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' If diagnostic is not configurable, keep it as it is.
             If diagnostic.IsNotConfigurable Then
-                Return diagnostic
+                If diagnostic.IsEnabledByDefault Then
+                    ' Enabled NotConfigurable should always be reported as it is.
+                    Return diagnostic
+                Else
+                    ' Disabled NotConfigurable should never be reported.
+                    Return Nothing
+                End If
             End If
 
             ' In the native compiler, all warnings originating from alink.dll were issued

--- a/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
@@ -160,5 +160,47 @@ namespace Microsoft.CodeAnalysis
             }
 
         }
-    }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class NotConfigurableDiagnosticAnalyzer : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor EnabledRule = new DiagnosticDescriptor(
+                "ID1",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                customTags: WellKnownDiagnosticTags.NotConfigurable);
+
+            public static readonly DiagnosticDescriptor DisabledRule = new DiagnosticDescriptor(
+                "ID2",
+                "Title2",
+                "Message2",
+                "Category2",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: false,
+                customTags: WellKnownDiagnosticTags.NotConfigurable);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            {
+                get
+                {
+                    return ImmutableArray.Create(EnabledRule, DisabledRule);
+                }
+            }
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(compilationContext =>
+                {
+                    // Report enabled diagnostic.
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(EnabledRule, Location.None));
+
+                    // Try to report disabled diagnostic.
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(DisabledRule, Location.None));
+                });
+            }
+        }
+        }
 }


### PR DESCRIPTION
1. NotConfigurable diagnostic shouldn't be reported if it is disabled ( fixes #1473 )
2. NotConfigurable enabled diagnostics implies analyzer is never suppressed. NotConfigurable disable diagnostics shouldn't participate in deciding whether or not analyzer is suppressed.

See comments in #1379 for more context.

@heejaechang @JohnHamby @shyamnamboodiripad @jmarolf  @tmeschter  @srivatsn  @sharwell please review the change.