### PR TITLE
Fix that completion list doesn't include param entries for indexers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -250,6 +250,18 @@ public class foo<T>
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void IndexerParamTypeParam()
+        {
+            VerifyItemsExist(@"
+public class foo<T>
+{
+
+    /// $$
+    public int this[T green] { get { } set { } }
+}", "param name=\"green\"");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void ClassTypeParam()
         {
             VerifyItemsExist(@"

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -275,8 +275,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             Dim typeParameters = [property].GetTypeArguments().Select(Function(t) t.Name).ToSet()
             Dim value = True
 
-            RemoveExistingTags(parent, typeParameters, Function(e) FindName("typeparam", e))
-
             For Each node In parent.ChildNodes
                 Dim element = TryCast(node, XmlElementSyntax)
                 If element IsNot Nothing AndAlso Not element.StartTag.IsMissing AndAlso Not element.EndTag.IsMissing Then
@@ -287,6 +285,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
                     End If
                 End If
             Next
+
+            If [property].IsIndexer Then
+                Dim parameters = [property].Parameters.Select(Function(p) p.Name).ToSet()
+                RemoveExistingTags(parent, parameters, Function(e) FindName("param", e))
+                items.AddRange(parameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("param", p), GetCompletionItemRules())))
+            End If
 
             items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("typeparam", p), GetCompletionItemRules())))
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -206,6 +206,23 @@ End Class
     End Sub
 
     <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+    Public Sub IndexerParamTypeParam()
+        Dim text = <File>
+Class C(Of T)
+    ''' &lt;$$
+    Default Public Property Item(bar as T)
+        Get
+        End Get
+        Set
+        End Set
+    End Sub
+End Property
+</File>.Value
+
+        VerifyItemsExist(text, "param name=""bar""")
+    End Sub
+
+    <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
     Public Sub TypeTypeParam()
         Dim text = <File>
     ''' &lt;$$


### PR DESCRIPTION
This commit changes the completion list for indexers. The completion list now includes <param> entries for each parameter.
In C# completion for paramref's name tags in indexer documentation will now provide a parameter list.
Also some unnecessary code for typeref tags inside property declarations are removed, because properties and indexers can't have type arguments.

I can't test any of this so I don't know if this will work and if there are any tests that are failing now. So this might be completly wrong.

Fixes #1661.