### PR TITLE
Add the /analyzerdependency switch to the compilers

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -152,6 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         analyzers.AddRange(ParseAnalyzers(arg, value, diagnostics));
                         continue;
 
+                    case "ad":
                     case "analyzerdependency":
                         analyzerDependencies.AddRange(ParseAnalyzerDependencies(arg, value, diagnostics));
                         continue;

--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var defines = ArrayBuilder<string>.GetInstance();
             List<CommandLineReference> metadataReferences = new List<CommandLineReference>();
             List<CommandLineAnalyzerReference> analyzers = new List<CommandLineAnalyzerReference>();
+            List<CommandLineAnalyzerDependency> analyzerDependencies = new List<CommandLineAnalyzerDependency>();
             List<string> libPaths = new List<string>();
             List<string> keyFileSearchPaths = new List<string>();
             List<string> usings = new List<string>();
@@ -149,6 +150,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case "a":
                     case "analyzer":
                         analyzers.AddRange(ParseAnalyzers(arg, value, diagnostics));
+                        continue;
+
+                    case "analyzerdependency":
+                        analyzerDependencies.AddRange(ParseAnalyzerDependencies(arg, value, diagnostics));
                         continue;
 
                     case "d":
@@ -1075,6 +1080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ChecksumAlgorithm = checksumAlgorithm,
                 MetadataReferences = metadataReferences.AsImmutable(),
                 AnalyzerReferences = analyzers.AsImmutable(),
+                AnalyzerDependencies = analyzerDependencies.AsImmutable(),
                 AdditionalFiles = additionalFiles.AsImmutable(),
                 ReferencePaths = referencePaths,
                 KeyFileSearchPaths = keyFileSearchPaths.AsImmutable(),
