### PR TITLE
display the class's doc comment in attribute quick info

### DIFF
--- a/src/EditorFeatures/CSharp/QuickInfo/SemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/CSharp/QuickInfo/SemanticQuickInfoProvider.cs
@@ -2,10 +2,8 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -29,6 +27,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.QuickInfo
             : base(textBufferFactoryService, contentTypeRegistryService, projectionBufferFactoryService,
                    editorOptionsFactoryService, textEditorFactoryService, glyphService, typeMap)
         {
+        }
+
+        protected override bool IsAttributeSyntax(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.Attribute);
         }
 
         protected override bool ShouldCheckPreviousToken(SyntaxToken token)

--- a/src/EditorFeatures/CSharp/QuickInfo/SemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/CSharp/QuickInfo/SemanticQuickInfoProvider.cs
@@ -29,11 +29,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.QuickInfo
         {
         }
 
-        protected override bool IsAttributeSyntax(SyntaxNode node)
-        {
-            return node.IsKind(SyntaxKind.Attribute);
-        }
-
         protected override bool ShouldCheckPreviousToken(SyntaxToken token)
         {
             return !token.Parent.IsKind(SyntaxKind.XmlCrefAttribute);

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -2594,6 +2594,54 @@ class class1Attribute : Attribute
                 MainDescription($"({FeaturesResources.Field}) class1Attribute class1Attribute.x"));
         }
 
+        [WorkItem(1696, "https://github.com/dotnet/roslyn/issues/1696")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void AttributeQuickInfoBindsToClassTest()
+        {
+            Test(@"
+using System;
+
+/// <summary>
+/// class comment
+/// </summary>
+[Some$$]
+class SomeAttribute : Attribute
+{
+    /// <summary>
+    /// ctor comment
+    /// </summary>
+    public SomeAttribute()
+    {
+    }
+}
+",
+                Documentation("class comment"));
+        }
+
+        [WorkItem(1696, "https://github.com/dotnet/roslyn/issues/1696")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void AttributeConstructorQuickInfo()
+        {
+            Test(@"
+using System;
+
+/// <summary>
+/// class comment
+/// </summary>
+class SomeAttribute : Attribute
+{
+    /// <summary>
+    /// ctor comment
+    /// </summary>
+    public SomeAttribute()
+    {
+        var s = new Some$$Attribute();
+    }
+}
+",
+                Documentation("ctor comment"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void TestLabel()
         {

--- a/src/EditorFeatures/VisualBasic/QuickInfo/SemanticQuickInfoProvider.vb
+++ b/src/EditorFeatures/VisualBasic/QuickInfo/SemanticQuickInfoProvider.vb
@@ -6,7 +6,6 @@ Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Intellisense.QuickInfo
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
 Imports Microsoft.VisualStudio.Language.Intellisense
@@ -105,6 +104,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.QuickInfo
             End Select
 
             Return Await MyBase.BuildContentAsync(document, token, cancellationToken).ConfigureAwait(False)
+        End Function
+
+        Protected Overrides Function IsAttributeSyntax(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.Attribute)
         End Function
 
         Private Overloads Async Function BuildContentAsync(document As Document,

--- a/src/EditorFeatures/VisualBasic/QuickInfo/SemanticQuickInfoProvider.vb
+++ b/src/EditorFeatures/VisualBasic/QuickInfo/SemanticQuickInfoProvider.vb
@@ -106,10 +106,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.QuickInfo
             Return Await MyBase.BuildContentAsync(document, token, cancellationToken).ConfigureAwait(False)
         End Function
 
-        Protected Overrides Function IsAttributeSyntax(node As SyntaxNode) As Boolean
-            Return node.IsKind(SyntaxKind.Attribute)
-        End Function
-
         Private Overloads Async Function BuildContentAsync(document As Document,
                                                 token As SyntaxToken,
                                                 declarators As SeparatedSyntaxList(Of VariableDeclaratorSyntax),

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -830,6 +830,52 @@ End Class]]></Text>.NormalizedValue,
             MainDescription($"({FeaturesResources.Field}) Class1Attribute.x As Class1Attribute"))
         End Sub
 
+        <WorkItem(1696, "https://github.com/dotnet/roslyn/issues/1696")>
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Sub AttributeQuickInfoBindsToClassTest()
+            Test("
+Imports System
+
+''' <summary>
+''' class comment
+''' </summary>
+<Some$$>
+Class SomeAttribute
+    Inherits Attribute
+
+    ''' <summary>
+    ''' ctor comment
+    ''' </summary>
+    Public Sub New()
+    End Sub
+End Class
+",
+                Documentation("class comment"))
+        End Sub
+
+        <WorkItem(1696, "https://github.com/dotnet/roslyn/issues/1696")>
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Sub AttributeConstructorQuickInfo()
+            Test("
+Imports System
+
+''' <summary>
+''' class comment
+''' </summary>
+Class SomeAttribute
+    Inherits Attribute
+
+    ''' <summary>
+    ''' ctor comment
+    ''' </summary>
+    Public Sub New()
+        Dim s = New Some$$Attribute()
+    End Sub
+End Class
+",
+                Documentation("ctor comment"))
+        End Sub
+
         <WorkItem(542613)>
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Sub TestUnboundGeneric()


### PR DESCRIPTION
When displaying quick info for attributes, the attribute binds to the constructor symbol so that's where the doc comment is pulled from.  As discussed in the bug, this fix is to special-case attributes to show the type's doc comment instead of the .ctor.

Fixes #1696.

Tagging @Pilchie @dpoeschl @jasonmalinowski @rchande @balajikris @basoundr for review.