### PR TITLE
Rename commonly used method to a shorter version.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine())
 
             ' leading whitespace until we see # should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine())
 
             ' leading whitespace until we see # should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
+            If CanGet() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -223,7 +223,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function ScanNextCharAsToken(leadingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Dim token As SyntaxToken
 
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 token = MakeEofToken(leadingTrivia)
             Else
                 ' // Don't break up surrogate pairs
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim condLineStart = _lineBufferOffset
 
-            While (CanGetChar())
+            While (CanGet())
                 Dim c As Char = Peek()
 
                 Select Case (c)
@@ -312,7 +312,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub EatThroughLine()
-            While CanGetChar()
+            While CanGet()
                 Dim c As Char = Peek()
 
                 If IsNewLine(c) Then
@@ -400,7 +400,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return True
         End Function
 
-        Private Function CanGetChar() As Boolean
+        Private Function CanGet() As Boolean
             Return _lineBufferOffset < _bufferLen
         End Function
 
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         Private Function GetNextChar() As String
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
 
             Dim ch = GetChar()
             _lineBufferOffset += 1
@@ -512,7 +512,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanLineContinuation(tList As SyntaxListBuilder) As Boolean
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return False
             End If
 
@@ -580,7 +580,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Consumes all trivia until a nontrivia char is found
         ''' </summary>
         Friend Function ScanMultilineTrivia() As SyntaxList(Of VisualBasicSyntaxNode)
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return Nothing
             End If
 
@@ -605,7 +605,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Scans a single piece of trivia
         ''' </summary>
         Private Function TryScanSinglePieceOfMultilineTrivia(tList As SyntaxListBuilder) As Boolean
-            If CanGetChar() Then
+            If CanGet() Then
 
                 Dim atNewLine = IsAtNewLine()
 
@@ -709,7 +709,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         Private Sub ScanSingleLineTriviaInXmlDoc(tList As SyntaxListBuilder)
-            If CanGetChar() Then
+            If CanGet() Then
                 Dim c As Char = Peek()
                 Select Case (c)
                     ' // Whitespace
@@ -742,7 +742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub ScanWhitespaceAndLineContinuations(tList As SyntaxListBuilder)
-            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
+            If CanGet() AndAlso IsWhitespace(Peek()) Then
                 tList.Add(ScanWhitespace(1))
                 ' collect { lineCont, ws }
                 While ScanLineContinuation(tList)
@@ -812,7 +812,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' Case 3 is required to parse single line if's and numeric labels. 
             ' Case 4 is required to limit explicit line continuations to single new line
 
-            If CanGetChar() Then
+            If CanGet() Then
 
                 Dim ch As Char = Peek()
                 Dim startOfTerminatorTrivia = _lineBufferOffset
@@ -853,7 +853,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         Private Function ScanCommentIfAny(tList As SyntaxListBuilder) As Boolean
-            If CanGetChar() Then
+            If CanGet() Then
                 ' check for comment
                 Dim comment = ScanComment()
                 If comment IsNot Nothing Then
@@ -897,13 +897,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub EatWhitespace()
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
             Debug.Assert(IsWhitespace(Peek()))
 
             AdvanceChar()
 
             ' eat until linebreak or nonwhitespace
-            While CanGetChar() AndAlso IsWhitespace(Peek)
+            While CanGet() AndAlso IsWhitespace(Peek)
                 AdvanceChar()
             End While
         End Sub
@@ -933,7 +933,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanComment() As SyntaxTrivia
-            Debug.Assert(CanGetChar())
+            Debug.Assert(CanGet())
 
             Dim length = PeekStartComment(0)
             If length > 0 Then
@@ -966,7 +966,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanColonAsTrivia() As SyntaxTrivia
-            Debug.Assert(CanGetChar())
+            Debug.Assert(CanGet())
             Debug.Assert(IsColonAndNotColonEquals(Peek(), offset:=0))
 
             Return MakeColonTrivia(GetText(1))
@@ -978,7 +978,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' the beginning of a token        
         Private Function TryScanToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
 
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return MakeEofToken(precedingTrivia)
             End If
 
@@ -1444,7 +1444,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanRightAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As SyntaxToken
-            Debug.Assert(CanGetChar)  ' > 
+            Debug.Assert(CanGet)  ' > 
             Debug.Assert(Peek() = ">"c OrElse Peek() = FULLWIDTH_GREATER_THAN_SIGN)
 
             Dim length As Integer = 1
@@ -1471,7 +1471,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanLeftAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean, scanTrailingTrivia As ScanTriviaFunc) As SyntaxToken
-            Debug.Assert(CanGetChar)  ' < 
+            Debug.Assert(CanGet)  ' < 
             Debug.Assert(Peek() = "<"c OrElse Peek() = FULLWIDTH_LESS_THAN_SIGN)
 
             Dim length As Integer = 1
