### PR TITLE
Workaround ISymUnmanagedReader bug

### DIFF
--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
@@ -39,7 +39,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // The EE should never be calling ISymUnmanagedReader.GetSymAttribute.  
             // In order to account for EnC updates, it should always be calling 
             // ISymUnmanagedReader3.GetSymAttributeByVersion instead.
-            throw ExceptionUtilities.Unreachable;
+            // TODO (DevDiv #1145183): throw ExceptionUtilities.Unreachable;
+
+            return GetSymAttributeByVersion(methodToken, 1, name, bufferLength, out count, customDebugInformation);
         }
 
         public int GetSymAttributeByVersion(int methodToken, int version, string name, int bufferLength, out int count, byte[] customDebugInformation)

--- a/src/Test/PdbUtilities/Pdb/SymReader.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReader.cs
@@ -83,7 +83,9 @@ namespace Roslyn.Test.PdbUtilities
             // The EE should never be calling ISymUnmanagedReader.GetSymAttribute.  
             // In order to account for EnC updates, it should always be calling 
             // ISymUnmanagedReader3.GetSymAttributeByVersion instead.
-            throw ExceptionUtilities.Unreachable;
+            // TODO (DevDiv #1145183): throw ExceptionUtilities.Unreachable;
+
+            return UnversionedReader.GetSymAttribute(token, name, sizeBuffer, out lengthBuffer, buffer);
         }
 
         public int GetSymAttributeByVersion(int methodToken, int version, string name, int bufferLength, out int count, byte[] customDebugInformation)

--- a/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
+++ b/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
@@ -157,11 +157,17 @@ namespace Microsoft.DiaSymReader
         public static byte[] GetCustomDebugInfoBytes(this ISymUnmanagedReader reader, int methodToken, int methodVersion)
         {
             return GetItems(
-                (ISymUnmanagedReader3)reader,
+                reader,
                 methodToken,
                 methodVersion,
-                (ISymUnmanagedReader3 pReader, int pMethodToken, int pMethodVersion, int pBufferLength, out int pCount, byte[] pCustomDebugInfo) =>
-                    pReader.GetSymAttributeByVersion(pMethodToken, pMethodVersion, CdiAttributeName, pBufferLength, out pCount, pCustomDebugInfo));
+                (ISymUnmanagedReader pReader, int pMethodToken, int pMethodVersion, int pBufferLength, out int pCount, byte[] pCustomDebugInfo) =>
+                {
+                    // TODO (DevDiv #1145183): cast should always succeed.
+                    var pReader3 = pReader as ISymUnmanagedReader3;
+                    return pReader3 == null
+                        ? pReader.GetSymAttribute(pMethodToken, CdiAttributeName, pBufferLength, out pCount, pCustomDebugInfo)
+                        : pReader3.GetSymAttributeByVersion(pMethodToken, pMethodVersion, CdiAttributeName, pBufferLength, out pCount, pCustomDebugInfo);
+                });
         }
 
         public static int GetUserEntryPoint(this ISymUnmanagedReader symReader)


### PR DESCRIPTION
For some reason, the EnC code hangs when it tries to cast the symbol
reader returned by the debugger to ISymUnmanagedReader.  Until we get that
sorted out, put a workaround in place.