### PR TITLE
Port git commit 1e759e to dotnet/preview.

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.AnalyzerAndOptions.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.AnalyzerAndOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         private sealed class AnalyzerAndOptions
         {
-            private readonly DiagnosticAnalyzer _analyzer;
+            public readonly DiagnosticAnalyzer Analyzer;
             private readonly AnalyzerOptions _analyzerOptions;
 
             public AnalyzerAndOptions(DiagnosticAnalyzer analyzer, AnalyzerOptions analyzerOptions)
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 Debug.Assert(analyzer != null);
                 Debug.Assert(analyzerOptions != null);
 
-                _analyzer = analyzer;
+                Analyzer = analyzer;
                 _analyzerOptions = analyzerOptions;
             }
 
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 return other != null &&
-                    _analyzer.Equals(other._analyzer) &&
+                    Analyzer.Equals(other.Analyzer) &&
                     _analyzerOptions.Equals(other._analyzerOptions);
             }
 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             public override int GetHashCode()
             {
-                return Hash.Combine(_analyzer.GetHashCode(), _analyzerOptions.GetHashCode());
+                return Hash.Combine(Analyzer.GetHashCode(), _analyzerOptions.GetHashCode());
             }
         }
     }

--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -31,32 +32,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         // This map stores the tasks to compute HostSessionStartAnalysisScope for session wide analyzer actions, i.e. AnalyzerActions registered by analyzer's Initialize method.
         // These are run only once per every analyzer.
-        private readonly ConditionalWeakTable<DiagnosticAnalyzer, Task<HostSessionStartAnalysisScope>> _sessionScopeMap =
-            new ConditionalWeakTable<DiagnosticAnalyzer, Task<HostSessionStartAnalysisScope>>();
+        private readonly ConcurrentDictionary<DiagnosticAnalyzer, Task<HostSessionStartAnalysisScope>> _sessionScopeMap =
+            new ConcurrentDictionary<DiagnosticAnalyzer, Task<HostSessionStartAnalysisScope>>(concurrencyLevel: 2, capacity: 5);
 
         // This map stores the tasks to compute HostCompilationStartAnalysisScope for per-compilation analyzer actions, i.e. AnalyzerActions registered by analyzer's CompilationStartActions.
         // Compilation start actions will get executed once per-each AnalyzerAndOptions as user might want to return different set of custom actions for each compilation/analyzer options.
-        private readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>>> _compilationScopeMap =
-            new ConditionalWeakTable<Compilation, ConcurrentDictionary<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>>>();
-
-        private readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>>>.CreateValueCallback _compilationScopeMapCallback =
-            new ConditionalWeakTable<Compilation, ConcurrentDictionary<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>>>.CreateValueCallback(
-                comp => new ConcurrentDictionary<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>>(concurrencyLevel: 2, capacity: 5));
+        private readonly ConcurrentDictionary<AnalyzerAndOptions, ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>>> _compilationScopeMap =
+            new ConcurrentDictionary<AnalyzerAndOptions, ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>>>(concurrencyLevel: 2, capacity: 5);
 
         /// <summary>
         /// Cache descriptors for each diagnostic analyzer. We do this since <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> is
         /// a property rather than metadata. We expect it to be cheap and immutable, but we can't force them to be so, we cache them
         /// and ask only once.
         /// </summary>
