### PR TITLE
Add the IAnalyzerDependencyHost interface

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IAnalyzerHost.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -11,7 +12,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal partial class AbstractProject : IAnalyzerHost
+    internal partial class AbstractProject : IAnalyzerHost, IAnalyzerDependencyHost
     {
         private AnalyzerFileWatcherService _analyzerFileWatcherService = null;
         private AnalyzerDependencyCheckingService _dependencyCheckingService = null;
@@ -108,6 +109,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             RemoveAdditionalDocument(document);
         }
 
+
+        public void AddAnalyzerDependency(string analyzerDependencyFullPath)
+        {
+        }
+
+        public void RemoveAnalyzerDependency(string analyzerDependencyFullPath)
+        {
+        }
+
         private void ResetAnalyzerRuleSet(string ruleSetFileFullPath)
         {
             ClearAnalyzerRuleSet();
@@ -163,5 +173,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             return _dependencyCheckingService;
         }
+
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IAnalyzerDependencyHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IAnalyzerDependencyHost.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop
+{
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("91A139C9-8197-42ED-9081-32FB5C75E482")]
+    internal interface IAnalyzerDependencyHost
+    {
+        void AddAnalyzerDependency([MarshalAs(UnmanagedType.LPWStr)] string analyzerDependencyFullPath);
+        void RemoveAnalyzerDependency([MarshalAs(UnmanagedType.LPWStr)] string analyzerDependencyFullPath);
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Implementation\Preview\ReferenceChange.ProjectReferenceChange.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.cs" />
     <Compile Include="Implementation\ProjectSystem\AbstractEncProject.cs" />
+    <Compile Include="Implementation\ProjectSystem\Interop\IAnalyzerDependencyHost.cs" />
     <Compile Include="Implementation\ProjectSystem\IVisualStudioWorkingFolder.cs" />
     <Compile Include="Implementation\ProjectSystem\MetadataReferences\VisualStudioAnalyzerServiceFactory.cs" />
     <Compile Include="Implementation\ProjectSystem\RuleSets\RuleSetEventHandler.cs" />


### PR DESCRIPTION
This interface defines the methods used to pass information about
analyzer dependencies from the project system to the language services.

For the moment these are just stubs. Once the related msbuild and
project system changes are in place they will be filled in.