### PR TITLE
Code Cleanup should remove spaces between Colon and Equals

### DIFF
--- a/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
@@ -1049,6 +1049,26 @@ End Module";
             Verify(code, expected);
         }
 
+        [Fact]
+        [WorkItem(1534, "https://github.com/dotnet/roslyn/issues/1534")]
+        [Trait(Traits.Feature, Traits.Features.NormalizeModifiersOrOperators)]
+        public void TestColonEqualsToken()
+        {
+            var code = @"[|Module Program
+    Sub Main(args As String())
+        Main(args   :     =    args)
+    End Sub
+End Module|]";
+
+            var expected = @"Module Program
+    Sub Main(args As String())
+        Main(args:=args)
+    End Sub
+End Module";
+
+            Verify(code, expected);
+        }
+
         private void Verify(string codeWithMarker, string expectedResult)
         {
             var codeWithoutMarker = default(string);

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
 
         Public Function Cleanup(root As SyntaxNode, spans As IEnumerable(Of TextSpan), workspace As Workspace, Optional cancellationToken As CancellationToken = Nothing) As SyntaxNode Implements ICodeCleanupProvider.Cleanup
             Dim rewriter = New Rewriter(spans, cancellationToken)
-            Dim newRoot = Rewriter.Visit(root)
+            Dim newRoot = rewriter.Visit(root)
 
             Return If(root Is newRoot, root, newRoot)
         End Function
@@ -258,7 +258,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                     Return newToken
                 End If
 
-                If token.IsMissing OrElse Not SyntaxFacts.IsOperator(token.Kind) Then
+                If token.IsMissing OrElse Not (SyntaxFacts.IsOperator(token.Kind) OrElse token.IsKind(SyntaxKind.ColonEqualsToken)) Then
                     Return newToken
                 End If
 


### PR DESCRIPTION
Fix #1534 : Code Cleanup should handle the case of removing the spaces
between colon and equals inside of a ColonEqualsToken