### PR TITLE
Don't call InstantiateResultsViewProxy on values that are not Enumerable...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
@@ -1407,7 +1407,7 @@ class C : IEnumerable
             }
         }
 
-        [Fact]
+        [Fact, WorkItem(1145125, "DevDiv")]
         public void GetEnumerableException()
         {
             var source =

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 errorMessage = (string)value.HostObjectValue;
             }
-            else if (value.HasExceptionThrown(parent: null))
+            else if (value.HasExceptionThrown())
             {
                 errorMessage = value.GetExceptionMessage(name, formatter);
             }
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             Debug.Assert(!value.IsError());
 
-            if (value.IsNull)
+            if (value.IsNull || value.HasExceptionThrown())
             {
                 return false;
             }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
@@ -22,12 +22,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return valueStr;
         }
 
-        // Some evaluation results, like base type, reuse their parent's value.  They should
-        // not, however, report that their evaluation triggered an exception.
-        internal static bool HasExceptionThrown(this DkmClrValue value, EvalResultDataItem parent)
+        internal static bool HasExceptionThrown(this DkmClrValue value)
         {
-            return value.EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown) &&
-                ((parent == null) || (value != parent.Value));
+            return value.EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown);
         }
 
         internal static string GetExceptionMessage(this DkmClrValue value, string fullNameWithoutFormatSpecifiers, Formatter formatter)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // If the declared type is Nullable<T>, the value should
             // have no expansion if null, or be expanded as a T.
             var lmrNullableTypeArg = declaredType.GetNullableTypeArgument();
-            if (lmrNullableTypeArg != null && !value.HasExceptionThrown(parent))
+            if (lmrNullableTypeArg != null && !value.HasExceptionThrown())
             {
                 Debug.Assert(value.Type.GetProxyType() == null);
 
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     this.Formatter.GetEditableValue(value, inspectionContext));
                 if (expansion == null)
                 {
-                    var expansionType = value.HasExceptionThrown(parent) ? value.Type.GetLmrType() : declaredType;
+                    var expansionType = value.HasExceptionThrown() ? value.Type.GetLmrType() : declaredType;
                     expansion = this.GetTypeExpansion(inspectionContext, expansionType, value, expansionFlags);
                 }
             }
@@ -568,7 +568,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var value = dataItem.Value;
             string display;
-            if (value.HasExceptionThrown(parent))
+            if (value.HasExceptionThrown())
             {
                 display = dataItem.DisplayValue ?? value.GetExceptionMessage(dataItem.FullNameWithoutFormatSpecifiers, this.Formatter);
             }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
@@ -580,6 +580,11 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 
         public DkmClrValue InstantiateResultsViewProxy(DkmInspectionContext inspectionContext, DkmClrType enumerableType)
         {
+            if (EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown))
+            {
+                throw new InvalidOperationException();
+            }
+
             if (inspectionContext == null)
             {
                 throw new ArgumentNullException("inspectionContext");


### PR DESCRIPTION
......

(and update our test mock to better approximate the real DkmClrValue behavior)

Also, remove the "parent" parameter from HasExceptionThrown.  It's not needed now that we do "flat list" expansion.