### PR TITLE
Add filter for SyntaxGenerator.Declaration

### DIFF
--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editting
         private readonly SyntaxGenerator _g = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
 
         private readonly CSharpCompilation _emptyCompilation = CSharpCompilation.Create("empty",
-                references: new[] { TestReferences.NetFx.v4_0_30319.mscorlib });
+                references: new[] { TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System });
 
         private readonly INamedTypeSymbol _ienumerableInt;
 
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editting
             Assert.Equal(expectedText, normalized);
         }
 
+        #region Expressions and Statements
         [Fact]
         public void TestLiteralExpressions()
         {
@@ -559,7 +560,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editting
                 _g.VoidReturningLambdaExpression(new[] { _g.LambdaParameter("x", _g.IdentifierName("y")), _g.LambdaParameter("a", _g.IdentifierName("b")) }, _g.IdentifierName("z")),
                 "(y x, b a) => z");
         }
+        #endregion
 
+        #region Declarations
         [Fact]
         public void TestFieldDeclarations()
         {
@@ -1376,6 +1379,24 @@ public class C { } // end").Members[0];
                     "a", _g.IdentifierName("x")),
             "delegate void d<a, b>()where a : x;");
         }
+
+        [Fact]
+        public void TestInterfaceDeclarationWithEventFromSymbol()
+        {
+            VerifySyntax<InterfaceDeclarationSyntax>(
+                _g.Declaration(_emptyCompilation.GetTypeByMetadataName("System.ComponentModel.INotifyPropertyChanged")),
+@"public interface INotifyPropertyChanged
+{
+    event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged
+    {
+        add;
+        remove;
+    }
+}");
+        }
+        #endregion
+
+        #region Add/Insert/Remove/Get declarations & members/elements
 
         private void AssertNamesEqual(string[] expectedNames, IEnumerable<SyntaxNode> actualNodes)
         {
@@ -2750,5 +2771,6 @@ public void M()
 {
 }");
         }
+        #endregion
     }
 }

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editting
     Public Class SyntaxGeneratorTests
         Private ReadOnly _g As SyntaxGenerator = SyntaxGenerator.GetGenerator(New AdhocWorkspace(), LanguageNames.VisualBasic)
 
-        Private ReadOnly _emptyCompilation As VisualBasicCompilation = VisualBasicCompilation.Create("empty", references:={TestReferences.NetFx.v4_0_30319.mscorlib})
+        Private ReadOnly _emptyCompilation As VisualBasicCompilation = VisualBasicCompilation.Create("empty", references:={TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System})
 
         Private _ienumerableInt As INamedTypeSymbol
 
@@ -38,6 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editting
             Return SyntaxFactory.ParseCompilationUnit(fixedText)
         End Function
 
+#Region "Expressions & Statements"
         <Fact>
         Public Sub TestLiteralExpressions()
             VerifySyntax(Of LiteralExpressionSyntax)(_g.LiteralExpression(0), "0")
@@ -621,7 +622,9 @@ End Sub</x>.Value)
                 _g.VoidReturningLambdaExpression({_g.LambdaParameter("x", _g.IdentifierName("y")), _g.LambdaParameter("a", _g.IdentifierName("b"))}, _g.IdentifierName("z")),
                 <x>Sub(x As y, a As b) z</x>.Value)
         End Sub
+#End Region
 
+#Region "Declarations"
         <Fact>
         Public Sub TestFieldDeclarations()
             VerifySyntax(Of FieldDeclarationSyntax)(
@@ -1741,6 +1744,19 @@ End Class ' end</x>.Value)
 
         End Sub
 
+        <Fact>
+        Public Sub TestInterfaceDeclarationWithEventSymbol()
+            VerifySyntax(Of InterfaceBlockSyntax)(
+                _g.Declaration(_emptyCompilation.GetTypeByMetadataName("System.ComponentModel.INotifyPropertyChanged")),
+<x>Public Interface INotifyPropertyChanged
+
+    Event PropertyChanged As Global.System.ComponentModel.PropertyChangedEventHandler
+
+End Interface</x>.Value)
+        End Sub
+#End Region
+
+#Region "Add/Insert/Remove/Get/Set members & elements"
         <Fact>
         Public Sub TestDeclarationKind()
             Assert.Equal(DeclarationKind.CompilationUnit, _g.GetDeclarationKind(_g.CompilationUnit()))
@@ -3032,6 +3048,7 @@ Imports X
 </x>.Value)
 
         End Sub
+#End Region
 
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #1500 

This change adds a filter to the places where SyntaxGenerator.Declaration recursively calls itself. For example, when a class symbol is converted to a declaration, the method recursively calls itself on all the class symbol's members. The filter culls all member symbols that are not supported for converting into declarations directly such as property accessors, etc, so they don't cause an exception to be thrown.

@tmeschter, @srivatsn  please review