### PR TITLE
Fix OpenSourceDebugPackage F5

### DIFF
--- a/src/Tools/Source/OpenSourceDebug/enableopensource.pkgdef
+++ b/src/Tools/Source/OpenSourceDebug/enableopensource.pkgdef
@@ -8,118 +8,118 @@
 @="OpenSourceDebugPackage"
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "Class"="Microsoft.OpenSourceDebug.OpenSourceDebugPackage"
-"Assembly"="OpenSourceDebug, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+"Assembly"="OpenSourceDebug, Version=42.42.42.42, Culture=neutral, PublicKeyToken=fc793a00266884fb"
 [$RootKey$\AutoLoadPackages\{f1536ef8-92ec-443c-9ed7-fdadf150da82}]
 "{7922692f-f018-45e7-8f3f-d3b7c0262841}"=dword:00000000
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{B0633220-CC49-4846-95FE-BF14E45A7746}]
 "name"="OpenSourceDebug"
-"publicKeyToken"="31bf3856ad364e35"
+"publicKeyToken"="fc793a00266884fb"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\OpenSourceDebug.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{BD63FD05-C1FF-4FC9-8B16-1F89252C1AA6}]
 "name"="Microsoft.CodeAnalysis.CSharp.Desktop"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.CSharp.Desktop.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{6F2F49AD-3400-468C-A4E3-DF22A400A5BE}]
 "name"="Microsoft.CodeAnalysis.CSharp"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.CSharp.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{FB16B8CA-5B0D-4907-B53C-5A6280A18D26}]
 "name"="Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{6197998F-B175-40ED-83A6-6B9F3F5957EB}]
 "name"="Microsoft.CodeAnalysis.CSharp.Workspaces"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.CSharp.Workspaces.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{BEFBFC1B-A65A-4673-A2D8-DDF88FE832F1}]
 "name"="Microsoft.CodeAnalysis.Desktop"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.Desktop.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{9191E7D9-AD0F-4FC4-9BAA-13F5AEB7B7A9}]
 "name"="Microsoft.CodeAnalysis"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{F7B75996-8BE1-407F-8F17-54AB745CD804}]
 "name"="Microsoft.CodeAnalysis.FxCopAnalyzers"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.FxCopAnalyzers.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{A0B7536E-8ADA-4108-8E98-ECFDAC4BBB79}]
 "name"="Microsoft.CodeAnalysis.VisualBasic.Desktop"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{74465C32-9A24-44DE-BDD0-6A335D926101}]
 "name"="Microsoft.CodeAnalysis.VisualBasic"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.VisualBasic.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{455F6A8A-1385-4443-B440-A97B4206BACB}]
 "name"="Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{4B14766C-ED6F-4A10-8374-7FA73055D4E4}]
 "name"="Microsoft.CodeAnalysis.VisualBasic.Workspaces"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{F9F9D431-7216-4199-8648-DDC26E7BCF76}]
 "name"="Microsoft.CodeAnalysis.Workspaces"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Microsoft.CodeAnalysis.Workspaces.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{61F3FC17-A4C1-43C7-B5A4-28EC69C2B2DE}]
 "name"="Roslyn.SyntaxVisualizer.Control"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Roslyn.SyntaxVisualizer.Control.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{32142B8B-4B9B-48A6-8DD9-30C279581098}]
 "name"="Roslyn.SyntaxVisualizer.DgmlHelper"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\Roslyn.SyntaxVisualizer.DgmlHelper.dll"
 
 [$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{E53DF9E9-CA2D-4F64-9DA6-4CB504612A1E}]
 "name"=">Roslyn.Diagnostics.Analyzers.VisualBasic"
 "publicKeyToken"="31bf3856ad364e35"
 "culture"="neutral"
-"version"="0.7.0.0"
+"version"="42.42.42.42"
 "codeBase"="$PackageFolder$\>Roslyn.Diagnostics.Analyzers.VisualBasic.dll"


### PR DESCRIPTION
The F5 scenario for OpenSourceDebugPackage was blocked because of the
following issues:

- The pkgdef was using 0.7.0.0 as the version instead of 42.42.42.42
- OpenSourceDebugPackage uses a different public key than the rest of
the code base and it was incorrectly listed in the pkgdef file.

Note: In order to ensure you can F5 after syncing to this fix please run
the following command in a VS command prompt:

> devenv /rootSuffix Roslyn /resetSkipPkgs