@@ -1352,6 +1358,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (string path in paths)
             {
                 yield return new CommandLineAnalyzerReference(path);
+            }
+        }
+
+        private IEnumerable<CommandLineAnalyzerDependency> ParseAnalyzerDependencies(string arg, string value, List<Diagnostic> diagnostics)
+        {
+            if (value == null)
+            {
+                AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, MessageID.IDS_Text.Localize(), arg);
+                yield break;
+            }
+            else if (value.Length == 0)
+            {
+                AddDiagnostic(diagnostics, ErrorCode.ERR_NoFileSpec, arg);
+                yield break;
+            }
+
+            List<string> paths = ParseSeparatedPaths(value).Where((path) => !string.IsNullOrWhiteSpace(path)).ToList();
+
+            foreach (string path in paths)
+            {
+                yield return new CommandLineAnalyzerDependency(path);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4377,6 +4377,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
                                assembly files (Short form: /l)
  /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
                                (Short form: /a)
+ /analyzerdependency:&lt;file list&gt; Additional assemblies required by analyzers
+                               (Short form: /ad)
  /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
                                generation but may be used by analyzers for producing
                                errors or warnings.

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7481,6 +7481,11 @@ class C {
             Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
 
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ad:foo.dll", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length);
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
+
             parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/analyzerdependency:\"foo.dll\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length);
@@ -7491,6 +7496,14 @@ class C {
             Assert.Equal(2, parsedArgs.AnalyzerDependencies.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
             Assert.Equal("bar.dll", parsedArgs.AnalyzerDependencies[1].FilePath);
+
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzerdependency:alpha.dll;beta.dll", @"/analyzerdependency:delta.dll,gamma.dll", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(4, parsedArgs.AnalyzerDependencies.Length);
+            Assert.Equal("alpha.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
+            Assert.Equal("beta.dll", parsedArgs.AnalyzerDependencies[1].FilePath);
+            Assert.Equal("delta.dll", parsedArgs.AnalyzerDependencies[2].FilePath);
+            Assert.Equal("gamma.dll", parsedArgs.AnalyzerDependencies[3].FilePath);
 
             parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzerdependency:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7472,6 +7472,34 @@ class C {
 
             CleanupAllGeneratedFiles(src.Path);
         }
+
+        [Fact]
+        public void ParseAnalyzerDependencies()
+        {
+            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzerdependency:foo.dll", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length);
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
+
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/analyzerdependency:\"foo.dll\"", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length);
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
+
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzerdependency:foo.dll;bar.dll", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(2, parsedArgs.AnalyzerDependencies.Length);
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies[0].FilePath);
+            Assert.Equal("bar.dll", parsedArgs.AnalyzerDependencies[1].FilePath);
+
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzerdependency:", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify(
+                Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/analyzerdependency:"));
+
+            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/analyzerdependency", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify(
+                Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/analyzerdependency"));
+        }
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]

--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -58,6 +58,7 @@
     </Compile>
     <Compile Include="AssemblyPortabilityPolicy.cs" />
     <Compile Include="AssemblyVersion.cs" />
+    <Compile Include="CommandLine\CommandLineAnalyzerDependency.cs" />
     <Compile Include="CommandLine\CommandLineReference.cs" />
     <Compile Include="CommandLine\CommandLineSourceFile.cs" />
     <Compile Include="CommandLine\CommonCommandLineArguments.cs" />

--- a/src/Compilers/Core/Desktop/CommandLine/CommandLineAnalyzerDependency.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommandLineAnalyzerDependency.cs
@@ -1,12 +1,13 @@
-﻿using Roslyn.Utilities;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+    /// <summary>
+    /// Describes a command-line analyzer assembly dependency specification.
+    /// </summary>
     public struct CommandLineAnalyzerDependency : IEquatable<CommandLineAnalyzerDependency>
     {
         public CommandLineAnalyzerDependency(string path)
@@ -14,6 +15,9 @@ namespace Microsoft.CodeAnalysis
             FilePath = path;
         }
 
+        /// <summary>
+        /// Assembly file path.
+        /// </summary>
         public string FilePath { get; }
 
         public override bool Equals(object obj)

--- a/src/Compilers/Core/Desktop/CommandLine/CommandLineAnalyzerDependency.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommandLineAnalyzerDependency.cs
@@ -1,0 +1,34 @@
+﻿using Roslyn.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    public struct CommandLineAnalyzerDependency : IEquatable<CommandLineAnalyzerDependency>
+    {
+        public CommandLineAnalyzerDependency(string path)
+        {
+            FilePath = path;
+        }
+
+        public string FilePath { get; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CommandLineAnalyzerDependency && base.Equals((CommandLineAnalyzerDependency)obj);
+        }
+
+        public bool Equals(CommandLineAnalyzerDependency other)
+        {
+            return FilePath == other.FilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(FilePath, 0);
+        }
+    }
+}

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineArguments.cs
@@ -111,6 +111,11 @@ namespace Microsoft.CodeAnalysis
         public ImmutableArray<CommandLineAnalyzerReference> AnalyzerReferences { get; internal set; }
 
         /// <summary>
+        /// References to analyzer dependencies supplied on the command line.
+        /// </summary>
+        public ImmutableArray<CommandLineAnalyzerDependency> AnalyzerDependencies { get; internal set; }
+
+        /// <summary>
         /// A set of additional non-code text files that can be used by analyzers.
         /// </summary>
         public ImmutableArray<CommandLineSourceFile> AdditionalFiles { get; internal set; }

--- a/src/Compilers/Core/Desktop/CommandLineAnalyzerReference.cs
+++ b/src/Compilers/Core/Desktop/CommandLineAnalyzerReference.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Describes a command line analyzer assembly specification.
     /// </summary>
-    public struct CommandLineAnalyzerReference : IEquatable<CommandLineAnalyzerReference>
+    public struct CommandLineAnalyzerReference
     {
         private readonly string _path;
 
@@ -26,21 +26,6 @@ namespace Microsoft.CodeAnalysis
             {
                 return _path;
             }
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is CommandLineAnalyzerReference && base.Equals((CommandLineAnalyzerReference)obj);
-        }
-
-        public bool Equals(CommandLineAnalyzerReference other)
-        {
-            return _path == other._path;
-        }
-
-        public override int GetHashCode()
-        {
-            return Hash.Combine(_path, 0);
         }
     }
 }

