### PR TITLE
Changed generation of PrivateImplementationDetails to append module name...

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         moduleId = moduleId.Substring(0, moduleId.Length - extension.Length);
                     }
 
-                    moduleId = moduleId.MangleForTypeNameIfNeeded();
+                    moduleId = MetadataHelpers.MangleForTypeNameIfNeeded(moduleId);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         moduleId = moduleId.Substring(0, moduleId.Length - extension.Length);
                     }
 
-                    moduleId = moduleId.Replace('.', '_');
+                    moduleId = moduleId.MangleForTypeNameIfNeeded();
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -121,7 +121,7 @@ class C
   IL_0001:  ldc.i4.4
   IL_0002:  newobj     ""double[*,*]..ctor""
   IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=64 <PrivateImplementationDetails><MODULE>.E19C080DB8DAB85AF7CA3EF40FFB01B0778F9D25""
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=64 <PrivateImplementationDetails>.E19C080DB8DAB85AF7CA3EF40FFB01B0778F9D25""
   IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0012:  stloc.0
   IL_0013:  ldloc.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -3241,7 +3241,7 @@ public class D
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     ""int""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><ＭＯＤＵＬＥ>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails><ＭＯＤＵＬＥ>.42F1B77334EDFA917032CCF8353020C73F8C62E1""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.42F1B77334EDFA917032CCF8353020C73F8C62E1""
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  stloc.0
   IL_0012:  ldloc.0
@@ -3560,7 +3560,7 @@ CCC
 ");
 
             #region IL
