### PR TITLE
Remove schema validation

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>";
 
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "There is a duplicate key sequence 'CA1012' for the 'UniqueRuleName' key or unique identity constraint."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetHasDuplicateRules, "CA1012", "Error", "Warn"));
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The 'Action' attribute is invalid - The value 'Default' is invalid according to its datatype 'TIncludeAllAction' - The Enumeration constraint failed."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetBadAttributeValue, "Action", "Default"));
         }
 
         [Fact]
@@ -303,8 +303,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            string locMessage = string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "");
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'Id' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "Rule", "Id"));
         }
 
         [Fact]
@@ -318,7 +317,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'Action' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "Rule", "Action"));
         }
 
         [Fact]
@@ -332,7 +331,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'AnalyzerId' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "Rules", "AnalyzerId"));
         }
 
         [Fact]
@@ -346,7 +345,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'RuleNamespace' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "Rules", "RuleNamespace"));
         }
 
         [Fact]
@@ -361,7 +360,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 </RuleSet>
 ";
 
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'ToolsVersion' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "RuleSet", "ToolsVersion"));
         }
 
         [Fact]
@@ -375,7 +374,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The required attribute 'Name' is missing."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetMissingAttribute, "RuleSet", "Name"));
         }
 
         [Fact]
@@ -420,7 +419,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 </RuleSet>
 ";
 
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "The 'Action' attribute is invalid - The value 'Default' is invalid according to its datatype 'TRuleAction' - The Enumeration constraint failed."));
+            VerifyRuleSetError(source, () => string.Format(CodeAnalysisDesktopResources.RuleSetBadAttributeValue, "Action", "Default"));
         }
 
         [Fact]
@@ -968,7 +967,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
                 catch (InvalidRuleSetException e)
                 {
-                    Assert.Contains(string.Format(CodeAnalysisResources.InvalidRuleSetInclude, newFile.Path, string.Format(CodeAnalysisResources.RuleSetSchemaViolation, "")), e.Message, StringComparison.Ordinal);
+                    Assert.Contains(string.Format(CodeAnalysisResources.InvalidRuleSetInclude, newFile.Path, string.Format(CodeAnalysisDesktopResources.RuleSetBadAttributeValue, "Action", "Default")), e.Message, StringComparison.Ordinal);
                 }
             }
         }

--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -168,10 +168,10 @@
       <SubType>Designer</SubType>
       <LastGenOutput>CodeAnalysisDesktopResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="CommandLine\RuleSet\RuleSetSchema.xsd">
+    <None Include="CommandLine\RuleSet\RuleSetSchema.xsd">
       <SubType>Designer</SubType>
       <LogicalName>Microsoft.CodeAnalysis.RuleSet.xsd</LogicalName>
-    </EmbeddedResource>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\CodeAnalysisRules.ruleset">

--- a/src/Compilers/Core/Desktop/CodeAnalysisDesktopResources.Designer.cs
+++ b/src/Compilers/Core/Desktop/CodeAnalysisDesktopResources.Designer.cs
@@ -104,5 +104,23 @@ namespace Microsoft.CodeAnalysis {
                 return ResourceManager.GetString("MissingKeepAlive", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The attribute {0} has an invalid value of {1}..
+        /// </summary>
+        internal static string RuleSetBadAttributeValue {
+            get {
+                return ResourceManager.GetString("RuleSetBadAttributeValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The element {0} is missing an attribute named {1}..
+        /// </summary>
+        internal static string RuleSetMissingAttribute {
+            get {
+                return ResourceManager.GetString("RuleSetMissingAttribute", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Desktop/CodeAnalysisDesktopResources.resx
+++ b/src/Compilers/Core/Desktop/CodeAnalysisDesktopResources.resx
@@ -132,4 +132,10 @@
   <data name="MissingKeepAlive" xml:space="preserve">
     <value>Missing argument for '/keepalive' option.</value>
   </data>
+  <data name="RuleSetBadAttributeValue" xml:space="preserve">
+    <value>The attribute {0} has an invalid value of {1}.</value>
+  </data>
+  <data name="RuleSetMissingAttribute" xml:space="preserve">
+    <value>The element {0} is missing an attribute named {1}.</value>
+  </data>
 </root>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -809,15 +809,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file does not conform to the rule set schema - {0}.
-        /// </summary>
-        internal static string RuleSetSchemaViolation {
-            get {
-                return ResourceManager.GetString("RuleSetSchemaViolation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to error.
         /// </summary>
         internal static string SeverityError {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -348,9 +348,6 @@
   <data name="XmlReferencesNotSupported" xml:space="preserve">
     <value>References to XML documents are not supported.</value>
   </data>
-  <data name="RuleSetSchemaViolation" xml:space="preserve">
-    <value>The file does not conform to the rule set schema - {0}</value>
-  </data>
   <data name="FailedToResolveRuleSetName" xml:space="preserve">
     <value>Could not locate the rule set file '{0}'.</value>
   </data>


### PR DESCRIPTION
XML schema validation is not available on core clr and hence can't be in this
particular layer of the compiler.  Instead moving to the manual validation of the
small amount of data required for this rule.