### PR TITLE
Fixed incorrect codegen when rethrow is used in a regular catch next to ...

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -501,7 +501,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (!_analysis.CatchContainsAwait(node))
             {
-                return base.VisitCatchBlock(node);
+                var origCurrentAwaitCatchFrame = _currentAwaitCatchFrame;
+                _currentAwaitCatchFrame = null;
+
+                var result = base.VisitCatchBlock(node);
+                _currentAwaitCatchFrame = origCurrentAwaitCatchFrame;
+                return result;
             }
 
             var currentAwaitCatchFrame = _currentAwaitCatchFrame;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -1229,6 +1229,75 @@ Attempted to divide by zero.
             CompileAndVerify(source, expectedOutput: expected);
         }
 
+        [WorkItem(74, "https://github.com/dotnet/roslyn/issues/1334")]
+        [Fact]
+        public void AsyncInCatchRethrow01()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class Test
+{
+    static async Task<int> F()
+    {
+        await Task.Yield();
+        return 2;
+    }
+
+    static async Task<int> G()
+    {
+        int x = 0;
+
+        try
+        {
+            try
+            {
+                x = x / x;
+            }
+            catch (ArgumentNullException)
+            {
+                x = await F();
+            }
+            catch
+            {
+                throw;
+            }
+        }
+        catch(DivideByZeroException ex)
+        {
+            x = await F();
+            System.Console.WriteLine(ex.Message);
+        }
+
+        return x;
+    }
+
+    public static void Main()
+    {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
+        try
+        {
+            Task<int> t2 = G();
+            t2.Wait(1000 * 60);
+            Console.WriteLine(t2.Result);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
+        }
+    }
+}";
+            var expected = @"
+Attempted to divide by zero.
+2
+";
+            CompileAndVerify(source, expectedOutput: expected);
+        }
+
+
         [Fact]
         public void AsyncInCatchFilter()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -1261,12 +1261,13 @@ class Test
             }
             catch
             {
+                Console.WriteLine(""rethrowing"");
                 throw;
             }
         }
         catch(DivideByZeroException ex)
         {
-            x = await F();
+            x += await F();
             System.Console.WriteLine(ex.Message);
         }
 
@@ -1290,9 +1291,83 @@ class Test
         }
     }
 }";
-            var expected = @"
+            var expected = @"rethrowing
 Attempted to divide by zero.
 2
+";
+            CompileAndVerify(source, expectedOutput: expected);
+        }
+
+        [WorkItem(74, "https://github.com/dotnet/roslyn/issues/1334")]
+        [Fact]
+        public void AsyncInCatchRethrow02()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class Test
+{
+    static async Task<int> F()
+    {
+        await Task.Yield();
+        return 2;
+    }
+
+    static async Task<int> G()
+    {
+        int x = 0;
+
+        try
+        {
+            try
+            {
+                x = x / x;
+            }
+            catch (ArgumentNullException)
+            {
+                Console.WriteLine(""should not get here"");
+            }
+            catch (Exception ex) when (ex == null)
+            {
+                Console.WriteLine(""should not get here"");
+            }
+            catch
+            {
+                x = await F();
+                Console.WriteLine(""rethrowing"");
+                throw;
+            }
+        }
+        catch(DivideByZeroException ex)
+        {
+            x += await F();
+            System.Console.WriteLine(ex.Message);
+        }
+
+        return x;
+    }
+
+    public static void Main()
+    {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
+        try
+        {
+            Task<int> t2 = G();
+            t2.Wait(1000 * 60);
+            Console.WriteLine(t2.Result);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
+        }
+    }
+}";
+            var expected = @"rethrowing
+Attempted to divide by zero.
+4
 ";
             CompileAndVerify(source, expectedOutput: expected);
         }


### PR DESCRIPTION
...catches with awaits.

Catches without awaits should not be rewritten in a context of an await catch frame since rethrow in such catch is just a regular rethrow.
Fixes #1334