@@ -1566,7 +1566,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanIdentifierOrKeyword(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
             Debug.Assert(IsIdentifierStartCharacter(Peek))
             Debug.Assert(PeekStartComment(0) = 0) ' comment should be handled by caller
 
@@ -1684,7 +1684,7 @@ FullWidthRepeat:
         End Function
 
         Private Function ScanBracketedIdentifier(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            Debug.Assert(CanGetChar)  ' [
+            Debug.Assert(CanGet)  ' [
             Debug.Assert(Peek() = "["c OrElse Peek() = FULLWIDTH_LEFT_SQUARE_BRACKET)
 
             Dim IdStart As Integer = 1
@@ -1757,7 +1757,7 @@ FullWidthRepeat:
         End Enum
 
         Private Function ScanNumericLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
 
             Dim Here As Integer = 0
             Dim IntegerLiteralStart As Integer
@@ -2190,7 +2190,7 @@ FullWidthRepeat2:
         End Function
 
         Private Function ScanDateLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
             Debug.Assert(IsHash(Peek()))
 
             Dim Here As Integer = 1 'skip #
@@ -2499,7 +2499,7 @@ baddate:
         End Function
 
         Private Function ScanStringLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
             Debug.Assert(IsDoubleQuote(Peek))
 
             Dim length As Integer = 1

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -391,19 +391,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "Buffer helpers"
 
         Private Function NextAre(chars As String) As Boolean
-            Debug.Assert(Not String.IsNullOrEmpty(chars))
-            Dim n = chars.Length-1
-            If Not CanGet( n) Then Return False
-            For i = 0 To n
-                If chars(i) <> Peek(i) Then Return False
-            Next
-            Return True
+            Return NextAre(0, chars)
         End Function
 
         Private Function NextAre(offset As Integer, chars As String) As Boolean
             Debug.Assert(Not String.IsNullOrEmpty(chars))
             Dim n = chars.Length
-            If Not CanGet(offset + n) Then Return False
+            If Not CanGet(offset + n - 1) Then Return False
             For i = 0 To n - 1
                 If chars(i) <> Peek(offset + i) Then Return False
             Next

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -404,7 +404,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return True
         End Function
 
-        Private Function NextIs(offset As Integer, c As String) As Boolean
+        Private Function NextIs(offset As Integer, c As Char) As Boolean
             Return CanGet(offset) AndAlso (Peek(offset) = c)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -400,6 +400,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return True
         End Function
 
+        Private Function NextIs(offset As Integer, c As String) As Boolean
+            Return CanGet(offset) AndAlso (Peek(offset) = c)
+        End Function
+
         Private Function CanGet() As Boolean
             Return _lineBufferOffset < _bufferLen
         End Function

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -390,6 +390,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "Buffer helpers"
 
+        Private Function NextAre(chars As String) As Boolean
+            Debug.Assert(Not String.IsNullOrEmpty(chars))
+            Dim n = chars.Length-1
+            If Not CanGet( n) Then Return False
+            For i = 0 To n
+                If chars(i) <> Peek(i) Then Return False
+            Next
+            Return True
+        End Function
+
         Private Function NextAre(offset As Integer, chars As String) As Boolean
             Debug.Assert(Not String.IsNullOrEmpty(chars))
             Dim n = chars.Length
@@ -472,10 +482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Debug.Assert(StartCharacter = Peek(here))
 
-            If StartCharacter = CARRIAGE_RETURN AndAlso
-                CanGet(here + 1) AndAlso
-                Peek(here + 1) = LINE_FEED Then
-
+            If StartCharacter = CARRIAGE_RETURN AndAlso NextIs(here + 1, LINE_FEED) Then
                 Return 2
             End If
             Return 1

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -227,8 +227,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 token = MakeEofToken(leadingTrivia)
             Else
                 ' // Don't break up surrogate pairs
-                Dim c = PeekChar()
-                Dim length = If(IsHighSurrogate(c) AndAlso CanGetCharAtOffset(1) AndAlso IsLowSurrogate(PeekAheadChar(1)), 2, 1)
+                Dim c = Peek()
+                Dim length = If(IsHighSurrogate(c) AndAlso CanGet(1) AndAlso IsLowSurrogate(Peek(1)), 2, 1)
                 token = MakeBadToken(leadingTrivia, length, ERRID.ERR_IllegalChar)
             End If
 
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim condLineStart = _lineBufferOffset
 
             While (CanGetChar())
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
 
@@ -267,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Continue While
 
                     Case SPACE, CHARACTER_TABULATION
-                        Debug.Assert(IsWhitespace(PeekChar()))
+                        Debug.Assert(IsWhitespace(Peek()))
                         EatWhitespace()
                         Continue While
 
@@ -313,7 +313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Sub EatThroughLine()
             While CanGetChar()
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 If IsNewLine(c) Then
                     EatThroughLineBreak(c)
@@ -393,9 +393,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function NextAre(offset As Integer, chars As String) As Boolean
             Debug.Assert(Not String.IsNullOrEmpty(chars))
             Dim n = chars.Length
-            If Not CanGetCharAtOffset(offset + n) Then Return False
+            If Not CanGet(offset + n) Then Return False
             For i = 0 To n - 1
-                If chars(i) <> PeekAheadChar(offset + i) Then Return False
+                If chars(i) <> Peek(offset + i) Then Return False
             Next
             Return True
         End Function
@@ -404,7 +404,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return _lineBufferOffset < _bufferLen
         End Function
 
-        Private Function CanGetCharAtOffset(num As Integer) As Boolean
+        Private Function CanGet(num As Integer) As Boolean
             Debug.Assert(_lineBufferOffset + num >= 0)
             Debug.Assert(num >= -MaxCharsLookBehind)
 
@@ -413,7 +413,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function GetText(length As Integer) As String
             Debug.Assert(length > 0)
-            Debug.Assert(CanGetCharAtOffset(length - 1))
+            Debug.Assert(CanGet(length - 1))
 
             If length = 1 Then
                 Return GetNextChar()
@@ -426,7 +426,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function GetTextNotInterned(length As Integer) As String
             Debug.Assert(length > 0)
-            Debug.Assert(CanGetCharAtOffset(length - 1))
+            Debug.Assert(CanGet(length - 1))
 
             If length = 1 Then
                 ' we will still intern single chars. There could not be too many.
@@ -440,7 +440,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Sub AdvanceChar(Optional howFar As Integer = 1)
             Debug.Assert(howFar > 0)
-            Debug.Assert(CanGetCharAtOffset(howFar - 1))
+            Debug.Assert(CanGet(howFar - 1))
 
             _lineBufferOffset += howFar
         End Sub
@@ -463,14 +463,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function LengthOfLineBreak(StartCharacter As Char, Optional here As Integer = 0) As Integer
-            Debug.Assert(CanGetCharAtOffset(here))
+            Debug.Assert(CanGet(here))
             Debug.Assert(IsNewLine(StartCharacter))
 
-            Debug.Assert(StartCharacter = PeekAheadChar(here))
+            Debug.Assert(StartCharacter = Peek(here))
 
             If StartCharacter = CARRIAGE_RETURN AndAlso
-                CanGetCharAtOffset(here + 1) AndAlso
-                PeekAheadChar(here + 1) = LINE_FEED Then
+                CanGet(here + 1) AndAlso
+                Peek(here + 1) = LINE_FEED Then
 
                 Return 2
             End If
@@ -520,14 +520,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return False
             End If
 
-            Dim ch As Char = PeekChar()
+            Dim ch As Char = Peek()
             If Not IsUnderscore(ch) Then
                 Return False
             End If
 
             Dim Here = 1
-            While CanGetCharAtOffset(Here)
-                ch = PeekAheadChar(Here)
+            While CanGet(Here)
+                ch = Peek(Here)
                 If IsWhitespace(ch) Then
                     Here += 1
                 Else
@@ -538,7 +538,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' Line continuation is valid at the end of the
             ' line or at the end of file only.
             Dim atNewLine = IsNewLine(ch)
-            If Not atNewLine AndAlso CanGetCharAtOffset(Here) Then
+            If Not atNewLine AndAlso CanGet(Here) Then
                 Return False
             End If
 
@@ -558,8 +558,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 ' implicit line continuations. (See Scanner::EatLineContinuation.) Otherwise,
                 ' include the new line and any additional spaces as trivia.
                 If startComment = 0 AndAlso
-                    CanGetCharAtOffset(Here) AndAlso
-                    Not IsNewLine(PeekAheadChar(Here)) Then
+                    CanGet(Here) AndAlso
+                    Not IsNewLine(Peek(Here)) Then
 
                     tList.Add(MakeEndOfLineTrivia(GetText(newLine)))
                     If spaces > 0 Then
@@ -584,7 +584,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return Nothing
             End If
 
-            Dim ch = PeekChar()
+            Dim ch = Peek()
 
             ' optimization for a common case
             ' the ASCII range between ': and ~ , with exception of except "'", "_" and R cannot start trivia
@@ -620,7 +620,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
                 End If
 
-                Dim ch = PeekChar()
+                Dim ch = Peek()
                 If IsWhitespace(ch) Then
                     ' eat until linebreak or nonwhitespace
                     Dim wslen = GetWhitespaceLength(1)
@@ -656,24 +656,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' check for '''(~')
         Private Function StartsXmlDoc(Here As Integer) As Boolean
             Return _options.DocumentationMode >= DocumentationMode.Parse AndAlso
-                CanGetCharAtOffset(Here + 3) AndAlso
-                IsSingleQuote(PeekAheadChar(Here)) AndAlso
-                IsSingleQuote(PeekAheadChar(Here + 1)) AndAlso
-                IsSingleQuote(PeekAheadChar(Here + 2)) AndAlso
-                Not IsSingleQuote(PeekAheadChar(Here + 3))
+                CanGet(Here + 3) AndAlso
+                IsSingleQuote(Peek(Here)) AndAlso
+                IsSingleQuote(Peek(Here + 1)) AndAlso
+                IsSingleQuote(Peek(Here + 2)) AndAlso
+                Not IsSingleQuote(Peek(Here + 3))
         End Function
 
         ' check for #
         Private Function StartsDirective(Here As Integer) As Boolean
-            If CanGetCharAtOffset(Here) Then
-                Dim ch = PeekAheadChar(Here)
+            If CanGet(Here) Then
+                Dim ch = Peek(Here)
                 Return IsHash(ch)
             End If
             Return False
         End Function
 
         Private Function IsAtNewLine() As Boolean
-            Return _lineBufferOffset = 0 OrElse IsNewLine(PeekAheadChar(-1))
+            Return _lineBufferOffset = 0 OrElse IsNewLine(Peek(-1))
         End Function
 
         Private Function IsAfterWhitespace() As Boolean
@@ -681,7 +681,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return True
             End If
 
-            Dim prevChar = PeekAheadChar(-1)
+            Dim prevChar = Peek(-1)
             Return IsWhitespace(prevChar)
         End Function
 
@@ -710,7 +710,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Sub ScanSingleLineTriviaInXmlDoc(tList As SyntaxListBuilder)
             If CanGetChar() Then
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
                 Select Case (c)
                     ' // Whitespace
                     ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
@@ -742,7 +742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub ScanWhitespaceAndLineContinuations(tList As SyntaxListBuilder)
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 tList.Add(ScanWhitespace(1))
                 ' collect { lineCont, ws }
                 While ScanLineContinuation(tList)
@@ -814,7 +814,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             If CanGetChar() Then
 
-                Dim ch As Char = PeekChar()
+                Dim ch As Char = Peek()
                 Dim startOfTerminatorTrivia = _lineBufferOffset
 
                 If IsNewLine(ch) Then
@@ -826,11 +826,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     ' collect { ws, colon }
                     Do
                         Dim len = GetWhitespaceLength(0)
-                        If Not CanGetCharAtOffset(len) Then
+                        If Not CanGet(len) Then
                             Exit Do
                         End If
 
-                        ch = PeekAheadChar(len)
+                        ch = Peek(len)
                         If Not IsColonAndNotColonEquals(ch, offset:=len) Then
                             Exit Do
                         End If
@@ -866,7 +866,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function GetWhitespaceLength(len As Integer) As Integer
             ' eat until linebreak or nonwhitespace
-            While CanGetCharAtOffset(len) AndAlso IsWhitespace(PeekAheadChar(len))
+            While CanGet(len) AndAlso IsWhitespace(Peek(len))
                 len += 1
             End While
             Return len
@@ -874,7 +874,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function GetXmlWhitespaceLength(len As Integer) As Integer
             ' eat until linebreak or nonwhitespace
-            While CanGetCharAtOffset(len) AndAlso IsXmlWhitespace(PeekAheadChar(len))
+            While CanGet(len) AndAlso IsXmlWhitespace(Peek(len))
                 len += 1
             End While
             Return len
@@ -898,31 +898,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Sub EatWhitespace()
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsWhitespace(PeekChar()))
+            Debug.Assert(IsWhitespace(Peek()))
 
             AdvanceChar()
 
             ' eat until linebreak or nonwhitespace
-            While CanGetChar() AndAlso IsWhitespace(PeekChar)
+            While CanGetChar() AndAlso IsWhitespace(Peek)
                 AdvanceChar()
             End While
         End Sub
 
         Private Function PeekStartComment(i As Integer) As Integer
 
-            If CanGetCharAtOffset(i) Then
-                Dim ch = PeekAheadChar(i)
+            If CanGet(i) Then
+                Dim ch = Peek(i)
 
                 If IsSingleQuote(ch) Then
                     Return 1
                 ElseIf MatchOneOrAnotherOrFullwidth(ch, "R"c, "r"c) AndAlso
-                    CanGetCharAtOffset(i + 2) AndAlso MatchOneOrAnotherOrFullwidth(PeekAheadChar(i + 1), "E"c, "e"c) AndAlso
-                    MatchOneOrAnotherOrFullwidth(PeekAheadChar(i + 2), "M"c, "m"c) Then
+                    CanGet(i + 2) AndAlso MatchOneOrAnotherOrFullwidth(Peek(i + 1), "E"c, "e"c) AndAlso
+                    MatchOneOrAnotherOrFullwidth(Peek(i + 2), "M"c, "m"c) Then
 
-                    If Not CanGetCharAtOffset(i + 3) OrElse IsNewLine(PeekAheadChar(i + 3)) Then
+                    If Not CanGet(i + 3) OrElse IsNewLine(Peek(i + 3)) Then
                         ' have only 'REM'
                         Return 3
-                    ElseIf Not IsIdentifierPartCharacter(PeekAheadChar(i + 3)) Then
+                    ElseIf Not IsIdentifierPartCharacter(Peek(i + 3)) Then
                         ' have 'REM '
                         Return 4
                     End If
@@ -940,8 +940,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Dim looksLikeDocComment As Boolean = StartsXmlDoc(0)
 
                 ' eat all chars until EoL
-                While CanGetCharAtOffset(length) AndAlso
-                    Not IsNewLine(PeekAheadChar(length))
+                While CanGet(length) AndAlso
+                    Not IsNewLine(Peek(length))
 
                     length += 1
                 End While
@@ -967,7 +967,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanColonAsTrivia() As SyntaxTrivia
             Debug.Assert(CanGetChar())
-            Debug.Assert(IsColonAndNotColonEquals(PeekChar(), offset:=0))
+            Debug.Assert(IsColonAndNotColonEquals(Peek(), offset:=0))
 
             Return MakeColonTrivia(GetText(1))
         End Function
@@ -982,7 +982,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return MakeEofToken(precedingTrivia)
             End If
 
-            Dim ch As Char = PeekChar()
+            Dim ch As Char = Peek()
             Select Case ch
                 Case CARRIAGE_RETURN, LINE_FEED, NEXT_LINE, LINE_SEPARATOR, PARAGRAPH_SEPARATOR
                     Return ScanNewlineAsStatementTerminator(ch, precedingTrivia)
@@ -1018,7 +1018,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                 Case "&"c
-                    If CanGetCharAtOffset(1) AndAlso BeginsBaseLiteral(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso BeginsBaseLiteral(Peek(1)) Then
                         Return ScanNumericLiteral(precedingTrivia)
                     End If
 
@@ -1098,7 +1098,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return MakeExclamationToken(precedingTrivia, False)
 
                 Case "."c
-                    If CanGetCharAtOffset(1) AndAlso IsDecimalDigit(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso IsDecimalDigit(Peek(1)) Then
                         Return ScanNumericLiteral(precedingTrivia)
                     Else
                         Return MakeDotToken(precedingTrivia, False)
@@ -1161,13 +1161,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "_"c
-                    If CanGetCharAtOffset(1) AndAlso IsIdentifierPartCharacter(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso IsIdentifierPartCharacter(Peek(1)) Then
                         Return ScanIdentifierOrKeyword(precedingTrivia)
                     End If
 
                     Dim err As ERRID = ERRID.ERR_ExpectedIdentifier
                     Dim len = GetWhitespaceLength(1)
-                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(PeekAheadChar(len)) OrElse PeekStartComment(len) > 0 Then
+                    If Not CanGet(len) OrElse IsNewLine(Peek(len)) OrElse PeekStartComment(len) > 0 Then
                         err = ERRID.ERR_LineContWithCommentOrNoPrecSpace
                     End If
 
@@ -1181,13 +1181,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return MakeQuestionToken(precedingTrivia, False)
 
                 Case "%"c
-                    If CanGetCharAtOffset(1) AndAlso
-                        PeekAheadChar(1) = ">"c Then
+                    If CanGet(1) AndAlso
+                        Peek(1) = ">"c Then
                         Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
                     End If
 
                 Case "$"c, FULLWIDTH_DOLLAR_SIGN
-                    If CanGetCharAtOffset(1) AndAlso IsDoubleQuote(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso IsDoubleQuote(Peek(1)) Then
                         Return MakePunctuationToken(precedingTrivia, 2, SyntaxKind.DollarSignDoubleQuoteToken)
                     End If
 
@@ -1248,7 +1248,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                 Case "&"c
-                    If CanGetCharAtOffset(1) AndAlso BeginsBaseLiteral(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso BeginsBaseLiteral(Peek(1)) Then
                         Return ScanNumericLiteral(precedingTrivia)
                     End If
 
@@ -1328,7 +1328,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return MakeExclamationToken(precedingTrivia, True)
 
                 Case "."c
-                    If CanGetCharAtOffset(1) AndAlso IsDecimalDigit(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso IsDecimalDigit(Peek(1)) Then
                         Return ScanNumericLiteral(precedingTrivia)
                     Else
                         Return MakeDotToken(precedingTrivia, True)
@@ -1383,13 +1383,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ScanIdentifierOrKeyword(precedingTrivia)
 
                 Case "_"c
-                    If CanGetCharAtOffset(1) AndAlso IsIdentifierPartCharacter(PeekAheadChar(1)) Then
+                    If CanGet(1) AndAlso IsIdentifierPartCharacter(Peek(1)) Then
                         Return ScanIdentifierOrKeyword(precedingTrivia)
                     End If
 
                     Dim err As ERRID = ERRID.ERR_ExpectedIdentifier
                     Dim len = GetWhitespaceLength(1)
-                    If Not CanGetCharAtOffset(len) OrElse IsNewLine(PeekAheadChar(len)) OrElse PeekStartComment(len) > 0 Then
+                    If Not CanGet(len) OrElse IsNewLine(Peek(len)) OrElse PeekStartComment(len) > 0 Then
                         err = ERRID.ERR_LineContWithCommentOrNoPrecSpace
                     End If
 
@@ -1403,8 +1403,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return MakeQuestionToken(precedingTrivia, True)
 
                 Case "%"c
-                    If CanGetCharAtOffset(1) AndAlso
-                        PeekAheadChar(1) = ">"c Then
+                    If CanGet(1) AndAlso
+                        Peek(1) = ">"c Then
                         Return XmlMakeEndEmbeddedToken(precedingTrivia, _scanSingleLineTriviaFunc)
                     End If
 
@@ -1423,13 +1423,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' // Allow whitespace between the characters of a two-character token.
         Private Function TrySkipFollowingEquals(ByRef Index As Integer) As Boolean
             Debug.Assert(Index > 0)
-            Debug.Assert(CanGetCharAtOffset(Index - 1))
+            Debug.Assert(CanGet(Index - 1))
 
             Dim Here = Index
             Dim eq As Char
 
-            While CanGetCharAtOffset(Here)
-                eq = PeekAheadChar(Here)
+            While CanGet(Here)
+                eq = Peek(Here)
                 Here += 1
                 If Not IsWhitespace(eq) Then
                     If eq = "="c OrElse eq = FULLWIDTH_EQUALS_SIGN Then
@@ -1445,15 +1445,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanRightAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As SyntaxToken
             Debug.Assert(CanGetChar)  ' > 
-            Debug.Assert(PeekChar() = ">"c OrElse PeekChar() = FULLWIDTH_GREATER_THAN_SIGN)
+            Debug.Assert(Peek() = ">"c OrElse Peek() = FULLWIDTH_GREATER_THAN_SIGN)
 
             Dim length As Integer = 1
 
             ' // Allow whitespace between the characters of a two-character token.
             length = GetWhitespaceLength(length)
 
-            If CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
+            If CanGet(length) Then
+                Dim c As Char = Peek(length)
 
                 If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN Then
                     length += 1
@@ -1472,19 +1472,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanLeftAngleBracket(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean, scanTrailingTrivia As ScanTriviaFunc) As SyntaxToken
             Debug.Assert(CanGetChar)  ' < 
-            Debug.Assert(PeekChar() = "<"c OrElse PeekChar() = FULLWIDTH_LESS_THAN_SIGN)
+            Debug.Assert(Peek() = "<"c OrElse Peek() = FULLWIDTH_LESS_THAN_SIGN)
 
             Dim length As Integer = 1
 
             ' Check for XML tokens
-            If Not charIsFullWidth AndAlso CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
+            If Not charIsFullWidth AndAlso CanGet(length) Then
+                Dim c As Char = Peek(length)
                 Select Case c
                     Case "!"c
-                        If CanGetCharAtOffset(length + 2) Then
-                            Select Case (PeekAheadChar(length + 1))
+                        If CanGet(length + 2) Then
+                            Select Case (Peek(length + 1))
                                 Case "-"c
-                                    If CanGetCharAtOffset(length + 3) AndAlso PeekAheadChar(length + 2) = "-"c Then
+                                    If CanGet(length + 3) AndAlso Peek(length + 2) = "-"c Then
                                         Return XmlMakeBeginCommentToken(precedingTrivia, scanTrailingTrivia)
                                     End If
                                 Case "["c
@@ -1506,8 +1506,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' // Allow whitespace between the characters of a two-character token.
             length = GetWhitespaceLength(length)
 
-            If CanGetCharAtOffset(length) Then
-                Dim c As Char = PeekAheadChar(length)
+            If CanGet(length) Then
+                Dim c As Char = Peek(length)
 
                 If c = "="c OrElse c = FULLWIDTH_EQUALS_SIGN Then
                     length += 1
@@ -1518,8 +1518,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 ElseIf c = "<"c OrElse c = FULLWIDTH_LESS_THAN_SIGN Then
                     length += 1
 
-                    If CanGetCharAtOffset(length) Then
-                        c = PeekAheadChar(length)
+                    If CanGet(length) Then
+                        c = Peek(length)
 
                         'if the second "<" is a part of "<%" - like in "<<%" , we do not want to use it.
                         If c <> "%"c AndAlso c <> FULLWIDTH_PERCENT_SIGN Then
@@ -1567,12 +1567,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ScanIdentifierOrKeyword(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsIdentifierStartCharacter(PeekChar))
+            Debug.Assert(IsIdentifierStartCharacter(Peek))
             Debug.Assert(PeekStartComment(0) = 0) ' comment should be handled by caller
 
-            Dim ch = PeekChar()
-            If CanGetCharAtOffset(1) Then
-                Dim ch1 = PeekAheadChar(1)
+            Dim ch = Peek()
+            If CanGet(1) Then
+                Dim ch1 = Peek(1)
                 If IsConnectorPunctuation(ch) AndAlso Not IsIdentifierPartCharacter(ch1) Then
                     Return MakeBadToken(precedingTrivia, 1, ERRID.ERR_ExpectedIdentifier)
                 End If
@@ -1583,8 +1583,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' // The C++ compiler refuses to inline IsIdentifierCharacter, so the
             ' // < 128 test is inline here. (This loop gets a *lot* of traffic.)
             ' TODO: make sure we get good perf here
-            While CanGetCharAtOffset(len)
-                ch = PeekAheadChar(len)
+            While CanGet(len)
+                ch = Peek(len)
 
                 Dim code = Convert.ToUInt16(ch)
                 If code < 128 AndAlso IsNarrowIdentifierCharacter(code) OrElse
@@ -1598,15 +1598,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             'Check for a type character
             Dim TypeCharacter As TypeCharacter = TypeCharacter.None
-            If CanGetCharAtOffset(len) Then
-                ch = PeekAheadChar(len)
+            If CanGet(len) Then
+                ch = Peek(len)
 
 FullWidthRepeat:
                 Select Case ch
                     Case "!"c
                         ' // If the ! is followed by an identifier it is a dictionary lookup operator, not a type character.
-                        If CanGetCharAtOffset(len + 1) Then
-                            Dim NextChar As Char = PeekAheadChar(len + 1)
+                        If CanGet(len + 1) Then
+                            Dim NextChar As Char = Peek(len + 1)
 
                             If IsIdentifierStartCharacter(NextChar) OrElse
                                 MatchOneOrAnotherOrFullwidth(NextChar, "["c, "]"c) Then
@@ -1685,31 +1685,31 @@ FullWidthRepeat:
 
         Private Function ScanBracketedIdentifier(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)  ' [
-            Debug.Assert(PeekChar() = "["c OrElse PeekChar() = FULLWIDTH_LEFT_SQUARE_BRACKET)
+            Debug.Assert(Peek() = "["c OrElse Peek() = FULLWIDTH_LEFT_SQUARE_BRACKET)
 
             Dim IdStart As Integer = 1
             Dim Here As Integer = IdStart
 
             Dim InvalidIdentifier As Boolean = False
 
-            If Not CanGetCharAtOffset(Here) Then
+            If Not CanGet(Here) Then
                 Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_MissingEndBrack)
             End If
 
-            Dim ch = PeekAheadChar(Here)
+            Dim ch = Peek(Here)
 
             ' check if we can start an ident.
             If Not IsIdentifierStartCharacter(ch) OrElse
                 (IsConnectorPunctuation(ch) AndAlso
-                    Not (CanGetCharAtOffset(Here + 1) AndAlso
-                         IsIdentifierPartCharacter(PeekAheadChar(Here + 1)))) Then
+                    Not (CanGet(Here + 1) AndAlso
+                         IsIdentifierPartCharacter(Peek(Here + 1)))) Then
 
                 InvalidIdentifier = True
             End If
 
             ' check ident until ]
-            While CanGetCharAtOffset(Here)
-                Dim [Next] As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim [Next] As Char = Peek(Here)
 
                 If [Next] = "]"c OrElse [Next] = FULLWIDTH_RIGHT_SQUARE_BRACKET Then
                     Dim IdStringLength As Integer = Here - IdStart
@@ -1771,10 +1771,10 @@ FullWidthRepeat:
 
             ' // First read a leading base specifier, if present, followed by a sequence of zero
             ' // or more digits.
-            Dim ch = PeekChar()
+            Dim ch = Peek()
             If ch = "&"c OrElse ch = FULLWIDTH_AMPERSAND Then
                 Here += 1
-                ch = If(CanGetCharAtOffset(Here), PeekAheadChar(Here), ChrW(0))
+                ch = If(CanGet(Here), Peek(Here), ChrW(0))
 
 FullWidthRepeat:
                 Select Case ch
@@ -1783,8 +1783,8 @@ FullWidthRepeat:
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Hexadecimal
 
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
+                        While CanGet(Here)
+                            ch = Peek(Here)
                             If Not IsHexDigit(ch) Then
                                 Exit While
                             End If
@@ -1796,8 +1796,8 @@ FullWidthRepeat:
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Octal
 
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
+                        While CanGet(Here)
+                            ch = Peek(Here)
                             If Not IsOctalDigit(ch) Then
                                 Exit While
                             End If
@@ -1815,8 +1815,8 @@ FullWidthRepeat:
             Else
                 ' no base specifier - just go through decimal digits.
                 IntegerLiteralStart = Here
-                While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
+                While CanGet(Here)
+                    ch = Peek(Here)
                     If Not IsDecimalDigit(ch) Then
                         Exit While
                     End If
@@ -1829,18 +1829,18 @@ FullWidthRepeat:
 
             ' // Unless there was an explicit base specifier (which indicates an integer literal),
             ' // read the rest of a float literal.
-            If Base = LiteralBase.Decimal AndAlso CanGetCharAtOffset(Here) Then
+            If Base = LiteralBase.Decimal AndAlso CanGet(Here) Then
                 ' // First read a '.' followed by a sequence of one or more digits.
-                ch = PeekAheadChar(Here)
+                ch = Peek(Here)
                 If (ch = "."c Or ch = FULLWIDTH_FULL_STOP) AndAlso
-                        CanGetCharAtOffset(Here + 1) AndAlso
-                        IsDecimalDigit(PeekAheadChar(Here + 1)) Then
+                        CanGet(Here + 1) AndAlso
+                        IsDecimalDigit(Peek(Here + 1)) Then
 
                     Here += 2   ' skip dot and first digit
 
                     ' all following decimal digits belong to the literal (fractional part)
-                    While CanGetCharAtOffset(Here)
-                        ch = PeekAheadChar(Here)
+                    While CanGet(Here)
+                        ch = Peek(Here)
                         If Not IsDecimalDigit(ch) Then
                             Exit While
                         End If
@@ -1851,21 +1851,21 @@ FullWidthRepeat:
 
                 ' // Read an exponent symbol followed by an optional sign and a sequence of
                 ' // one or more digits.
-                If CanGetCharAtOffset(Here) AndAlso BeginsExponent(PeekAheadChar(Here)) Then
+                If CanGet(Here) AndAlso BeginsExponent(Peek(Here)) Then
                     Here += 1
 
-                    If CanGetCharAtOffset(Here) Then
-                        ch = PeekAheadChar(Here)
+                    If CanGet(Here) Then
+                        ch = Peek(Here)
 
                         If MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c) Then
                             Here += 1
                         End If
                     End If
 
-                    If CanGetCharAtOffset(Here) AndAlso IsDecimalDigit(PeekAheadChar(Here)) Then
+                    If CanGet(Here) AndAlso IsDecimalDigit(Peek(Here)) Then
                         Here += 1
-                        While CanGetCharAtOffset(Here)
-                            ch = PeekAheadChar(Here)
+                        While CanGet(Here)
+                            ch = Peek(Here)
                             If Not IsDecimalDigit(ch) Then
                                 Exit While
                             End If
@@ -1887,8 +1887,8 @@ FullWidthRepeat:
 
             Dim TypeCharacter As TypeCharacter = TypeCharacter.None
 
-            If CanGetCharAtOffset(Here) Then
-                ch = PeekAheadChar(Here)
+            If CanGet(Here) Then
+                ch = Peek(Here)
 
 FullWidthRepeat2:
                 Select Case ch
@@ -1964,8 +1964,8 @@ FullWidthRepeat2:
                             literalKind = NumericLiteralKind.Decimal
 
                             ' check if this was not attempt to use obsolete exponent
-                            If CanGetCharAtOffset(Here + 1) Then
-                                ch = PeekAheadChar(Here + 1)
+                            If CanGet(Here + 1) Then
+                                ch = Peek(Here + 1)
 
                                 If IsDecimalDigit(ch) OrElse MatchOneOrAnotherOrFullwidth(ch, "+"c, "-"c) Then
                                     Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_ObsoleteExponent)
@@ -1976,8 +1976,8 @@ FullWidthRepeat2:
                         End If
 
                     Case "U"c, "u"c
-                        If literalKind <> NumericLiteralKind.Float AndAlso CanGetCharAtOffset(Here + 1) Then
-                            Dim NextChar As Char = PeekAheadChar(Here + 1)
+                        If literalKind <> NumericLiteralKind.Float AndAlso CanGet(Here + 1) Then
+                            Dim NextChar As Char = Peek(Here + 1)
 
                             'unsigned suffixes - US, UL, UI
                             If MatchOneOrAnotherOrFullwidth(NextChar, "S"c, "s"c) Then
@@ -2013,12 +2013,12 @@ FullWidthRepeat2:
                 If IntegerLiteralStart = IntegerLiteralEnd Then
                     Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_Syntax)
                 Else
-                    IntegralValue = IntegralLiteralCharacterValue(PeekAheadChar(IntegerLiteralStart))
+                    IntegralValue = IntegralLiteralCharacterValue(Peek(IntegerLiteralStart))
 
                     If Base = LiteralBase.Decimal Then
                         ' Init For loop
                         For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1
-                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(PeekAheadChar(LiteralCharacter))
+                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(Peek(LiteralCharacter))
 
                             If IntegralValue < 1844674407370955161UL OrElse
                               (IntegralValue = 1844674407370955161UL AndAlso NextCharacterValue <= 5UI) Then
@@ -2043,7 +2043,7 @@ FullWidthRepeat2:
                                 Overflows = True
                             End If
 
-                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(PeekAheadChar(LiteralCharacter))
+                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(Peek(LiteralCharacter))
                         Next
                     End If
 
@@ -2085,7 +2085,7 @@ FullWidthRepeat2:
                 ' // Copy the text of the literal to deal with fullwidth 
                 Dim scratch = GetScratch()
                 For i = 0 To literalWithoutTypeChar - 1
-                    Dim curCh = PeekAheadChar(i)
+                    Dim curCh = Peek(i)
                     scratch.Append(If(IsFullWidth(curCh), MakeHalfWidth(curCh), curCh))
                 Next
                 Dim LiteralSpelling = GetScratchTextInterned(scratch)
@@ -2155,11 +2155,11 @@ FullWidthRepeat2:
            ) As Boolean
             Debug.Assert(Here >= 0)
 
-            If Not CanGetCharAtOffset(Here) Then
+            If Not CanGet(Here) Then
                 Return False
             End If
 
-            Dim ch = PeekAheadChar(Here)
+            Dim ch = Peek(Here)
             If Not IsDecimalDigit(ch) Then
                 Return False
             End If
@@ -2167,8 +2167,8 @@ FullWidthRepeat2:
             Dim IntegralValue As Integer = IntegralLiteralCharacterValue(ch)
             Here += 1
 
-            While CanGetCharAtOffset(Here)
-                ch = PeekAheadChar(Here)
+            While CanGet(Here)
+                ch = Peek(Here)
 
                 If Not IsDecimalDigit(ch) Then
                     Exit While
@@ -2191,7 +2191,7 @@ FullWidthRepeat2:
 
         Private Function ScanDateLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsHash(PeekChar()))
+            Debug.Assert(IsHash(Peek()))
 
             Dim Here As Integer = 1 'skip #
             Dim FirstValue As Integer
@@ -2223,7 +2223,7 @@ FullWidthRepeat2:
 
             ' // If we see a /, then it's a date
 
-            If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+            If CanGet(Here) AndAlso IsDateSeparatorCharacter(Peek(Here)) Then
                 Dim FirstDateSeparator As Integer = Here
 
                 ' // We've got a date
@@ -2243,10 +2243,10 @@ FullWidthRepeat2:
                     End If
 
                     ' Do we have a day value?
-                    If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+                    If CanGet(Here) AndAlso IsDateSeparatorCharacter(Peek(Here)) Then
                         ' // Check to see they used a consistent separator
 
-                        If PeekAheadChar(Here) <> PeekAheadChar(FirstDateSeparator) Then
+                        If Peek(Here) <> Peek(FirstDateSeparator) Then
                             GoTo baddate
                         End If
 
@@ -2269,10 +2269,10 @@ FullWidthRepeat2:
 
                     ' // Do we have a year value?
 
-                    If CanGetCharAtOffset(Here) AndAlso IsDateSeparatorCharacter(PeekAheadChar(Here)) Then
+                    If CanGet(Here) AndAlso IsDateSeparatorCharacter(Peek(Here)) Then
                         ' // Check to see they used a consistent separator
 
-                        If PeekAheadChar(Here) <> PeekAheadChar(FirstDateSeparator) Then
+                        If Peek(Here) <> Peek(FirstDateSeparator) Then
                             GoTo baddate
                         End If
 
@@ -2312,7 +2312,7 @@ FullWidthRepeat2:
             If HaveTimeValue Then
                 ' // Do we see a :?
 
-                If CanGetCharAtOffset(Here) AndAlso IsColon(PeekAheadChar(Here)) Then
+                If CanGet(Here) AndAlso IsColon(Peek(Here)) Then
                     Here += 1
 
                     ' // Now let's get the minute value
@@ -2325,7 +2325,7 @@ FullWidthRepeat2:
 
                     ' // Do we have a second value?
 
-                    If CanGetCharAtOffset(Here) AndAlso IsColon(PeekAheadChar(Here)) Then
+                    If CanGet(Here) AndAlso IsColon(Peek(Here)) Then
                         ' // Yes.
                         HaveSecondValue = True
                         Here += 1
@@ -2340,24 +2340,24 @@ FullWidthRepeat2:
 
                 ' // Check AM/PM
 
-                If CanGetCharAtOffset(Here) Then
-                    If PeekAheadChar(Here) = "A"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_A OrElse
-                        PeekAheadChar(Here) = "a"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_A Then
+                If CanGet(Here) Then
+                    If Peek(Here) = "A"c OrElse Peek(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_A OrElse
+                        Peek(Here) = "a"c OrElse Peek(Here) = FULLWIDTH_LATIN_SMALL_LETTER_A Then
 
                         HaveAM = True
                         Here += 1
 
-                    ElseIf PeekAheadChar(Here) = "P"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_P OrElse
-                           PeekAheadChar(Here) = "p"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_P Then
+                    ElseIf Peek(Here) = "P"c OrElse Peek(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_P OrElse
+                           Peek(Here) = "p"c OrElse Peek(Here) = FULLWIDTH_LATIN_SMALL_LETTER_P Then
 
                         HavePM = True
                         Here += 1
 
                     End If
 
-                    If CanGetCharAtOffset(Here) AndAlso (HaveAM OrElse HavePM) Then
-                        If PeekAheadChar(Here) = "M"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_M OrElse
-                           PeekAheadChar(Here) = "m"c OrElse PeekAheadChar(Here) = FULLWIDTH_LATIN_SMALL_LETTER_M Then
+                    If CanGet(Here) AndAlso (HaveAM OrElse HavePM) Then
+                        If Peek(Here) = "M"c OrElse Peek(Here) = FULLWIDTH_LATIN_CAPITAL_LETTER_M OrElse
+                           Peek(Here) = "m"c OrElse Peek(Here) = FULLWIDTH_LATIN_SMALL_LETTER_M Then
 
                             Here = GetWhitespaceLength(Here + 1)
 
@@ -2374,7 +2374,7 @@ FullWidthRepeat2:
                 End If
             End If
 
-            If Not CanGetCharAtOffset(Here) OrElse Not IsHash(PeekAheadChar(Here)) Then
+            If Not CanGet(Here) OrElse Not IsHash(Peek(Here)) Then
                 GoTo baddate
             End If
 
@@ -2480,19 +2480,19 @@ baddate:
             ' // If we can find a closing #, then assume it's a malformed date,
             ' // otherwise, it's not a date
 
-            While CanGetCharAtOffset(Here)
-                Dim ch As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim ch As Char = Peek(Here)
                 If IsHash(ch) OrElse IsNewLine(ch) Then
                     Exit While
                 End If
                 Here += 1
             End While
 
-            If Not CanGetCharAtOffset(Here) OrElse IsNewLine(PeekAheadChar(Here)) Then
+            If Not CanGet(Here) OrElse IsNewLine(Peek(Here)) Then
                 ' // No closing #
                 Return Nothing
             Else
-                Debug.Assert(IsHash(PeekAheadChar(Here)))
+                Debug.Assert(IsHash(Peek(Here)))
                 Here += 1  ' consume trailing #
                 Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_InvalidDate)
             End If
@@ -2500,7 +2500,7 @@ baddate:
 
         Private Function ScanStringLiteral(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As SyntaxToken
             Debug.Assert(CanGetChar)
-            Debug.Assert(IsDoubleQuote(PeekChar))
+            Debug.Assert(IsDoubleQuote(Peek))
 
             Dim length As Integer = 1
             Dim ch As Char
@@ -2509,37 +2509,37 @@ baddate:
             ' // Check for a Char literal, which can be of the form:
             ' // """"c or "<anycharacter-except-">"c
 
-            If CanGetCharAtOffset(3) AndAlso IsDoubleQuote(PeekAheadChar(2)) Then
-                If IsDoubleQuote(PeekAheadChar(1)) Then
-                    If IsDoubleQuote(PeekAheadChar(3)) AndAlso
-                       CanGetCharAtOffset(4) AndAlso
-                       IsLetterC(PeekAheadChar(4)) Then
+            If CanGet(3) AndAlso IsDoubleQuote(Peek(2)) Then
+                If IsDoubleQuote(Peek(1)) Then
+                    If IsDoubleQuote(Peek(3)) AndAlso
+                       CanGet(4) AndAlso
+                       IsLetterC(Peek(4)) Then
 
                         ' // Double-quote Char literal: """"c
                         Return MakeCharacterLiteralToken(precedingTrivia, """"c, 5)
                     End If
 
-                ElseIf IsLetterC(PeekAheadChar(3)) Then
+                ElseIf IsLetterC(Peek(3)) Then
                     ' // Char literal.  "x"c
-                    Return MakeCharacterLiteralToken(precedingTrivia, PeekAheadChar(1), 4)
+                    Return MakeCharacterLiteralToken(precedingTrivia, Peek(1), 4)
                 End If
             End If
 
-            If CanGetCharAtOffset(2) AndAlso
-               IsDoubleQuote(PeekAheadChar(1)) AndAlso
-               IsLetterC(PeekAheadChar(2)) Then
+            If CanGet(2) AndAlso
+               IsDoubleQuote(Peek(1)) AndAlso
+               IsLetterC(Peek(2)) Then
 
                 ' // Error. ""c is not a legal char constant
                 Return MakeBadToken(precedingTrivia, 3, ERRID.ERR_IllegalCharConstant)
             End If
 
             Dim scratch = GetScratch()
-            While CanGetCharAtOffset(length)
-                ch = PeekAheadChar(length)
+            While CanGet(length)
+                ch = Peek(length)
 
                 If IsDoubleQuote(ch) Then
-                    If CanGetCharAtOffset(length + 1) Then
-                        ch = PeekAheadChar(length + 1)
+                    If CanGet(length + 1) Then
+                        ch = Peek(length + 1)
 
                         If IsDoubleQuote(ch) Then
                             ' // An escaped double quote
@@ -2575,7 +2575,7 @@ baddate:
             End While
 
             ' CC has trouble to prove this after the loop
-            Debug.Assert(CanGetCharAtOffset(length - 1))
+            Debug.Assert(CanGet(length - 1))
 
             '// The literal does not have an explicit termination.      
             ' DIFFERENT: here in IDE we used to report string token marked as unterminated

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
@@ -96,8 +96,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         ' PERF CRITICAL
-        Private Function PeekAheadChar(skip As Integer) As Char
-            Debug.Assert(CanGetCharAtOffset(skip))
+        Private Function Peek(skip As Integer) As Char
+            Debug.Assert(CanGet(skip))
             Debug.Assert(skip >= -MaxCharsLookBehind)
 
             Dim position = _lineBufferOffset
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         ' PERF CRITICAL
-        Friend Function PeekChar() As Char
+        Friend Function Peek() As Char
             Dim page = _curPage
             Dim position = _lineBufferOffset
             Dim ch = page._arr(position And s_PAGE_MASK)
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend Function GetChar() As String
-            Return Intern(PeekChar())
+            Return Intern(Peek())
         End Function
 
         Friend Function GetText(start As Integer, length As Integer) As String

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
@@ -20,25 +20,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim offset = leadingTriviaLength
             Dim length As Integer
 
-            If Not CanGetCharAtOffset(offset) Then
+            If Not CanGet(offset) Then
                 Return MakeEndOfInterpolatedStringToken()
             End If
 
-            Dim c = PeekAheadChar(offset)
+            Dim c = Peek(offset)
 
             ' This should only ever happen for $" or }
             Debug.Assert(leadingTriviaLength = 0 OrElse c = "$"c OrElse c = FULLWIDTH_DOLLAR_SIGN OrElse IsRightCurlyBracket(c))
 
             ' Another } may follow the close brace of an interpolation if the interpolation lacked a format clause.
             ' This is because the normal escaping rules only apply when parsing the format string.
-            Debug.Assert(Not CanGetCharAtOffset(1) OrElse PeekAheadChar(offset + 1) <> c OrElse IsRightCurlyBracket(c), "Escape sequence not detected.")
+            Debug.Assert(Not CanGet(1) OrElse Peek(offset + 1) <> c OrElse IsRightCurlyBracket(c), "Escape sequence not detected.")
 
             Dim scanTrailingTrivia As Boolean
 
             Select Case c
                 Case "$"c, FULLWIDTH_DOLLAR_SIGN
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(PeekAheadChar(offset + 1)) Then
+                    If CanGet(offset + 1) AndAlso IsDoubleQuote(Peek(offset + 1)) Then
                         kind = SyntaxKind.DollarSignDoubleQuoteToken
                         length = 2
                         scanTrailingTrivia = False ' Trailing whitespace should be scanned as interpolated string text.
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case Else
 
                     If IsDoubleQuote(c) Then
-                        Debug.Assert(Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(PeekAheadChar(offset + 1)))
+                        Debug.Assert(Not CanGet(offset + 1) OrElse Not IsDoubleQuote(Peek(offset + 1)))
 
                         kind = SyntaxKind.DoubleQuoteToken
                         length = 1
@@ -112,22 +112,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function IsInterpolatedStringPunctuation(Optional offset As Integer = 0) As Boolean
-            If Not CanGetCharAtOffset(offset) Then Return False
+            If Not CanGet(offset) Then Return False
 
-            Dim c = PeekAheadChar(offset)
+            Dim c = Peek(offset)
 
             If IsLeftCurlyBracket(c) Then
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsLeftCurlyBracket(PeekAheadChar(offset + 1))
+                Return Not CanGet(offset + 1) OrElse Not IsLeftCurlyBracket(Peek(offset + 1))
 
             ElseIf IsRightCurlyBracket(c) Then
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsRightCurlyBracket(PeekAheadChar(offset + 1))
+                Return Not CanGet(offset + 1) OrElse Not IsRightCurlyBracket(Peek(offset + 1))
 
             ElseIf IsDoubleQuote(c)
                 'A subtle difference between this case and the one above.
                 ' In both interpolated and literal strings the two quote characters used in an escape sequence don't have to match.
                 ' It's enough that the next character is *a* quote char. It doesn't have to be the same quote.
                 ' If we want to preserve consistency the quotes need to be special cased.
-                Return Not CanGetCharAtOffset(offset + 1) OrElse Not IsDoubleQuote(PeekAheadChar(offset + 1))
+                Return Not CanGet(offset + 1) OrElse Not IsDoubleQuote(Peek(offset + 1))
 
             Else
                 Return False
@@ -141,16 +141,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim pendingWhitespace = 0
             Dim valueBuilder = GetScratch()
 
-            Do While CanGetCharAtOffset(offset)
+            Do While CanGet(offset)
 
-                Dim c = PeekAheadChar(offset)
+                Dim c = Peek(offset)
 
                 ' Any combination of fullwidth and ASCII curly braces of the same direction is an escaping sequence for the corresponding ASCII curly brace.
                 ' We insert that curly brace doubled and because this is the escaping sequence understood by String.Format, that will be replaced by a single brace.
                 ' This is deliberate design and it aligns with existing rules for double quote escaping in strings.
                 If IsLeftCurlyBracket(c) Then
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsLeftCurlyBracket(PeekAheadChar(offset + 1)) Then
+                    If CanGet(offset + 1) AndAlso IsLeftCurlyBracket(Peek(offset + 1)) Then
                         ' This is an escape sequence.
 
                         valueBuilder.Append("{{")
@@ -164,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ElseIf IsRightCurlyBracket(c) Then
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsRightCurlyBracket(PeekAheadChar(offset + 1)) Then
+                    If CanGet(offset + 1) AndAlso IsRightCurlyBracket(Peek(offset + 1)) Then
                         ' This is an escape sequence.
 
                         valueBuilder.Append("}}")
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ElseIf IsDoubleQuote(c)
 
-                    If CanGetCharAtOffset(offset + 1) AndAlso IsDoubleQuote(PeekAheadChar(offset + 1)) Then
+                    If CanGet(offset + 1) AndAlso IsDoubleQuote(Peek(offset + 1)) Then
                         ' This is a VB double quote escape. Oddly enough this logic allows mixing and matching of
                         ' smart and dumb double quotes in any order. Regardless we always emit as a standard double quote.
                         ' This is consistent with their handling in string literals.

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerInterpolatedString.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Partial Friend Class Scanner
 
         Private Function ScanInterpolatedStringPunctuation() As SyntaxToken
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return MakeEndOfInterpolatedStringToken()
             End If
 
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ScanInterpolatedStringText(scanTrailingWhitespaceAsTrivia As Boolean) As SyntaxToken
-            If Not CanGetChar() Then Return MakeEndOfInterpolatedStringToken()
+            If Not CanGet() Then Return MakeEndOfInterpolatedStringToken()
 
             Dim offset = 0
             Dim pendingWhitespace = 0

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim leadingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
 
-            While CanGetChar()
+            While CanGet()
                 Dim c As Char = Peek()
 
                 Select Case (c)
@@ -226,7 +226,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         '// NL WS* '
         '// Example ' This is a comment
         Private Function ScanXmlForPossibleStatement(state As ScannerState) As Boolean
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return False
             End If
 
@@ -687,7 +687,7 @@ ScanChars:
             Dim precedingTrivia = _triviaListPool.Allocate(Of VisualBasicSyntaxNode)()
             Dim result As SyntaxToken
 
-            If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
+            If state = ScannerState.StartProcessingInstruction AndAlso CanGet() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
                 Dim c = Peek()
@@ -760,7 +760,7 @@ CleanUp:
             ' // Misc    ::=    Comment | PI | S
 
             Dim precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
-            While CanGetChar()
+            While CanGet()
                 Dim c As Char = Peek()
 
                 Select Case (c)
@@ -838,7 +838,7 @@ CleanUp:
         End Function
 
         Friend Function ScanXmlStringUnQuoted() As SyntaxToken
-            If Not CanGetChar() Then
+            If Not CanGet() Then
                 Return MakeEofToken()
             End If
 
@@ -1198,7 +1198,7 @@ CreateNCNameToken:
         End Function
 
         Private Function ScanXmlReference(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As XmlTextTokenSyntax
-            Debug.Assert(CanGetChar)
+            Debug.Assert(CanGet)
             Debug.Assert(Peek() = "&"c)
 
             ' skip 1 char for "&"

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -120,37 +120,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
+                                                If NextIs(3,"-"c) Then
                                                     Return XmlMakeBeginCommentToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "C"c AndAlso
-                                                    Peek(4) = "D"c AndAlso
-                                                    Peek(5) = "A"c AndAlso
-                                                    Peek(6) = "T"c AndAlso
-                                                    Peek(7) = "A"c AndAlso
-                                                    Peek(8) = "["c Then
-
+                                                If NextAre(3,"CDATA[") Then
                                                     Return XmlMakeBeginCDataToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "O"c AndAlso
-                                                    Peek(4) = "C"c AndAlso
-                                                    Peek(5) = "T"c AndAlso
-                                                    Peek(6) = "Y"c AndAlso
-                                                    Peek(7) = "P"c AndAlso
-                                                    Peek(8) = "E"c Then
+                                                If Nextare(3,"OCTYPE") Then
                                                     Return XmlMakeBeginDTDToken(leadingTrivia)
                                                 End If
                                         End Select
                                     End If
                                     Return XmlLessThanExclamationToken(state, leadingTrivia)
                                 Case "%"c
-                                    If CanGet(2) AndAlso
-                                        Peek(2) = "=" Then
-
+                                    If NextIs(2,"="c) Then
                                         Return XmlMakeBeginEmbeddedToken(leadingTrivia)
                                     End If
                                 Case "?"c
@@ -164,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "?"c
 
-                        If CanGet(1) AndAlso Peek(1) = ">"c Then
+                        If NextIs(1,">"c) Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(leadingTrivia)
                         End If
@@ -177,11 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Case ")"c
                         Return XmlMakeRightParenToken(leadingTrivia)
 
-                    Case "!"c,
-                       ";"c,
-                       "#"c,
-                       ","c,
-                       "}"c
+                    Case "!"c, ";"c, "#"c, ","c, "}"c
                         Return XmlMakeBadToken(leadingTrivia, 1, ERRID.ERR_IllegalXmlNameChar)
 
                     Case ":"c
@@ -368,36 +349,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
+                                                If NextIs(3,"-"c) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGet(8) AndAlso _
-                                                    Peek(3) = "C"c AndAlso _
-                                                    Peek(4) = "D"c AndAlso _
-                                                    Peek(5) = "A"c AndAlso _
-                                                    Peek(6) = "T"c AndAlso _
-                                                    Peek(7) = "A"c AndAlso _
-                                                    Peek(8) = "["c Then
-
+                                                If NextAre(3,"CDATA[") Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "O"c AndAlso
-                                                    Peek(4) = "C"c AndAlso
-                                                    Peek(5) = "T"c AndAlso
-                                                    Peek(6) = "Y"c AndAlso
-                                                    Peek(7) = "P"c AndAlso
-                                                    Peek(8) = "E"c Then
+                                                If NextAre(3,"OCTYPE") Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
                                     End If
                                 Case "%"c
-                                    If CanGet(2) AndAlso
-                                        Peek(2) = "=" Then
-
+                                    If NextIs(2, "="c) Then
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
                                 Case "?"c
@@ -410,9 +376,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If CanGet(Here + 2) AndAlso _
-                           Peek(Here + 1) = "]"c AndAlso _
-                           Peek(Here + 2) = ">"c Then
+                        If NextAre(Here+1,"]>") Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -536,8 +500,7 @@ ScanChars:
                         Return XmlMakeCommentToken(precedingTrivia, Here + LengthOfLineBreak(c, Here))
 
                     Case "-"c
-                        If CanGet(Here + 1) AndAlso _
-                           Peek(Here + 1) = "-"c Then
+                        If NextIs(Here + 1,"-"c) Then
 
                             ' // --> terminates an Xml comment but otherwise -- is an illegal character sequence.
                             ' // The scanner will always returns "--" as a separate comment data string and the
@@ -631,9 +594,7 @@ ScanChars:
                         Return XmlMakeCDataToken(precedingTrivia, Here, scratch)
 
                     Case "]"c
-                        If CanGet(Here + 2) AndAlso _
-                           Peek(Here + 1) = "]"c AndAlso _
-                           Peek(Here + 2) = ">"c Then
+                        If NextAre(Here+1,"]>") Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -708,8 +669,7 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If CanGet(Here + 1) AndAlso _
-                           Peek(Here + 1) = ">"c Then
+                        If NextIs(Here + 1, ">"c) Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -776,25 +736,13 @@ CleanUp:
                             Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGet(3) AndAlso
-                                        Peek(2) = "-"c AndAlso
-                                        Peek(3) = "-"c Then
-
+                                    If NextAre(2,"--") Then
                                         Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
-                                    ElseIf CanGet(8) AndAlso
-                                            Peek(2) = "D"c AndAlso
-                                            Peek(3) = "O"c AndAlso
-                                            Peek(4) = "C"c AndAlso
-                                            Peek(5) = "T"c AndAlso
-                                            Peek(6) = "Y"c AndAlso
-                                            Peek(7) = "P"c AndAlso
-                                            Peek(8) = "E"c Then
+                                    ElseIf NextAre(2,"DOCTYPE") Then
                                         Return XmlMakeBeginDTDToken(precedingTrivia)
                                     End If
                                 Case "%"c
-                                    If CanGet(2) AndAlso
-                                        Peek(2) = "=" Then
-
+                                    If NextIs(2,"="c) Then
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
                                 Case "?"c
@@ -876,7 +824,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGet(Here + 1) AndAlso Peek(Here + 1) = ">"c Then
+                        If NextIs(Here + 1, ">"c) Then
                             If Here <> 0 Then
                                 Return XmlMakeAttributeDataToken(Nothing, Here, scratch)
                             Else
@@ -975,10 +923,7 @@ ScanChars:
                             GoTo CleanUp
                         Else
                             ' report unexpected <%= in a special way.
-                            If CanGet(2) AndAlso
-                                Peek(1) = "%"c AndAlso
-                                Peek(2) = "=" Then
-
+                            If NextAre(1,"%=") Then
                                 Dim errEmbedStart = XmlMakeAttributeDataToken(precedingTrivia, 3, "<%=")
                                 Dim errEmberinfo = ErrorFactory.ErrorInfo(ERRID.ERR_QuotedEmbeddedExpression)
                                 result = DirectCast(errEmbedStart.SetDiagnostics({errEmberinfo}), SyntaxToken)
@@ -1126,23 +1071,10 @@ CleanUp:
 
                 Select Case (c)
 
-                    Case ":"c, _
-                        " "c, _
-                        CHARACTER_TABULATION, _
-                        LINE_FEED, _
-                        CARRIAGE_RETURN, _
-                        "="c, _
-                        "'"c, _
-                        """"c, _
-                        "/"c, _
-                        ">"c, _
-                        "<"c, _
-                        "("c, _
-                        ")"c, _
-                        "?"c, _
-                        ";"c, _
-                        ","c, _
-                        "}"c
+                    Case ":"c, " "c, CHARACTER_TABULATION, LINE_FEED, CARRIAGE_RETURN,
+                        "="c, "'"c, """"c, "/"c,
+                        ">"c, "<"c, "("c, ")"c,
+                        "?"c, ";"c, ","c, "}"c
 
                         GoTo CreateNCNameToken
 
@@ -1231,10 +1163,7 @@ CreateNCNameToken:
                         ' // &amp;
                         ' // &apos;
 
-                        If CanGet(4) AndAlso
-                           Peek(2) = "m"c AndAlso
-                           Peek(3) = "p"c Then
-
+                        If CanGet(4) AndAlso NextAre(2,"mp") Then
                             If Peek(4) = ";"c Then
                                 Return XmlMakeAmpLiteralToken(precedingTrivia)
                             Else
@@ -1243,10 +1172,7 @@ CreateNCNameToken:
                                 Return DirectCast(noSemicolon.SetDiagnostics({noSemicolonError}), XmlTextTokenSyntax)
                             End If
 
-                        ElseIf CanGet(5) AndAlso
-                               Peek(2) = "p"c AndAlso
-                               Peek(3) = "o"c AndAlso
-                               Peek(4) = "s"c Then
+                        ElseIf CanGet(5) AndAlso NextAre(2,"pos") Then
 
                             If Peek(5) = ";"c Then
                                 Return XmlMakeAposLiteralToken(precedingTrivia)
@@ -1260,8 +1186,7 @@ CreateNCNameToken:
                     Case "l"c
                         ' // &lt;
 
-                        If CanGet(3) AndAlso
-                           Peek(2) = "t"c Then
+                        If CanGet(3) AndAlso NextIs(2,"t"c) Then
 
                             If Peek(3) = ";"c Then
                                 Return XmlMakeLtLiteralToken(precedingTrivia)
@@ -1275,8 +1200,7 @@ CreateNCNameToken:
                     Case "g"c
                         ' // &gt;
 
-                        If CanGet(3) AndAlso
-                           Peek(2) = "t"c Then
+                        If CanGet(3) AndAlso NextIs(2,"t"c) Then
 
                             If Peek(3) = ";"c Then
                                 Return XmlMakeGtLiteralToken(precedingTrivia)
@@ -1290,10 +1214,7 @@ CreateNCNameToken:
                     Case "q"c
                         ' // &quot;
 
-                        If CanGet(5) AndAlso
-                           Peek(2) = "u"c AndAlso
-                           Peek(3) = "o"c AndAlso
-                           Peek(4) = "t"c Then
+                        If CanGet(5) AndAlso NextAre(2,"uot") Then
 
                             If Peek(5) = ";"c Then
                                 Return XmlMakeQuotLiteralToken(precedingTrivia)

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -34,10 +34,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Exit Do
                 End If
 
-                If Not CanGetCharAtOffset(len) Then
+                If Not CanGet(len) Then
                     Exit Do
                 End If
-                c = PeekAheadChar(len)
+                c = Peek(len)
             Loop
 
             If len > 0 Then
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim leadingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
 
             While CanGetChar()
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         leadingTrivia = ScanXmlTrivia(c)
 
                     Case "/"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">" Then
+                        If CanGet(1) AndAlso Peek(1) = ">" Then
                             Return XmlMakeEndEmptyElementToken(leadingTrivia)
                         End If
                         Return XmlMakeDivToken(leadingTrivia)
@@ -113,43 +113,43 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeDoubleQuoteToken(leadingTrivia, c, isOpening:=True)
 
                     Case "<"c
-                        If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                        If CanGet(1) Then
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                    If CanGet(2) Then
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "C"c AndAlso
-                                                    PeekAheadChar(4) = "D"c AndAlso
-                                                    PeekAheadChar(5) = "A"c AndAlso
-                                                    PeekAheadChar(6) = "T"c AndAlso
-                                                    PeekAheadChar(7) = "A"c AndAlso
-                                                    PeekAheadChar(8) = "["c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "C"c AndAlso
+                                                    Peek(4) = "D"c AndAlso
+                                                    Peek(5) = "A"c AndAlso
+                                                    Peek(6) = "T"c AndAlso
+                                                    Peek(7) = "A"c AndAlso
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(leadingTrivia)
                                                 End If
                                         End Select
                                     End If
                                     Return XmlLessThanExclamationToken(state, leadingTrivia)
                                 Case "%"c
-                                    If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                    If CanGet(2) AndAlso
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(leadingTrivia)
                                     End If
@@ -164,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "?"c
 
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">"c Then
+                        If CanGet(1) AndAlso Peek(1) = ">"c Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(leadingTrivia)
                         End If
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim token As SyntaxToken
             Dim possibleStatement As Boolean = False
             Dim offsets = CreateOffsetRestorePoint()
-            Dim c As Char = PeekChar()
+            Dim c As Char = Peek()
 
             Select Case c
                 Case "#"c,
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     If name IsNot Nothing AndAlso Not name.IsMissing Then
                         If name.PossibleKeywordKind <> SyntaxKind.XmlNameToken Then
                             leadingTrivia = ScanSingleLineTrivia()
-                            c = PeekChar()
+                            c = Peek()
                             possibleStatement =
                                 c = "("c OrElse c = FULLWIDTH_LEFT_PARENTHESIS
                         End If
@@ -320,7 +320,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim IsAllWhitespace As Boolean = True
             ' lets do an unusual peek-behind to make sure we are not restarting after a non-Ws char.
             If _lineBufferOffset > 0 Then
-                Dim prevChar = PeekAheadChar(-1)
+                Dim prevChar = Peek(-1)
                 If prevChar <> ">"c AndAlso Not XmlCharType.IsWhiteSpace(prevChar) Then
                     IsAllWhitespace = False
                 End If
@@ -328,8 +328,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim scratch = GetScratch()
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -356,47 +356,47 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                             Else
                                 scratch.Clear() ' will not use this
                                 Here = 0        ' consumed chars. 
-                                precedingTrivia = ScanXmlTrivia(PeekChar)
+                                precedingTrivia = ScanXmlTrivia(Peek)
                             End If
                         End If
 
                         Debug.Assert(Here = 0)
-                        If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                        If CanGet(1) Then
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                    If CanGet(2) Then
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGetCharAtOffset(8) AndAlso _
-                                                    PeekAheadChar(3) = "C"c AndAlso _
-                                                    PeekAheadChar(4) = "D"c AndAlso _
-                                                    PeekAheadChar(5) = "A"c AndAlso _
-                                                    PeekAheadChar(6) = "T"c AndAlso _
-                                                    PeekAheadChar(7) = "A"c AndAlso _
-                                                    PeekAheadChar(8) = "["c Then
+                                                If CanGet(8) AndAlso _
+                                                    Peek(3) = "C"c AndAlso _
+                                                    Peek(4) = "D"c AndAlso _
+                                                    Peek(5) = "A"c AndAlso _
+                                                    Peek(6) = "T"c AndAlso _
+                                                    Peek(7) = "A"c AndAlso _
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
                                     End If
                                 Case "%"c
-                                    If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                    If CanGet(2) AndAlso
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
@@ -410,9 +410,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                        If CanGet(Here + 2) AndAlso _
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -528,16 +528,16 @@ ScanChars:
             End If
 
             Dim Here = 0
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
                         Return XmlMakeCommentToken(precedingTrivia, Here + LengthOfLineBreak(c, Here))
 
                     Case "-"c
-                        If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = "-"c Then
+                        If CanGet(Here + 1) AndAlso _
+                           Peek(Here + 1) = "-"c Then
 
                             ' // --> terminates an Xml comment but otherwise -- is an illegal character sequence.
                             ' // The scanner will always returns "--" as a separate comment data string and the
@@ -548,9 +548,9 @@ ScanChars:
                                 Return XmlMakeCommentToken(precedingTrivia, Here)
                             End If
 
-                            If CanGetCharAtOffset(Here + 2) Then
+                            If CanGet(Here + 2) Then
 
-                                c = PeekAheadChar(Here + 2)
+                                c = Peek(Here + 2)
                                 Here += 2
                                 ' // if > is not found then this is an error.  Return the -- string
 
@@ -621,8 +621,8 @@ ScanChars:
             Dim scratch = GetScratch()
             Dim Here = 0
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -631,9 +631,9 @@ ScanChars:
                         Return XmlMakeCDataToken(precedingTrivia, Here, scratch)
 
                     Case "]"c
-                        If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                        If CanGet(Here + 2) AndAlso _
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -690,7 +690,7 @@ ScanChars:
             If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
-                Dim c = PeekChar()
+                Dim c = Peek()
                 Select Case c
                     Case CARRIAGE_RETURN, LINE_FEED, " "c, CHARACTER_TABULATION
                         Dim wsTrivia = ScanXmlTrivia(c)
@@ -699,8 +699,8 @@ ScanChars:
             End If
 
             Dim Here = 0
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -708,8 +708,8 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = ">"c Then
+                        If CanGet(Here + 1) AndAlso _
+                           Peek(Here + 1) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -761,7 +761,7 @@ CleanUp:
 
             Dim precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode) = Nothing
             While CanGetChar()
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -772,28 +772,28 @@ CleanUp:
                         precedingTrivia = ScanXmlTrivia(c)
 
                     Case "<"c
-                        If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                        If CanGet(1) Then
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGetCharAtOffset(3) AndAlso
-                                        PeekAheadChar(2) = "-"c AndAlso
-                                        PeekAheadChar(3) = "-"c Then
+                                    If CanGet(3) AndAlso
+                                        Peek(2) = "-"c AndAlso
+                                        Peek(3) = "-"c Then
 
                                         Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
-                                    ElseIf CanGetCharAtOffset(8) AndAlso
-                                            PeekAheadChar(2) = "D"c AndAlso
-                                            PeekAheadChar(3) = "O"c AndAlso
-                                            PeekAheadChar(4) = "C"c AndAlso
-                                            PeekAheadChar(5) = "T"c AndAlso
-                                            PeekAheadChar(6) = "Y"c AndAlso
-                                            PeekAheadChar(7) = "P"c AndAlso
-                                            PeekAheadChar(8) = "E"c Then
+                                    ElseIf CanGet(8) AndAlso
+                                            Peek(2) = "D"c AndAlso
+                                            Peek(3) = "O"c AndAlso
+                                            Peek(4) = "C"c AndAlso
+                                            Peek(5) = "T"c AndAlso
+                                            Peek(6) = "Y"c AndAlso
+                                            Peek(7) = "P"c AndAlso
+                                            Peek(8) = "E"c Then
                                         Return XmlMakeBeginDTDToken(precedingTrivia)
                                     End If
                                 Case "%"c
-                                    If CanGetCharAtOffset(2) AndAlso
-                                        PeekAheadChar(2) = "=" Then
+                                    If CanGet(2) AndAlso
+                                        Peek(2) = "=" Then
 
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
@@ -848,8 +848,8 @@ CleanUp:
             Dim Here = 0
             Dim scratch = GetScratch()
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
 
@@ -876,7 +876,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGetCharAtOffset(Here + 1) AndAlso PeekAheadChar(Here + 1) = ">"c Then
+                        If CanGet(Here + 1) AndAlso Peek(Here + 1) = ">"c Then
                             If Here <> 0 Then
                                 Return XmlMakeAttributeDataToken(Nothing, Here, scratch)
                             Else
@@ -941,8 +941,8 @@ ScanChars:
             Dim Here = 0
             Dim scratch = GetScratch()
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
                 If c = terminatingChar Or c = altTerminatingChar Then
                     If Here > 0 Then
                         result = XmlMakeAttributeDataToken(precedingTrivia, Here, scratch)
@@ -975,9 +975,9 @@ ScanChars:
                             GoTo CleanUp
                         Else
                             ' report unexpected <%= in a special way.
-                            If CanGetCharAtOffset(2) AndAlso
-                                PeekAheadChar(1) = "%"c AndAlso
-                                PeekAheadChar(2) = "=" Then
+                            If CanGet(2) AndAlso
+                                Peek(1) = "%"c AndAlso
+                                Peek(2) = "=" Then
 
                                 Dim errEmbedStart = XmlMakeAttributeDataToken(precedingTrivia, 3, "<%=")
                                 Dim errEmberinfo = ErrorFactory.ErrorInfo(ERRID.ERR_QuotedEmbeddedExpression)
@@ -1044,11 +1044,11 @@ CleanUp:
         ''' </summary>
         Private Function ScanSurrogatePair(c1 As Char, Here As Integer) As XmlCharResult
             Debug.Assert(Here >= 0)
-            Debug.Assert(CanGetCharAtOffset(Here))
-            Debug.Assert(PeekAheadChar(Here) = c1)
+            Debug.Assert(CanGet(Here))
+            Debug.Assert(Peek(Here) = c1)
 
-            If IsHighSurrogate(c1) AndAlso CanGetCharAtOffset(Here + 1) Then
-                Dim c2 = PeekAheadChar(Here + 1)
+            If IsHighSurrogate(c1) AndAlso CanGet(Here + 1) Then
+                Dim c2 = Peek(Here + 1)
 
                 If IsLowSurrogate(c2) Then
                     Return New XmlCharResult(c1, c2)
@@ -1088,9 +1088,9 @@ CleanUp:
 
         Private Function ScanXmlChar(Here As Integer) As XmlCharResult
             Debug.Assert(Here >= 0)
-            Debug.Assert(CanGetCharAtOffset(Here))
+            Debug.Assert(CanGet(Here))
 
-            Dim c = PeekAheadChar(Here)
+            Dim c = Peek(Here)
 
             If Not isValidUtf16(c) Then
                 Return Nothing
@@ -1121,8 +1121,8 @@ CleanUp:
 
             'TODO - Fix ScanXmlNCName to conform to XML spec instead of old loose scanning.
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
 
@@ -1199,11 +1199,11 @@ CreateNCNameToken:
 
         Private Function ScanXmlReference(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As XmlTextTokenSyntax
             Debug.Assert(CanGetChar)
-            Debug.Assert(PeekChar() = "&"c)
+            Debug.Assert(Peek() = "&"c)
 
             ' skip 1 char for "&"
-            If CanGetCharAtOffset(1) Then
-                Dim c As Char = PeekAheadChar(1)
+            If CanGet(1) Then
+                Dim c As Char = Peek(1)
 
                 Select Case (c)
                     Case "#"c
@@ -1218,7 +1218,7 @@ CreateNCNameToken:
                                 value = Intern({result.Char1, result.Char2})
                             End If
 
-                            If CanGetCharAtOffset(Here) AndAlso PeekAheadChar(Here) = ";"c Then
+                            If CanGet(Here) AndAlso Peek(Here) = ";"c Then
                                 Return XmlMakeEntityLiteralToken(precedingTrivia, Here + 1, value)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, Here, value)
@@ -1231,11 +1231,11 @@ CreateNCNameToken:
                         ' // &amp;
                         ' // &apos;
 
-                        If CanGetCharAtOffset(4) AndAlso
-                           PeekAheadChar(2) = "m"c AndAlso
-                           PeekAheadChar(3) = "p"c Then
+                        If CanGet(4) AndAlso
+                           Peek(2) = "m"c AndAlso
+                           Peek(3) = "p"c Then
 
-                            If PeekAheadChar(4) = ";"c Then
+                            If Peek(4) = ";"c Then
                                 Return XmlMakeAmpLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 4, "&")
@@ -1243,12 +1243,12 @@ CreateNCNameToken:
                                 Return DirectCast(noSemicolon.SetDiagnostics({noSemicolonError}), XmlTextTokenSyntax)
                             End If
 
-                        ElseIf CanGetCharAtOffset(5) AndAlso
-                               PeekAheadChar(2) = "p"c AndAlso
-                               PeekAheadChar(3) = "o"c AndAlso
-                               PeekAheadChar(4) = "s"c Then
+                        ElseIf CanGet(5) AndAlso
+                               Peek(2) = "p"c AndAlso
+                               Peek(3) = "o"c AndAlso
+                               Peek(4) = "s"c Then
 
-                            If PeekAheadChar(5) = ";"c Then
+                            If Peek(5) = ";"c Then
                                 Return XmlMakeAposLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 5, "'")
@@ -1260,10 +1260,10 @@ CreateNCNameToken:
                     Case "l"c
                         ' // &lt;
 
-                        If CanGetCharAtOffset(3) AndAlso
-                           PeekAheadChar(2) = "t"c Then
+                        If CanGet(3) AndAlso
+                           Peek(2) = "t"c Then
 
-                            If PeekAheadChar(3) = ";"c Then
+                            If Peek(3) = ";"c Then
                                 Return XmlMakeLtLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 3, "<")
@@ -1275,10 +1275,10 @@ CreateNCNameToken:
                     Case "g"c
                         ' // &gt;
 
-                        If CanGetCharAtOffset(3) AndAlso
-                           PeekAheadChar(2) = "t"c Then
+                        If CanGet(3) AndAlso
+                           Peek(2) = "t"c Then
 
-                            If PeekAheadChar(3) = ";"c Then
+                            If Peek(3) = ";"c Then
                                 Return XmlMakeGtLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 3, ">")
@@ -1290,12 +1290,12 @@ CreateNCNameToken:
                     Case "q"c
                         ' // &quot;
 
-                        If CanGetCharAtOffset(5) AndAlso
-                           PeekAheadChar(2) = "u"c AndAlso
-                           PeekAheadChar(3) = "o"c AndAlso
-                           PeekAheadChar(4) = "t"c Then
+                        If CanGet(5) AndAlso
+                           Peek(2) = "u"c AndAlso
+                           Peek(3) = "o"c AndAlso
+                           Peek(4) = "t"c Then
 
-                            If PeekAheadChar(5) = ";"c Then
+                            If Peek(5) = ";"c Then
                                 Return XmlMakeQuotLiteralToken(precedingTrivia)
                             Else
                                 Dim noSemicolon = XmlMakeEntityLiteralToken(precedingTrivia, 5, """")
@@ -1316,7 +1316,7 @@ CreateNCNameToken:
         Private Function ScanXmlCharRef(ByRef index As Integer) As XmlCharResult
             Debug.Assert(index >= 0)
 
-            If Not CanGetCharAtOffset(index) Then
+            If Not CanGet(index) Then
                 Return Nothing
             End If
 
@@ -1324,12 +1324,12 @@ CreateNCNameToken:
             Dim charRefSb As New StringBuilder
             Dim Here = index
 
-            Dim ch = PeekAheadChar(Here)
+            Dim ch = Peek(Here)
             If ch = "x"c Then
                 Here += 1
 
-                While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
+                While CanGet(Here)
+                    ch = Peek(Here)
                     If XmlCharType.IsHexDigit(ch) Then
                         charRefSb.Append(ch)
                     Else
@@ -1345,8 +1345,8 @@ CreateNCNameToken:
                     Return result
                 End If
             Else
-                While CanGetCharAtOffset(Here)
-                    ch = PeekAheadChar(Here)
+                While CanGet(Here)
+                    ch = Peek(Here)
                     If XmlCharType.IsDigit(ch) Then
                         charRefSb.Append(ch)
                     Else

--- a/src/Compilers/VisualBasic/Portable/Scanner/TokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/TokenFactories.vb
@@ -448,7 +448,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function MakeColonToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), charIsFullWidth As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = If(charIsFullWidth, FULLWIDTH_COLON, ":"c))
+            Debug.Assert(Peek() = If(charIsFullWidth, FULLWIDTH_COLON, ":"c))
             Debug.Assert(Not precedingTrivia.Any())
 
             Dim width = _endOfTerminatorTrivia - _lineBufferOffset

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine)
 
             ' leading whitespace until we see ''' should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
+            If CanGet() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If
@@ -385,7 +385,7 @@ ScanChars:
                 precedingTrivia.Add(xDocTrivia)
             End If
 
-            If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
+            If state = ScannerState.StartProcessingInstruction AndAlso CanGet() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
                 Dim c = Peek()
@@ -477,7 +477,7 @@ CleanUp:
                 precedingTrivia = New SyntaxList(Of VisualBasicSyntaxNode)(xDocTrivia)
             End If
 
-            While CanGetChar()
+            While CanGet()
                 If Not precedingTrivia.Any AndAlso IsAtNewLine() AndAlso Not Me._doNotRequireXmlDocCommentPrefix Then
                     ' this would indicate that we looked at Trivia, but did not find
                     ' XmlDoc prefix (or we would not be at the line start)

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -289,28 +289,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
+                                                If NextIs(3,"-"c) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGet(8) AndAlso _
-                                                    Peek(3) = "C"c AndAlso _
-                                                    Peek(4) = "D"c AndAlso _
-                                                    Peek(5) = "A"c AndAlso _
-                                                    Peek(6) = "T"c AndAlso _
-                                                    Peek(7) = "A"c AndAlso _
-                                                    Peek(8) = "["c Then
-
+                                                If NextAre(3,"CDATA[") Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "O"c AndAlso
-                                                    Peek(4) = "C"c AndAlso
-                                                    Peek(5) = "T"c AndAlso
-                                                    Peek(6) = "Y"c AndAlso
-                                                    Peek(7) = "P"c AndAlso
-                                                    Peek(8) = "E"c Then
+                                                If  NextAre(3,"OCTYPE") Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -325,9 +312,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If CanGet(Here + 2) AndAlso _
-                           Peek(Here + 1) = "]"c AndAlso _
-                           Peek(Here + 2) = ">"c Then
+                        If NextAre(Here + 2,"]>") Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -411,8 +396,7 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If CanGet(Here + 1) AndAlso _
-                           Peek(Here + 1) = ">"c Then
+                        If NextIs(Here + 1,">"c) Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -504,7 +488,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGet(1) AndAlso Peek(1) = ">" Then
+                        If NextIs(1,">"c) Then
                             Return XmlMakeEndEmptyElementToken(precedingTrivia)
                         End If
                         Return XmlMakeDivToken(precedingTrivia)
@@ -529,28 +513,15 @@ CleanUp:
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
+                                                If NextIs(3,"-"c) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "C"c AndAlso
-                                                    Peek(4) = "D"c AndAlso
-                                                    Peek(5) = "A"c AndAlso
-                                                    Peek(6) = "T"c AndAlso
-                                                    Peek(7) = "A"c AndAlso
-                                                    Peek(8) = "["c Then
-
+                                                If NextAre(3,"CDATA[") Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGet(8) AndAlso
-                                                    Peek(3) = "O"c AndAlso
-                                                    Peek(4) = "C"c AndAlso
-                                                    Peek(5) = "T"c AndAlso
-                                                    Peek(6) = "Y"c AndAlso
-                                                    Peek(7) = "P"c AndAlso
-                                                    Peek(8) = "E"c Then
+                                                If NextAre(3,"OCTYPE") Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -566,7 +537,7 @@ CleanUp:
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "?"c
-                        If CanGet(1) AndAlso Peek(1) = ">"c Then
+                        If NextIs(1, ">"c) Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(precedingTrivia)
                         End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Debug.Assert(IsAtNewLine)
 
             ' leading whitespace until we see ''' should be regular whitespace
-            If CanGetChar() AndAlso IsWhitespace(PeekChar()) Then
+            If CanGetChar() AndAlso IsWhitespace(Peek()) Then
                 Dim ws = ScanWhitespace()
                 tList.Add(ws)
             End If
@@ -148,8 +148,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' lexes (ws)'''
         Private Function TrySkipXmlDocMarker(ByRef len As Integer) As Boolean
             Dim Here = len
-            While CanGetCharAtOffset(Here)
-                Dim c = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c = Peek(Here)
                 If IsWhitespace(c) Then
                     Here += 1
                 Else
@@ -212,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Exit Do
                 End If
 
-                c = PeekAheadChar(len)
+                c = Peek(len)
             Loop
 
             If len > 0 Then
@@ -241,8 +241,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim Here As Integer = 0
             Dim scratch = GetScratch()
 
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
 
                 Select Case (c)
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -282,35 +282,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         End If
 
                         Debug.Assert(Here = 0)
-                        If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                        If CanGet(1) Then
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                    If CanGet(2) Then
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGetCharAtOffset(8) AndAlso _
-                                                    PeekAheadChar(3) = "C"c AndAlso _
-                                                    PeekAheadChar(4) = "D"c AndAlso _
-                                                    PeekAheadChar(5) = "A"c AndAlso _
-                                                    PeekAheadChar(6) = "T"c AndAlso _
-                                                    PeekAheadChar(7) = "A"c AndAlso _
-                                                    PeekAheadChar(8) = "["c Then
+                                                If CanGet(8) AndAlso _
+                                                    Peek(3) = "C"c AndAlso _
+                                                    Peek(4) = "D"c AndAlso _
+                                                    Peek(5) = "A"c AndAlso _
+                                                    Peek(6) = "T"c AndAlso _
+                                                    Peek(7) = "A"c AndAlso _
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -325,9 +325,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If CanGetCharAtOffset(Here + 2) AndAlso _
-                           PeekAheadChar(Here + 1) = "]"c AndAlso _
-                           PeekAheadChar(Here + 2) = ">"c Then
+                        If CanGet(Here + 2) AndAlso _
+                           Peek(Here + 1) = "]"c AndAlso _
+                           Peek(Here + 2) = ">"c Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -388,7 +388,7 @@ ScanChars:
             If state = ScannerState.StartProcessingInstruction AndAlso CanGetChar() Then
                 ' // Whitespace
                 ' //  S    ::=    (#x20 | #x9 | #xD | #xA)+
-                Dim c = PeekChar()
+                Dim c = Peek()
                 Select Case c
                     Case CARRIAGE_RETURN, LINE_FEED, " "c, CHARACTER_TABULATION
                         Dim offsets = CreateOffsetRestorePoint()
@@ -402,8 +402,8 @@ ScanChars:
             End If
 
             Dim Here = 0
-            While CanGetCharAtOffset(Here)
-                Dim c As Char = PeekAheadChar(Here)
+            While CanGet(Here)
+                Dim c As Char = Peek(Here)
                 Select Case (c)
 
                     Case CARRIAGE_RETURN, LINE_FEED
@@ -411,8 +411,8 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If CanGetCharAtOffset(Here + 1) AndAlso _
-                           PeekAheadChar(Here + 1) = ">"c Then
+                        If CanGet(Here + 1) AndAlso _
+                           Peek(Here + 1) = ">"c Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -485,7 +485,7 @@ CleanUp:
                     Return MakeEofToken(precedingTrivia)
                 End If
 
-                Dim c As Char = PeekChar()
+                Dim c As Char = Peek()
 
                 Select Case (c)
                     ' // Whitespace
@@ -504,7 +504,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">" Then
+                        If CanGet(1) AndAlso Peek(1) = ">" Then
                             Return XmlMakeEndEmptyElementToken(precedingTrivia)
                         End If
                         Return XmlMakeDivToken(precedingTrivia)
@@ -522,35 +522,35 @@ CleanUp:
                         Return XmlMakeDoubleQuoteToken(precedingTrivia, c, isOpening:=True)
 
                     Case "<"c
-                        If CanGetCharAtOffset(1) Then
-                            Dim ch As Char = PeekAheadChar(1)
+                        If CanGet(1) Then
+                            Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If CanGetCharAtOffset(2) Then
-                                        Select Case (PeekAheadChar(2))
+                                    If CanGet(2) Then
+                                        Select Case (Peek(2))
                                             Case "-"c
-                                                If CanGetCharAtOffset(3) AndAlso PeekAheadChar(3) = "-"c Then
+                                                If CanGet(3) AndAlso Peek(3) = "-"c Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "C"c AndAlso
-                                                    PeekAheadChar(4) = "D"c AndAlso
-                                                    PeekAheadChar(5) = "A"c AndAlso
-                                                    PeekAheadChar(6) = "T"c AndAlso
-                                                    PeekAheadChar(7) = "A"c AndAlso
-                                                    PeekAheadChar(8) = "["c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "C"c AndAlso
+                                                    Peek(4) = "D"c AndAlso
+                                                    Peek(5) = "A"c AndAlso
+                                                    Peek(6) = "T"c AndAlso
+                                                    Peek(7) = "A"c AndAlso
+                                                    Peek(8) = "["c Then
 
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If CanGetCharAtOffset(8) AndAlso
-                                                    PeekAheadChar(3) = "O"c AndAlso
-                                                    PeekAheadChar(4) = "C"c AndAlso
-                                                    PeekAheadChar(5) = "T"c AndAlso
-                                                    PeekAheadChar(6) = "Y"c AndAlso
-                                                    PeekAheadChar(7) = "P"c AndAlso
-                                                    PeekAheadChar(8) = "E"c Then
+                                                If CanGet(8) AndAlso
+                                                    Peek(3) = "O"c AndAlso
+                                                    Peek(4) = "C"c AndAlso
+                                                    Peek(5) = "T"c AndAlso
+                                                    Peek(6) = "Y"c AndAlso
+                                                    Peek(7) = "P"c AndAlso
+                                                    Peek(8) = "E"c Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -566,7 +566,7 @@ CleanUp:
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "?"c
-                        If CanGetCharAtOffset(1) AndAlso PeekAheadChar(1) = ">"c Then
+                        If CanGet(1) AndAlso Peek(1) = ">"c Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(precedingTrivia)
                         End If

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -312,7 +312,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If NextAre(Here + 2,"]>") Then
+                        If NextAre(Here + 1, "]>") Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function XmlMakeSingleQuoteToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode),
                                                  spelling As Char,
                                                  isOpening As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = spelling)
