### PR TITLE
More CoreFx porting work

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override DiagnosticFormatter DiagnosticFormatter { get { return _diagnosticFormatter; } }
         protected internal new CSharpCommandLineArguments Arguments { get { return (CSharpCommandLineArguments)base.Arguments; } }
 
-        protected override Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger)
+        public override Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger)
         {
             var parseOptions = Arguments.ParseOptions;
             var scriptParseOptions = parseOptions.WithKind(SourceCodeKind.Script);
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Print compiler logo
         /// </summary>
         /// <param name="consoleOutput"></param>
-        protected override void PrintLogo(TextWriter consoleOutput)
+        public override void PrintLogo(TextWriter consoleOutput)
         {
             consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LogoLine1, Culture), GetToolName(), GetAssemblyFileVersion());
             consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LogoLine2, Culture));
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Print Commandline help message (up to 80 English characters per line)
         /// </summary>
         /// <param name="consoleOutput"></param>
-        protected override void PrintHelp(TextWriter consoleOutput)
+        public override void PrintHelp(TextWriter consoleOutput)
         {
             consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_CSCHelp, Culture));
         }

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static bool DerivesFromDiagnosticAnalyzer(Type type)
         {
-            return type.IsSubclassOf(typeof(DiagnosticAnalyzer));
+            return type.GetTypeInfo().IsSubclassOf(typeof(DiagnosticAnalyzer));
         }
 
         public override bool Equals(object obj)

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -56,6 +56,9 @@ namespace Microsoft.CodeAnalysis
         public abstract DiagnosticFormatter DiagnosticFormatter { get; }
         private readonly HashSet<Diagnostic> _reportedDiagnostics = new HashSet<Diagnostic>();
 
+        public abstract Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger);
+        public abstract void PrintLogo(TextWriter consoleOutput);
+        public abstract void PrintHelp(TextWriter consoleOutput);
         internal abstract string GetToolName();
         internal abstract Version GetAssemblyVersion();
         internal abstract string GetAssemblyFileVersion();
@@ -190,6 +193,7 @@ namespace Microsoft.CodeAnalysis
             return diagnosticInfo;
         }
 
+        public bool ReportErrors(IEnumerable<Diagnostic> diagnostics, TextWriter consoleOutput, ErrorLogger errorLogger)
         {
             bool hasErrors = false;
             foreach (var diag in diagnostics)
@@ -226,6 +230,7 @@ namespace Microsoft.CodeAnalysis
             return hasErrors;
         }
 
+        public bool ReportErrors(IEnumerable<DiagnosticInfo> diagnostics, TextWriter consoleOutput, ErrorLogger errorLogger)
         {
             bool hasErrors = false;
             if (diagnostics != null && diagnostics.Any())
@@ -256,6 +261,7 @@ namespace Microsoft.CodeAnalysis
             consoleOutput.WriteLine(diagnostic.ToString(Culture));
         }
 
+        public ErrorLogger GetErrorLogger(TextWriter consoleOutput, CancellationToken cancellationToken)
         {
             Debug.Assert(Arguments.ErrorLogPath != null);
 

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -56,9 +56,6 @@ namespace Microsoft.CodeAnalysis
         public abstract DiagnosticFormatter DiagnosticFormatter { get; }
         private readonly HashSet<Diagnostic> _reportedDiagnostics = new HashSet<Diagnostic>();
 
-        protected abstract Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger);
-        protected abstract void PrintLogo(TextWriter consoleOutput);
-        protected abstract void PrintHelp(TextWriter consoleOutput);
         internal abstract string GetToolName();
         internal abstract Version GetAssemblyVersion();
         internal abstract string GetAssemblyFileVersion();
@@ -193,7 +190,6 @@ namespace Microsoft.CodeAnalysis
             return diagnosticInfo;
         }
 
-        protected bool ReportErrors(IEnumerable<Diagnostic> diagnostics, TextWriter consoleOutput, ErrorLogger errorLogger)
         {
             bool hasErrors = false;
             foreach (var diag in diagnostics)
@@ -230,7 +226,6 @@ namespace Microsoft.CodeAnalysis
             return hasErrors;
         }
 