--- a/src/Compilers/Core/Desktop/PublicAPI.txt
+++ b/src/Compilers/Core/Desktop/PublicAPI.txt
@@ -4,7 +4,6 @@ Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.Equals(Microsoft.CodeAnalys
 Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.FilePath.get -> string
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference.CommandLineAnalyzerReference(string path) -> void
-Microsoft.CodeAnalysis.CommandLineAnalyzerReference.Equals(Microsoft.CodeAnalysis.CommandLineAnalyzerReference other) -> bool
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference.FilePath.get -> string
 Microsoft.CodeAnalysis.CommandLineArguments
 Microsoft.CodeAnalysis.CommandLineArguments.AdditionalFiles.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineSourceFile>
@@ -95,8 +94,6 @@ abstract Microsoft.CodeAnalysis.CommandLineParser.RegularFileExtension.get -> st
 abstract Microsoft.CodeAnalysis.CommandLineParser.ScriptFileExtension.get -> string
 override Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.GetHashCode() -> int
-override Microsoft.CodeAnalysis.CommandLineAnalyzerReference.Equals(object obj) -> bool
-override Microsoft.CodeAnalysis.CommandLineAnalyzerReference.GetHashCode() -> int
 override Microsoft.CodeAnalysis.CommandLineReference.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.CommandLineReference.GetHashCode() -> int
 override Microsoft.CodeAnalysis.DesktopStrongNameProvider.Equals(object obj) -> bool

--- a/src/Compilers/Core/Desktop/PublicAPI.txt
+++ b/src/Compilers/Core/Desktop/PublicAPI.txt
@@ -1,9 +1,14 @@
+Microsoft.CodeAnalysis.CommandLineAnalyzerDependency
+Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.CommandLineAnalyzerDependency(string path) -> void
+Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.Equals(Microsoft.CodeAnalysis.CommandLineAnalyzerDependency other) -> bool
+Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.FilePath.get -> string
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference.CommandLineAnalyzerReference(string path) -> void
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference.Equals(Microsoft.CodeAnalysis.CommandLineAnalyzerReference other) -> bool
 Microsoft.CodeAnalysis.CommandLineAnalyzerReference.FilePath.get -> string
 Microsoft.CodeAnalysis.CommandLineArguments
 Microsoft.CodeAnalysis.CommandLineArguments.AdditionalFiles.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineSourceFile>
+Microsoft.CodeAnalysis.CommandLineArguments.AnalyzerDependencies.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineAnalyzerDependency>
 Microsoft.CodeAnalysis.CommandLineArguments.AnalyzerReferences.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineAnalyzerReference>
 Microsoft.CodeAnalysis.CommandLineArguments.AppConfigPath.get -> string
 Microsoft.CodeAnalysis.CommandLineArguments.BaseDirectory.get -> string
@@ -88,6 +93,8 @@ abstract Microsoft.CodeAnalysis.CommandLineArguments.CompilationOptionsCore.get 
 abstract Microsoft.CodeAnalysis.CommandLineArguments.ParseOptionsCore.get -> Microsoft.CodeAnalysis.ParseOptions
 abstract Microsoft.CodeAnalysis.CommandLineParser.RegularFileExtension.get -> string
 abstract Microsoft.CodeAnalysis.CommandLineParser.ScriptFileExtension.get -> string
+override Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.Equals(object obj) -> bool
+override Microsoft.CodeAnalysis.CommandLineAnalyzerDependency.GetHashCode() -> int
 override Microsoft.CodeAnalysis.CommandLineAnalyzerReference.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.CommandLineAnalyzerReference.GetHashCode() -> int
 override Microsoft.CodeAnalysis.CommandLineReference.Equals(object obj) -> bool

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -192,7 +192,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         analyzers.AddRange(ParseAnalyzers(name, value, diagnostics))
                         Continue For
 
-                    Case "analyzerdependency"
+                    Case "ad", "analyzerdependency"
                         analyzerDependencies.AddRange(ParseAnalyzerDependencies(name, value, diagnostics))
                         Continue For
 

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -112,6 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim defines As IReadOnlyDictionary(Of String, Object) = Nothing
             Dim metadataReferences = New List(Of CommandLineReference)()
             Dim analyzers = New List(Of CommandLineAnalyzerReference)()
+            Dim analyzerDependencies = New List(Of CommandLineAnalyzerDependency)()
             Dim sdkPaths As New List(Of String)()
             Dim libPaths As New List(Of String)()
             Dim keyFileSearchPaths = New List(Of String)()
@@ -189,6 +190,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Case "a", "analyzer"
                         analyzers.AddRange(ParseAnalyzers(name, value, diagnostics))
+                        Continue For
+
+                    Case "analyzerdependency"
+                        analyzerDependencies.AddRange(ParseAnalyzerDependencies(name, value, diagnostics))
                         Continue For
 
                     Case "d", "define"
@@ -1185,6 +1190,7 @@ lVbRuntimePlus:
                     .ChecksumAlgorithm = checksumAlgorithm,
                     .MetadataReferences = metadataReferences.AsImmutable(),
                     .AnalyzerReferences = analyzers.AsImmutable(),
+                    .AnalyzerDependencies = analyzerDependencies.AsImmutable(),
                     .AdditionalFiles = additionalFiles.AsImmutable(),
                     .ReferencePaths = searchPaths,
                     .KeyFileSearchPaths = keyFileSearchPaths.AsImmutable(),
@@ -1385,6 +1391,19 @@ lVbRuntimePlus:
             Return ParseSeparatedPaths(value).
                    Select(Function(path)
                               Return New CommandLineAnalyzerReference(path)
+                          End Function)
+        End Function
+
+        Private Function ParseAnalyzerDependencies(name As String, value As String, diagnostics As IList(Of Diagnostic)) As IEnumerable(Of CommandLineAnalyzerDependency)
+            If String.IsNullOrEmpty(value) Then
+                ' TODO: localize <file_list>?
+                AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<file_list>")
+                Return SpecializedCollections.EmptyEnumerable(Of CommandLineAnalyzerDependency)()
+            End If
+
+            Return ParseSeparatedPaths(value).
+                   Select(Function(path)
+                              Return New CommandLineAnalyzerDependency(path)
                           End Function)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5025,6 +5025,8 @@
                                   assembly. (Short form: /r)
 /analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
                                   (Short form: /a)
+/analyzerdependency:&lt;file_list&gt;   Additional assemblies required by analyzers
+                                  (Short form: /a)
 /additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
                                   generation but may be used by analyzers for producing
                                   errors or warnings.

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7100,6 +7100,31 @@ out
             Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.SpecificDiagnosticOptions("Test001"))
         End Sub
 