+            Debug.Assert(Peek() = spelling)
 
             AdvanceChar()
 
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function XmlMakeDoubleQuoteToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode),
                                                  spelling As Char,
                                                  isOpening As Boolean) As PunctuationSyntax
-            Debug.Assert(PeekChar() = spelling)
+            Debug.Assert(Peek() = spelling)
 
             AdvanceChar()
 
@@ -297,8 +297,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeBeginEndElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "/"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "/"c)
 
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
@@ -306,8 +306,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndEmptyElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "/"c)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "/"c)
+            Debug.Assert(Peek(1) = ">"c)
 
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.SlashGreaterThanToken, "/>", precedingTrivia, Nothing)
@@ -315,20 +315,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "EmbeddedToken"
         Private Function XmlMakeBeginEmbeddedToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "%"c)
-            Debug.Assert(PeekAheadChar(2) = "="c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "%"c)
+            Debug.Assert(Peek(2) = "="c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.LessThanPercentEqualsToken, "<%=", precedingTrivia, Nothing)
         End Function
 
         Private Function XmlMakeEndEmbeddedToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "%"c OrElse PeekChar() = FULLWIDTH_PERCENT_SIGN)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "%"c OrElse Peek() = FULLWIDTH_PERCENT_SIGN)