-        protected bool ReportErrors(IEnumerable<DiagnosticInfo> diagnostics, TextWriter consoleOutput, ErrorLogger errorLogger)
         {
             bool hasErrors = false;
             if (diagnostics != null && diagnostics.Any())
@@ -261,7 +256,6 @@ namespace Microsoft.CodeAnalysis
             consoleOutput.WriteLine(diagnostic.ToString(Culture));
         }
 
-        private ErrorLogger GetErrorLogger(TextWriter consoleOutput, CancellationToken cancellationToken)
         {
             Debug.Assert(Arguments.ErrorLogPath != null);
 
@@ -763,105 +757,6 @@ namespace Microsoft.CodeAnalysis
         {
             code = 0;
             return diagnosticId.StartsWith(expectedPrefix, StringComparison.Ordinal) && uint.TryParse(diagnosticId.Substring(expectedPrefix.Length), out code);
-        }
-
-        /// <summary>
-        /// csi.exe and vbi.exe entry point.
-        /// </summary>
-        internal int RunInteractive(TextWriter consoleOutput)
-        {
-            ErrorLogger errorLogger = null;
-            if (Arguments.ErrorLogPath != null)
-            {
-                errorLogger = GetErrorLogger(consoleOutput, CancellationToken.None);
-                if (errorLogger == null)
-                {
-                    return Failed;
-                }
-            }
-
-            using (errorLogger)
-            {
-                return RunInteractiveCore(consoleOutput, errorLogger);
-            }
-        }
-
-        /// <summary>
-        /// csi.exe and vbi.exe entry point.
-        /// </summary>
-        private int RunInteractiveCore(TextWriter consoleOutput, ErrorLogger errorLogger)
-        {
-            Debug.Assert(Arguments.IsInteractive);
-
-            var hasScriptFiles = Arguments.SourceFiles.Any(file => file.IsScript);
-
-            if (Arguments.DisplayLogo && !hasScriptFiles)
-            {
-                PrintLogo(consoleOutput);
-            }
-
-            if (Arguments.DisplayHelp)
-            {
-                PrintHelp(consoleOutput);
-                return 0;
-            }
-
-            // TODO (tomat):
-            // When we have command line REPL enabled we'll launch it if there are no input files. 
-            IEnumerable<Diagnostic> errors = Arguments.Errors;
-            if (!hasScriptFiles)
-            {
-                errors = errors.Concat(new[] { Diagnostic.Create(MessageProvider, MessageProvider.ERR_NoScriptsSpecified) });
-            }
-
-            if (ReportErrors(errors, consoleOutput, errorLogger))
-            {
-                return Failed;
-            }
-
-            // arguments are always available when executing script code:
-            Debug.Assert(Arguments.ScriptArguments != null);
-
-            var compilation = CreateCompilation(consoleOutput, touchedFilesLogger: null, errorLogger: errorLogger);
-            if (compilation == null)
-            {
-                return Failed;
-            }
-
-            byte[] compiledAssembly;
-            using (MemoryStream output = new MemoryStream())
-            {
-                EmitResult emitResult = compilation.Emit(output);
-                if (ReportErrors(emitResult.Diagnostics, consoleOutput, errorLogger))
-                {
-                    return Failed;
-                }
-
-                compiledAssembly = output.ToArray();
-            }
-
-            var assembly = Assembly.Load(compiledAssembly);
-
-            return Execute(assembly, Arguments.ScriptArguments.ToArray());
-        }
-
-        private static int Execute(Assembly assembly, string[] scriptArguments)
-        {
-            var parameters = assembly.EntryPoint.GetParameters();
-            object[] arguments;
-
-            if (parameters.Length == 0)
-            {
-                arguments = SpecializedCollections.EmptyObjects;
-            }
-            else
-            {
-                Debug.Assert(parameters.Length == 1);
-                arguments = new object[] { scriptArguments };
-            }
-
-            object result = assembly.EntryPoint.Invoke(null, arguments);
-            return result is int ? (int)result : Succeeded;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Desktop/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/ErrorLogger.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis
             // End dictionary for log file key-value pairs.
             EndGroup();
 
-            _writer.Close();
+            _writer.Dispose();
         }
     }
 }

