### PR TITLE
Fix incorrect logic in LocalRewriter.CouldPossiblyBeNothing around method calls.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -164,9 +164,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return False
                 Case BoundKind.Call
                     Dim t = DirectCast(node, BoundCall)
-                    Return t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Delegate__CreateDelegate, True) OrElse
-                        t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Delegate__CreateDelegate4, True) OrElse
-                        t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Reflection_MethodInfo__CreateDelegate, True)
+                    Return Not (t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Delegate__CreateDelegate, True) OrElse
+                                t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Delegate__CreateDelegate4, True) OrElse
+                                t.Method = F.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Reflection_MethodInfo__CreateDelegate, True))
                 Case Else
                     Return True
             End Select

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions_AnonymousDelegates.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions_AnonymousDelegates.vb
@@ -2515,6 +2515,29 @@ BC30521: Overload resolution failed because no accessible 'Test1' is most specif
 </expected>)
         End Sub
 
+        <Fact(), WorkItem(377, "https://github.com/dotnet/roslyn/issues/377")>
+        Public Sub ConvertingNullDelegate()
+
+            Dim compilationDef =
+<compilation name="LambdaTests1">
+    <file name="a.vb">
+Imports System        
+
+Module Program
+    Sub Main()
+        Dim f As Func(Of Boolean) = (Function() If(True, Nothing, Function() True))()
+        System.Console.WriteLine(f Is Nothing)
+    End Sub
+End Module
+    </file>
+</compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(compilation, expectedOutput:="True")
+            verifier.VerifyDiagnostics()
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
This change is related to issue #377. It looks like original repro was addressed in commit 755ffcd, but there was a mistake around handling method calls.