### PR TITLE
Add MSBuild support for AnalyzerDependency items

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -487,6 +487,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 {
                     param = "Analyzers"; this.CheckHostObjectSupport(param, analyzerHostObject.SetAnalyzers(this.Analyzers));
                 }
+
+                // For host objects which support it, pass the list of analyzer dependencies.
+                IAnalyzerDependencyHostObject analyzerDependencyHostObject = cscHostObject as IAnalyzerDependencyHostObject;
+                if (analyzerDependencyHostObject != null)
+                {
+                    param = "AnalyzerDependencies"; this.CheckHostObjectSupport(param, analyzerDependencyHostObject.SetAnalyzerDependencies(this.AnalyzerDependencies));
+                }
             }
             catch (Exception e) when (!Utilities.IsCriticalException(e))
             {

--- a/src/Compilers/Core/MSBuildTask/IAnalyzerDependencyHostObject.cs
+++ b/src/Compilers/Core/MSBuildTask/IAnalyzerDependencyHostObject.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("13926637-09A6-438A-9418-DE6B9D2BEC6B")]
+    public interface IAnalyzerDependencyHostObject
+    {
+        bool SetAnalyzerDependencies(ITaskItem[] analyzerDependencies);
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -60,6 +60,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>ErrorString.resx</DependentUpon>
     </Compile>
+    <Compile Include="IAnalyzerDependencyHostObject.cs" />
     <Compile Include="ICscHostObject5.cs" />
     <Compile Include="IVbcHostObject6.cs" />
     <Compile Include="ManagedCompiler.cs" />

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -599,6 +599,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         /// <summary>
         /// Adds a "/analyzerdependency:" switch to the command line for each provided analyzer dependency.
+        /// 
+        /// Note that even though MSBuild makes a distinction between analyzers and dependencies, the
+        /// command-line compilers do not--both are passed in via "/analyzer".
         /// </summary>
         private void AddAnalyzerDependenciesToCommandLine(CommandLineBuilderExtension commandLine)
         {
@@ -611,7 +614,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             foreach (ITaskItem dependency in this.AnalyzerDependencies)
             {
-                commandLine.AppendSwitchIfNotNull("/analyzerdependency:", dependency.ItemSpec);
+                commandLine.AppendSwitchIfNotNull("/analyzer:", dependency.ItemSpec);
             }
         }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -50,6 +50,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (ITaskItem[])_store["Analyzers"]; }
         }
 
+        public ITaskItem[] AnalyzerDependencies
+        {
+            set { _store["AnalyzerDependencies"] = value; }
+            get { return (ITaskItem[])_store["AnalyzerDependencies"]; }
+        }
+
         // We do not support BugReport because it always requires user interaction,
         // which will cause a hang.
 
@@ -563,6 +569,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // Append the analyzers.
             this.AddAnalyzersToCommandLine(commandLine);
 
+            // Append the analyzer dependencies.
+            this.AddAnalyzerDependenciesToCommandLine(commandLine);
+
             // Append additional files.
             this.AddAdditionalFilesToCommandLine(commandLine);
 
@@ -589,7 +598,25 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Adds a "/analyzer:" switch to the command line for each provided analyzer.
+        /// Adds a "/analyzerdependency:" switch to the command line for each provided analyzer dependency.
+        /// </summary>
+        private void AddAnalyzerDependenciesToCommandLine(CommandLineBuilderExtension commandLine)
+        {
+            // If there were no analyzers passed in, don't add any /analyzer: switches
+            // on the command-line.
+            if ((this.AnalyzerDependencies == null) || (this.AnalyzerDependencies.Length == 0))
+            {
+                return;
+            }
+
+            foreach (ITaskItem dependency in this.AnalyzerDependencies)
+            {
+                commandLine.AppendSwitchIfNotNull("/analyzerdependency:", dependency.ItemSpec);
+            }
+        }
+
+        /// <summary>
+        /// Adds a "/additionalfile:" switch to the command line for each additional file.
         /// </summary>
         private void AddAdditionalFilesToCommandLine(CommandLineBuilderExtension commandLine)
         {

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -70,6 +70,7 @@
           AdditionalFiles="@(AdditionalFiles)"
           AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
           Analyzers="@(Analyzer)"
+          AnalyzerDependencies="@(AnalyzerDependency)"
           ApplicationConfiguration="$(AppConfigForCompiler)"
           BaseAddress="$(BaseAddress)"
           CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -58,6 +58,7 @@
           AddModules="@(AddModules)"
           AdditionalFiles="@(AdditionalFiles)"
           Analyzers="@(Analyzer)"
+          AnalyzerDependencies="@(AnalyzerDependency)"
           BaseAddress="$(BaseAddress)"
           CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
           CodePage="$(CodePage)"

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -840,6 +840,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     param = "AdditionalFiles"; this.CheckHostObjectSupport(param, analyzerHostObject.SetAdditionalFiles(this.AdditionalFiles));
                 }
 
+                // For host objects which support them, set the analyzers' dependencies.
+                IAnalyzerDependencyHostObject analyzerDependencyHostObject = vbcHostObject as IAnalyzerDependencyHostObject;
+                if (analyzerDependencyHostObject != null)
+                {
+                    param = "AnalyzerDependencies"; this.CheckHostObjectSupport(param, analyzerDependencyHostObject.SetAnalyzerDependencies(this.AnalyzerDependencies));
+                }
+
                 param = "BaseAddress"; this.CheckHostObjectSupport(param, vbcHostObject.SetBaseAddress(this.TargetType, this.GetBaseAddressInHex()));
                 param = "CodePage"; this.CheckHostObjectSupport(param, vbcHostObject.SetCodePage(this.CodePage));
                 param = "DebugType"; this.CheckHostObjectSupport(param, vbcHostObject.SetDebugType(this.EmitDebugInformation, this.DebugType));


### PR DESCRIPTION
This commit updates the Vbc and Csc build tasks (and related targets
files) to consume AnalyzerDependency items. They are passed to the
command-line compilers using the "/analyzerdependency" switch, or on to
a build host through a new IAnalyzerDependencyHostObject COM interface.