+            Debug.Assert(Peek(1) = ">"c)
 
             Dim spelling As String
-            If PeekChar() = "%"c Then
+            If Peek() = "%"c Then
                 AdvanceChar(2)
                 spelling = "%>"
             Else
@@ -343,34 +343,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "DTD"
         Private Function XmlMakeBeginDTDToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "D"c)
-            Debug.Assert(PeekAheadChar(3) = "O"c)
-            Debug.Assert(PeekAheadChar(4) = "C"c)
-            Debug.Assert(PeekAheadChar(5) = "T"c)
-            Debug.Assert(PeekAheadChar(6) = "Y"c)
-            Debug.Assert(PeekAheadChar(7) = "P"c)
-            Debug.Assert(PeekAheadChar(8) = "E"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "D"c)
+            Debug.Assert(Peek(3) = "O"c)
+            Debug.Assert(Peek(4) = "C"c)
+            Debug.Assert(Peek(5) = "T"c)
+            Debug.Assert(Peek(6) = "Y"c)
+            Debug.Assert(Peek(7) = "P"c)
+            Debug.Assert(Peek(8) = "E"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.BeginDocTypeToken, precedingTrivia, 9, ERRID.ERR_DTDNotSupported)
         End Function
 
         Private Function XmlLessThanExclamationToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.LessThanExclamationToken, precedingTrivia, 2, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_Syntax))
         End Function
 
         Private Function XmlMakeOpenBracketToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "["c)
