### PR TITLE
turn off project analysis when closed file diagnostic is off

### DIFF
--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         {
             try
             {
-                if (!skipClosedFileChecks && !CheckOption(project.Solution.Workspace, project.Language, documentOpened: project.Documents.Any(d => d.IsOpen())))
+                if (!skipClosedFileChecks && !CheckOption(project.Solution.Workspace, project.Language, documentOpened: false))
                 {
                     return;
                 }


### PR DESCRIPTION
this should make us not to run compilation end actions when the option is off