### PR TITLE
don't do partial analysis on out of sync range

### DIFF
--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
@@ -89,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     var existingData = await state.TryGetExistingDataAsync(document, cancellationToken).ConfigureAwait(false);
 
                     ImmutableArray<DiagnosticData> diagnosticData;
-                    if (supportsSemanticInSpan && CanUseDocumentState(existingData, ranges.TextVersion, versions.DataVersion))
+                    if (supportsSemanticInSpan && CanUseRange(memberId, ranges.Ranges) && CanUseDocumentState(existingData, ranges.TextVersion, versions.DataVersion))
                     {
                         var memberDxData = await GetSemanticDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
 
@@ -109,6 +110,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
+            }
+
+            private bool CanUseRange(int memberId, ImmutableArray<TextSpan> ranges)
+            {
+                // range got out of sync, don't do partial analysis
+                return memberId >= 0 && memberId < ranges.Length;
             }
 
             public async Task<AnalysisData> GetProjectAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, VersionArgument versions)

--- a/src/Features/Core/Diagnostics/EngineV1/MemberRangeMap.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/MemberRangeMap.cs
@@ -102,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return;
             }
 
+            // if range is invalid, create new member map
             if (memberId < 0 ||
                 !data.MemberRangeMap.TryGetValue(oldVersion, out range) ||
                 range.Length <= memberId)

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -199,7 +199,7 @@
     <Compile Include="Diagnostics\DiagnosticProviderMetadata.cs" />
     <Compile Include="Diagnostics\DiagnosticService.cs" />
     <Compile Include="Diagnostics\DiagnosticsUpdatedArgs.cs" />
-    <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.IncrementalAnalyzer.AnalyzerExecutor.cs" />
+    <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer_GetDiagnostics.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.NestedTypes.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer.StateType.cs" />


### PR DESCRIPTION
when a user types inside of method body, diagnostic service tries to do only local analysis on that method body for diagnostic analyzer that supports it.

to do that, it tracks member (such as method, property and etc) ranges over user typing. the tracking is relying on parser and syntax tree. but time to time, user types something that throw away syntax tree completely (such as making portion of file skipped tokens). when that happens we need to throw away member range tracking information and re-build them.

we found a case where we didn't check whether range before using it which leads to a crash.

now we should skip local analysis and do full document analysis on such case and re-start range tracking.

...

this is a fix for a external crash report

...

this is a port from - Merge pull request #1609 from heejaechang/watsonfix