### PR TITLE
Unskip tests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2633,12 +2633,12 @@ namespace ConsoleApplication1
 @"using System ; class C { public E B { get ; private set ; } void Main ( C a ) { var x = a ? . B . C ( ) ; } public class E { internal object C ( ) { throw new NotImplementedException ( ) ; } } } ");
         }
 
-        [Fact(Skip = "1561"), WorkItem(1561, "https://github.com/dotnet/roslyn/issues/1561"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInPropertyInitializer()
         {
             Test(
 @"class Program { public int MyProperty { get ; } = [|y|] ( ) ; } ",
-@"using System ; class Program { public int MyProperty { get ; } = y ( ) ; private int y ( ) { throw new NotImplementedException ( ) ; } } ");
+@"using System ; class Program { public int MyProperty { get ; } = y ( ) ; private static int y ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -2576,29 +2576,29 @@ index: 2);
 index: 2);
         }
 
-        [Fact(Skip = "1561"), WorkItem(1561, "https://github.com/dotnet/roslyn/issues/1561"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
-        public void TestGeneratePropertyInPropertyInitializers()
-        {
-            Test(
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public int MyProperty { get ; } = [|y|] ; } ",
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { private int y ; public int MyProperty { get ; } = y ; } ");
-        }
-
-        [Fact(Skip = "1561"), WorkItem(1561, "https://github.com/dotnet/roslyn/issues/1561"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInPropertyInitializers()
         {
             Test(
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public int MyProperty { get ; } = [|y|] ; } ",
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { private readonly int y ; public int MyProperty { get ; } = y ; } ",
-index: 1);
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { private static int y ; public int MyProperty { get ; } = y ; } ");
         }
 
-        [Fact(Skip = "1561"), WorkItem(1561, "https://github.com/dotnet/roslyn/issues/1561"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInPropertyInitializers()
         {
             Test(
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public int MyProperty { get ; } = [|y|] ; } ",
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public int MyProperty { get ; } = y ; public int y { get ; private set ; } } ",
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { private static readonly int y ; public int MyProperty { get ; } = y ; } ",
+index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public void TestGeneratePropertyInPropertyInitializers()
+        {
+            Test(
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public int MyProperty { get ; } = [|y|] ; } ",
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { public static int y { get ; private set ; } public int MyProperty { get ; } = y ;  } ",
 index: 2);
         }
 


### PR DESCRIPTION
Some tests for generate variable and generate method incorrectly
asserted that instance members were generated from property
initializers. This was revealed by #1442.

Fixes #1561.

Can you review? @balajikris @basoundr @dpoeschl @jasonmalinowski @Pilchie @mavasani 