### PR TITLE
Add a Roslyn-wide rule set file.

### DIFF
--- a/build/TestProjectRules.ruleset
+++ b/build/TestProjectRules.ruleset
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Ruleset for Roslyn test projects." Description="These rule are identical to the minimum recommended ruleset, but specific roslyn performance rules have been turned off." ToolsVersion="14.0">
   <!-- Include all non-shipping project rules -->
-  <Include Path="..\..\..\..\..\Open\src\Tools\Microsoft.CodeAnalysis.Toolset.Open\Rulesets\NonShippingProjectRules.ruleset" Action="Default" />
+  <Include Path="..\src\Tools\Microsoft.CodeAnalysis.Toolset.Open\Rulesets\NonShippingProjectRules.ruleset" Action="Default" />
 
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />

--- a/src/Compilers/CSharp/CSharpCodeAnalysisRules.ruleset
+++ b/src/Compilers/CSharp/CSharpCodeAnalysisRules.ruleset
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Diagnostic rules for the CSharpCodeAnalysis (Portable and Desktop) projects" Description="Enables rules specific to these projects." ToolsVersion="14.0">
+  <!-- Include default rules -->
+  <Include Path="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Rulesets\Roslyn.ruleset" Action="Default" />
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.CSharp" RuleNamespace="Roslyn.Diagnostics.Analyzers.CSharp">
     <Rule Id="RS0013" Action="Warning" />
   </Rules>

--- a/src/Compilers/Core/CodeAnalysisRules.ruleset
+++ b/src/Compilers/Core/CodeAnalysisRules.ruleset
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Diagnostic rules for the CodeAnalysis (Portable and Desktop) projects" Description="Enables rules specific to these projects." ToolsVersion="14.0">
+  <!-- Include default rules -->
+  <Include Path="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Rulesets\Roslyn.ruleset" Action="Default" />
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.CSharp" RuleNamespace="Roslyn.Diagnostics.Analyzers.CSharp">
     <Rule Id="RS0013" Action="Warning" />
   </Rules>

--- a/src/Compilers/VisualBasic/BasicCodeAnalysisRules.ruleset
+++ b/src/Compilers/VisualBasic/BasicCodeAnalysisRules.ruleset
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Diagnostic rules for the BasicCodeAnalysis (Portable and Desktop) projects" Description="Enables rules specific to these projects." ToolsVersion="14.0">
+  <!-- Include default rules -->
+  <Include Path="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Rulesets\Roslyn.ruleset" Action="Default" />
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.VisualBasic" RuleNamespace="Roslyn.Diagnostics.Analyzers.VisualBasic">
     <Rule Id="RS0004" Action="Error" />
   </Rules>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/AnalyzerProjectRules.ruleset
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/AnalyzerProjectRules.ruleset
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Common diagnostic rules for all analyzer projects" Description="Enables/disable rules specific to all analyzer projects." ToolsVersion="14.0">
+  <Include Path=".\Roslyn.ruleset" Action="Default" />
   <!-- Enable rule RS1007 (Provide localizable arguments to diagnostic descriptor constructor). -->
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.CSharp" RuleNamespace="Roslyn.Diagnostics.Analyzers.MetaAnalyzers.CSharp">
     <Rule Id="RS1007" Action="Warning" />

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/NonShippingProjectRules.ruleset
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/NonShippingProjectRules.ruleset
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Common diagnostic rules for all non-shipping projects" Description="Enables/disable rules specific to all non-shipping projects." ToolsVersion="14.0">
+  <Include Path=".\Roslyn.ruleset" Action="Default" />
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.MetaAnalyzers" RuleNamespace="Roslyn.Diagnostics.Analyzers.MetaAnalyzers">
     <!-- Suppress rule RS1001 (Missing diagnostic analyzer attribute) for non-shipping projects, as they may have test analyzers. -->
     <Rule Id="RS1001" Action="None" />

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/Roslyn.ruleset
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Rulesets/Roslyn.ruleset
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules for all Roslyn projects"
+         Description="This file contains diagnostic settings used by all Roslyn projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the necessary adjustments." 
+         ToolsVersion="14.0">
+</RuleSet>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Imports.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Imports.targets
@@ -16,9 +16,11 @@
     <OutputPath>$(OutDir)</OutputPath>
     <DocumentationFile Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(ProjectLanguage)' == 'VB' AND '$(AssemblyName)' != ''">$(AssemblyName).xml</DocumentationFile>
     <DocumentationFile Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(ProjectLanguage)' == 'CSharp' AND '$(AssemblyName)' != ''">$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+
     <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == '' AND '$(NonShipping)' == 'true'">$(VSLToolsPath)\Rulesets\NonShippingProjectRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == '' AND '$(AnalyzerProject)' == 'true'">$(VSLToolsPath)\Rulesets\AnalyzerProjectRules.ruleset</CodeAnalysisRuleSet>
-
+    <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">$(VSLToolsPath)\Rulesets\Roslyn.ruleset</CodeAnalysisRuleSet>
+    
     <RoslynInternalKey>002400000480000094000000060200000024000052534131000400000100010055e0217eb635f69281051f9a823e0c7edd90f28063eb6c7a742a19b4f6139778ee0af438f47aed3b6e9f99838aa8dba689c7a71ddb860c96d923830b57bbd5cd6119406ddb9b002cf1c723bf272d6acbb7129e9d6dd5a5309c94e0ff4b2c884d45a55f475cd7dba59198086f61f5a8c8b5e601c0edbf269733f6f578fc8579c2</RoslynInternalKey>
   </PropertyGroup>
 


### PR DESCRIPTION
While we have several different .ruleset files covering specific parts
of the Roslyn code (e.g., compiler projects, or projects that contain
analyzers, etc.) we do not currently have a rule set file that covers
all of Roslyn. This would be useful as a single place to turn off a
badly-behaved diagnostic, or turn on a new one that is off by default.

This commit adds such a file, and updates the other rule set files to
refer back to it. It also updates one of our .targets files to set this
as the default rule set automatically; this way we don't need to go back
and update every project to refer to it.

Fixes #1061.