-            // Can NOT compare IL because the Guid is different every time - <PrivateImplementationDetails><MODULE>{a6c2d596-042b-4294-99ab-d34a2758ec15}
+            // Can NOT compare IL because the Guid is different every time - <PrivateImplementationDetails>{a6c2d596-042b-4294-99ab-d34a2758ec15}
 #if false
             compilation.VerifyIL("MyArray.Main",
 @"{
@@ -3594,7 +3594,7 @@ CCC
   IL_0028:  ldc.i4.3
   IL_0029:  newarr     ""byte""
   IL_002e:  dup
-  IL_002f:  ldtoken    ""<PrivateImplementationDetails><MODULE>{a6c2d596-042b-4294-99ab-d34a2758ec15}.__StaticArrayInitTypeSize=3  <PrivateImplementationDetails><MODULE>{a6c2d596-042b-4294-99ab-d34a2758ec15}.0""
+  IL_002f:  ldtoken    ""<PrivateImplementationDetails>{a6c2d596-042b-4294-99ab-d34a2758ec15}.__StaticArrayInitTypeSize=3  <PrivateImplementationDetails>{a6c2d596-042b-4294-99ab-d34a2758ec15}.0""
   IL_0034:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0039:  ldc.i4.0
   IL_003a:  ldelem.u1
@@ -3620,7 +3620,7 @@ CCC
   IL_005f:  ldc.i4.3
   IL_0060:  newarr     ""short""
   IL_0065:  dup
-  IL_0066:  ldtoken    ""<PrivateImplementationDetails><MODULE>{a6c2d596-042b-4294-99ab-d34a2758ec15}.__StaticArrayInitTypeSize=6  <PrivateImplementationDetails><MODULE>{a6c2d596-042b-4294-99ab-d34a2758ec15}.1""
+  IL_0066:  ldtoken    ""<PrivateImplementationDetails>{a6c2d596-042b-4294-99ab-d34a2758ec15}.__StaticArrayInitTypeSize=6  <PrivateImplementationDetails>{a6c2d596-042b-4294-99ab-d34a2758ec15}.1""
   IL_006b:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0070:  stelem.ref
   IL_0071:  ldc.i4.1
@@ -6406,7 +6406,7 @@ e
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     ""int""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.56C14CB445C628421AC674599E302B0879FB496F""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.56C14CB445C628421AC674599E302B0879FB496F""
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  dup
   IL_0012:  ldc.i4.2
@@ -6418,7 +6418,7 @@ e
   IL_0020:  ldc.i4.5
   IL_0021:  newarr     ""bool""
   IL_0026:  dup
-  IL_0027:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails><MODULE>.4E724558F6B816715597A51663AD8F05247E2C4A""
+  IL_0027:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.4E724558F6B816715597A51663AD8F05247E2C4A""
   IL_002c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0031:  dup
   IL_0032:  ldc.i4.2
@@ -6430,7 +6430,7 @@ e
   IL_0040:  ldc.i4.5
   IL_0041:  newarr     ""byte""
   IL_0046:  dup
-  IL_0047:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails><MODULE>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB""
+  IL_0047:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB""
   IL_004c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0051:  dup
   IL_0052:  ldc.i4.2
@@ -6442,7 +6442,7 @@ e
   IL_0060:  ldc.i4.5
   IL_0061:  newarr     ""char""
   IL_0066:  dup
-  IL_0067:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails><MODULE>.E313A2813013780396D58750DC5D62221C86F42F""
+  IL_0067:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails>.E313A2813013780396D58750DC5D62221C86F42F""
   IL_006c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0071:  dup
   IL_0072:  ldc.i4.2
@@ -6454,7 +6454,7 @@ e
   IL_0080:  ldc.i4.5
   IL_0081:  newarr     ""float""
   IL_0086:  dup
-  IL_0087:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.2F3DD953DBFB23217E7CE0E76630EBD31267E237""
+  IL_0087:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.2F3DD953DBFB23217E7CE0E76630EBD31267E237""
   IL_008c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0091:  dup
   IL_0092:  ldc.i4.2
@@ -6466,7 +6466,7 @@ e
   IL_00a0:  ldc.i4.5
   IL_00a1:  newarr     ""double""
   IL_00a6:  dup
-  IL_00a7:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails><MODULE>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A""
+  IL_00a7:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A""
   IL_00ac:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00b1:  dup
   IL_00b2:  ldc.i4.2
@@ -6500,7 +6500,7 @@ public class D
 }
 ";
             var compilation = CompileAndVerify(source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"), expectedOutput: @"3-5");
-            //string pid = "<PrivateImplementationDetails><MODULE>" + compilation.Compilation.SourceModule.Pers
+            //string pid = "<PrivateImplementationDetails>" + compilation.Compilation.SourceModule.Pers
             compilation.VerifyIL("D.Main",
 @"{
   // Code size       73 (0x49)
@@ -6509,7 +6509,7 @@ public class D
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     ""int""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.FF942E5F620FC460CF9424D564C73AD8A99C74EE""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.FF942E5F620FC460CF9424D564C73AD8A99C74EE""
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  dup
   IL_0012:  ldc.i4.2
@@ -6524,7 +6524,7 @@ public class D
   IL_0027:  ldc.i4.5
   IL_0028:  newarr     ""int""
   IL_002d:  dup
-  IL_002e:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.89E37886EEEDC70AEF61138E037CC60EFC35535F""
+  IL_002e:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.89E37886EEEDC70AEF61138E037CC60EFC35535F""
   IL_0033:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0038:  dup
   IL_0039:  ldc.i4.4
@@ -6562,7 +6562,7 @@ public class D
 }
 ";
             var compilation = CompileAndVerify(source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"), expectedOutput: @"30");
-            //string pid = "<PrivateImplementationDetails><MODULE>" + compilation.Compilation.SourceModule.Pers
+            //string pid = "<PrivateImplementationDetails>" + compilation.Compilation.SourceModule.Pers
             compilation.VerifyIL("D.Main",
 @"{
   // Code size       82 (0x52)
@@ -6592,7 +6592,7 @@ public class D
   IL_002e:  ldc.i4.s   15
   IL_0030:  newarr     ""int""
   IL_0035:  dup
-  IL_0036:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=60 <PrivateImplementationDetails><MODULE>.49608711F905702F9F227AA782F8B408777D5DF9""
+  IL_0036:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=60 <PrivateImplementationDetails>.49608711F905702F9F227AA782F8B408777D5DF9""
   IL_003b:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0040:  dup
   IL_0041:  ldc.i4.s   12
@@ -6728,7 +6728,7 @@ DBNull
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     ""System.TypeCode""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.3191FF614021ADF3122AC274EA5B6097C21BEB81""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.3191FF614021ADF3122AC274EA5B6097C21BEB81""
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  dup
   IL_0012:  ldc.i4.1
@@ -7301,7 +7301,7 @@ Abc123
   IL_0085:  ldc.i4.4
   IL_0086:  newarr     ""ushort""
   IL_008b:  dup
-  IL_008c:  ldtoken    ""long <PrivateImplementationDetails><MODULE>.E9E8A66A117598333ABACF5B65971C2366E19B6C""
+  IL_008c:  ldtoken    ""long <PrivateImplementationDetails>.E9E8A66A117598333ABACF5B65971C2366E19B6C""
   IL_0091:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0096:  callvirt   ""uint Program.C.Foo(out short, params ushort[])""
   IL_009b:  call       ""void System.Console.WriteLine(uint)""
@@ -7534,7 +7534,7 @@ class A
   IL_0001:  ldc.i4.5
   IL_0002:  newarr     ""int""
   IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
   IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0012:  stloc.0
   IL_0013:  ret
@@ -13047,7 +13047,7 @@ True");
   IL_0040:  ldc.i4.4
   IL_0041:  newarr     ""bool""
   IL_0046:  dup
-  IL_0047:  ldtoken    ""int <PrivateImplementationDetails><MODULE>.35CCB1599F52363510686EF38B7DB5E7998DB108""
+  IL_0047:  ldtoken    ""int <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108""
   IL_004c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0051:  ldc.i4.2
   IL_0052:  ldelem.u1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexerTests.cs
@@ -458,7 +458,7 @@ class Test
   IL_003f:  ldc.i4.3
   IL_0040:  newarr     ""int""
   IL_0045:  dup
-  IL_0046:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_0046:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_004b:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0050:  callvirt   ""int C.this[params int[]].get""
   IL_0055:  pop
@@ -466,7 +466,7 @@ class Test
   IL_0057:  ldc.i4.3
   IL_0058:  newarr     ""int""
   IL_005d:  dup
-  IL_005e:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_005e:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_0063:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0068:  callvirt   ""int C.this[params int[]].get""
   IL_006d:  pop
@@ -606,7 +606,7 @@ class Test
   IL_003f:  ldc.i4.3
   IL_0040:  newarr     ""int""
   IL_0045:  dup
-  IL_0046:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_0046:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_004b:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0050:  ldc.i4.4
   IL_0051:  callvirt   ""void C.this[params int[]].set""
@@ -614,7 +614,7 @@ class Test
   IL_0057:  ldc.i4.3
   IL_0058:  newarr     ""int""
   IL_005d:  dup
-  IL_005e:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_005e:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_0063:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0068:  ldc.i4.4
   IL_0069:  callvirt   ""void C.this[params int[]].set""
@@ -800,7 +800,7 @@ class Test
   IL_0084:  ldc.i4.3
   IL_0085:  newarr     ""int""
   IL_008a:  dup
-  IL_008b:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_008b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_0090:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0095:  stloc.3
   IL_0096:  ldloc.2
@@ -818,7 +818,7 @@ class Test
   IL_00aa:  ldc.i4.3
   IL_00ab:  newarr     ""int""
   IL_00b0:  dup
-  IL_00b1:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_00b1:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_00b6:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00bb:  stloc.3
   IL_00bc:  ldloc.2
@@ -1030,7 +1030,7 @@ class Test
   IL_00a2:  ldc.i4.3
   IL_00a3:  newarr     ""int""
   IL_00a8:  dup
-  IL_00a9:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_00a9:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_00ae:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00b3:  stloc.2
   IL_00b4:  ldloc.1
@@ -1047,7 +1047,7 @@ class Test
   IL_00cb:  ldc.i4.3
   IL_00cc:  newarr     ""int""
   IL_00d1:  dup
-  IL_00d2:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_00d2:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_00d7:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00dc:  stloc.2
   IL_00dd:  ldloc.1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -2283,7 +2283,7 @@ class Test
             var reference = compVerifier.Compilation.EmitToImageReference();
             var comp = CSharpCompilation.Create("Name", references: new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
 
-            var pid = ((NamedTypeSymbol)comp.GlobalNamespace.GetMembers().Single(s => s.Name.StartsWith("<PrivateImplementationDetails><MODULE>", StringComparison.Ordinal)));
+            var pid = ((NamedTypeSymbol)comp.GlobalNamespace.GetMembers().Single(s => s.Name.StartsWith("<PrivateImplementationDetails>", StringComparison.Ordinal)));
             var member = pid.GetMembers(PrivateImplementationDetails.SynthesizedStringHashFunctionName).Single();
             Assert.Equal(Accessibility.Internal, member.DeclaredAccessibility);
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2519,7 +2519,7 @@ class C
   IL_0001:  ldc.i4.3
   IL_0002:  newarr     ""int""
   IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0012:  stloc.0
   IL_0013:  ldloc.0
@@ -2828,7 +2828,7 @@ class C
             var generation0 = EmitBaseline.CreateInitialBaseline(ModuleMetadata.CreateFromImage(bytes0), methodData0.EncDebugInfoProvider());
 
             // Should have generated call to ComputeStringHash and
-            // added the method to <PrivateImplementationDetails><MODULE>.
+            // added the method to <PrivateImplementationDetails>.
             var actualIL0 = methodData0.GetMethodIL();
             Assert.True(actualIL0.Contains(ComputeStringHashName));
 
@@ -2843,7 +2843,7 @@ class C
                     ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, method0, method1, GetEquivalentNodesMap(method1, method0), preserveLocalVariables: true)));
 
                 // Should not have generated call to ComputeStringHash nor
-                // added the method to <PrivateImplementationDetails><MODULE>.
+                // added the method to <PrivateImplementationDetails>.
                 var actualIL1 = diff1.GetMethodIL("C.F");
                 Assert.False(actualIL1.Contains(ComputeStringHashName));
 

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -1135,7 +1135,7 @@ class C
   IL_0003:  ldc.i4.2
   IL_0004:  newobj     ""int[*,*,*]..ctor""
   IL_0009:  dup
-  IL_000a:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails><MODULE>.EB196F988F4F427D318CA25B68671CF3A4510012""
+  IL_000a:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.EB196F988F4F427D318CA25B68671CF3A4510012""
   IL_000f:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0014:  stloc.0
  -IL_0015:  nop

--- a/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
@@ -5242,7 +5242,7 @@ class AllMembers
   IL_005b:  ldc.i4.5
   IL_005c:  newarr     ""int""
   IL_0061:  dup
-  IL_0062:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.864782BF337E3DBC1A27023D5C0C065C80F17087""
+  IL_0062:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.864782BF337E3DBC1A27023D5C0C065C80F17087""
   IL_0067:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_006c:  ldloc.0
   IL_006d:  ldftn      ""bool AllMembers.<>c__DisplayClass3_0.<TestLINQ>b__0(int)""

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             // we include the module name in the name of the PrivateImplementationDetails class so that more than
             // one of them can be included in an assembly as part of netmodules.    
             var name = isNetModule ?
-                        $"<PrivateImplementationDetails><{moduleName.MangleForTypeNameIfNeeded()}>" :
+                        $"<PrivateImplementationDetails><{MetadataHelpers.MangleForTypeNameIfNeeded(moduleName)}>" :
                         $"<PrivateImplementationDetails>";
 
             if (submissionSlotIndex >= 0)

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -80,14 +80,25 @@ namespace Microsoft.CodeAnalysis.CodeGen
             _systemInt64Type = systemInt64Type;
 
             _compilerGeneratedAttribute = compilerGeneratedAttribute;
-            _name = GetClassName(moduleName, submissionSlotIndex);
+
+            var isNetModule = moduleBuilder.AsAssembly == null;
+            _name = GetClassName(moduleName, submissionSlotIndex, isNetModule);
         }
 
