### PR TITLE
Fixes #1604.

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             parameters = this.ClearTrivia(parameters);
             returnType = this.ClearTrivia(returnType);
 
-            bool hasBody = !modifiers.IsAbstract;
+            bool hasBody = !modifiers.IsAbstract && (!modifiers.IsPartial || statements != null);
 
             return SyntaxFactory.MethodDeclaration(
                 default(SyntaxList<AttributeListSyntax>),

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -614,6 +614,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editting
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.MethodDeclaration("m", returnType: _g.IdentifierName("x"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.Abstract),
                 "public abstract x m();");
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.MethodDeclaration("m", modifiers: DeclarationModifiers.Partial),
+                "partial void m();");
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.MethodDeclaration("m", modifiers: DeclarationModifiers.Partial, statements: new[] { _g.IdentifierName("y") }),
+                "partial void m()\r\n{\r\n    y;\r\n}");
         }
 
         [Fact]

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -682,6 +682,11 @@ End Function</x>.Value)
             VerifySyntax(Of MethodStatementSyntax)(
                 _g.MethodDeclaration("m", returnType:=_g.IdentifierName("x"), accessibility:=Accessibility.Public, modifiers:=DeclarationModifiers.Abstract),
 <x>Public MustInherit Function m() As x</x>.Value)
+
+            VerifySyntax(Of MethodBlockSyntax)(
+                _g.MethodDeclaration("m", accessibility:=Accessibility.Private, modifiers:=DeclarationModifiers.Partial),
+<x>Private Partial Sub m()
+End Sub</x>.Value)
         End Sub
 
         <Fact>


### PR DESCRIPTION
This PR fixes #1604 by ensuring the C# syntax generator recognises partial methods. If statements are not provided, the method declaration is terminated with `;` rather than including an empty body (i.e. it is the declaration of the `partial` method). If statements *are* provided, the method is still declared `partial` but it includes those statements in its body (i.e. it is the implementation of the `partial` method).

Visual Basic syntax is a bit odd in that only the declaration of the partial method can be declared `Partial`. It's debatable whether the syntax generator should automatically ignore a `Partial` modifier if it's given statements, or whether it should put the onus on the caller to not specify the `Partial` modifier for the implementation of a partial method. I opted for the latter (i.e. left the VB code as is), partly because I don't know VB well, and partly because I thought it worth discussing the right approach before investing time in the other solution.