### PR TITLE
Don't show warning icon for method overloads

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6880,6 +6880,7 @@ class C
             VerifyItemInLinkedFiles(markup, "y", expectedDescription);
         }
 
+        [WorkItem(1063403)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void MethodOverloadDifferencesIgnored()
         {
@@ -6913,6 +6914,7 @@ class C
             VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
         }
 
+        [WorkItem(1063403)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void WarningForSymbolsOfDifferingKind()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6910,7 +6910,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = $"void C.Do(string x)";
+            var expectedDescription = $"void C.Do(int x)";
             VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
         }
 
@@ -6944,7 +6944,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = $"({FeaturesResources.Field}) int C.Do\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.Available)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
+            var expectedDescription = $"void C.Do(int x) (+ 1 {FeaturesResources.Overload})\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.NotAvailable)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
             VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
         }
 
@@ -6979,6 +6979,45 @@ public static class Extensions
         </Document>
     </Project>
     <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"void C.Do(int x)";
+            VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored_ExtensionMethod2()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""TWO"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+
+    void Shared()
+    {
+        this.$$
+    }
+
+}
+
+public static class Extensions
+{
+#if TWO
+    public static void Do (this C c, string x)
+    {
+    }
+#endif
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""ONE"">
         <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
     </Project>
 </Workspace>";
@@ -7037,7 +7076,7 @@ public class Methods2
     </Project>
 </Workspace>";
 
-            var expectedDescription = $"void Methods2.Do(string x)";
+            var expectedDescription = $"void Methods1.Do(string x)";
             VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6949,6 +6949,99 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored_ExtensionMethod()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+
+    void Shared()
+    {
+        this.$$
+    }
+
+}
+
+public static class Extensions
+{
+#if TWO
+    public static void Do (this C c, string x)
+    {
+    }
+#endif
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"(extension) void C.Do(string x)";
+            VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored_ContainingType()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C
+{
+    void Shared()
+    {
+        var x = GetThing();
+        x.$$
+    }
+
+#if ONE
+    private Methods1 GetThing()
+    {
+        return new Methods1();
+    }
+#endif
+
+#if TWO
+    private Methods2 GetThing()
+    {
+        return new Methods2();
+    }
+#endif
+}
+
+#if ONE
+public class Methods1
+{
+    public void Do(string x) { }
+}
+#endif
+
+#if TWO
+public class Methods2
+{
+    public void Do(string x) { }
+}
+#endif
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"void Methods2.Do(string x)";
+            VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void ConditionalAccessWalkUp()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6881,6 +6881,72 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+#if TWO
+    void Do(string x){}
+#endif
+
+    void Shared()
+    {
+        $$
+    }
+
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"void C.Do(string x)";
+            VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void WarningForSymbolsOfDifferingKind()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+#if TWO
+    int Do;
+#endif
+
+    void Shared()
+    {
+        $$
+    }
+
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""CurrentDocument.cs""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"({FeaturesResources.Field}) int C.Do\r\n\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj1", FeaturesResources.NotAvailable)}\r\n{string.Format(FeaturesResources.ProjectAvailability, "Proj2", FeaturesResources.Available)}\r\n\r\n{FeaturesResources.UseTheNavigationBarToSwitchContext}";
+            VerifyItemInLinkedFiles(markup, "Do", expectedDescription);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void ConditionalAccessWalkUp()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -4004,5 +4004,35 @@ class Program
 }";
             Test(markup, MainDescription("dynamic"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""SourceDocument""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+#if TWO
+    void Do(string x){}
+#endif
+    void Shared()
+    {
+        this.Do$$
+    }
+
+}]]></Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = $"void C.Do(int x)";
+            VerifyWithReferenceWorker(markup, MainDescription(expectedDescription));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -1863,5 +1863,35 @@ class Foo
 
             Test(markup);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void MethodOverloadDifferencesIgnored()
