### PR TITLE
Add a fallback for when the build task client is GAC'd.

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -313,7 +313,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         CurrentDirectoryToUse(),
                         GetArguments(commandLineCommands, responseFileCommands),
                         _sharedCompileCts.Token,
-                        libEnvVariable: LibDirectoryToUse());
+                        libEnvVariable: LibDirectoryToUse(),
+                        fallbackCompilerExeDir: Path.GetDirectoryName(pathToTool));
 
                     responseTask.Wait(_sharedCompileCts.Token);
 


### PR DESCRIPTION
Normally, the build client for the compiler server looks for the server
in the same directory as itself (the running executable), however when
the client is inside the build task, the task may be GAC'd and thus the
server may be nowhere near by.

If so, we should fallback to the location MSBuild found the client exe
in (usually the default MSBuild directory), and otherwise give up if
we aren't given a fallback path.

@pharring @jaredpar @gafter @AlekseyTs @VSadov @VladimirReshetnikov 