-        private readonly ConditionalWeakTable<DiagnosticAnalyzer, Tuple<ImmutableArray<DiagnosticDescriptor>, EventHandler<Exception>>> _descriptorCache =
-            new ConditionalWeakTable<DiagnosticAnalyzer, Tuple<ImmutableArray<DiagnosticDescriptor>, EventHandler<Exception>>>();
+        private readonly ConcurrentDictionary<DiagnosticAnalyzer, Tuple<ImmutableArray<DiagnosticDescriptor>, EventHandler<Exception>>> _descriptorCache =
+            new ConcurrentDictionary<DiagnosticAnalyzer, Tuple<ImmutableArray<DiagnosticDescriptor>, EventHandler<Exception>>>(concurrencyLevel: 2, capacity: 5);
 
         private Task<HostCompilationStartAnalysisScope> GetCompilationAnalysisScopeCoreAsync(
             AnalyzerAndOptions analyzerAndOptions,
             HostSessionStartAnalysisScope sessionScope,
             AnalyzerExecutor analyzerExecutor)
         {
-            Func<AnalyzerAndOptions, Task<HostCompilationStartAnalysisScope>> getTask = a =>
+            Func<Compilation, Task<HostCompilationStartAnalysisScope>> getTask = comp =>
             {
                 return Task.Run(() =>
                 {
@@ -66,8 +63,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }, analyzerExecutor.CancellationToken);
             };
 
-            var compilationActionsMap = _compilationScopeMap.GetValue(analyzerExecutor.Compilation, _compilationScopeMapCallback);
-            return compilationActionsMap.GetOrAdd(analyzerAndOptions, getTask);
+            var callback = new ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>>.CreateValueCallback(getTask);
+            var compilationActionsMap = _compilationScopeMap.GetOrAdd(analyzerAndOptions, new ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>>());
+            return compilationActionsMap.GetValue(analyzerExecutor.Compilation, callback);
         }
 
         private async Task<HostCompilationStartAnalysisScope> GetCompilationAnalysisScopeAsync(
@@ -85,9 +83,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // Task to compute the scope was cancelled.
                 // Clear the entry in scope map for analyzer, so we can attempt a retry.
-                var compilationActionsMap = _compilationScopeMap.GetOrCreateValue(analyzerExecutor.Compilation);
-                Task<HostCompilationStartAnalysisScope> cancelledTask;
-                compilationActionsMap.TryRemove(analyzerAndOptions, out cancelledTask);
+                ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>> compilationActionsMap;
+                if (_compilationScopeMap.TryGetValue(analyzerAndOptions, out compilationActionsMap))
+                {
+                    compilationActionsMap.Remove(analyzerExecutor.Compilation);
+                }
 
                 analyzerExecutor.CancellationToken.ThrowIfCancellationRequested();
                 return await GetCompilationAnalysisScopeAsync(analyzer, sessionScope, analyzerExecutor).ConfigureAwait(false);
@@ -108,8 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }, analyzerExecutor.CancellationToken);
             };
 
