### PR TITLE
Add the complete exception stack trace to the description field of analy...

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -956,7 +956,7 @@ public class B
                 .VerifyDiagnostics()
                 .VerifyAnalyzerDiagnostics(analyzers, null, null, logAnalyzerExceptionAsDiagnostics: true,
                      expected: Diagnostic("AD0001")
-                     .WithArguments("Microsoft.CodeAnalysis.CSharp.UnitTests.DiagnosticAnalyzerTests+AnalyzerReportingUnsupportedDiagnostic", message)
+                     .WithArguments("Microsoft.CodeAnalysis.CSharp.UnitTests.DiagnosticAnalyzerTests+AnalyzerReportingUnsupportedDiagnostic", "System.ArgumentException", message)
                      .WithLocation(1, 1));
         }
 

--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
@@ -494,14 +494,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal static Diagnostic GetAnalyzerExceptionDiagnostic(DiagnosticAnalyzer analyzer, Exception e)
         {
+            var analyzerName = analyzer.ToString();
+
+            // TODO: It is not ideal to create a new descriptor per analyzer exception diagnostic instance.
+            // However, until we add a LongMessage field to the Diagnostic, we are forced to park the instance specific description onto the Descriptor's Description field.
+            // This requires us to create a new DiagnosticDescriptor instance per diagnostic instance.
             var descriptor = new DiagnosticDescriptor(AnalyzerExceptionDiagnosticId,
-                AnalyzerDriverResources.AnalyzerFailure,
-                AnalyzerDriverResources.AnalyzerThrows,
+                title: AnalyzerDriverResources.AnalyzerFailure,
+                messageFormat: AnalyzerDriverResources.AnalyzerThrows,
+                description: string.Format(AnalyzerDriverResources.AnalyzerThrowsDescription, analyzerName, e.ToString()),
                 category: DiagnosticCategory,
                 defaultSeverity: DiagnosticSeverity.Info,
                 isEnabledByDefault: true,
                 customTags: WellKnownDiagnosticTags.AnalyzerException);
-            return Diagnostic.Create(descriptor, Location.None, analyzer.ToString(), e.Message);
+
+            return Diagnostic.Create(descriptor, Location.None, analyzerName, e.GetType(), e.Message);
         }
 
         internal static bool IsAnalyzerExceptionDiagnostic(Diagnostic diagnostic)

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeTests.cs
@@ -1125,7 +1125,12 @@ public class C2
                 onAnalyzerException: (ex, a, d) => exceptionDiagnostics.Add(d));
 
             exceptionDiagnostics.Verify(
-                Diagnostic("AD0001", null).WithArguments("Microsoft.CodeAnalysis.UnitTests.Diagnostics.SuppressMessageAttributeTests+ThrowExceptionForEachNamedTypeAnalyzer", "ThrowExceptionAnalyzer exception").WithLocation(1, 1));
+                Diagnostic("AD0001", null)
+                    .WithArguments(
+                        "Microsoft.CodeAnalysis.UnitTests.Diagnostics.SuppressMessageAttributeTests+ThrowExceptionForEachNamedTypeAnalyzer",
+                        "System.Exception",
+                        "ThrowExceptionAnalyzer exception")
+                    .WithLocation(1, 1));
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -260,11 +260,21 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Compiler Analyzer &apos;{0}&apos; threw an exception with message &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The Compiler Analyzer &apos;{0}&apos; threw an exception of type &apos;{1}&apos; with message &apos;{2}&apos;..
         /// </summary>
         internal static string CompilerAnalyzerThrows {
             get {
                 return ResourceManager.GetString("CompilerAnalyzerThrows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzer &apos;{0}&apos; threw the following exception:
+        ///&apos;{1}&apos;..
+        /// </summary>
+        internal static string CompilerAnalyzerThrowsDescription {
+            get {
+                return ResourceManager.GetString("CompilerAnalyzerThrowsDescription", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -358,7 +358,11 @@
     <value>Compiler Analyzer Failure</value>
   </data>
   <data name="CompilerAnalyzerThrows" xml:space="preserve">
-    <value>The Compiler Analyzer '{0}' threw an exception with message '{1}'.</value>
+    <value>The Compiler Analyzer '{0}' threw an exception of type '{1}' with message '{2}'.</value>
+  </data>
+  <data name="CompilerAnalyzerThrowsDescription" xml:space="preserve">
+    <value>Analyzer '{0}' threw the following exception:
+'{1}'.</value>
   </data>
   <data name="PEImageDoesntContainManagedMetadata" xml:space="preserve">
     <value>PE image doesn't contain managed metadata.</value>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -973,6 +973,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         internal static string AnalyzerFailure => CodeAnalysisResources.CompilerAnalyzerFailure;
         internal static string AnalyzerThrows => CodeAnalysisResources.CompilerAnalyzerThrows;
+        internal static string AnalyzerThrowsDescription => CodeAnalysisResources.CompilerAnalyzerThrowsDescription;
         internal static string ArgumentElementCannotBeNull => CodeAnalysisResources.ArgumentElementCannotBeNull;
         internal static string ArgumentCannotBeEmpty => CodeAnalysisResources.ArgumentCannotBeEmpty;
         internal static string UnsupportedDiagnosticReported => CodeAnalysisResources.UnsupportedDiagnosticReported;

--- a/src/Diagnostics/FxCop/Test/HardeningAnalyzer/HardeningAnalyzerTests.cs
+++ b/src/Diagnostics/FxCop/Test/HardeningAnalyzer/HardeningAnalyzerTests.cs
@@ -47,7 +47,7 @@ public class Class6<TTypeParameter>
             AnalyzeDocumentCore(GetCSharpDiagnosticAnalyzer(), documentsAndSpan.Item1[0], diagnosticsBag.Add, null, logAnalyzerExceptionAsDiagnostics: true);
             var diagnostics = diagnosticsBag.ToReadOnlyAndFree();
             Assert.True(diagnostics.Length > 0);
-            Assert.Equal(string.Format("info AD0001: " + AnalyzerDriverResources.AnalyzerThrows, GetCSharpDiagnosticAnalyzer().GetType(), "The method or operation is not implemented."),
+            Assert.Equal(string.Format("info AD0001: " + AnalyzerDriverResources.AnalyzerThrows, GetCSharpDiagnosticAnalyzer().GetType(), "System.NotImplementedException", "The method or operation is not implemented."),
                 DiagnosticFormatter.Instance.Format(diagnostics[0], EnsureEnglishUICulture.PreferredOrNull));
         }
 

--- a/src/Features/Core/Diagnostics/AnalyzerDriverResources.cs
+++ b/src/Features/Core/Diagnostics/AnalyzerDriverResources.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         internal static string AnalyzerFailure => FeaturesResources.UserDiagnosticAnalyzerFailure;
         internal static string AnalyzerThrows => FeaturesResources.UserDiagnosticAnalyzerThrows;
+        internal static string AnalyzerThrowsDescription => FeaturesResources.UserDiagnosticAnalyzerThrowsDescription;
         internal static string ArgumentElementCannotBeNull => FeaturesResources.ArgumentElementCannotBeNull;
         internal static string ArgumentCannotBeEmpty => FeaturesResources.ArgumentCannotBeEmpty;
         internal static string UnsupportedDiagnosticReported => FeaturesResources.UnsupportedDiagnosticReported;

--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -1953,11 +1953,21 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The User Diagnostic Analyzer &apos;{0}&apos; threw an exception with message &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The User Diagnostic Analyzer &apos;{0}&apos; threw an exception of type &apos;{1}&apos; with message &apos;{2}&apos;..
         /// </summary>
         internal static string UserDiagnosticAnalyzerThrows {
             get {
                 return ResourceManager.GetString("UserDiagnosticAnalyzerThrows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzer &apos;{0}&apos; threw the following exception:
+        ///&apos;{1}&apos;..
+        /// </summary>
+        internal static string UserDiagnosticAnalyzerThrowsDescription {
+            get {
+                return ResourceManager.GetString("UserDiagnosticAnalyzerThrowsDescription", resourceCulture);
             }
         }
         

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -657,7 +657,11 @@ Do you want to continue?</value>
     <value>User Diagnostic Analyzer Failure.</value>
   </data>
   <data name="UserDiagnosticAnalyzerThrows" xml:space="preserve">
-    <value>The User Diagnostic Analyzer '{0}' threw an exception with message '{1}'.</value>
+    <value>The User Diagnostic Analyzer '{0}' threw an exception of type '{1}' with message '{2}'.</value>
+  </data>
+  <data name="UserDiagnosticAnalyzerThrowsDescription" xml:space="preserve">
+    <value>Analyzer '{0}' threw the following exception:
+'{1}'.</value>
   </data>
   <data name="RemoveUnnecessaryCast" xml:space="preserve">
     <value>Remove Unnecessary Cast</value>


### PR DESCRIPTION
...zer exception diagnostics. This will ensure that the stack trace can be viewed in the error list by expanding the diagnostic message.

Fixes #1444 

@shyamnamboodiripad @jmarolf @JohnHamby @heejaechang @tmeschter @srivatsn can you please review?