+        <Fact>
+        Public Sub ParseAnalyzerDependencies()
+            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:foo.dll", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length)
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
+
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:""foo.dll""", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length)
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
+
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:foo.dll,bar.dll", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(2, parsedArgs.AnalyzerDependencies.Length)
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
+            Assert.Equal("bar.dll", parsedArgs.AnalyzerDependencies(1).FilePath)
+
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("analyzerdependency", ":<file_list>"))
+
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("analyzerdependency", ":<file_list>"))
+        End Sub
+
     End Class
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7107,6 +7107,11 @@ out
             Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
 
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/ad:foo.dll", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length)
+            Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
+
             parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:""foo.dll""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(1, parsedArgs.AnalyzerDependencies.Length)
@@ -7117,6 +7122,14 @@ out
             Assert.Equal(2, parsedArgs.AnalyzerDependencies.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
             Assert.Equal("bar.dll", parsedArgs.AnalyzerDependencies(1).FilePath)
+
+            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:alpha.dll,beta.dll", "/analyzerdependency:gamma.dll;delta.dll", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(4, parsedArgs.AnalyzerDependencies.Length)
+            Assert.Equal("alpha.dll", parsedArgs.AnalyzerDependencies(0).FilePath)
+            Assert.Equal("beta.dll", parsedArgs.AnalyzerDependencies(1).FilePath)
+            Assert.Equal("gamma.dll", parsedArgs.AnalyzerDependencies(2).FilePath)
+            Assert.Equal("delta.dll", parsedArgs.AnalyzerDependencies(3).FilePath)
 
             parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzerdependency:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("analyzerdependency", ":<file_list>"))


### PR DESCRIPTION
Currently we require that an analyzer's dependencies be deployed
immediately next to it in the file system, and the various analyzer
hosts (csc.exe, vbc.ex, VS, etc.) handle finding and loading these
dependencies automatically.

It has become clear, however, that this deployment requirement needs to
be relaxed. For example, some of our analyzer NuGets have C# analyzers
in a C# subdirectory, and VB analyzers in a VB subdirectory. If the C#
and VB analyzers both depend on another assembly, we now need to have an
identical copy in each subdirectory, which is silly.

Instead we should allow dependencies to be placed anywhere they make
sense, but to enable this we will need to know which .dlls are
dependencies and which are not. Hence the /analyzerdependency switch.

This commit just adds the switch to the compilers' command line parsing
so they don't fail when they see it. Later changes will pipe support
through MSBuild, the language services, and the VB and C# project system
support. Once all of that is in place the compilers will be updated to
only look for dependencies in the locations specified by the the switch.