-        internal static string GetClassName(string moduleName, int submissionSlotIndex)
+        private static string GetClassName(string moduleName, int submissionSlotIndex, bool isNetModule)
         {
             // we include the module name in the name of the PrivateImplementationDetails class so that more than
-            // one of them can be included in an assembly as part of netmodules.
-            return $"<PrivateImplementationDetails><{(submissionSlotIndex >= 0 ? submissionSlotIndex.ToString() : moduleName)}>";
+            // one of them can be included in an assembly as part of netmodules.    
+            var name = isNetModule ?
+                        $"<PrivateImplementationDetails><{moduleName.MangleForTypeNameIfNeeded()}>" :
+                        $"<PrivateImplementationDetails>";
+
+            if (submissionSlotIndex >= 0)
+            {
+                name += submissionSlotIndex.ToString();
+            }
+
+            return name;
         }
 
         internal void Freeze()

--- a/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
@@ -49,20 +49,6 @@ namespace Roslyn.Utilities
             return name.Length >= 3 && name[0] == 'T' && char.IsUpper(name[1]) && char.IsLower(name[2]);
         }
 
-        /// <summary>
-        /// Given an input string changes it to be acceptable as a part of a type name.
-        /// For now we will simply replace '.' with '_'as the most common case.
-        /// </summary>
-        internal static string MangleForTypeNameIfNeeded(this string original)
-        {
-            // TODO: it may make sense to strenthen this algorithm 
-            //       to result in 1-1 mapping to reduce chances of
-            //       producing matching results for distinct original strings
-            var result = original.Replace('.', '_');
-
-            return result;
-        }
-
         private static readonly Func<char, char> s_toLower = char.ToLower;
         private static readonly Func<char, char> s_toUpper = char.ToUpper;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