--- a/src/Compilers/Core/Desktop/CommandLine/RuleSet/RuleSet.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/RuleSet/RuleSet.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // If this file has already been included don't recurse into it.
-                if (!arrayBuilder.Contains(ruleSet.FilePath, StringComparer.InvariantCultureIgnoreCase))
+                if (!arrayBuilder.Contains(ruleSet.FilePath, StringComparer.OrdinalIgnoreCase))
                 {
                     ruleSet.GetEffectiveIncludesCore(arrayBuilder);
                 }

--- a/src/Compilers/Core/MSBuildTask/BuildClient.cs
+++ b/src/Compilers/Core/MSBuildTask/BuildClient.cs
@@ -164,8 +164,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         {
                             try
                             {
-                                holdsMutex = mutex.WaitOne(TimeOutMsNewProcess,
-                                    exitContext: false);
+                                holdsMutex = mutex.WaitOne(TimeOutMsNewProcess);
                             }
                             catch (AbandonedMutexException)
                             {

--- a/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
+++ b/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 // Grab the MemoryStream and its internal buffer
                 // to prevent making another copy.
-                var stream = (MemoryStream)writer.BaseStream;
+                var stream = writer.BaseStream;
                 // Write the length of the request
                 int length = checked((int)stream.Length);
 
@@ -258,8 +258,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     ///
     /// Field Name       Field Type          Size (bytes)
     /// -------------------------------------------------
-    /// responseType     enum ResponseType   4
     /// responseLength   int (positive)      4  
+    /// responseType     enum ResponseType   4
     /// responseBody     Response subclass   variable
     /// </summary>
     internal abstract class BuildResponse
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 // Grab the MemoryStream and its internal buffer to prevent
                 // making another copy.
-                var stream = (MemoryStream)writer.BaseStream;
+                var stream = writer.BaseStream;
 
                 // Write the length of the response
                 int length = checked((int)stream.Length);

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return analyzers;
         }
 
-        protected override Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger)
+        public override Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLogger)
         {
             Compilation = base.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger);
             return Compilation;

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -48,7 +48,7 @@ Friend Class MockVisualBasicCompiler
         Return analyzers
     End Function
 
-    Protected Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger) As Compilation
+    Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger) As Compilation
         Compilation = MyBase.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger)
         Return Compilation
     End Function

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return tree
         End Function
 
-        Protected Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger) As Compilation
+        Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger) As Compilation
             Dim parseOptions = Arguments.ParseOptions
             Dim scriptParseOptions = parseOptions.WithKind(SourceCodeKind.Script)
 
@@ -169,7 +169,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Print compiler logo
         ''' </summary>
         ''' <param name="consoleOutput"></param>
-        Protected Overrides Sub PrintLogo(consoleOutput As TextWriter)
+        Public Overrides Sub PrintLogo(consoleOutput As TextWriter)
             consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LogoLine1, Culture), GetToolName(), GetAssemblyFileVersion())
             consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LogoLine2, Culture))
             consoleOutput.WriteLine()
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Print Commandline help message (up to 80 English characters per line)
         ''' </summary>
         ''' <param name="consoleOutput"></param>
-        Protected Overrides Sub PrintHelp(consoleOutput As TextWriter)
+        Public Overrides Sub PrintHelp(consoleOutput As TextWriter)
             consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture))
         End Sub
 

