### PR TITLE
Format Trivia inside ArrayInitializer by preserving the existing format

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6220,5 +6220,33 @@ class Program
 }";
             AssertFormat(expected, code);
         }
+
+        [WorkItem(939, "https://github.com/dotnet/roslyn/issues/939")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DontFormatInsideArrayInitializers()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int[] sss = new[] {
+                       //Comment1
+                2,
+            5,            324534,    345345,
+                        //Comment2
+                            //This comment should not line up with the previous comment
+                    234234
+                     //Comment3
+                ,         234,
+            234234
+                                /*
+                                This is a multiline comment
+                                */
+                    //Comment4
+              };
+    }
+}";
+            AssertFormat(code, code);
         }
     }
+}

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/LineColumnRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/LineColumnRule.cs
@@ -139,6 +139,19 @@ namespace Microsoft.CodeAnalysis.Formatting
             };
         }
 
+        public static LineColumnRule PreserveSpaces(int spaces)
+        {
+            return new LineColumnRule
+            {
+                SpaceOperation = SpaceOperations.Preserve,
+                LineOperation = LineOperations.Preserve,
+                IndentationOperation = IndentationOperations.Preserve,
+                Lines = 0,
+                Spaces = spaces,
+                Indentation = 0
+            };
+        }
+
         public static LineColumnRule PreserveSpacesOrUseDefaultIndentation(int spaces)
         {
             return new LineColumnRule


### PR DESCRIPTION
Fix #939 : Array Initializers are custom formatted by the user hence the
trivia inside them should be formatted in such a way that we preserve
the custom format