### PR TITLE
[EnC] Fix ArgumentException in SymbolMatcher

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol VisitArrayType(ArrayTypeSymbol symbol)
             {
                 var otherElementType = (TypeSymbol)this.Visit(symbol.ElementType);
-                if (otherElementType == null)
+                if ((object)otherElementType == null)
                 {
                     // For a newly added type, there is no match in the previous generation, so it could be null.
                     return null;
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol VisitPointerType(PointerTypeSymbol symbol)
             {
                 var otherPointedAtType = (TypeSymbol)this.Visit(symbol.PointedAtType);
-                if (otherPointedAtType == null)
+                if ((object)otherPointedAtType == null)
                 {
                     // For a newly added type, there is no match in the previous generation, so it could be null.
                     return null;

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -350,7 +350,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol VisitArrayType(ArrayTypeSymbol symbol)
             {
                 var otherElementType = (TypeSymbol)this.Visit(symbol.ElementType);
-                Debug.Assert((object)otherElementType != null);
+                if (otherElementType == null)
+                {
+                    // For a newly added type, there is no match in the previous generation, so it could be null.
+                    return null;
+                }
                 var otherModifiers = VisitCustomModifiers(symbol.CustomModifiers);
                 return new ArrayTypeSymbol(_otherAssembly, otherElementType, otherModifiers, symbol.Rank);
             }
@@ -421,7 +425,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                     var otherTypeParameters = otherDef.GetAllTypeParameters();
                     var otherTypeArguments = typeArguments.SelectAsArray((t, v) => (TypeSymbol)v.Visit(t), this);
-                    Debug.Assert(otherTypeArguments.All(t => (object)t != null));
+                    if (otherTypeArguments.Any(t => (object)t == null))
+                    {
+                        // For a newly added type, there is no match in the previous generation, so it could be null.
+                        return null;
+                    }
 
                     // TODO: LambdaFrame has alpha renamed type parameters, should we rather fix that?
                     var typeMap = new TypeMap(otherTypeParameters, otherTypeArguments, allowAlpha: true);
@@ -474,7 +482,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol VisitPointerType(PointerTypeSymbol symbol)
             {
                 var otherPointedAtType = (TypeSymbol)this.Visit(symbol.PointedAtType);
-                Debug.Assert((object)otherPointedAtType != null);
+                if (otherPointedAtType == null)
+                {
+                    // For a newly added type, there is no match in the previous generation, so it could be null.
+                    return null;
+                }
                 var otherModifiers = VisitCustomModifiers(symbol.CustomModifiers);
                 return new PointerTypeSymbol(otherPointedAtType, otherModifiers);
             }

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -284,7 +284,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
             Public Overrides Function VisitArrayType(symbol As ArrayTypeSymbol) As Symbol
                 Dim otherElementType As TypeSymbol = DirectCast(Me.Visit(symbol.ElementType), TypeSymbol)
-                Debug.Assert(otherElementType IsNot Nothing)
+                If otherElementType Is Nothing Then
+                    ' For a newly added type, there is no match in the previous generation, so it could be Nothing.
+                    Return Nothing
+                End If
                 Dim otherModifiers = VisitCustomModifiers(symbol.CustomModifiers)
                 Return New ArrayTypeSymbol(otherElementType, otherModifiers, symbol.Rank, Me._otherAssembly)
             End Function
@@ -341,7 +344,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                     Dim otherTypeParameters As ImmutableArray(Of TypeParameterSymbol) = otherDef.GetAllTypeParameters()
                     Dim otherTypeArguments As ImmutableArray(Of TypeSymbol) = typeArguments.SelectAsArray(Function(t, v) DirectCast(v.Visit(t), TypeSymbol), Me)
-                    Debug.Assert(otherTypeArguments.All(Function(t) t IsNot Nothing))
+                    If otherTypeArguments.Any(Function(t) t Is Nothing) Then
+                        ' For a newly added type, there is no match in the previous generation, so it could be Nothing.
+                        Return Nothing
+                    End If
 
                     Dim typeMap = TypeSubstitution.Create(otherDef, otherTypeParameters, otherTypeArguments, False)
                     Return otherDef.Construct(typeMap)

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -161,6 +161,7 @@
     <Compile Include="Emit\EditAndContinue\EditAndContinueStateMachineTests.vb" />
     <Compile Include="Emit\EditAndContinue\EditAndContinueTestBase.vb" />
     <Compile Include="Emit\EditAndContinue\EditAndContinueTests.vb" />
+    <Compile Include="Emit\EditAndContinue\SymbolMatcherTests.vb" />
     <Compile Include="Emit\EmitCustomModifiers.vb" />
     <Compile Include="Emit\EmitErrorTests.vb" />
     <Compile Include="Emit\EmitMetadata.vb" />

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -1,0 +1,134 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.CodeGen
+Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Emit
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+    Public Class SymbolMatcherTests
+        Inherits EditAndContinueTestBase
+
+        <WorkItem(1533)>
+        <Fact>
+        Public Sub PreviousType_ArrayType()
+            Dim sources0 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Class C
+    Shared Sub M()
+        Dim x As Integer = 0
+    End Sub
+    Class D : End Class
+End Class
+]]></file>
+                           </compilation>
+            Dim sources1 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Class C
+    Shared Sub M()
+        Dim x() As D = Nothing
+    End Sub
+    Class D : End Class
+End Class
+]]></file>
+                           </compilation>
+
+            Dim compilation0 = CreateCompilationWithMscorlib(sources0, TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(sources1)
+            Dim matcher = New VisualBasicSymbolMatcher(
+                Nothing,
+                compilation1.SourceAssembly,
+                Nothing,
+                compilation0.SourceAssembly,
+                Nothing,
+                Nothing)
+            Dim elementType = compilation1.GetMember(Of TypeSymbol)("C.D")
+            Dim member = compilation1.CreateArrayTypeSymbol(elementType)
+            Dim other = matcher.MapReference(member)
+            Assert.NotNull(other)
+        End Sub
+
+        <WorkItem(1533)>
+        <Fact>
+        Public Sub NoPreviousType_ArrayType()
+            Dim sources0 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Class C
+    Shared Sub M()
+        Dim x As Integer = 0
+    End Sub
+End Class
+]]></file>
+                           </compilation>
+            Dim sources1 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Class C
+    Shared Sub M()
+        Dim x() As D = Nothing
+    End Sub
+    Class D : End Class
+End Class
+]]></file>
+                           </compilation>
+
+            Dim compilation0 = CreateCompilationWithMscorlib(sources0, TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(sources1)
+            Dim matcher = New VisualBasicSymbolMatcher(
+                Nothing,
+                compilation1.SourceAssembly,
+                Nothing,
+                compilation0.SourceAssembly,
+                Nothing,
+                Nothing)
+            Dim elementType = compilation1.GetMember(Of TypeSymbol)("C.D")
+            Dim member = compilation1.CreateArrayTypeSymbol(elementType)
+            Dim other = matcher.MapReference(member)
+            ' For a newly added type, there is no match in the previous generation.
+            Assert.Null(other)
+        End Sub
+
+        <WorkItem(1533)>
+                                   <Fact>
+        Public Sub NoPreviousType_GenericType()
+            Dim sources0 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Imports System.Collections.Generic
+Class C
+    Shared Sub M()
+        Dim x As Integer = 0
+    End Sub
+End Class
+]]></file>
+                           </compilation>
+            Dim sources1 = <compilation>
+                               <file name="a.vb"><![CDATA[
+Imports System.Collections.Generic
+Class C
+    Shared Sub M()
+        Dim x As List(Of D) = Nothing
+    End Sub
+    Class D : End Class
+    Dim y As List(Of D)
+End Class
+]]></file>
+                           </compilation>
+
+            Dim compilation0 = CreateCompilationWithMscorlib(sources0, TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(sources1)
+            Dim matcher = New VisualBasicSymbolMatcher(
+                Nothing,
+                compilation1.SourceAssembly,
+                Nothing,
+                compilation0.SourceAssembly,
+                Nothing,
+                Nothing)
+            Dim member = compilation1.GetMember(Of FieldSymbol)("C.y")
+            Dim other = matcher.MapReference(DirectCast(member.Type, Cci.ITypeReference))
+            ' For a newly added type, there is no match in the previous generation.
+            Assert.Null(other)
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
For a newly added type, there is no match in the previous generation but we were still looking for its match in some cases like array, type arguments and pointer. This fixes issue #1533.