-            var callback = new ConditionalWeakTable<DiagnosticAnalyzer, Task<HostSessionStartAnalysisScope>>.CreateValueCallback(getTask);
-            return _sessionScopeMap.GetValue(analyzer, callback);
+            return _sessionScopeMap.GetOrAdd(analyzer, getTask);
         }
 
         private async Task<HostSessionStartAnalysisScope> GetSessionAnalysisScopeAsync(
@@ -124,7 +123,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // Task to compute the scope was cancelled.
                 // Clear the entry in scope map for analyzer, so we can attempt a retry.
-                _sessionScopeMap.Remove(analyzer);
+                Task<HostSessionStartAnalysisScope> cancelledTask;
+                _sessionScopeMap.TryRemove(analyzer, out cancelledTask);
 
                 analyzerExecutor.CancellationToken.ThrowIfCancellationRequested();
                 return await GetSessionAnalysisScopeAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
@@ -179,25 +179,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             AnalyzerExecutor analyzerExecutor)
         {
-            var descriptors = _descriptorCache.GetValue(analyzer, key =>
+            var descriptors = _descriptorCache.GetOrAdd(analyzer, key =>
             {
                 var supportedDiagnostics = ImmutableArray<DiagnosticDescriptor>.Empty;
 
                 // Catch Exception from analyzer.SupportedDiagnostics
                 analyzerExecutor.ExecuteAndCatchIfThrows(analyzer, () => { supportedDiagnostics = analyzer.SupportedDiagnostics; });
 
-                var handler = new EventHandler<Exception>((sender, ex) =>
+                EventHandler<Exception> handler = null;
+                Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = analyzerExecutor.OnAnalyzerException;
+                if (onAnalyzerException != null)
+                {
+                    handler = new EventHandler<Exception>((sender, ex) =>
                     {
                         var diagnostic = AnalyzerExecutor.GetAnalyzerExceptionDiagnostic(analyzer, ex);
-                        analyzerExecutor.OnAnalyzerException?.Invoke(ex, analyzer, diagnostic);
+                        onAnalyzerException(ex, analyzer, diagnostic);
                     });
 
-                // Subscribe for exceptions from lazily evaluated localizable strings in the descriptors.
-                foreach (var descriptor in supportedDiagnostics)
-                {
-                    descriptor.Title.OnException += handler;
-                    descriptor.MessageFormat.OnException += handler;
-                    descriptor.Description.OnException += handler;
+                    // Subscribe for exceptions from lazily evaluated localizable strings in the descriptors.
+                    foreach (var descriptor in supportedDiagnostics)
+                    {
+                        descriptor.Title.OnException += handler;
+                        descriptor.MessageFormat.OnException += handler;
+                        descriptor.Description.OnException += handler;
+                    }
                 }
 
                 return Tuple.Create(supportedDiagnostics, handler);
@@ -206,20 +211,51 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return descriptors.Item1;
         }
 
-        internal void ClearAnalyzerExceptionHandlers(DiagnosticAnalyzer analyzer)
+        /// <summary>
+        /// This method should be invoked when the analyzer host is disposing off the analyzers.
+        /// It unregisters the exception handler hooked up to the descriptors' LocalizableString fields and subsequently removes the cached descriptors for the analyzers.
+        /// </summary>
+        internal void ClearAnalyzerState(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            foreach (var analyzer in analyzers)
+            {
+                ClearDescriptorState(analyzer);
+                ClearAnalysisScopeState(analyzer);
+            }
+        }
+
+        private void ClearDescriptorState(DiagnosticAnalyzer analyzer)
         {
             // Host is disposing the analyzer instance, unsubscribe analyzer exception handlers.
             Tuple<ImmutableArray<DiagnosticDescriptor>, EventHandler<Exception>> value;
-            if (_descriptorCache.TryGetValue(analyzer, out value))
+            if (_descriptorCache.TryRemove(analyzer, out value))
             {
                 var descriptors = value.Item1;
                 var handler = value.Item2;
-                foreach (var descriptor in descriptors)
+                if (handler != null)
                 {
-                    descriptor.Title.OnException -= handler;
-                    descriptor.MessageFormat.OnException -= handler;
-                    descriptor.Description.OnException -= handler;
+                    foreach (var descriptor in descriptors)
+                    {
+                        descriptor.Title.OnException -= handler;
+                        descriptor.MessageFormat.OnException -= handler;
+                        descriptor.Description.OnException -= handler;
+                    }
                 }
+            }
+        }
+
+        private void ClearAnalysisScopeState(DiagnosticAnalyzer analyzer)
+        {
+            // Clear session scope.
+            Task<HostSessionStartAnalysisScope> canceledTask;
+            _sessionScopeMap.TryRemove(analyzer, out canceledTask);
+
+            // Clear compilation scope.
+            var keysToRemove = _compilationScopeMap.Keys.Where(analyzerAndOptions => analyzerAndOptions.Analyzer.Equals(analyzer)).ToImmutableArray();
+            foreach (var analyzerAndOptions in keysToRemove)
+            {
+                ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>> map;
+                _compilationScopeMap.TryRemove(analyzerAndOptions, out map);
             }
         }
 

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.AssemblyPathHelper.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.AssemblyPathHelper.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
-using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -329,13 +329,14 @@ namespace Microsoft.CodeAnalysis
             cancellationToken.ThrowIfCancellationRequested();
 
             CancellationTokenSource analyzerCts = null;
+            AnalyzerManager analyzerManager = null;
             try
             {
                 Func<ImmutableArray<Diagnostic>> getAnalyzerDiagnostics = null;
                 if (!analyzers.IsDefaultOrEmpty)
                 {
                     analyzerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    var analyzerManager = new AnalyzerManager();
+                    analyzerManager = new AnalyzerManager();
                     var analyzerExceptionDiagnostics = new ConcurrentSet<Diagnostic>();
                     Action<Diagnostic> addExceptionDiagnostic = diagnostic => analyzerExceptionDiagnostics.Add(diagnostic);
                     var analyzerOptions = new AnalyzerOptions(ImmutableArray.Create<AdditionalText, AdditionalTextFile>(additionalTextFiles));
@@ -496,6 +497,9 @@ namespace Microsoft.CodeAnalysis
                 if (analyzerCts != null)
                 {
                     analyzerCts.Cancel();
+
+                    // Clear cached analyzer descriptors and unregister exception handlers hooked up to the LocalizableString fields of the associated descriptors.
+                    analyzerManager.ClearAnalyzerState(analyzers);
                 }
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -956,9 +956,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var nodesToAnalyze = descendantDeclsToSkip == null ?
                 declaredNode.DescendantNodesAndSelf(descendIntoTrivia: true) :
-                declaredNode.DescendantNodesAndSelf(n => !descendantDeclsToSkip.Contains(n), descendIntoTrivia: true).Except(descendantDeclsToSkip);
+                GetSyntaxNodesToAnalyze(declaredNode, descendantDeclsToSkip);
 
             analyzerExecutor.ExecuteSyntaxNodeActions(nodesToAnalyze, actionsByKind, semanticModel, getKind);
+        }
+
+        private static IEnumerable<SyntaxNode> GetSyntaxNodesToAnalyze(SyntaxNode declaredNode, HashSet<SyntaxNode> descendantDeclsToSkip)
+        {
+            Debug.Assert(declaredNode != null);
+            Debug.Assert(descendantDeclsToSkip != null);
+
+            foreach (var node in declaredNode.DescendantNodesAndSelf(n => !descendantDeclsToSkip.Contains(n), descendIntoTrivia: true))
+            {
+                if (!descendantDeclsToSkip.Contains(node))
+                {
+                    yield return node;
+                }
+            }
         }
     }
 

--- a/src/Features/Core/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -44,12 +44,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal void ReportAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Workspace workspace, Project project)
+        internal void ReportAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Workspace workspace, ProjectId projectId)
         {
             if (workspace != this.Workspace)
             {
                 return;
             }
+
+            var project = workspace.CurrentSolution.GetProject(projectId);
 
             bool raiseDiagnosticsUpdated = true;
             var diagnosticData = project != null ?
@@ -74,10 +76,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void ClearAnalyzerReferenceDiagnostics(AnalyzerFileReference analyzerReference, string language, ProjectId projectId)
         {
-            foreach (var analyzer in analyzerReference.GetAnalyzers(language))
+            var analyzers = analyzerReference.GetAnalyzers(language);
+            ClearAnalyzerDiagnostics(analyzers, projectId);
+            AnalyzerManager.Instance.ClearAnalyzerState(analyzers);
+        }
+
+        private void ClearAnalyzerDiagnostics(ImmutableArray<DiagnosticAnalyzer> analyzers, ProjectId projectId)
+        {
+            foreach (var analyzer in analyzers)
             {
                 ClearAnalyzerDiagnostics(analyzer, projectId);
-                AnalyzerManager.Instance.ClearAnalyzerExceptionHandlers(analyzer);
             }
         }
 

--- a/src/Features/Core/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Diagnostics/AnalyzerHelper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             Diagnostic diagnostic,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
-            Project projectOpt = null)
+            ProjectId projectOpt = null)
         {
             if (diagnostic != null)
             {

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private void Default_OnAnalyzerException_NoTelemetryLogging(Exception e, DiagnosticAnalyzer analyzer, Diagnostic diagnostic)
         {
-            AnalyzerHelper.OnAnalyzerException_NoTelemetryLogging(e, analyzer, diagnostic, _hostDiagnosticUpdateSource, _project);
+            AnalyzerHelper.OnAnalyzerException_NoTelemetryLogging(e, analyzer, diagnostic, _hostDiagnosticUpdateSource, _project.Id);
         }
 
         private void Default_OnAnalyzerException(Exception e, DiagnosticAnalyzer analyzer, Diagnostic diagnostic)


### PR DESCRIPTION
Fix memory leaks in AnalyzerManager:

1) Statically created LocalizableString instances by analyzers were holding onto instances of AnalyzerExecutor (which holds onto the compilation on which it executes) for exception reporting, causing us to leak compilations in command line builds. Fixed this by making sure that we unregister these exception handlers during analyzer cleanup in CommonCompiler, we already did so for VisualStudioAnalyzer created in IDE.

2) Switch all the state caches in AnalyzerManager to be keyed with analyzer, and clear all state for analyzer when host disposes it. Performance analysis showed that analyzers that capture the CompilationStartAnalysisContext in its RegisterCompilationStartAction via some lambda were rooting the compilation objects.

Above two changes got rid of all the static and dependent handles rooting compilations during command line builds, and I see a perceived reduction in memory used by VBCSCompiler during building Roslyn.

3) Fix the IDE onAnalyzerException delegate to not capture project instance, but instead use the projectId. Otherwise, VSIX analyzers that live for lifetime of VS instance would leak compilations.

While I was at it, I also got rid of functionality added to MetadataCache that was caching and re-using analyzer instances across AnalyzerFileReference instances, we had already decided to instead keep lifetime of analyzer instances bound by lifetime of owning AnalyzerFileReference.

@srivatsn Can you please review?