--- a/src/Interactive/csi/Csi.cs
+++ b/src/Interactive/csi/Csi.cs
@@ -28,7 +28,7 @@ namespace CSharpInteractive
             try
             {
                 var responseFile = CommonCompiler.GetResponseFileFullPath(InteractiveResponseFileName);
-                return new Csi(responseFile, Directory.GetCurrentDirectory(), args).RunInteractive(Console.Out);
+                return ScriptCompilerUtil.RunInteractive(new Csi(responseFile, Directory.GetCurrentDirectory(), args), Console.Out);
             }
             catch (Exception ex)
             {
@@ -48,7 +48,7 @@ namespace CSharpInteractive
             return new GacFileResolver(Arguments.ReferencePaths, Arguments.BaseDirectory, GacFileResolver.Default.Architectures, CultureInfo.CurrentCulture);
         }
 
-        protected override void PrintLogo(TextWriter consoleOutput)
+        public override void PrintLogo(TextWriter consoleOutput)
         {
             Assembly thisAssembly = typeof(Csi).Assembly;
             consoleOutput.WriteLine(CsiResources.LogoLine1, FileVersionInfo.GetVersionInfo(thisAssembly.Location).FileVersion);
@@ -56,7 +56,7 @@ namespace CSharpInteractive
             consoleOutput.WriteLine();
         }
 
