### PR TITLE
force error list update when we find snapshot becomes out of sync

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
+{
+    internal abstract class AbstractRoslynTableDataSource<TArgs, TData> : AbstractTableDataSource<TData>
+    {
+        protected abstract AbstractTableEntriesFactory<TData> CreateTableEntryFactory(object key, TArgs data);
+
+        protected void OnDataAddedOrChanged(object key, TArgs data, int itemCount)
+        {
+            // reuse factory. it is okay to re-use factory since we make sure we remove the factory before
+            // adding it back
+            bool newFactory = false;
+            ImmutableArray<SubscriptionWithoutLock> snapshot;
+            AbstractTableEntriesFactory<TData> factory;
+
+            lock (Gate)
+            {
+                snapshot = Subscriptions;
+                if (!Map.TryGetValue(key, out factory))
+                {
+                    factory = CreateTableEntryFactory(key, data);
+                    Map.Add(key, factory);
+                    newFactory = true;
+                }
+            }
+
+            factory.OnUpdated(itemCount);
+
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                snapshot[i].AddOrUpdate(factory, newFactory);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
@@ -15,9 +15,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         private readonly Workspace _workspace;
         private readonly ITableManagerProvider _provider;
 
-        protected readonly AbstractTableDataSource<TArgs, TData> Source;
+        protected readonly AbstractRoslynTableDataSource<TArgs, TData> Source;
 
-        protected AbstractTable(Workspace workspace, ITableManagerProvider provider, Guid tableIdentifier, AbstractTableDataSource<TArgs, TData> source)
+        protected AbstractTable(Workspace workspace, ITableManagerProvider provider, Guid tableIdentifier, AbstractRoslynTableDataSource<TArgs, TData> source)
         {
             _workspace = workspace;
             _provider = provider;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
@@ -6,23 +6,22 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.SolutionCrawler;
-using Microsoft.VisualStudio.TableControl;
 using Microsoft.VisualStudio.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    internal abstract class AbstractTableDataSource<TArgs, TData> : ITableDataSource
+    internal abstract class AbstractTableDataSource<TData> : ITableDataSource
     {
-        private readonly object _gate;
-        private readonly Dictionary<object, AbstractTableEntriesFactory<TData>> _map;
+        protected readonly object Gate;
+        protected readonly Dictionary<object, AbstractTableEntriesFactory<TData>> Map;
 
-        private ImmutableArray<SubscriptionWithoutLock> _subscriptions;
+        protected ImmutableArray<SubscriptionWithoutLock> Subscriptions;
 
         public AbstractTableDataSource()
         {
-            _gate = new object();
-            _map = new Dictionary<object, AbstractTableEntriesFactory<TData>>();
-            _subscriptions = ImmutableArray<SubscriptionWithoutLock>.Empty;
+            Gate = new object();
+            Map = new Dictionary<object, AbstractTableEntriesFactory<TData>>();
+            Subscriptions = ImmutableArray<SubscriptionWithoutLock>.Empty;
         }
 
         public virtual void OnProjectDependencyChanged(Solution solution)
@@ -36,7 +35,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         public abstract Guid Identifier { get; }
 
-        protected abstract AbstractTableEntriesFactory<TData> CreateTableEntryFactory(object key, TArgs data);
+        public void Refresh(AbstractTableEntriesFactory<TData> factory)
+        {
+            var snapshot = this.Subscriptions;
+
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                snapshot[i].AddOrUpdate(factory, newFactory: false);
+            }
+        }
 
         protected void ConnectToSolutionCrawlerService(Workspace workspace)
         {
@@ -60,49 +67,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             ChangeStableState(stable: true);
         }
 
-        protected void OnDataAddedOrChanged(object key, TArgs data, int itemCount)
-        {
-            // reuse factory. it is okay to re-use factory since we make sure we remove the factory before
-            // adding it back
-            bool newFactory = false;
-            ImmutableArray<SubscriptionWithoutLock> snapshot;
-            AbstractTableEntriesFactory<TData> factory;
-
-            lock (_gate)
-            {
-                snapshot = _subscriptions;
-                if (!_map.TryGetValue(key, out factory))
-                {
-                    factory = CreateTableEntryFactory(key, data);
-                    _map.Add(key, factory);
-                    newFactory = true;
-                }
-            }
-
-            factory.OnUpdated(itemCount);
-
-            for (var i = 0; i < snapshot.Length; i++)
-            {
-                snapshot[i].AddOrUpdate(factory, newFactory);
-            }
-        }
-
         protected void OnDataRemoved(object key)
         {
             ImmutableArray<SubscriptionWithoutLock> snapshot;
             AbstractTableEntriesFactory<TData> factory;
 
-            lock (_gate)
+            lock (Gate)
             {
-                snapshot = _subscriptions;
-                if (!_map.TryGetValue(key, out factory))
+                snapshot = Subscriptions;
+                if (!Map.TryGetValue(key, out factory))
                 {
                     // never reported about this before
                     return;
                 }
 
                 // remove it from map
-                _map.Remove(key);
+                Map.Remove(key);
             }
 
             factory.OnUpdated(0);
@@ -118,9 +98,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         {
             ImmutableArray<SubscriptionWithoutLock> snapshot;
 
-            lock (_gate)
+            lock (Gate)
             {
-                snapshot = _subscriptions;
+                snapshot = Subscriptions;
             }
 
             for (var i = 0; i < snapshot.Length; i++)
@@ -134,10 +114,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             ImmutableArray<SubscriptionWithoutLock> snapshot;
             List<AbstractTableEntriesFactory<TData>> factories;
 
-            lock (_gate)
+            lock (Gate)
             {
-                snapshot = _subscriptions;
-                factories = _map.Values.ToList();
+                snapshot = Subscriptions;
+                factories = Map.Values.ToList();
             }
 
             // let table manager know that we want to refresh factories.
@@ -154,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         IDisposable ITableDataSource.Subscribe(ITableDataSink sink)
         {
-            lock (_gate)
+            lock (Gate)
             {
                 return new SubscriptionWithoutLock(this, sink);
             }
@@ -162,15 +142,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         internal int NumberOfSubscription_TestOnly
         {
-            get { return _subscriptions.Length; }
+            get { return Subscriptions.Length; }
         }
 
-        private class SubscriptionWithoutLock : IDisposable
+        protected class SubscriptionWithoutLock : IDisposable
         {
-            private readonly AbstractTableDataSource<TArgs, TData> _source;
+            private readonly AbstractTableDataSource<TData> _source;
             private readonly ITableDataSink _sink;
 
-            public SubscriptionWithoutLock(AbstractTableDataSource<TArgs, TData> source, ITableDataSink sink)
+            public SubscriptionWithoutLock(AbstractTableDataSource<TData> source, ITableDataSink sink)
             {
                 _source = source;
                 _sink = sink;
@@ -216,7 +196,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
             private void ReportInitialData()
             {
-                foreach (var provider in _source._map.Values)
+                foreach (var provider in _source.Map.Values)
                 {
                     AddOrUpdate(provider, newFactory: true);
                 }
@@ -236,11 +216,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             {
                 while (true)
                 {
-                    var current = _source._subscriptions;
+                    var current = _source.Subscriptions;
                     var @new = update(current);
 
                     // try replace with new list
-                    var registered = ImmutableInterlocked.InterlockedCompareExchange(ref _source._subscriptions, @new, current);
+                    var registered = ImmutableInterlocked.InterlockedCompareExchange(ref _source.Subscriptions, @new, current);
                     if (registered == current)
                     {
                         // succeeded

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesFactory.cs
@@ -15,10 +15,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     internal abstract class AbstractTableEntriesFactory<TData> : ITableEntriesSnapshotFactory
     {
         private readonly object _gate = new object();
+        private readonly AbstractTableDataSource<TData> _source;
         private readonly WeakReference<ITableEntriesSnapshot> _lastSnapshotWeakReference = new WeakReference<ITableEntriesSnapshot>(null);
 
         private int _lastVersion = 0;
         private int _lastItemCount = 0;
+
+        public AbstractTableEntriesFactory(AbstractTableDataSource<TData> source)
+        {
+            _source = source;
+        }
 
         protected abstract ImmutableArray<TData> GetItems();
         protected abstract ImmutableArray<ITrackingPoint> GetTrackingPoints(ImmutableArray<TData> items);
@@ -53,6 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 if (items.Length != itemCount)
                 {
                     _lastItemCount = items.Length;
+                    _source.Refresh(this);
                 }
 
                 return CreateSnapshot(version, items);
@@ -72,6 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 var version = _lastVersion;
                 if (version != versionNumber)
                 {
+                    _source.Refresh(this);
                     return null;
                 }
 
@@ -83,6 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 var items = GetItems();
                 if (items.Length != _lastItemCount)
                 {
+                    _source.Refresh(this);
                     return null;
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             }
         }
 
-        private class TableDataSource : AbstractTableDataSource<DiagnosticsUpdatedArgs, DiagnosticData>
+        private class TableDataSource : AbstractRoslynTableDataSource<DiagnosticsUpdatedArgs, DiagnosticData>
         {
             private readonly Guid _identifier;
             private readonly IDiagnosticService _diagnosticService;
@@ -182,7 +182,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 private readonly DocumentId _documentId;
                 private readonly object _id;
 
-                public TableEntriesFactory(TableDataSource source, Workspace workspace, ProjectId projectId, DocumentId documentId, object id)
+                public TableEntriesFactory(TableDataSource source, Workspace workspace, ProjectId projectId, DocumentId documentId, object id) : 
+                    base(source)
                 {
                     _source = source;
                     _workspace = workspace;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         internal override IReadOnlyCollection<string> Columns { get { return s_columns; } }
 
-        private class TableDataSource : AbstractTableDataSource<TaskListEventArgs, TodoTaskItem>
+        private class TableDataSource : AbstractRoslynTableDataSource<TaskListEventArgs, TodoTaskItem>
         {
             private readonly Workspace _workspace;
             private readonly Guid _identifier;
@@ -110,7 +110,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 private readonly Workspace _workspace;
                 private readonly DocumentId _documentId;
 
-                public TableEntriesFactory(TableDataSource source, Workspace workspace, DocumentId documentId)
+                public TableEntriesFactory(TableDataSource source, Workspace workspace, DocumentId documentId) : 
+                    base(source)
                 {
                     _source = source;
                     _workspace = workspace;

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Implementation\ProjectSystem\Interop\IVsUndoState.cs" />
     <Compile Include="Implementation\Serialization\AssemblySerializationInfoService.cs" />
     <Compile Include="Implementation\SolutionSize\SolutionSizeTracker.cs" />
+    <Compile Include="Implementation\TableDataSource\AbstractTableDataSource.cs" />
     <Compile Include="Implementation\TableDataSource\MiscDiagnosticTableControlEventProcessorProvider.cs" />
     <Compile Include="Implementation\TableDataSource\MiscellaneousDiagnosticListTable.cs" />
     <Compile Include="Implementation\TableDataSource\MiscellaneousTodoListTable.cs" />
@@ -352,7 +353,7 @@
     <Compile Include="Implementation\ProjectSystem\RuleSets\VisualStudioRuleSetManager.RuleSetFile.cs" />
     <Compile Include="Implementation\TableDataSource\AbstractTable.cs" />
     <Compile Include="Implementation\TableDataSource\AbstractTableControlEventProcessorProvider.cs" />
-    <Compile Include="Implementation\TableDataSource\AbstractTableDataSource.cs" />
+    <Compile Include="Implementation\TableDataSource\AbstractRoslynTableDataSource.cs" />
     <Compile Include="Implementation\TableDataSource\AbstractTableEntriesFactory.cs" />
     <Compile Include="Implementation\TableDataSource\AbstractTableEntriesSnapshot.cs" />
     <Compile Include="Implementation\TableDataSource\DiagnosticTableControlEventProcessorProvider.cs" />

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.Equal(manager.Identifier, StandardTables.ErrorsTable)
                 Assert.Equal(1, manager.Sources.Count())
 
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 AssertEx.SetEqual(table.Columns, manager.GetColumnsForSources(SpecializedCollections.SingletonEnumerable(source)))
 
                 Assert.Equal(ServicesVSResources.DiagnosticsTableSourceName, source.DisplayName)
@@ -61,7 +61,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -79,7 +79,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim table = New VisualStudioDiagnosticListTable(workspace, provider, tableManagerProvider)
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
 
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -148,7 +148,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -196,7 +196,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -228,7 +228,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -254,7 +254,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -282,7 +282,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                     provider.RaiseDiagnosticsUpdated(workspace1)
 
                     Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                    Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                    Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                     Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                     Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -316,7 +316,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -353,7 +353,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -385,7 +385,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -417,7 +417,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -446,7 +446,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -475,7 +475,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseDiagnosticsUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of DiagnosticsUpdatedArgs, DiagnosticData))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)

--- a/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.Equal(manager.Identifier, StandardTables.TasksTable)
                 Assert.Equal(1, manager.Sources.Count())
 
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 AssertEx.SetEqual(table.Columns, manager.GetColumnsForSources(SpecializedCollections.SingletonEnumerable(source)))
 
                 Assert.Equal(ServicesVSResources.TodoTableSourceName, source.DisplayName)
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim table = New VisualStudioTodoListTable(workspace, provider, tableManagerProvider)
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
 
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -103,7 +103,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -144,7 +144,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -192,7 +192,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -222,7 +222,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -255,7 +255,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
@@ -288,7 +288,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 provider.RaiseTodoListUpdated(workspace)
 
                 Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim source = DirectCast(manager.Sources.First(), AbstractTableDataSource(Of TaskListEventArgs, TodoTaskItem))
+                Dim source = DirectCast(manager.Sources.First(), AbstractRoslynTableDataSource(Of TaskListEventArgs, TodoTaskItem))
                 Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)


### PR DESCRIPTION
there is a situation where in project k our error list snapshot and diagnostic service snapshot get out of sync.

when that is detected, made error list to request snapshot update to us

...

this is port from master branch to preview branch.
https://github.com/dotnet/roslyn/commit/9a48dff69585b642ccc8951c11c5c94084ad83e9