@@ -49,6 +49,20 @@ namespace Roslyn.Utilities
             return name.Length >= 3 && name[0] == 'T' && char.IsUpper(name[1]) && char.IsLower(name[2]);
         }
 
+        /// <summary>
+        /// Given an input string changes it to be acceptable as a part of a type name.
+        /// For now we will simply replace '.' with '_'as the most common case.
+        /// </summary>
+        internal static string MangleForTypeNameIfNeeded(this string original)
+        {
+            // TODO: it may make sense to strenthen this algorithm 
+            //       to result in 1-1 mapping to reduce chances of
+            //       producing matching results for distinct original strings
+            var result = original.Replace('.', '_');
+
+            return result;
+        }
+
         private static readonly Func<char, char> s_toLower = char.ToLower;
         private static readonly Func<char, char> s_toUpper = char.ToUpper;
 

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -1047,5 +1047,19 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
         }
+
+        /// <summary>
+        /// Given an input string changes it to be acceptable as a part of a type name.
+        /// For now we will simply replace '.' with '_'as the most common case.
+        /// </summary>
+        internal static string MangleForTypeNameIfNeeded(string moduleName)
+        {
+            // TODO: it may make sense to strenthen this algorithm 
+            //       to result in 1-1 mapping to reduce chances of
+            //       producing matching results for distinct original strings
+            var result = moduleName.Replace('.', '_');
+
+            return result;
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
@@ -91,7 +91,7 @@ End Class
   IL_0000:  ldc.i4.3
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  stloc.0
   IL_0012:  ldc.i4.0
@@ -927,7 +927,7 @@ End Class
     IL_0000:  ldc.i4.3
     IL_0001:  newarr     "Integer"
     IL_0006:  dup
-    IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
+    IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
     IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
     IL_0011:  ldsfld     "C._Closure$__.$I1-0 As System.Func(Of Integer, String)"
     IL_0016:  brfalse.s  IL_001f
@@ -3041,7 +3041,7 @@ End Class
   IL_0000:  ldc.i4.3
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  stloc.0
   .try

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenMultiDimensionalArray.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenMultiDimensionalArray.vb
@@ -30,7 +30,7 @@ End Module
   IL_0001:  ldc.i4.3
   IL_0002:  newobj     "Integer(*,*)..ctor"
   IL_0007:  dup
-  IL_0008:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails><MODULE>.D64E555B758C5B66DFAC42F18587BB1B3C9BCFA8"
+  IL_0008:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails>.D64E555B758C5B66DFAC42F18587BB1B3C9BCFA8"
   IL_000d:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0012:  ldc.i4.1
   IL_0013:  ldc.i4.1
@@ -64,7 +64,7 @@ End Module
   IL_0001:  ldc.i4.3
   IL_0002:  newobj     "Integer(*,*)..ctor"
   IL_0007:  dup
-  IL_0008:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails><MODULE>.A4B74E064E285570B3499538C5B205C3D0972FDF"
+  IL_0008:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails>.A4B74E064E285570B3499538C5B205C3D0972FDF"
   IL_000d:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0012:  dup
   IL_0013:  ldc.i4.1

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -4845,7 +4845,7 @@ expectedOutput:="3b").VerifyIL("M1.Main",
   IL_0000:  ldc.i4.3
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  stloc.0
   IL_0012:  ldc.i4.2
@@ -6796,25 +6796,25 @@ End Module
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     "Byte"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails><MODULE>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  pop
   IL_0012:  ldc.i4.5
   IL_0013:  newarr     "Double"
   IL_0018:  dup
-  IL_0019:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails><MODULE>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A"
+  IL_0019:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A"
   IL_001e:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0023:  pop
   IL_0024:  ldc.i4.5
   IL_0025:  newarr     "Boolean"
   IL_002a:  dup
-  IL_002b:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails><MODULE>.4E724558F6B816715597A51663AD8F05247E2C4A"
+  IL_002b:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.4E724558F6B816715597A51663AD8F05247E2C4A"
   IL_0030:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0035:  pop
   IL_0036:  ldc.i4.5
   IL_0037:  newarr     "Char"
   IL_003c:  dup
-  IL_003d:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails><MODULE>.E313A2813013780396D58750DC5D62221C86F42F"
+  IL_003d:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails>.E313A2813013780396D58750DC5D62221C86F42F"
   IL_0042:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0047:  pop
   IL_0048:  ret
@@ -6897,7 +6897,7 @@ End Module
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     "System.TypeCode"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.3191FF614021ADF3122AC274EA5B6097C21BEB81"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.3191FF614021ADF3122AC274EA5B6097C21BEB81"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  pop
   IL_0012:  ret
@@ -10615,7 +10615,7 @@ True
   IL_0040:  ldc.i4.4
   IL_0041:  newarr     "Boolean"
   IL_0046:  dup
-  IL_0047:  ldtoken    "Integer <PrivateImplementationDetails><MODULE>.35CCB1599F52363510686EF38B7DB5E7998DB108"
+  IL_0047:  ldtoken    "Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108"
   IL_004c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0051:  ldc.i4.2
   IL_0052:  ldelem.u1
@@ -11474,7 +11474,7 @@ End Module
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails><MODULE>.1456763F890A84558F99AFA687C36B9037697848"
+  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_0011:  stloc.0
   IL_0012:  ldloc.0

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -4431,7 +4431,7 @@ End Class
   IL_005b:  ldc.i4.5
   IL_005c:  newarr     "Integer"
   IL_0061:  dup
-  IL_0062:  ldtoken    "<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><MODULE>.864782BF337E3DBC1A27023D5C0C065C80F17087"
+  IL_0062:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.864782BF337E3DBC1A27023D5C0C065C80F17087"
   IL_0067:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
   IL_006c:  ldloc.0
   IL_006d:  ldftn      "Function AllMembers._Closure$__5-0._Lambda$__0(Integer) As Boolean"

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -459,7 +459,7 @@ End Class
   IL_0001:  ldc.i4.3
   IL_0002:  newarr     ""Integer""
   IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails><MODULE>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails><MODULE>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
   IL_000d:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0012:  stloc.0
   IL_0013:  ldloc.0
@@ -554,7 +554,7 @@ End Class
             Dim generation0 = EmitBaseline.CreateInitialBaseline(ModuleMetadata.CreateFromImage(bytes0), methodData0.EncDebugInfoProvider)
 
             ' Should have generated call to ComputeStringHash and
-            ' added the method to <PrivateImplementationDetails><MODULE>.
+            ' added the method to <PrivateImplementationDetails>.
             Dim actualIL0 = methodData0.GetMethodIL()
             Assert.True(actualIL0.Contains(ComputeStringHashName))
 
@@ -570,7 +570,7 @@ End Class
                 ImmutableArray.Create(edit))
 
                 ' Should not have generated call to ComputeStringHash nor