+            Debug.Assert(Peek() = "["c)
 
             Return XmlMakeBadToken(SyntaxSubKind.OpenBracketToken, precedingTrivia, 1, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_IllegalXmlNameChar))
         End Function
 
         Private Function XmlMakeCloseBracketToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(PeekChar() = "]"c)
+            Debug.Assert(Peek() = "]"c)
 
             Return XmlMakeBadToken(SyntaxSubKind.CloseBracketToken, precedingTrivia, 1, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_IllegalXmlNameChar))
         End Function
@@ -379,8 +379,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "ProcessingInstruction"
 
         Private Function XmlMakeBeginProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "?"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "?"c)
 
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
@@ -397,8 +397,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "?"c)
-            Debug.Assert(PeekAheadChar(1) = ">"c)
+            Debug.Assert(Peek() = "?"c)
+            Debug.Assert(Peek(1) = ">"c)
 
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.QuestionGreaterThanToken, "?>", precedingTrivia, Nothing)
@@ -408,10 +408,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "Comment"
 
         Private Function XmlMakeBeginCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "-"c)
-            Debug.Assert(PeekAheadChar(3) = "-"c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "-"c)
+            Debug.Assert(Peek(3) = "-"c)
 
             AdvanceChar(4)
             Dim followingTrivia = scanTrailingTrivia()
