### PR TITLE
report project k/shared project IVsHierarchy to error list

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -38,11 +38,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private ITextBuffer _openTextBuffer;
             private readonly string _itemMoniker;
 
-            public DocumentId Id { get; private set; }
-            public IReadOnlyList<string> Folders { get; private set; }
-            public IVisualStudioHostProject Project { get; private set; }
-            public SourceCodeKind SourceCodeKind { get; private set; }
-            public DocumentKey Key { get; private set; }
+            public DocumentId Id { get; }
+            public IReadOnlyList<string> Folders { get; }
+            public IVisualStudioHostProject Project { get; }
+            public SourceCodeKind SourceCodeKind { get; }
+            public DocumentKey Key { get; }
+
+            /// <summary>
+            /// <see cref="IVsHierarchy"/> of shared or project k project.
+            /// </summary>
+            public IVsHierarchy SharedHierarchy { get; }
 
             public event EventHandler UpdatedOnDisk;
             public event EventHandler<bool> Opened;
@@ -66,7 +71,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this.Project = project;
                 this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
                 this.Folders = project.GetFolderNames(itemId);
+
+                this.SharedHierarchy = project.Hierarchy == null ? null : LinkedFileUtilities.GetSharedHierarchyForItem(project.Hierarchy, itemId);
                 _documentProvider = documentProvider;
+
                 this.Key = documentKey;
                 this.SourceCodeKind = sourceCodeKind;
                 _itemMoniker = documentKey.Moniker;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
@@ -97,6 +97,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         uint GetItemId();
 
         /// <summary>
+        /// Returns <see cref="IVsHierarchy"/> of the shared (or project k) project this <see cref="IVisualStudioHostDocument"/> belongs to.
+        /// it will return null if it belongs to a normal project.
+        /// </summary>
+        IVsHierarchy SharedHierarchy { get; }
+
+        /// <summary>
         /// Gets the text container associated with the document when it is in an opened state.
         /// </summary>
         /// <returns></returns>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/LinkedFileUtilities.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/LinkedFileUtilities.cs
@@ -3,6 +3,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -62,7 +63,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
-            var hierarchy = document.Project.Hierarchy;
             var itemId = document.GetItemId();
             if (itemId == (uint)VSConstants.VSITEMID.Nil)
             {
@@ -70,7 +70,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return null;
             }
 
-            var sharedHierarchy = GetSharedHierarchyForItem(hierarchy, itemId);
+            var sharedHierarchy = document.SharedHierarchy;
+            Contract.Requires(GetSharedHierarchyForItem(document.Project.Hierarchy, itemId) == sharedHierarchy);
+
             if (sharedHierarchy == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -799,7 +799,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         internal override void SetDocumentContext(DocumentId documentId)
         {
             var hostDocument = GetHostDocument(documentId);
-            var hierarchy = hostDocument.Project.Hierarchy;
             var itemId = hostDocument.GetItemId();
             if (itemId == (uint)VSConstants.VSITEMID.Nil)
             {
@@ -807,7 +806,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return;
             }
 
-            var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId);
+            var hierarchy = hostDocument.Project.Hierarchy;
+            var sharedHierarchy = hostDocument.SharedHierarchy;
+            Contract.Requires(LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId) == sharedHierarchy);
+
             if (sharedHierarchy != null)
             {
                 if (sharedHierarchy.SetProperty(
@@ -895,7 +897,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             // If this is a regular document or a closed linked (non-shared) document, then use the
             // default logic for determining current context.
-            var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId);
+            var sharedHierarchy = hostDocument.SharedHierarchy;
+            Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId));
+
             if (sharedHierarchy == null)
             {
                 return base.GetDocumentIdInCurrentContext(documentId);
@@ -1097,7 +1101,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId);
+                var sharedHierarchy = hostDocument.SharedHierarchy;
+                Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId));
                 if (sharedHierarchy != null)
                 {
                     uint cookie;
@@ -1114,8 +1119,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private void UnsubscribeFromSharedHierarchyEvents(DocumentId documentId)
             {
                 var hostDocument = _workspace.GetHostDocument(documentId);
-                var hierarchy = hostDocument.Project.Hierarchy;
-
                 var itemId = hostDocument.GetItemId();
                 if (itemId == (uint)VSConstants.VSITEMID.Nil)
                 {
@@ -1123,7 +1126,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId);
+                var sharedHierarchy = hostDocument.SharedHierarchy;
+                Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId));
 
                 if (sharedHierarchy != null)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TableControl;
 using Microsoft.VisualStudio.TableManager;
@@ -199,17 +200,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             return project.Name;
         }
 
-        protected IVsHierarchy GetHierarchy(Workspace workspace, ProjectId projectId)
+        protected IVsHierarchy GetHierarchy(Workspace workspace, ProjectId projectId, DocumentId documentId)
         {
             if (projectId == null)
             {
                 return null;
             }
 
-            var vsWorkspace = workspace as VisualStudioWorkspace;
+            var vsWorkspace = workspace as VisualStudioWorkspaceImpl;
             if (vsWorkspace == null)
             {
                 return null;
+            }
+
+            if (documentId != null)
+            {
+                // document doesn't actually exist in the workspace
+                var document = vsWorkspace.GetHostDocument(documentId);
+                if (document == null)
+                {
+                    return null;
+                }
+
+                return document.SharedHierarchy ?? document.Project.Hierarchy;
             }
 
             return vsWorkspace.GetHierarchy(projectId);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetProjectName(_factory._workspace, _factory._projectId);
                                 return content != null;
                             case StandardTableKeyNames.Project:
-                                content = GetHierarchy(_factory._workspace, _factory._projectId);
+                                content = GetHierarchy(_factory._workspace, _factory._projectId, _factory._documentId);
                                 return content != null;
                             default:
                                 content = null;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 private readonly Workspace _workspace;
                 private readonly DocumentId _documentId;
 
-                public TableEntriesFactory(TableDataSource source, Workspace workspace, DocumentId documentId) : 
+                public TableEntriesFactory(TableDataSource source, Workspace workspace, DocumentId documentId) :
                     base(source)
                 {
                     _source = source;
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetProjectName(_factory._workspace, _factory._documentId.ProjectId);
                                 return content != null;
                             case StandardTableKeyNames.Project:
-                                content = GetHierarchy(_factory._workspace, _factory._documentId.ProjectId);
+                                content = GetHierarchy(_factory._workspace, _factory._documentId.ProjectId, _factory._documentId);
                                 return content != null;
                             case StandardTableKeyNames.TaskCategory:
                                 content = VSTASKCATEGORY.CAT_COMMENTS;

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -115,6 +115,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             _vbHelperFormattingRule = vbHelperFormattingRule;
         }
 
+        public IVsHierarchy SharedHierarchy
+        {
+            get { return null; }
+        }
+
         private HostType GetHostType()
         {
             var projectionBuffer = _containedLanguage.DataBuffer as IProjectionBuffer;


### PR DESCRIPTION
changed IVsHierarchy reported to error list for files that belong to project k or shared project.

previously we reported actual project (active context project in case of project k/shared project) to error list. this should let error list to only show errors for one specific project when current project filtering is set.

but right now error list uses IVsHierarchy of project k/shared project rather than active context. so for RC, we will do that for the filtering to work. that means for project k/shared project, we will show errors for all context (multiple projects)  when the filtering is set.

for RTM, we will resolve design issue of what "Current Project" filtering means for error list.