### PR TITLE
Don't trigger completion on space next to words

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1453,5 +1453,37 @@ class C
                 state.AssertNoCompletionSession()
             End Using
         End Sub
+
+        <WorkItem(1594, "https://github.com/dotnet/roslyn/issues/1594")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NoPreselectionOnSpaceWhenAbuttingWord()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class Program
+{
+    void Main()
+    {
+        Program p = new $$Program();
+    }
+}]]></Document>)
+                state.SendTypeChars(" ")
+                state.AssertNoCompletionSession()
+            End Using
+        End Sub
+
+        <WorkItem(1594, "https://github.com/dotnet/roslyn/issues/1594")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub SpacePreselectionAtEndOfFile()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class Program
+{
+    void Main()
+    {
+        Program p = new $$]]></Document>)
+                state.SendTypeChars(" ")
+                state.AssertCompletionSession()
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Features/CSharp/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/CompletionUtilities.cs
@@ -81,11 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             // Bring up on space or at the start of a word.
             var ch = text[characterPosition];
-            return SpaceTypedNotAdjacentToWord(ch, text, characterPosition) ||
+            return SpaceTypedNotBeforeWord(ch, text, characterPosition) ||
                 (CompletionUtilities.IsStartingNewWord(text, characterPosition) && options.GetOption(CompletionOptions.TriggerOnTypingLetters, LanguageNames.CSharp));
         }
 
-        private static bool SpaceTypedNotAdjacentToWord(char ch, SourceText text, int characterPosition)
+        private static bool SpaceTypedNotBeforeWord(char ch, SourceText text, int characterPosition)
         {
             return ch == ' ' && (characterPosition == text.Length - 1 || !IsWordStartCharacter(text[characterPosition + 1]));
         }

--- a/src/Features/CSharp/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/CompletionUtilities.cs
@@ -81,7 +81,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             // Bring up on space or at the start of a word.
             var ch = text[characterPosition];
-            return ch == ' ' || (CompletionUtilities.IsStartingNewWord(text, characterPosition) && options.GetOption(CompletionOptions.TriggerOnTypingLetters, LanguageNames.CSharp));
+            return SpaceTypedNotAdjacentToWord(ch, text, characterPosition) ||
+                (CompletionUtilities.IsStartingNewWord(text, characterPosition) && options.GetOption(CompletionOptions.TriggerOnTypingLetters, LanguageNames.CSharp));
+        }
+
+        private static bool SpaceTypedNotAdjacentToWord(char ch, SourceText text, int characterPosition)
+        {
+            return ch == ' ' && (characterPosition == text.Length - 1 || !IsWordStartCharacter(text[characterPosition + 1]));
         }
 
         public static bool IsStartingNewWord(SourceText text, int characterPosition)


### PR DESCRIPTION
Don't trigger preselection when the user types space if the caret is
next to a word.

Fixes #1594 

Reviewers: @balajikris @basoundr @brettfo @dpoeschl @jasonmalinowski @Pilchie 

Note that this isn't for preview.