@@ -428,9 +428,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "-"c)
-            Debug.Assert(PeekAheadChar(1) = "-"c)
-            Debug.Assert(PeekAheadChar(2) = ">"c)
+            Debug.Assert(Peek() = "-"c)
+            Debug.Assert(Peek(1) = "-"c)
+            Debug.Assert(Peek(2) = ">"c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.MinusMinusGreaterThanToken, "-->", precedingTrivia, Nothing)
@@ -440,15 +440,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "CData"
         Private Function XmlMakeBeginCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "<"c)
-            Debug.Assert(PeekAheadChar(1) = "!"c)
-            Debug.Assert(PeekAheadChar(2) = "["c)
-            Debug.Assert(PeekAheadChar(3) = "C"c)
-            Debug.Assert(PeekAheadChar(4) = "D"c)
-            Debug.Assert(PeekAheadChar(5) = "A"c)
-            Debug.Assert(PeekAheadChar(6) = "T"c)
-            Debug.Assert(PeekAheadChar(7) = "A"c)
-            Debug.Assert(PeekAheadChar(8) = "["c)
+            Debug.Assert(Peek() = "<"c)
+            Debug.Assert(Peek(1) = "!"c)
+            Debug.Assert(Peek(2) = "["c)
+            Debug.Assert(Peek(3) = "C"c)
+            Debug.Assert(Peek(4) = "D"c)
+            Debug.Assert(Peek(5) = "A"c)
+            Debug.Assert(Peek(6) = "T"c)
+            Debug.Assert(Peek(7) = "A"c)
+            Debug.Assert(Peek(8) = "["c)
 
             AdvanceChar(9)
             Dim followingTrivia = scanTrailingTrivia()
