### PR TITLE
Unskip tests fixed by #662 and #679. 

### DIFF
--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/DefineAccessorsForAttributeArguments.Fixer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/DefineAccessorsForAttributeArguments.Fixer.cs
@@ -119,6 +119,18 @@ namespace System.Runtime.Analyzers
             if (propertyAccessibility != Accessibility.Public)
             {
                 editor.SetAccessibility(property, Accessibility.Public);
+
+                // Having just made the property public, if it has a setter with no accesibility set, then we've just made the setter public. 
+                // Instead restore the setter's original accessibility so that we don't fire a violation with the generated code.
+                var setter = editor.Generator.GetAccessor(property, DeclarationKind.SetAccessor);
+                if (setter != null)
+                {
+                    var setterAccesibility = editor.Generator.GetAccessibility(setter);
+                    if (setterAccesibility == Accessibility.NotApplicable)
+                    {
+                        editor.SetAccessibility(setter, propertyAccessibility);
+                    }
+                }
             }
 
             return editor.GetChangedDocument();

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
@@ -173,7 +173,48 @@ public sealed class InternalGetterTestAttribute : Attribute
     public string Name
     {
         get { return m_name; }
-        set { m_name = value; }
+
+        internal set { m_name = value; }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void CSharp_CA1019_MakeGetterPublic3()
+        {
+            VerifyCSharpFix(@"
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+public sealed class InternalGetterTestAttribute : Attribute
+{
+    private string m_name;
+
+    public InternalGetterTestAttribute(string name)
+    {
+        m_name = name;
+    }
+
+    internal string Name
+    {
+        get { return m_name; }
+    }
+}", @"
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+public sealed class InternalGetterTestAttribute : Attribute
+{
+    private string m_name;
+
+    public InternalGetterTestAttribute(string name)
+    {
+        m_name = name;
+    }
+
+    public string Name
+    {
+        get { return m_name; }
     }
 }");
         }
@@ -381,9 +422,49 @@ Public NotInheritable Class InternalGetterTestAttribute
         Get
             Return m_name
         End Get
-        Set
+        Friend Set
             m_name = value
         End Set
+    End Property
+End Class", allowNewCompilerDiagnostics: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void VisualBasic_CA1019_MakeGetterPublic3()
+        {
+            VerifyBasicFix(@"
+Imports System
+
+<AttributeUsage(AttributeTargets.All)> _
+Public NotInheritable Class InternalGetterTestAttribute
+    Inherits Attribute
+    Private m_name As String
+    
+    Public Sub New(name As String)
+        m_name = name
+    End Sub
+
+    Friend Property Name() As String
+        Get
+            Return m_name
+        End Get
+    End Property
+End Class", @"
+Imports System
+
+<AttributeUsage(AttributeTargets.All)> _
+Public NotInheritable Class InternalGetterTestAttribute
+    Inherits Attribute
+    Private m_name As String
+    
+    Public Sub New(name As String)
+        m_name = name
+    End Sub
+
+    Public Property Name() As String
+        Get
+            Return m_name
+        End Get
     End Property
 End Class", allowNewCompilerDiagnostics: true);
         }

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
@@ -94,7 +94,7 @@ public sealed class SetterOnlyTestAttribute : Attribute
 }", allowNewCompilerDiagnostics: true);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void CSharp_CA1019_MakeGetterPublic()
         {
             VerifyCSharpFix(@"
@@ -113,7 +113,7 @@ public sealed class InternalGetterTestAttribute : Attribute
     public string Name
     {
         internal get { return m_name; }
-        set { m_name = value; }
+        internal set { m_name = value; }
     }
 }", @"
 using System;
@@ -131,12 +131,12 @@ public sealed class InternalGetterTestAttribute : Attribute
     public string Name
     {
         get { return m_name; }
-        set { m_name = value; }
+        internal set { m_name = value; }
     }
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void CSharp_CA1019_MakeGetterPublic2()
         {
             VerifyCSharpFix(@"
@@ -178,7 +178,7 @@ public sealed class InternalGetterTestAttribute : Attribute
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void CSharp_CA1019_MakeSetterInternal()
         {
             VerifyCSharpFix(@"
@@ -215,6 +215,7 @@ public sealed class PublicSetterTestAttribute : Attribute
     public string Name
     {
         get { return m_name; }
+
         internal set { m_name = value; }
     }
 }");
@@ -253,7 +254,7 @@ Public NotInheritable Class NoAccessorTestAttribute
 End Class", allowNewCompilerDiagnostics: true);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/679"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void VisualBasic_CA1019_AddAccessor2()
         {
             VerifyBasicFix(@"
@@ -267,9 +268,9 @@ Public NotInheritable Class SetterOnlyTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public WriteOnly Property Name() As String
-        Set
+        Friend Set
             m_name = value
         End Set
     End Property
@@ -284,9 +285,9 @@ Public NotInheritable Class SetterOnlyTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public Property Name() As String
-        Set
+        Friend Set
             m_name = value
         End Set
         Get
@@ -295,7 +296,7 @@ Public NotInheritable Class SetterOnlyTestAttribute
 End Class", allowNewCompilerDiagnostics: true);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void VisualBasic_CA1019_MakeGetterPublic()
         {
             VerifyBasicFix(@"
@@ -309,12 +310,12 @@ Public NotInheritable Class InternalGetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public Property Name() As String
         Friend Get
             Return m_name
         End Get
-        Set
+        Friend Set
             m_name = value
         End Set
     End Property
@@ -329,19 +330,19 @@ Public NotInheritable Class InternalGetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public Property Name() As String
         Get
             Return m_name
         End Get
-        Set
+        Friend Set
             m_name = value
         End Set
     End Property
 End Class", allowNewCompilerDiagnostics: true);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void VisualBasic_CA1019_MakeGetterPublic2()
         {
             VerifyBasicFix(@"
@@ -355,7 +356,7 @@ Public NotInheritable Class InternalGetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Friend Property Name() As String
         Get
             Return m_name
@@ -375,7 +376,7 @@ Public NotInheritable Class InternalGetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public Property Name() As String
         Get
             Return m_name
@@ -387,7 +388,7 @@ Public NotInheritable Class InternalGetterTestAttribute
 End Class", allowNewCompilerDiagnostics: true);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/662"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void VisualBasic_CA1019_MakeSetterInternal()
         {
             VerifyBasicFix(@"
@@ -401,8 +402,8 @@ Public NotInheritable Class PublicSetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
-    Property Name() As String
+
+    Public Property Name() As String
         Get
             Return m_name
         End Get
@@ -421,7 +422,7 @@ Public NotInheritable Class PublicSetterTestAttribute
     Public Sub New(name As String)
         m_name = name
     End Sub
-    
+
     Public Property Name() As String
         Get
             Return m_name


### PR DESCRIPTION
This required fixing up the codefixer to address a couple of cases:
- To make a property getter public, simply clear the accessibility on the getter and make the property public.
- While adding a getter to a property, make to sure to remove the WriteOnly modifier so that the keyword is removed in VB.