### PR TITLE
Explicitly pass down compiler exe location

### DIFF
--- a/src/Compilers/CSharp/csc/Csc.cs
+++ b/src/Compilers/CSharp/csc/Csc.cs
@@ -16,11 +16,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
         {
         }
 
-        internal static int Run(string[] args)
+        internal static int Run(string clientDir, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
-            var responseFile = CommonCompiler.GetResponseFileFullPath(CSharpCompiler.ResponseFileName);
+            var responseFile = Path.Combine(clientDir, CSharpCompiler.ResponseFileName);
             Csc compiler = new Csc(responseFile, Directory.GetCurrentDirectory(), args);
 
             // We store original encoding and restore it later to revert 

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.BuildTasks;
 using System;
+using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine
@@ -9,14 +9,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
     public class Program
     {
         public static int Main(string[] args)
-        {
-            var clientDir = AppDomain.CurrentDomain.BaseDirectory;
-            return BuildClient.RunWithConsoleOutput(
+            => BuildClient.RunWithConsoleOutput(
                 args,
-                clientDir: clientDir,
+                clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Environment.CurrentDirectory,
                 language: RequestLanguage.CSharpCompile,
-                fallbackCompiler: x => Csc.Run(clientDir, x));
-        }
+                fallbackCompiler: Csc.Run);
     }
 }

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.BuildTasks;
+using System;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine
@@ -8,6 +9,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
     public class Program
     {
         public static int Main(string[] args)
-            => BuildClient.RunWithConsoleOutput(args, RequestLanguage.CSharpCompile, Csc.Run);
+        {
+            var clientDir = AppDomain.CurrentDomain.BaseDirectory;
+            return BuildClient.RunWithConsoleOutput(
+                args,
+                clientDir: clientDir,
+                workingDir: Environment.CurrentDirectory,
+                language: RequestLanguage.CSharpCompile,
+                fallbackCompiler: x => Csc.Run(clientDir, x));
+        }
     }
 }

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -26,31 +26,6 @@ namespace Microsoft.CodeAnalysis
         internal const int Failed = 1;
         internal const int Succeeded = 0;
 
-        /// <summary>
-        /// Return the path in which to look for response files.  This should only be called 
-        /// on EXE entry points as the implementation relies on managed entry points.
-        /// </summary>
-        /// <returns></returns>
-        internal static string GetResponseFileDirectory()
-        {
-            var exePath = Assembly.GetEntryAssembly().Location;
-
-            // This assert will fire when this method is called from places like xUnit and certain
-            // types of AppDomains.  It should only be called on EXE entry points to help guarantee
-            // this is being called from an executed assembly.
-            Debug.Assert(exePath != null);
-            return Path.GetDirectoryName(exePath);
-        }
-
-        /// <summary>
-        /// Called from a compiler exe entry point to get the full path to the response file for
-        /// the given name.  Will return a fully qualified path.
-        /// </summary>
-        internal static string GetResponseFileFullPath(string responseFileName)
-        {
-            return Path.Combine(GetResponseFileDirectory(), responseFileName);
-        }
-
         public CommonMessageProvider MessageProvider { get; private set; }
         public CommandLineArguments Arguments { get; private set; }
         public abstract DiagnosticFormatter DiagnosticFormatter { get; }

--- a/src/Compilers/Core/MSBuildTask/BuildClient.cs
+++ b/src/Compilers/Core/MSBuildTask/BuildClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             string clientDir,
             string workingDir,
             RequestLanguage language,