@@ -460,9 +460,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(PeekChar() = "]"c)
-            Debug.Assert(PeekAheadChar(1) = "]"c)
-            Debug.Assert(PeekAheadChar(2) = ">"c)
+            Debug.Assert(Peek() = "]"c)
+            Debug.Assert(Peek(1) = "]"c)
+            Debug.Assert(Peek(2) = ">"c)
 
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.EndCDataToken, "]]>", precedingTrivia, Nothing)

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
@@ -297,8 +297,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeBeginEndElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "/"c)
+            Debug.Assert(NextAre("</"))
 
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
@@ -306,8 +305,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndEmptyElementToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(Peek() = "/"c)
-            Debug.Assert(Peek(1) = ">"c)
+            Debug.Assert(NextAre("/>"))
 
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.SlashGreaterThanToken, "/>", precedingTrivia, Nothing)
@@ -315,10 +313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "EmbeddedToken"
         Private Function XmlMakeBeginEmbeddedToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "%"c)
-            Debug.Assert(Peek(2) = "="c)
-
+            Debug.Assert(NextAre("<%="))
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.LessThanPercentEqualsToken, "<%=", precedingTrivia, Nothing)
         End Function
@@ -343,29 +338,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "DTD"
         Private Function XmlMakeBeginDTDToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "!"c)
