### PR TITLE
Fix timestamp written to Debug Image Directory

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/ISymbolWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ISymbolWriter.cs
@@ -58,6 +58,17 @@ namespace Microsoft.Cci
         void DefineConstant2([MarshalAs(UnmanagedType.LPWStr)] string name, VariantStructure value, uint sigToken);
     }
 
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("98ECEE1E-752D-11d3-8D56-00C04F680B2B"), SuppressUnmanagedCodeSecurity]
+    internal interface IPdbWriter
+    {
+        int __SetPath(/*[in] const WCHAR* szFullPathName, [in] IStream* pIStream, [in] BOOL fFullBuild*/);
+        int __OpenMod(/*[in] const WCHAR* szModuleName, [in] const WCHAR* szFileName*/);
+        int __CloseMod();
+        int __GetPath(/*[in] DWORD ccData,[out] DWORD* pccData,[out, size_is(ccData),length_is(*pccData)] WCHAR szPath[]*/);
+
+        void GetSignatureAge(out uint sig, out uint age);
+    }
+
     internal static class ISymUnmanagedWriter2Helper
     {
         public static unsafe void DefineConstant2(this ISymUnmanagedWriter2 writer, string name, object value, uint sigToken)

--- a/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Cci
             }
         }
 
-        public unsafe Guid GetDebugDirectoryGuid()
+        public unsafe void GetDebugDirectoryGuidAndStamp(out Guid guid, out uint stamp)
         {
             // See symwrite.cpp - the data byte[] doesn't depend on the content of metadata tables or IL.
             // The writer only sets two values of the ImageDebugDirectory struct.
@@ -626,7 +626,13 @@ namespace Microsoft.Cci
             byte[] guidBytes = new byte[GuidSize];
             Buffer.BlockCopy(data, 4, guidBytes, 0, guidBytes.Length);
 
-            return new Guid(guidBytes);
+            guid = new Guid(guidBytes);
+
+            // Retrieve the timestamp the PDB writer generates when creating a new PDB stream.
+            // Note that ImageDebugDirectory.TimeDateStamp is not set by GetDebugInfo, 
+            // we need to go thru IPdbWriter interface to get it.
+            uint age;
+            ((IPdbWriter)_symWriter).GetSignatureAge(out stamp, out age);
         }
 
         public void SetEntryPoint(uint entryMethodToken)

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -1442,12 +1442,24 @@ namespace Microsoft.Cci
             MemoryStream stream = new MemoryStream();
             BinaryWriter writer = new BinaryWriter(stream);
 
+            Guid pdbId;
+            uint pdbStamp;
+            if (_nativePdbWriterOpt != null)
+            {
+                _nativePdbWriterOpt.GetDebugDirectoryGuidAndStamp(out pdbId, out pdbStamp);
+            }
+            else
+            {
+                pdbId = Guid.NewGuid();
+                pdbStamp = 0;
+            } 
+
             // characteristics:
             writer.WriteUint(0);
 
             // timestamp from NT headers
             timestampOffset = writer.BaseStream.Position + peStream.Position;
-            writer.WriteUint(_ntHeader.TimeDateStamp);
+            writer.WriteUint(pdbStamp);
 
             // version
             writer.WriteUint(0);
@@ -1472,9 +1484,7 @@ namespace Microsoft.Cci
             writer.WriteByte((byte)'D');
             writer.WriteByte((byte)'S');
 
-            // TODO: use deterministic hash
-            Guid guid = _nativePdbWriterOpt?.GetDebugDirectoryGuid() ?? Guid.NewGuid();
-            writer.WriteBytes(guid.ToByteArray());
+            writer.WriteBytes(pdbId.ToByteArray());
 
             // Age (EnC generation + 1): always 0x00000001.
             // We don't emit PE files when emitting EnC deltas.


### PR DESCRIPTION
Recent changes exposed a bug lurking in the PDB writer for ages. When the native PDB writer internally creates a PDB stream it generates a new GUID and saves the current time as a PDB timestamp. The PE file in its Debug Directory contains the guid and the timestamp. The debugger only uses specified PDB file if both of these values in the PE debug directory match exactly the values in the PDB. 

The PDB GUID is returned via ISymUnmanagedWriter2.GetDebugInfo method. The compiler called it and stored the GUID into the Debug Directory. But for the timestamp we used the timestamp from NT headers that we generate earlier in the writer. ISymUnmanagedWriter2.GetDebugInfo unfortunately doesn't return it and we didn't query the PDB writer for it in any other way.

It so happened that the points in time when we generated the NT header timestamp and when the PDB writer was created were so close that it was very unlikely that these two timestamps are different. With recent changes in the implementation the points got further away.

in this change we use IPdbWriter interface to retrieve the PDB timestamp and write it to the DebugDirectory.