+        {
+            var markup = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"" PreprocessorSymbols=""ONE"">
+        <Document FilePath=""SourceDocument""><![CDATA[
+class C
+{
+#if ONE
+    void Do(int x){}
+#endif
+#if TWO
+    void Do(string x){}
+#endif
+    void Shared()
+    {
+        this.Do($$
+    }
+
+}]]></Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"" PreprocessorSymbols=""TWO"">
+        <Document IsLinkFile=""true"" LinkAssemblyName=""Proj1"" LinkFilePath=""SourceDocument""/>
+    </Project>
+</Workspace>";
+
+            var expectedDescription = new SignatureHelpTestItem($"void C.Do(int x)", currentParameterIndex: 0);
+            VerifyItemWithReferenceWorker(markup, new[] { expectedDescription }, false);
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
             foreach (var candidate in candidateResults)
             {
-                if (!candidate.Item3.SequenceEqual(bestBinding.Item3, LinkedFilesSymbolEquivalenceComparer.IgnoreAssembliesInstance))
+                if (!candidate.Item3.SequenceEqual(bestBinding.Item3, LinkedFilesSymbolEquivalenceComparer.Instance))
                 {
                     invalidProjects.Add(candidate.Item1.ProjectId);
                 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     continue;
                 }
 
-                var invalidProjectsForCurrentSymbol = candidateLinkedProjectsAndSymbolSets.Where(c => !c.Item2.Contains(expectedSymbol, LinkedFilesSymbolEquivalenceComparer.IgnoreAssembliesInstance))
+                var invalidProjectsForCurrentSymbol = candidateLinkedProjectsAndSymbolSets.Where(c => !c.Item2.Contains(expectedSymbol, LinkedFilesSymbolEquivalenceComparer.Instance))
                                                                         .Select(c => c.Item1)
                                                                         .ToList();
 

--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 // We need to use the SemanticModel any particular symbol came from in order to generate its description correctly.
                 // Therefore, when we add a symbol to set of union symbols, add a mapping from it to its SyntaxContext.
-                foreach (var symbol in linkedContextSymbolList.Item3.GroupBy(s => new { s.ContainingType, s.Name, s.Kind }).Select(g => g.First()))
+                foreach (var symbol in linkedContextSymbolList.Item3.GroupBy(s => new { s.Name, s.Kind }).Select(g => g.First()))
                 {
                     if (set.Add(symbol))
                     {

--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 // We need to use the SemanticModel any particular symbol came from in order to generate its description correctly.
                 // Therefore, when we add a symbol to set of union symbols, add a mapping from it to its SyntaxContext.
-                foreach (var symbol in linkedContextSymbolList.Item3)
+                foreach (var symbol in linkedContextSymbolList.Item3.GroupBy(s => new { s.ContainingType, s.Name, s.Kind }).Select(g => g.First()))
                 {
                     if (set.Add(symbol))
                     {

--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             originDictionary = new Dictionary<ISymbol, AbstractSyntaxContext>(LinkedFilesSymbolEquivalenceComparer.Instance);
 
             // We don't care about assembly identity when creating the union.
-            var set = new HashSet<ISymbol>(LinkedFilesSymbolEquivalenceComparer.IgnoreAssembliesInstance);
+            var set = new HashSet<ISymbol>(LinkedFilesSymbolEquivalenceComparer.Instance);
             foreach (var linkedContextSymbolList in linkedContextSymbolLists)
             {
                 // We need to use the SemanticModel any particular symbol came from in order to generate its description correctly.
@@ -320,11 +320,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         /// <returns>The list of projects each recommended symbol did NOT appear in.</returns>
         protected Dictionary<ISymbol, List<ProjectId>> FindSymbolsMissingInLinkedContexts(HashSet<ISymbol> expectedSymbols, IEnumerable<Tuple<DocumentId, AbstractSyntaxContext, IEnumerable<ISymbol>>> linkedContextSymbolLists)
         {
-            var missingSymbols = new Dictionary<ISymbol, List<ProjectId>>(LinkedFilesSymbolEquivalenceComparer.IgnoreAssembliesInstance);
+            var missingSymbols = new Dictionary<ISymbol, List<ProjectId>>(LinkedFilesSymbolEquivalenceComparer.Instance);
 
             foreach (var linkedContextSymbolList in linkedContextSymbolLists)
             {
-                var symbolsMissingInLinkedContext = expectedSymbols.Except(linkedContextSymbolList.Item3, LinkedFilesSymbolEquivalenceComparer.IgnoreAssembliesInstance);
+                var symbolsMissingInLinkedContext = expectedSymbols.Except(linkedContextSymbolList.Item3, LinkedFilesSymbolEquivalenceComparer.Instance);
                 foreach (var missingSymbol in symbolsMissingInLinkedContext)
                 {
                     missingSymbols.GetOrAdd(missingSymbol, (m) => new List<ProjectId>()).Add(linkedContextSymbolList.Item1.ProjectId);

--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 return await CreateItemsAsync(position, itemsForCurrentDocument, context, null, null, preselect, cancellationToken).ConfigureAwait(false);
             }
 
-            var contextAndSymbolLists = await GetPerContextSymbols(document, position, options, relatedDocumentIds.Concat(document.Id), preselect, cancellationToken).ConfigureAwait(false);
+            var contextAndSymbolLists = await GetPerContextSymbols(document, position, options, new[] { document.Id }.Concat(relatedDocumentIds), preselect, cancellationToken).ConfigureAwait(false);
 
             Dictionary<ISymbol, AbstractSyntaxContext> orignatingContextMap = null;
             var unionedSymbolsList = UnionSymbols(contextAndSymbolLists, out orignatingContextMap);

--- a/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
+++ b/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
@@ -28,16 +28,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
         bool IEqualityComparer<ISymbol>.Equals(ISymbol x, ISymbol y)
         {
-            return x.Kind == y.Kind && (x.IsKind(SymbolKind.Local) || x.IsKind(SymbolKind.Label) || x.IsKind(SymbolKind.RangeVariable))
-                 ? x.Name == y.Name
-                 : x.Name == y.Name && x.Kind == y.Kind && _symbolEquivalenceComparer.Equals(x.ContainingType, y.ContainingType);
+            return x.Kind == y.Kind && x.Name == y.Name;
         }
 
         int IEqualityComparer<ISymbol>.GetHashCode(ISymbol symbol)
         {
-            return symbol.IsKind(SymbolKind.Local) || symbol.IsKind(SymbolKind.Label) || symbol.IsKind(SymbolKind.RangeVariable)
-                ? symbol.Name.GetHashCode()
-                : _symbolEquivalenceComparer.GetHashCode(symbol.ContainingType);
+            return symbol.Name.GetHashCode();
         }
     }
 }

--- a/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
+++ b/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
@@ -30,14 +30,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             return x.Kind == y.Kind && (x.IsKind(SymbolKind.Local) || x.IsKind(SymbolKind.Label) || x.IsKind(SymbolKind.RangeVariable))
                  ? x.Name == y.Name
-                 : _symbolEquivalenceComparer.Equals(x, y);
+                 : x.Name == y.Name && x.Kind == y.Kind && _symbolEquivalenceComparer.Equals(x.ContainingType, y.ContainingType);
         }
 
         int IEqualityComparer<ISymbol>.GetHashCode(ISymbol symbol)
         {
             return symbol.IsKind(SymbolKind.Local) || symbol.IsKind(SymbolKind.Label) || symbol.IsKind(SymbolKind.RangeVariable)
                 ? symbol.Name.GetHashCode()
-                : _symbolEquivalenceComparer.GetHashCode(symbol);
+                : _symbolEquivalenceComparer.GetHashCode(symbol.ContainingType);
         }
     }
 }

--- a/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
+++ b/src/Features/Core/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
@@ -7,24 +7,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
     /// <summary>
     /// For completion and quickinfo in linked files, we compare symbols from different documents
-    /// to determine if they are basically the same (which allows us to suppress the platform
-    /// dependence warning icon). A <see cref="SymbolEquivalenceComparer"/> handles this comparison
-    /// correctly for most symbols, but it compares locals, labels, and range variables by 
-    /// comparing their <see cref="Location"/>s. This fails for linked files because 
-    /// they have different trees. This class performs the special handling for these kinds of
-    /// symbols and passes through all other requests to a <see cref="SymbolEquivalenceComparer"/>.
+    /// to determine if they are similar enough for us to suppress the platform dependence
+    /// warning icon. We consider symbols equivalent if they have the same name and kind.
     /// </summary>
     internal sealed class LinkedFilesSymbolEquivalenceComparer : IEqualityComparer<ISymbol>
     {
-        public static readonly LinkedFilesSymbolEquivalenceComparer IgnoreAssembliesInstance = new LinkedFilesSymbolEquivalenceComparer(SymbolEquivalenceComparer.IgnoreAssembliesInstance);
-        public static readonly LinkedFilesSymbolEquivalenceComparer Instance = new LinkedFilesSymbolEquivalenceComparer(SymbolEquivalenceComparer.Instance);
-
-        private readonly SymbolEquivalenceComparer _symbolEquivalenceComparer;
-
-        public LinkedFilesSymbolEquivalenceComparer(SymbolEquivalenceComparer symbolEquivalenceComparer)
-        {
-            _symbolEquivalenceComparer = symbolEquivalenceComparer;
-        }
+        public static readonly LinkedFilesSymbolEquivalenceComparer Instance = new LinkedFilesSymbolEquivalenceComparer();
 
         bool IEqualityComparer<ISymbol>.Equals(ISymbol x, ISymbol y)
         {


### PR DESCRIPTION
Don't show warning icon for differing method overloads between heads,
unless none are available.

Fixes internal workitem 1063403

@Pilchie  @dpoeschl  @jasonmalinowski  @brettfo @balajikris @basoundr Can you review this? This is maybe for preview.