-            Func<string[], int> fallbackCompiler)
+            Func<string, string[], int> fallbackCompiler)
         {
             args = args.Select(arg => arg.Trim()).ToArray();
 
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
-            return fallbackCompiler(parsedArgs.ToArray());
+            return fallbackCompiler(clientDir, parsedArgs.ToArray());
         }
 
         private static int HandleResponse(BuildResponse response)

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         private static string TryGetClientDir()
         {
-            var assembly = typeof(BuildClient).Assembly;
+            var assembly = typeof(ManagedCompiler).Assembly;
 
             if (assembly.GlobalAssemblyCache)
                 return null;

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -6,12 +6,12 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.CodeAnalysis.CompilerServer;
-using System.Reflection;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
 {

--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -68,6 +68,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             TimeSpan? keepAliveTimeout = null;
 
+            // VBCSCompiler is installed in the same directory as csc.exe and vbc.exe which is also the 
+            // location of the response files.
+            var compilerExeDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
             try
             {
                 int keepAliveValue;
@@ -99,9 +103,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             CompilerServerLogger.Log("Keep alive timeout is: {0} milliseconds.", keepAliveTimeout?.TotalMilliseconds ?? 0);
             FatalError.Handler = FailFast.OnFatalException;
 
-            // VBCSCompiler is installed in the same directory as csc.exe and vbc.exe which is also the 
-            // location of the response files.
-            var compilerExeDirectory = CommonCompiler.GetResponseFileDirectory();
             var dispatcher = new ServerDispatcher(new CompilerRequestHandler(compilerExeDirectory), new EmptyDiagnosticListener());
 
             dispatcher.ListenAndDispatchConnections(

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.BuildTasks;
+using System;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
@@ -8,6 +9,14 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
     public class Program
     {
         public static int Main(string[] args)
-            => BuildClient.RunWithConsoleOutput(args, RequestLanguage.VisualBasicCompile, Vbc.Run);
+        {
+            var clientDir = AppDomain.CurrentDomain.BaseDirectory;
+            return BuildClient.RunWithConsoleOutput(
+                args,
+                clientDir: clientDir,
+                workingDir: Environment.CurrentDirectory,
+                language: RequestLanguage.VisualBasicCompile,
+                fallbackCompiler: x => Vbc.Run(x, clientDir));
+        }
     }
 }

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.BuildTasks;
 using System;
+using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
@@ -9,14 +9,11 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
     public class Program
     {
         public static int Main(string[] args)
-        {
-            var clientDir = AppDomain.CurrentDomain.BaseDirectory;
-            return BuildClient.RunWithConsoleOutput(
+            => BuildClient.RunWithConsoleOutput(
                 args,
-                clientDir: clientDir,
+                clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Environment.CurrentDirectory,
                 language: RequestLanguage.VisualBasicCompile,
-                fallbackCompiler: x => Vbc.Run(x, clientDir));
-        }
+                fallbackCompiler: Vbc.Run);
     }
 }

--- a/src/Compilers/VisualBasic/vbc/Vbc.cs
+++ b/src/Compilers/VisualBasic/vbc/Vbc.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
         {
         }
 
-        internal static int Run(string[] args, string clientDir)
+        internal static int Run(string clientDir, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 

--- a/src/Compilers/VisualBasic/vbc/Vbc.cs
+++ b/src/Compilers/VisualBasic/vbc/Vbc.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
         {
         }
 
-        internal static int Run(string[] args)
+        internal static int Run(string[] args, string clientDir)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
-            var responseFile = CommonCompiler.GetResponseFileFullPath(VisualBasicCompiler.ResponseFileName);
+            var responseFile = Path.Combine(clientDir, VisualBasicCompiler.ResponseFileName);
             Vbc compiler = new Vbc(responseFile, Directory.GetCurrentDirectory(), args);
 
             // We store original encoding and restore it later to revert 

--- a/src/Interactive/csi/Csi.cs
+++ b/src/Interactive/csi/Csi.cs
@@ -27,7 +27,7 @@ namespace CSharpInteractive
         {
             try
             {
-                var responseFile = CommonCompiler.GetResponseFileFullPath(InteractiveResponseFileName);
+                var responseFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, InteractiveResponseFileName);
                 return ScriptCompilerUtil.RunInteractive(new Csi(responseFile, Directory.GetCurrentDirectory(), args), Console.Out);
             }
             catch (Exception ex)

--- a/src/Interactive/vbi/Vbi.vb
+++ b/src/Interactive/vbi/Vbi.vb
@@ -22,7 +22,7 @@ Friend NotInheritable Class Vbi
 
     Public Shared Function Main(args As String()) As Integer
         Try
-            Dim responseFile = CommonCompiler.GetResponseFileFullPath(InteractiveResponseFileName)
+            Dim responseFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, InteractiveResponseFileName)
             Return ScriptCompilerUtil.RunInteractive(New Vbi(responseFile, Directory.GetCurrentDirectory(), args), Console.Out)
         Catch ex As Exception
             Console.WriteLine(ex.ToString())


### PR DESCRIPTION
The common parts of the compiler were attempting to deduce the directory
of the compiler exe by using various reflection / assembly APIs.  This
is a fragile method that is easy to break in unrelated code.
Additionally this API is not available on CoreFx.

The fix is to simply thread the compiler exe path through from the Main
methods on the EXE.