### PR TITLE
Allow subclasses of AbstractCompletionService to customize more behavior (esp. around MRU).

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Me.IntelliSenseCommandHandler = New IntelliSenseCommandHandler(CompletionCommandHandler, SignatureHelpCommandHandler, Nothing)
 
-            languageServices.GetService(Of ICompletionService).ClearMRUCache()
+            languageServices.GetService(Of AbstractCompletionService).ClearMostRecentlyUsedCache()
         End Sub
 
         Private Shared Function CreatePartCatalog(types As List(Of Type)) As ComposableCatalog

--- a/src/Features/Core/Completion/AbstractCompletionService.CompletionRules.cs
+++ b/src/Features/Core/Completion/AbstractCompletionService.CompletionRules.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 // MRU list, then we definitely want to include it.
                 if (filterText.Length == 0)
                 {
-                    if (item.Preselect || _completionService.GetMRUIndex(item) < 0)
+                    if (item.Preselect || _completionService.ShouldPreselect(item))
                     {
                         return true;
                     }
@@ -108,14 +108,9 @@ namespace Microsoft.CodeAnalysis.Completion
                     return item1.Glyph == Glyph.Keyword;
                 }
 
-                // They matched on everything, including preselection values.  Item1 is better if it
-                // has a lower MRU index.
-
-                var item1MRUIndex = _completionService.GetMRUIndex(item1);
-                var item2MRUIndex = _completionService.GetMRUIndex(item2);
-
-                // The one with the lower index is the better one.
-                return item1MRUIndex < item2MRUIndex;
+                // They matched on everything, including preselection values.  See if the service 
+                // thinks they're better.
+                return _completionService.IsBetterFilterMatch(item1, item2);
             }
 
             public virtual bool? ShouldSoftSelectItem(CompletionItem item, string filterText, CompletionTriggerInfo triggerInfo)

--- a/src/Features/Core/Completion/ICompletionService.cs
+++ b/src/Features/Core/Completion/ICompletionService.cs
@@ -24,11 +24,6 @@ namespace Microsoft.CodeAnalysis.Completion
         ICompletionRules GetDefaultCompletionRules();
 
         /// <summary>
-        /// Clears the most-recently-used cache used by completion.
-        /// </summary>
-        void ClearMRUCache();
-
-        /// <summary>
         /// Returns the CompletionItemGroups for the specified position in the document.
         /// </summary>
         Task<IEnumerable<CompletionItemGroup>> GetGroupsAsync(Document document, int position, CompletionTriggerInfo triggerInfo, IEnumerable<ICompletionProvider> completionProviders, CancellationToken cancellationToken);
@@ -49,6 +44,25 @@ namespace Microsoft.CodeAnalysis.Completion
         /// if a snippet exists with a shortcut that matches the completion item's insertion text.
         /// </summary>
         Task<string> GetSnippetExpansionNoteForCompletionItemAsync(CompletionItem completionItem, Workspace workspace);
+
+        /// <summary>
+        /// Called when a completion item is committed.  The completion service can then use this to
+        /// help inform future completion requests.  For example, it can use this information to 
+        /// help decide if this item is 'better' than another when queried.
+        /// </summary>
+        void CompletionItemComitted(CompletionItem item);
+
+        /// <summary>
+        /// Returns true if 'item1' is a better match for the filter text typed so far versus 
+        /// 'item2'.  The better match will be selected after text is typed.
+        /// </summary>
+        bool IsBetterFilterMatch(CompletionItem item1, CompletionItem item2);
+
+        /// <summary>
+        /// Used to allow the completion service to indicate if this item should be preselected.
+        /// Only called when no filter text has been provided.
+        /// </summary>
+        bool ShouldPreselect(CompletionItem item);
 
         /// <summary>
         /// True if the completion list should be dismissed if the user's typing causes it to filter

--- a/src/Features/Core/Completion/MostRecentlyUsedList.cs
+++ b/src/Features/Core/Completion/MostRecentlyUsedList.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Completion
+{
+    internal class MostRecentlyUsedList<T>
+    {
+        private readonly object gate = new object();
+        private readonly List<T> items = new List<T>();
+        private readonly int maxSize;
+
+        public MostRecentlyUsedList(int maxSize = 10)
+        {
+            this.maxSize = maxSize;
+        }
+
+        public void Add(T value)
+        {
+            lock (gate)
+            {
+                var removed = items.Remove(value);
+                if (!removed && items.Count == maxSize)
+                {
+                    items.RemoveAt(0);
+                }
+
+                items.Add(value);
+            }
+        }
+
+        public int IndexOf(T value)
+        {
+            lock (gate)
+            {
+                return items.IndexOf(value);
+            }
+        }
+
+        public bool Contains(T value)
+        {
+            lock (gate)
+            {
+                return items.Contains(value);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (gate)
+            {
+                items.Clear();
+            }
+        }
+    }
+}

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Completion\CompletionTriggerReason.cs" />
     <Compile Include="Completion\ICompletionService.cs" />
     <Compile Include="Completion\ITextCompletionService.cs" />
+    <Compile Include="Completion\MostRecentlyUsedList.cs" />
     <Compile Include="Completion\Providers\AbstractCompletionProvider.cs" />
     <Compile Include="Completion\Providers\AbstractCompletionProvider.UnionCompletionitemComparer.cs" />
     <Compile Include="Completion\Providers\AbstractKeywordCompletionProvider.cs" />

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
             Me.IntelliSenseCommandHandler = New IntelliSenseCommandHandler(CompletionCommandHandler, SignatureHelpCommandHandler, Nothing)
 
-            languageServices.GetService(Of ICompletionService).ClearMRUCache()
+            languageServices.GetService(Of ICompletionService).ClearMostRecentlyUsedCache()
 
             Dim spanDocument = Workspace.Documents.First(Function(x) x.SelectedSpans.Any())
             Dim statementSpan = spanDocument.SelectedSpans.First()

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
             Me.IntelliSenseCommandHandler = New IntelliSenseCommandHandler(CompletionCommandHandler, SignatureHelpCommandHandler, Nothing)
 
-            languageServices.GetService(Of ICompletionService).ClearMostRecentlyUsedCache()
+            languageServices.GetService(Of AbstractCompletionService).ClearMostRecentlyUsedCache()
 
             Dim spanDocument = Workspace.Documents.First(Function(x) x.SelectedSpans.Any())
             Dim statementSpan = spanDocument.SelectedSpans.First()

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6220,5 +6220,5 @@ class Program
 }";
             AssertFormat(expected, code);
         }
-        }
     }
+}


### PR DESCRIPTION
Right now TypeScript doesn't want the precise MRU algorithm you get by default with Roslyn's
completion list.  For example, we are working toward a concept of 'strong' completion
suggestions and 'weak' completion suggestions.  We'd prefer a 'strong' completion suggestion
be preselected over a 'weak' one if both are viable.

However, the MRU logic is baked into the existing completion service code.  I've broken this
out in a couple of ways.  First, instead of referring to MRU anywhere in the API, there are
just simple methods used for asking 'should i preselect this?' and 'is this item better than
this other item'.  By default these are implemented by using the MRU list.  However, a subclass
can use another mechanism.  Second, i broke out the MRU into its own class.  That way
if TypeScript wants to use MRU in some fashion, they can still leverage the same algorithm.