-        protected override void PrintHelp(TextWriter consoleOutput)
+        public override void PrintHelp(TextWriter consoleOutput)
         {
             // TODO: format with word wrapping
             consoleOutput.WriteLine(

--- a/src/Interactive/vbi/Vbi.vb
+++ b/src/Interactive/vbi/Vbi.vb
@@ -23,7 +23,7 @@ Friend NotInheritable Class Vbi
     Public Shared Function Main(args As String()) As Integer
         Try
             Dim responseFile = CommonCompiler.GetResponseFileFullPath(InteractiveResponseFileName)
-            Return New Vbi(responseFile, Directory.GetCurrentDirectory(), args).RunInteractive(Console.Out)
+            Return ScriptCompilerUtil.RunInteractive(New Vbi(responseFile, Directory.GetCurrentDirectory(), args), Console.Out)
         Catch ex As Exception
             Console.WriteLine(ex.ToString())
             Return Failed
@@ -39,20 +39,22 @@ Friend NotInheritable Class Vbi
         Return New GacFileResolver(Arguments.ReferencePaths, Arguments.BaseDirectory, GacFileResolver.Default.Architectures, CultureInfo.CurrentCulture)
     End Function
 
-    Protected Overrides Sub PrintLogo(consoleOutput As TextWriter)
+    Public Overrides Sub PrintLogo(consoleOutput As TextWriter)
         Dim thisAssembly As Assembly = GetType(Vbi).Assembly
         consoleOutput.WriteLine(VbiResources.LogoLine1, FileVersionInfo.GetVersionInfo(thisAssembly.Location).FileVersion)
         consoleOutput.WriteLine(VbiResources.LogoLine2)
         consoleOutput.WriteLine()
     End Sub
 
-    Protected Overrides Sub PrintHelp(consoleOutput As TextWriter)
+    Public Overrides Sub PrintHelp(consoleOutput As TextWriter)
         ' TODO
         consoleOutput.WriteLine("                        Roslyn Interactive Compiler Options")
     End Sub
+
     Protected Overrides Function GetSqmAppID() As UInt32
         Return SqmServiceProvider.BASIC_APPID
     End Function
+
     Protected Overrides Sub CompilerSpecificSqm(sqm As IVsSqmMulti, sqmSession As UInt32)
         sqm.SetDatapoint(sqmSession, SqmServiceProvider.DATAID_SQM_ROSLYN_COMPILERTYPE, CType(SqmServiceProvider.CompilerType.Interactive, UInt32))
     End Sub

--- a/src/Scripting/Core/ScriptCompilerUtil.cs
+++ b/src/Scripting/Core/ScriptCompilerUtil.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,6 +9,8 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Scripting
 {

--- a/src/Scripting/Core/ScriptCompilerUtil.cs
+++ b/src/Scripting/Core/ScriptCompilerUtil.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Scripting
+{
+    internal static class ScriptCompilerUtil
+    {
+        /// <summary>
+        /// csi.exe and vbi.exe entry point.
+        /// </summary>
+        internal static int RunInteractive(CommonCompiler compiler, TextWriter consoleOutput)
+        {
+            ErrorLogger errorLogger = null;
+            if (compiler.Arguments.ErrorLogPath != null)
+            {
+                errorLogger = compiler.GetErrorLogger(consoleOutput, CancellationToken.None);
+                if (errorLogger == null)
+                {
+                    return CommonCompiler.Failed;
+                }
+            }
+
+            using (errorLogger)
+            {
+                return RunInteractiveCore(compiler, consoleOutput, errorLogger);
+            }
+        }
+
+        /// <summary>
+        /// csi.exe and vbi.exe entry point.
+        /// </summary>
+        private static int RunInteractiveCore(CommonCompiler compiler, TextWriter consoleOutput, ErrorLogger errorLogger)
+        {
+            Debug.Assert(compiler.Arguments.IsInteractive);
+
+            var hasScriptFiles = compiler.Arguments.SourceFiles.Any(file => file.IsScript);
+
+            if (compiler.Arguments.DisplayLogo && !hasScriptFiles)
+            {
+                compiler.PrintLogo(consoleOutput);
+            }
+
+            if (compiler.Arguments.DisplayHelp)
+            {
+                compiler.PrintHelp(consoleOutput);
+                return 0;
+            }
+
+            // TODO (tomat):
+            // When we have command line REPL enabled we'll launch it if there are no input files. 
+            IEnumerable<Diagnostic> errors = compiler.Arguments.Errors;
+            if (!hasScriptFiles)
+            {
+                errors = errors.Concat(new[] { Diagnostic.Create(compiler.MessageProvider, compiler.MessageProvider.ERR_NoScriptsSpecified) });
+            }
+
+            if (compiler.ReportErrors(errors, consoleOutput, errorLogger))
+            {
+                return CommonCompiler.Failed;
+            }
+
+            // arguments are always available when executing script code:
+            Debug.Assert(compiler.Arguments.ScriptArguments != null);
+
+            var compilation = compiler.CreateCompilation(consoleOutput, touchedFilesLogger: null, errorLogger: errorLogger);
+            if (compilation == null)
+            {
+                return CommonCompiler.Failed;
+            }
+
+            byte[] compiledAssembly;
+            using (MemoryStream output = new MemoryStream())
+            {
+                EmitResult emitResult = compilation.Emit(output);
+                if (compiler.ReportErrors(emitResult.Diagnostics, consoleOutput, errorLogger))
+                {
+                    return CommonCompiler.Failed;
+                }
+
+                compiledAssembly = output.ToArray();
+            }
+
+            var assembly = Assembly.Load(compiledAssembly);
+
+            return Execute(assembly, compiler.Arguments.ScriptArguments.ToArray());
+        }
+
+        private static int Execute(Assembly assembly, string[] scriptArguments)
+        {
+            var parameters = assembly.EntryPoint.GetParameters();
+            object[] arguments;
+
+            if (parameters.Length == 0)
+            {
+                arguments = SpecializedCollections.EmptyObjects;
+            }
+            else
+            {
+                Debug.Assert(parameters.Length == 1);
+                arguments = new object[] { scriptArguments };
+            }
+
+            object result = assembly.EntryPoint.Invoke(null, arguments);
+            return result is int ? (int)result : CommonCompiler.Succeeded;
+        }
+    }
+}

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ObjectFormatter.Formatter.cs" />
     <Compile Include="Script.cs" />
     <Compile Include="ScriptBuilder.cs" />
+    <Compile Include="ScriptCompilerUtil.cs" />
     <Compile Include="ScriptingResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Made a number of small changes to enable building on CoreFx

- Remove uses of MemoryStream::GetBuffer.  This API isn't supported on
CoreFx. The TryGetBuffer is available but in these cases seemed better
to just call Stream::CopyTo
- Changed Type.Assembly to Type.GetTypeInfo().Assembly
- Moved scripting APIs out of CommonCompiler and into
ScriptCompilerUtil.  These methods relied on APIs that are not available
on CoreFx and have no equivalent.
- Minor API updates.