-            Debug.Assert(Peek(2) = "D"c)
-            Debug.Assert(Peek(3) = "O"c)
-            Debug.Assert(Peek(4) = "C"c)
-            Debug.Assert(Peek(5) = "T"c)
-            Debug.Assert(Peek(6) = "Y"c)
-            Debug.Assert(Peek(7) = "P"c)
-            Debug.Assert(Peek(8) = "E"c)
-
+            Debug.Assert(NextAre("<!DOCTYPE"))
             Return XmlMakeBadToken(SyntaxSubKind.BeginDocTypeToken, precedingTrivia, 9, ERRID.ERR_DTDNotSupported)
         End Function
 
         Private Function XmlLessThanExclamationToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "!"c)
-
+            Debug.Assert(NextAre("<!"))
             Return XmlMakeBadToken(SyntaxSubKind.LessThanExclamationToken, precedingTrivia, 2, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_Syntax))
         End Function
 
         Private Function XmlMakeOpenBracketToken(state As ScannerState, precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As BadTokenSyntax
             Debug.Assert(Peek() = "["c)
-
             Return XmlMakeBadToken(SyntaxSubKind.OpenBracketToken, precedingTrivia, 1, If(state = ScannerState.DocType, ERRID.ERR_DTDNotSupported, ERRID.ERR_IllegalXmlNameChar))
         End Function
 
@@ -379,9 +362,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "ProcessingInstruction"
 
         Private Function XmlMakeBeginProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "?"c)
-
+            Debug.Assert(NextAre("<?"))
             AdvanceChar(2)
             Dim followingTrivia = scanTrailingTrivia()
             Return MakePunctuationToken(SyntaxKind.LessThanQuestionToken, "<?", precedingTrivia, followingTrivia)
@@ -397,9 +378,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndProcessingInstructionToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(Peek() = "?"c)
-            Debug.Assert(Peek(1) = ">"c)
-
+            Debug.Assert(NextAre("?>"))
             AdvanceChar(2)
             Return MakePunctuationToken(SyntaxKind.QuestionGreaterThanToken, "?>", precedingTrivia, Nothing)
         End Function
@@ -408,11 +387,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 #Region "Comment"
 
         Private Function XmlMakeBeginCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "!"c)
-            Debug.Assert(Peek(2) = "-"c)
-            Debug.Assert(Peek(3) = "-"c)
-
+            Debug.Assert(NextAre("<!--"))
             AdvanceChar(4)
             Dim followingTrivia = scanTrailingTrivia()
             Return MakePunctuationToken(SyntaxKind.LessThanExclamationMinusMinusToken, "<!--", precedingTrivia, followingTrivia)
@@ -428,10 +403,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCommentToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(Peek() = "-"c)
-            Debug.Assert(Peek(1) = "-"c)
-            Debug.Assert(Peek(2) = ">"c)
-
+            Debug.Assert(NextAre("-->"))
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.MinusMinusGreaterThanToken, "-->", precedingTrivia, Nothing)
         End Function
@@ -440,16 +412,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 #Region "CData"
         Private Function XmlMakeBeginCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode), scanTrailingTrivia As ScanTriviaFunc) As PunctuationSyntax
-            Debug.Assert(Peek() = "<"c)
-            Debug.Assert(Peek(1) = "!"c)
-            Debug.Assert(Peek(2) = "["c)
-            Debug.Assert(Peek(3) = "C"c)
-            Debug.Assert(Peek(4) = "D"c)
-            Debug.Assert(Peek(5) = "A"c)
-            Debug.Assert(Peek(6) = "T"c)
-            Debug.Assert(Peek(7) = "A"c)
-            Debug.Assert(Peek(8) = "["c)
-
+            Debug.Assert(NextAre("<![CDATA["))
+ 
             AdvanceChar(9)
             Dim followingTrivia = scanTrailingTrivia()
             Return MakePunctuationToken(SyntaxKind.BeginCDataToken, "<![CDATA[", precedingTrivia, followingTrivia)
@@ -460,10 +424,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function XmlMakeEndCDataToken(precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode)) As PunctuationSyntax
-            Debug.Assert(Peek() = "]"c)
-            Debug.Assert(Peek(1) = "]"c)
-            Debug.Assert(Peek(2) = ">"c)
-
+            Debug.Assert(NextAre("]]>"))
             AdvanceChar(3)
             Return MakePunctuationToken(SyntaxKind.EndCDataToken, "]]>", precedingTrivia, Nothing)
         End Function


### PR DESCRIPTION
Rename commonly used method to a shorter version. To aid in source code.readability.

Previously | New Name
------------ | -------------
CanGetCharAtOffset | CanGet
PeekAheadChar | Peek
PeakChar | Peek


No formatting changes.