-                ' added the method to <PrivateImplementationDetails><MODULE>.
+                ' added the method to <PrivateImplementationDetails>.
                 Dim actualIL1 = diff1.GetMethodIL("C.F")
                 Assert.False(actualIL1.Contains(ComputeStringHashName))
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -3373,7 +3373,7 @@ class B : A
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     ""int""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><{#Module#}.dll>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><{#Module#}.dll>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  ret
 }");

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -2117,7 +2117,7 @@ End Class"
   IL_0000:  ldc.i4.5
   IL_0001:  newarr     ""Integer""
   IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails><{#Module#}.dll>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails><{#Module#}.dll>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.1036C5F8EF306104BD582D73E555F4DAE8EECB24""
   IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  ret
 }")


### PR DESCRIPTION
... only when dealing with netmudules.

The goal of module name apending is to avoid clashes when combining multiple netmodules into multifile assembly. When building a regular assembly, appending module name is not serving any purpose and just causes unnecessary metadata differences.

Also in this change - when we do apend the module name, replace '.' with `'_'` when that happens. For example when we build a netmodule and its name is Foo.Bar.dll
More complicated name mangling schemes were discussed, but at this point we will do a simple '.' --> '_' as the least destabilizing change which is still sufficient in the most common case of having dots in the module name.

Fixes #1430