### PR TITLE
Add AssemblyRefs and TypeRefs to assemblies and types referenced by imports

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -378,11 +378,11 @@ namespace Microsoft.Cci
         {
         }
 
-        public virtual void VisitNestedTypes(IEnumerable<INamedTypeDefinition> nestedTypes)
+        public void VisitNestedTypes(IEnumerable<INamedTypeDefinition> nestedTypes)
         {
             foreach (ITypeDefinitionMember nestedType in nestedTypes)
             {
-                this.Visit((ITypeDefinitionMember)nestedType);
+                this.Visit(nestedType);
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Roslyn.Utilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 
 namespace Microsoft.Cci
 {
     internal abstract class ReferenceIndexerBase : MetadataVisitor
     {
-        protected readonly HashSet<IReference> alreadySeen = new HashSet<IReference>();
-        protected readonly HashSet<IReference> alreadyHasToken = new HashSet<IReference>();
+        private readonly HashSet<IReference> _alreadySeen = new HashSet<IReference>();
+        private readonly HashSet<IReference> _alreadyHasToken = new HashSet<IReference>();
         protected bool typeReferenceNeedsToken;
         protected IModule module;
 
@@ -69,7 +71,7 @@ namespace Microsoft.Cci
 
         public override void Visit(IFieldReference fieldReference)
         {
-            if (!alreadySeen.Add(fieldReference))
+            if (!_alreadySeen.Add(fieldReference))
             {
                 return;
             }
@@ -148,7 +150,7 @@ namespace Microsoft.Cci
                 return;
             }
 
-            if (!alreadySeen.Add(methodReference))
+            if (!_alreadySeen.Add(methodReference))
             {
                 return;
             }
@@ -417,7 +419,7 @@ namespace Microsoft.Cci
         // Returns true if we need to look at the children, false otherwise.
         private bool VisitTypeReference(ITypeReference typeReference)
         {
-            if (!this.alreadySeen.Add(typeReference))
+            if (!this._alreadySeen.Add(typeReference))
             {
                 if (!this.typeReferenceNeedsToken)
                 {
@@ -425,7 +427,7 @@ namespace Microsoft.Cci
                 }
 
                 this.typeReferenceNeedsToken = false;
-                if (!this.alreadyHasToken.Add(typeReference))
+                if (!this._alreadyHasToken.Add(typeReference))
                 {
                     return false;
                 }
@@ -443,13 +445,13 @@ namespace Microsoft.Cci
                 if (specializedNestedTypeReference != null)
                 {
                     INestedTypeReference unspecializedNestedTypeReference = specializedNestedTypeReference.UnspecializedVersion;
-                    if (this.alreadyHasToken.Add(unspecializedNestedTypeReference))
+                    if (this._alreadyHasToken.Add(unspecializedNestedTypeReference))
                     {
                         RecordTypeReference(unspecializedNestedTypeReference);
                     }
                 }
 
-                if (this.typeReferenceNeedsToken && this.alreadyHasToken.Add(typeReference))
+                if (this.typeReferenceNeedsToken && this._alreadyHasToken.Add(typeReference))
                 {
                     RecordTypeReference(typeReference);
                 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -3598,15 +3598,9 @@ class C
             Assert.Equal(error, "error CS1061: 'object[]' does not contain a definition for 'First' and no extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)");
         }
 
-        /// <summary>
-        /// Evaluating an expression where the imported type
-        /// is valid but the required reference is missing.
-        /// </summary>
         [Fact]
-        public void EvaluateExpression_MissingReferenceImportedType()
+        public void EvaluateExpression_UnusedImportedType()
         {
-            // System.Linq namespace is available but System.Core is
-            // missing since the reference was not needed in compilation.
             var source =
 @"using E=System.Linq.Enumerable;
 class C
@@ -3624,8 +3618,19 @@ class C
                 runtime,
                 methodName: "C.M");
             string error;
-            var result = context.CompileExpression("E.First(o)", out error);
-            Assert.Equal(error, "error CS0103: The name 'E' does not exist in the current context");
+
+            var testData = new CompilationTestData();
+            var result = context.CompileExpression("E.First(o)", out error, testData);
+            Assert.Null(error);
+
+            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object System.Linq.Enumerable.First<object>(System.Collections.Generic.IEnumerable<object>)""
+  IL_0006:  ret
+}");
         }
 
         [Fact]


### PR DESCRIPTION
even if they are not referenced otherwise.

The Portable PDB format uses tokens rather than strings when encoding imports. The benefit is more compact encoding, simplicity, and support for arbitrary types (currently VB doesn't support encoding generic imports in PDBs). In rare cases when an imported type is actually not used anywhere in the assembly we were missing the AssemblyRef/TypeRef tokens required for the encoding.

Besides, the Expression Evaluator couldn't resolve such imports (even when using the current PDB format).

This change addresses both issues by indexing import scopes during emit to make sure all necessary tokens are present in the metadata. This is done regardless of whether we are building release or debug and regardless of what PDB format are we emitting, to avoid complexity and increasing test matrix.