### PR TITLE
Add support for "dynamic" in the result provider

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.TypeNames.cs
@@ -23,7 +23,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             builder.Append(identifier);
         }
 
-        protected override void AppendGenericTypeArgumentList(StringBuilder builder, Type[] typeArguments, int typeArgumentOffset, int arity, bool escapeKeywordIdentifiers)
+        protected override void AppendGenericTypeArgumentList(
+            StringBuilder builder, 
+            Type[] typeArguments,
+            int typeArgumentOffset, 
+            DynamicFlagsCustomTypeInfo dynamicFlags,
+            ref int index,
+            int arity, 
+            bool escapeKeywordIdentifiers)
         {
             builder.Append('<');
             for (int i = 0; i < arity; i++)
@@ -34,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 }
 
                 Type typeArgument = typeArguments[typeArgumentOffset + i];
-                AppendQualifiedTypeName(builder, typeArgument, escapeKeywordIdentifiers);
+                AppendQualifiedTypeName(builder, typeArgument, dynamicFlags, ref index, escapeKeywordIdentifiers);
             }
             builder.Append('>');
         }
@@ -48,8 +55,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             builder.Append(']');
         }
 
-        protected override bool AppendSpecialTypeName(StringBuilder builder, Type type, bool escapeKeywordIdentifiers)
+        protected override bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic, bool escapeKeywordIdentifiers)
         {
+            if (isDynamic)
+            {
+                Debug.Assert(type.IsObject());
+                builder.Append("dynamic"); // Not a keyword, does not require escaping.
+                return true;
+            }
+
             if (type.IsPredefinedType())
             {
                 builder.Append(type.GetPredefinedTypeName()); // Not an identifier, does not require escaping.

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Utilities;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
@@ -18,7 +17,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             if (typeToDisplayOpt != null)
             {
-                AppendQualifiedTypeName(builder, typeToDisplayOpt, escapeKeywordIdentifiers: true);
+                // We're showing the type of a value, so "dynamic" does not apply.
+                int index = 0;
+                AppendQualifiedTypeName(builder, typeToDisplayOpt, default(DynamicFlagsCustomTypeInfo), ref index, escapeKeywordIdentifiers: true);
                 builder.Append('.');
                 AppendIdentifierEscapingPotentialKeywords(builder, name);
             }
@@ -44,7 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var builder = pooled.Builder;
             builder.Append('{');
 
-            builder.Append(GetTypeName(lmrType)); // NOTE: call our impl directly, since we're coupled anyway.
+            // We're showing the type of a value, so "dynamic" does not apply.
+            builder.Append(GetTypeName(new TypeAndCustomInfo(lmrType))); // NOTE: call our impl directly, since we're coupled anyway.
 
             var numSizes = sizes.Count;
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ArrayExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ArrayExpansionTests.cs
@@ -185,7 +185,7 @@ class B : A
         }
 
         [WorkItem(1022157)]
-        [Fact(Skip = "1022157")]
+        [Fact]
         public void Covariance()
         {
             var source =
@@ -214,16 +214,16 @@ class C
                 EvalResult("H", "{B[1]}", "I[] {B[]}", "o.H", DkmEvaluationResultFlags.Expandable));
             var moreChildren = GetChildren(children[0]);
             Verify(moreChildren,
-                EvalResult("[0]", "{A}", "object {A}", "o.F[0]", DkmEvaluationResultFlags.Expandable));
+                EvalResult("[0]", "{A}", "object {A}", "((A[])o.F)[0]", DkmEvaluationResultFlags.Expandable));
             moreChildren = GetChildren(moreChildren[0]);
             Verify(moreChildren,
-                EvalResult("F", "1", "object {int}", "((A)o.F[0]).F"));
+                EvalResult("F", "1", "object {int}", "((A)((A[])o.F)[0]).F"));
             moreChildren = GetChildren(children[1]);
             Verify(moreChildren,
-                EvalResult("[0]", "{B}", "A {B}", "o.G[0]", DkmEvaluationResultFlags.Expandable));
+                EvalResult("[0]", "{B}", "A {B}", "((B[])o.G)[0]", DkmEvaluationResultFlags.Expandable));
             moreChildren = GetChildren(children[2]);
             Verify(moreChildren,
-                EvalResult("[0]", "{B}", "I {B}", "o.H[0]", DkmEvaluationResultFlags.Expandable));
+                EvalResult("[0]", "{B}", "I {B}", "((B[])o.H)[0]", DkmEvaluationResultFlags.Expandable));
         }
 
         [WorkItem(1001844)]

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTest.csproj
@@ -94,6 +94,8 @@
     <Compile Include="DebuggerTypeProxyAttributeTests.cs" />
     <Compile Include="DebuggerVisualizerAttributeTests.cs" />
     <Compile Include="CSharpResultProviderTestBase.cs" />
+    <Compile Include="DynamicFlagsCustomTypeInfoTests.cs" />
+    <Compile Include="DynamicTests.cs" />
     <Compile Include="ExpansionTests.cs" />
     <Compile Include="FormatSpecifierTests.cs" />
     <Compile Include="FullNameTests.cs" />

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
@@ -22,13 +22,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         public static Assembly GetAssembly(string source)
         {
-            var comp = CSharpTestBase.CreateCompilationWithMscorlib(source);
+            var comp = CSharpTestBaseBase.CreateCompilationWithMscorlib45AndCSruntime(source);
             return ReflectionUtilities.Load(comp.EmitToArray());
         }
 
         public static Assembly GetUnsafeAssembly(string source)
         {
-            var comp = CSharpTestBase.CreateCompilationWithMscorlib(source, options: TestOptions.UnsafeReleaseDll);
+            var comp = CSharpTestBaseBase.CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.UnsafeReleaseDll);
             return ReflectionUtilities.Load(comp.EmitToArray());
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class DynamicFlagsCustomTypeInfoTests : CSharpResultProviderTestBase
+    {
+        [Fact]
+        public void BitArrayConstructor()
+        {
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(new bool[0]));
+
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false), 0x00);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true), 0x01);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false), 0x00);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true, false), 0x01);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, true), 0x02);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true, true), 0x03);
+
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, true), 0x04);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, true), 0x08);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, true), 0x10);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, true), 0x20);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, true), 0x40);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, false, true), 0x80);
+            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, false, false, true), 0x00, 0x01);
+        }
+
+        [Fact]
+        public void CustomTypeInfoConstructor()
+        {
+            ValidateCustomTypeInfo();
+
+            ValidateCustomTypeInfo(0x00);
+            ValidateCustomTypeInfo(0x01);
+            ValidateCustomTypeInfo(0x02);
+            ValidateCustomTypeInfo(0x03);
+
+            ValidateCustomTypeInfo(0x04);
+            ValidateCustomTypeInfo(0x08);
+            ValidateCustomTypeInfo(0x10);
+            ValidateCustomTypeInfo(0x20);
+            ValidateCustomTypeInfo(0x40);
+            ValidateCustomTypeInfo(0x80);
+            ValidateCustomTypeInfo(0x00, 0x01);
+        }
+
+        [Fact]
+        public void CustomTypeInfoConstructor_OtherGuid()
+        {
+            ValidateBytes(new DynamicFlagsCustomTypeInfo(DkmClrCustomTypeInfo.Create(Guid.NewGuid(), new ReadOnlyCollection<byte>(new byte[] { 0x01 }))));
+        }
+
+        [Fact]
+        public void Indexer()
+        {
+            ValidateIndexer(null);
+            ValidateIndexer(false);
+            ValidateIndexer(true);
+            ValidateIndexer(false, false);
+            ValidateIndexer(false, true);
+            ValidateIndexer(true, false);
+            ValidateIndexer(true, true);
+
+            ValidateIndexer(false, false, true);
+            ValidateIndexer(false, false, false, true);
+            ValidateIndexer(false, false, false, false, true);
+            ValidateIndexer(false, false, false, false, false, true);
+            ValidateIndexer(false, false, false, false, false, false, true);
+            ValidateIndexer(false, false, false, false, false, false, false, true);
+            ValidateIndexer(false, false, false, false, false, false, false, false, true);
+        }
+
+        [Fact]
+        public void Any()
+        {
+            ValidateAny(null);
+            ValidateAny(false);
+            ValidateAny(true);
+            ValidateAny(false, false);
+            ValidateAny(false, true);
+            ValidateAny(true, false);
+            ValidateAny(true, true);
+
+            ValidateAny(false, false, true);
+            ValidateAny(false, false, false, true);
+            ValidateAny(false, false, false, false, true);
+            ValidateAny(false, false, false, false, false, true);
+            ValidateAny(false, false, false, false, false, false, true);
+            ValidateAny(false, false, false, false, false, false, false, true);
+            ValidateAny(false, false, false, false, false, false, false, false, true);
+        }
+
+        [Fact]
+        public void SkipOne()
+        {
+            var dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo((BitArray)null);
+
+            ValidateBytes(dynamicFlagsCustomTypeInfo.SkipOne());
+
+            var dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(new byte[] { 0x80 }));
+            dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x40);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x20);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x10);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x08);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x04);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x02);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x01);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x00);
+
+            dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(new byte[] { 0x00, 0x02 }));
+            dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x00, 0x01);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x80, 0x00);
+            dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
+            ValidateBytes(dynamicFlagsCustomTypeInfo, 0x40, 0x00);
+        }
+
+        private static void ValidateCustomTypeInfo(params byte[] payload)
+        {
+            Assert.NotNull(payload);
+
+            var dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(payload));
+            var dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+            ValidateBytes(dynamicFlagsCustomTypeInfo, payload);
+
+            var dkmClrCustomTypeInfo2 = dynamicFlagsCustomTypeInfo.GetCustomTypeInfo();
+            if (dynamicFlagsCustomTypeInfo.Any())
+            {
+                Assert.Equal(dkmClrCustomTypeInfo.PayloadTypeId, dkmClrCustomTypeInfo2.PayloadTypeId);
+                Assert.Equal(dkmClrCustomTypeInfo.Payload, dkmClrCustomTypeInfo2.Payload);
+            }
+            else
+            {
+                Assert.Null(dkmClrCustomTypeInfo2);
+            }
+        }
+
+        private static void ValidateIndexer(params bool[] flags)
+        {
+            var customTypeInfo = MakeDynamicFlagsCustomTypeInfo(flags);
+            if (flags == null)
+            {
+                Assert.False(customTypeInfo[0]);
+            }
+            else
+            {
+                AssertEx.All(flags.Select((f, i) => f == customTypeInfo[i]), x => x);
+                Assert.False(customTypeInfo[flags.Length]);
+            }
+        }
+
+        private static void ValidateAny(params bool[] flags)
+        {
+            var customTypeInfo = MakeDynamicFlagsCustomTypeInfo(flags);
+            if (flags == null)
+            {
+                Assert.False(customTypeInfo.Any());
+            }
+            else
+            {
+                Assert.Equal(flags.Any(x => x), customTypeInfo.Any());
+            }
+        }
+
+        private static void ValidateBytes(DynamicFlagsCustomTypeInfo dynamicFlags, params byte[] expectedBytes)
+        {
+            Assert.NotNull(expectedBytes);
+
+            var dkmClrCustomTypeInfo = dynamicFlags.GetCustomTypeInfo();
+            if (dynamicFlags.Any())
+            {
+                Assert.NotNull(dkmClrCustomTypeInfo);
+                var actualBytes = dkmClrCustomTypeInfo.Payload;
+                Assert.Equal(expectedBytes, actualBytes);
+            }
+            else
+            {
+                AssertEx.All(expectedBytes, b => b == 0);
+                Assert.Null(dkmClrCustomTypeInfo);
+            }
+        }
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicTests.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class DynamicTests : CSharpResultProviderTestBase
+    {
+        [Fact]
+        public void Simple()
+        {
+            var value = CreateDkmClrValue(new object());
+            var rootExpr = "d";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, declaredType: new DkmClrType((TypeImpl)typeof(object)), declaredTypeInfo: new[] { true });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{object}", "dynamic {object}", rootExpr));
+        }
+
+        [Fact]
+        public void Member()
+        {
+            var source = @"
+class C
+{
+    dynamic F;
+    dynamic P { get; set; }
+}";
+            var assembly = GetAssembly(source);
+            var type = assembly.GetType("C");
+            var value = CreateDkmClrValue(Activator.CreateInstance(type));
+            var rootExpr = "new C()";
+            var evalResult = FormatResult(rootExpr, value);
+            Verify(evalResult,
+                EvalResult(rootExpr, "{C}", "C", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("F", "null", "dynamic {object}", "(new C()).F"),
+                EvalResult("P", "null", "dynamic {object}", "(new C()).P"));
+        }
+
+        [Fact]
+        public void Member_ConstructedType()
+        {
+            var source = @"
+class C<T, U>
+{
+    T Simple;
+    U[] Array;
+    C<U, T> Constructed;
+    C<C<C<object, T>, dynamic[]>, U[]>[] Complex;
+}";
+            var assembly = GetAssembly(source);
+            var typeC = assembly.GetType("C`2");
+            var typeC_Constructed1 = typeC.MakeGenericType(typeof(object), typeof(object)); // C<object, dynamic>
+            var typeC_Constructed2 = typeC.MakeGenericType(typeof(object), typeC_Constructed1); // C<dynamic, C<object, dynamic>> (i.e. T = dynamic, U = C<object, dynamic>)
+            var value = CreateDkmClrValue(Activator.CreateInstance(typeC_Constructed2));
+            var rootExpr = "c";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, new DkmClrType((TypeImpl)typeC_Constructed2), new[] { false, true, false, false, true });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{C<object, C<object, object>>}", "C<dynamic, C<object, dynamic>> {C<object, C<object, object>>}", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("Array", "null", "C<object, dynamic>[] {C<object, object>[]}", "c.Array"),
+                EvalResult("Complex", "null", "C<C<C<object, dynamic>, dynamic[]>, C<object, dynamic>[]>[] {C<C<C<object, object>, object[]>, C<object, object>[]>[]}", "c.Complex"),
+                EvalResult("Constructed", "null", "C<C<object, dynamic>, dynamic> {C<C<object, object>, object>}", "c.Constructed"),
+                EvalResult("Simple", "null", "dynamic {object}", "c.Simple"));
+        }
+
+        [Fact]
+        public void Member_NestedType()
+        {
+            var source = @"
+class Outer<T>
+{
+    class Inner<U>
+    {
+        T Simple;
+        U[] Array;
+        Outer<U>.Inner<T> Constructed;
+    }
+}";
+            var assembly = GetAssembly(source);
+            var typeInner = assembly.GetType("Outer`1+Inner`1");
+            var typeInner_Constructed = typeInner.MakeGenericType(typeof(object), typeof(object)); // Outer<dynamic>.Inner<object>
+            var value = CreateDkmClrValue(Activator.CreateInstance(typeInner_Constructed));
+            var rootExpr = "i";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, new DkmClrType((TypeImpl)typeInner_Constructed), new[] { false, true, false });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{Outer<object>.Inner<object>}", "Outer<dynamic>.Inner<object> {Outer<object>.Inner<object>}", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("Array", "null", "object[]", "i.Array"),
+                EvalResult("Constructed", "null", "Outer<object>.Inner<dynamic> {Outer<object>.Inner<object>}", "i.Constructed"),
+                EvalResult("Simple", "null", "dynamic {object}", "i.Simple"));
+        }
+
+        [Fact]
+        public void Member_ConstructedTypeMember()
+        {
+            var source = @"
+class C<T>
+    where T : new()
+{
+    T Simple = new T();
+    T[] Array = new[] { new T() };
+    D<T, object, dynamic> Constructed = new D<T, object, dynamic>();
+}
+
+class D<T, U, V>
+{
+    T TT;
+    U UU;
+    V VV;
+}";
+            var assembly = GetAssembly(source);
+            var typeD = assembly.GetType("D`3");
+            var typeD_Constructed = typeD.MakeGenericType(typeof(object), typeof(object), typeof(int)); // D<object, dynamic, int>
+            var typeC = assembly.GetType("C`1");
+            var typeC_Constructed = typeC.MakeGenericType(typeD_Constructed); // C<D<object, dynamic, int>>
+            var value = CreateDkmClrValue(Activator.CreateInstance(typeC_Constructed));
+            var rootExpr = "c";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, new DkmClrType((TypeImpl)typeC_Constructed), new[] { false, false, false, true, false });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{C<D<object, object, int>>}", "C<D<object, dynamic, int>> {C<D<object, object, int>>}", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("Array", "{D<object, object, int>[1]}", "D<object, dynamic, int>[] {D<object, object, int>[]}", "c.Array", DkmEvaluationResultFlags.Expandable),
+                EvalResult("Constructed", "{D<D<object, object, int>, object, object>}", "D<D<object, dynamic, int>, object, dynamic> {D<D<object, object, int>, object, object>}", "c.Constructed", DkmEvaluationResultFlags.Expandable),
+                EvalResult("Simple", "{D<object, object, int>}", "D<object, dynamic, int> {D<object, object, int>}", "c.Simple", DkmEvaluationResultFlags.Expandable));
+
+            Verify(GetChildren(children[0]),
+                EvalResult("[0]", "{D<object, object, int>}", "D<object, dynamic, int> {D<object, object, int>}", "c.Array[0]", DkmEvaluationResultFlags.Expandable));
+
+            Verify(GetChildren(children[1]),
+                EvalResult("TT", "null", "D<object, dynamic, int> {D<object, object, int>}", "c.Constructed.TT"),
+                EvalResult("UU", "null", "object", "c.Constructed.UU"),
+                EvalResult("VV", "null", "dynamic {object}", "c.Constructed.VV"));
+
+            Verify(GetChildren(children[2]),
+                EvalResult("TT", "null", "object", "c.Simple.TT"),
+                EvalResult("UU", "null", "dynamic {object}", "c.Simple.UU"),
+                EvalResult("VV", "0", "int", "c.Simple.VV"));
+        }
+
+        [Fact]
+        public void Member_ExplicitInterfaceImplementation()
+        {
+            var source = @"
+interface I<V, W>
+{
+    V P { get; set; }
+    W Q { get; set; }
+}
+
+class C<T, U> : I<long, T>, I<bool, U>
+{
+    long I<long, T>.P { get; set; }
+    T I<long, T>.Q { get; set; }
+    bool I<bool, U>.P { get; set; }
+    U I<bool, U>.Q { get; set; }
+}";
+            var assembly = GetAssembly(source);
+            var typeC = assembly.GetType("C`2");
+            var typeC_Constructed = typeC.MakeGenericType(typeof(object), typeof(object)); // C<dynamic, object>
+            var value = CreateDkmClrValue(Activator.CreateInstance(typeC_Constructed));
+            var rootExpr = "c";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, new DkmClrType((TypeImpl)typeC_Constructed), new[] { false, true, false });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{C<object, object>}", "C<dynamic, object> {C<object, object>}", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("I<bool, object>.P", "false", "bool", "((I<bool, object>)c).P", DkmEvaluationResultFlags.Boolean),
+                EvalResult("I<bool, object>.Q", "null", "object", "((I<bool, object>)c).Q"),
+                EvalResult("I<long, dynamic>.P", "0", "long", "((I<long, dynamic>)c).P"),
+                EvalResult("I<long, dynamic>.Q", "null", "dynamic {object}", "((I<long, dynamic>)c).Q"));
+        }
+
+        [Fact]
+        public void Member_BaseType()
+        {
+            var source = @"
+class Base<T, U, V, W>
+{
+    public T P;
+    public U Q;
+    public V R;
+    public W S;
+}
+
+class Derived<T, U> : Base<T, U, object, dynamic>
+{
+    new public T[] P;
+    new public U[] Q;
+    new public dynamic[] R;
+    new public object[] S;
+}";
+            var assembly = GetAssembly(source);
+            var typeDerived = assembly.GetType("Derived`2");
+            var typeDerived_Constructed = typeDerived.MakeGenericType(typeof(object), typeof(object)); // Derived<dynamic, object>
+            var value = CreateDkmClrValue(Activator.CreateInstance(typeDerived_Constructed));
+            var rootExpr = "d";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, new DkmClrType((TypeImpl)typeDerived_Constructed), new[] { false, true, false });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{Derived<object, object>}", "Derived<dynamic, object> {Derived<object, object>}", rootExpr, DkmEvaluationResultFlags.Expandable));
+
+            // CONSIDER: It would be nice to substitute "dynamic" where appropriate.
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("P (Base<object, object, object, object>)", "null", "object", "((Base<object, object, object, object>)d).P"),
+                EvalResult("P", "null", "dynamic[] {object[]}", "d.P"),
+                EvalResult("Q (Base<object, object, object, object>)", "null", "object", "((Base<object, object, object, object>)d).Q"),
+                EvalResult("Q", "null", "object[]", "d.Q"),
+                EvalResult("R (Base<object, object, object, object>)", "null", "object", "((Base<object, object, object, object>)d).R"),
+                EvalResult("R", "null", "dynamic[] {object[]}", "d.R"),
+                EvalResult("S (Base<object, object, object, object>)", "null", "object", "((Base<object, object, object, object>)d).S"),
+                EvalResult("S", "null", "object[]", "d.S"));
+        }
+
+        [Fact]
+        public void ArrayElement()
+        {
+            var value = CreateDkmClrValue(new object[1]);
+            var rootExpr = "d";
+            var evalResult = FormatResult(rootExpr, rootExpr, value, declaredType: new DkmClrType((TypeImpl)typeof(object[])), declaredTypeInfo: new[] { false, true });
+            Verify(evalResult,
+                EvalResult(rootExpr, "{object[1]}", "dynamic[] {object[]}", rootExpr, DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("[0]", "null", "dynamic {object}", "d[0]"));
+        }
+
+        [Fact]
+        public void TypeVariables()
+        {
+            var intrinsicSource =
+@".class private abstract sealed beforefieldinit specialname '<>c__TypeVariables'<T,U,V>
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+}";
+            ImmutableArray<byte> assemblyBytes;
+            ImmutableArray<byte> pdbBytes;
+            CommonTestBase.EmitILToArray(intrinsicSource, appendDefaultHeader: true, includePdb: false, assemblyBytes: out assemblyBytes, pdbBytes: out pdbBytes);
+            var assembly = ReflectionUtilities.Load(assemblyBytes);
+            var reflectionType = assembly.GetType(ExpressionCompilerConstants.TypeVariablesClassName).MakeGenericType(new[] { typeof(object), typeof(object), typeof(object[]) });
+            var value = CreateDkmClrValue(value: null, type: reflectionType, valueFlags: DkmClrValueFlags.Synthetic);
+            var evalResult = FormatResult("typevars", "typevars", value, new DkmClrType((TypeImpl)reflectionType), new[] { false, true, false, false, true });
+            Verify(evalResult,
+                EvalResult("Type variables", "", "", null, DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("T", "dynamic", "dynamic", null, DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data),
+                EvalResult("U", "object", "object", null, DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data),
+                EvalResult("V", "dynamic[]", "dynamic[]", null, DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data));
+        }
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
@@ -1,15 +1,21 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     internal static class TestTypeExtensions
     {
-        public static string GetTypeName(this Type type, bool escapeKeywordIdentifiers = false)
+        public static string GetTypeName(this System.Type type, bool[] dynamicFlags = null, bool escapeKeywordIdentifiers = false)
         {
-            return CSharpFormatter.Instance.GetTypeName((TypeImpl)type, escapeKeywordIdentifiers);
+            return type.GetTypeName(ResultProviderTestBase.MakeDynamicFlagsCustomTypeInfo(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers);
+        }
+
+        public static string GetTypeName(this System.Type type, DkmClrCustomTypeInfo typeInfo, bool escapeKeywordIdentifiers = false)
+        {
+            return CSharpFormatter.Instance.GetTypeName(new TypeAndCustomInfo((TypeImpl)type, typeInfo), escapeKeywordIdentifiers);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal struct DynamicFlagsCustomTypeInfo
+    {
+        /// <remarks>Internal for testing.</remarks>
+        internal static readonly Guid PayloadTypeId = new Guid("826D6EC1-DC4B-46AF-BE05-CD3F1A1FD4AC");
+
+        private readonly BitArray _bits;
+
+        public DynamicFlagsCustomTypeInfo(BitArray bits)
+        {
+            _bits = bits;
+        }
+
+        public DynamicFlagsCustomTypeInfo(DkmClrCustomTypeInfo typeInfo)
+        {
+            if (typeInfo == null || typeInfo.PayloadTypeId != PayloadTypeId)
+            {
+                _bits = null;
+            }
+            else
+            {
+                var builder = ArrayBuilder<byte>.GetInstance();
+                builder.AddRange(typeInfo.Payload);
+                _bits = new BitArray(builder.ToArrayAndFree());
+            }
+        }
+
+        public bool this[int i]
+        {
+            get
+            {
+                Debug.Assert(i >= 0);
+                return _bits != null &&
+                    i < _bits.Length &&
+                    _bits[i];
+            }
+        }
+
+        public DkmClrCustomTypeInfo GetCustomTypeInfo()
+        {
+            if (!Any())
+            {
+                return null;
+            }
+
+            var numBits = _bits.Length;
+            var numBytes = (numBits + 7) / 8;
+            var bytes = new byte[numBytes];
+
+            // Unfortunately, BitArray.CopyTo is not portable.
+            for (int b = 0; b < numBytes; b++)
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    var index = 8 * b + i;
+                    if (index < numBits && _bits[index])
+                    {
+                        bytes[b] |= (byte)(1 << i);
+                    }
+                }
+            }
+
+            return DkmClrCustomTypeInfo.Create(PayloadTypeId, new ReadOnlyCollection<byte>(bytes));
+        }
+
+        public DynamicFlagsCustomTypeInfo SkipOne()
+        {
+            if (_bits == null)
+            {
+                return this;
+            }
+
+            var numBits = _bits.Length;
+            var newBits = new BitArray(numBits - 1);
+            for (int b = 0; b < numBits - 1; b++)
+            {
+                newBits[b] = _bits[b + 1];
+            }
+
+            return new DynamicFlagsCustomTypeInfo(newBits);
+        }
+
+        public bool Any()
+        {
+            if (_bits == null)
+            {
+                return false;
+            }
+
+            for (int b = 0; b < _bits.Length; b++)
+            {
+                if (_bits[b])
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -34,6 +34,7 @@
     </Compile>
     <Compile Include="AssemblyReaders.cs" />
     <Compile Include="AssemblyReference.cs" />
+    <Compile Include="DynamicFlagsCustomTypeInfo.cs" />
     <Compile Include="Placeholders.cs" />
     <Compile Include="ReflectionHelpers.cs" />
     <Compile Include="ImmutableArrayExtensions.cs" />

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompilerConstants.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompilerConstants.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
     internal static class ExpressionCompilerConstants

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ArrayExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ArrayExpansion.cs
@@ -1,21 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Debugger;
-using Microsoft.VisualStudio.Debugger.Evaluation;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
     internal sealed class ArrayExpansion : Expansion
     {
+        private readonly TypeAndCustomInfo _elementTypeAndInfo;
         private readonly ReadOnlyCollection<int> _divisors;
         private readonly ReadOnlyCollection<int> _lowerBounds;
         private readonly int _count;
 
-        internal static ArrayExpansion CreateExpansion(ReadOnlyCollection<int> sizes, ReadOnlyCollection<int> lowerBounds)
+        internal static ArrayExpansion CreateExpansion(TypeAndCustomInfo elementTypeAndInfo, ReadOnlyCollection<int> sizes, ReadOnlyCollection<int> lowerBounds)
         {
+            Debug.Assert(elementTypeAndInfo.Type != null);
             Debug.Assert(sizes != null);
             Debug.Assert(lowerBounds != null);
             Debug.Assert(sizes.Count > 0);
@@ -26,12 +28,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 count *= size;
             }
-            return (count > 0) ? new ArrayExpansion(sizes, lowerBounds, count) : null;
+            return (count > 0) ? new ArrayExpansion(elementTypeAndInfo, sizes, lowerBounds, count) : null;
         }
 
-        private ArrayExpansion(ReadOnlyCollection<int> sizes, ReadOnlyCollection<int> lowerBounds, int count)
+        private ArrayExpansion(TypeAndCustomInfo elementTypeAndInfo, ReadOnlyCollection<int> sizes, ReadOnlyCollection<int> lowerBounds, int count)
         {
             Debug.Assert(count > 0);
+            _elementTypeAndInfo = elementTypeAndInfo;
             _divisors = CalculateDivisors(sizes);
             _lowerBounds = lowerBounds;
             _count = count;
@@ -71,14 +74,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var indices = GetIndices(index);
             var formatter = resultProvider.Formatter;
             var name = formatter.GetArrayIndexExpression(indices);
-            var elementType = value.Type.ElementType;
             var element = value.GetArrayElement(indices, inspectionContext);
             var fullName = GetFullName(parent, name, formatter);
             return resultProvider.CreateDataItem(
                 inspectionContext,
                 name,
-                typeDeclaringMember: null,
-                declaredType: elementType.GetLmrType(),
+                typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                declaredTypeAndInfo: _elementTypeAndInfo,
                 value: element,
                 parent: parent,
                 expansionFlags: ExpansionFlags.IncludeBaseMembers,
@@ -133,11 +135,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 parentFullName = $"({parentFullName})";
             }
             var parentRuntimeType = parent.Value.Type.GetLmrType();
-            if (!parent.DeclaredType.Equals(parentRuntimeType))
+            if (!parent.DeclaredTypeAndInfo.Type.Equals(parentRuntimeType))
             {
                 parentFullName = formatter.GetCastExpression(
                     parentFullName,
-                    formatter.GetTypeName(parentRuntimeType, escapeKeywordIdentifiers: true),
+                    formatter.GetTypeName(new TypeAndCustomInfo(parentRuntimeType), escapeKeywordIdentifiers: true),
                     parenthesizeEntireExpression: true);
             }
             return parentFullName + name;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         internal static Expansion CreateExpansion(
             DkmInspectionContext inspectionContext,
-            Type declaredType,
+            TypeAndCustomInfo declaredTypeAndInfo,
             DkmClrValue value,
             ExpansionFlags flags,
             Predicate<MemberInfo> predicate,
@@ -35,6 +35,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return null;
             }
 
+            var dynamicFlagsMap = DynamicFlagsMap.Create(declaredTypeAndInfo);
+
             var expansions = ArrayBuilder<Expansion>.GetInstance();
 
             // From the members, collect the fields and properties,
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var allMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var includeInherited = (flags & ExpansionFlags.IncludeBaseMembers) == ExpansionFlags.IncludeBaseMembers;
             var hideNonPublic = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.HideNonPublicMembers) == DkmEvaluationFlags.HideNonPublicMembers;
-            runtimeType.AppendTypeMembers(allMembers, predicate, declaredType, appDomain, includeInherited, hideNonPublic);
+            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic);
 
             foreach (var member in allMembers)
             {
@@ -73,6 +75,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Expansion nonPublicInstanceExpansion;
             GetPublicAndNonPublicMembers(
                 instanceMembers,
+                dynamicFlagsMap,
                 out publicInstanceExpansion,
                 out nonPublicInstanceExpansion);
 
@@ -81,6 +84,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Expansion nonPublicStaticExpansion;
             GetPublicAndNonPublicMembers(
                 staticMembers,
+                dynamicFlagsMap,
                 out publicStaticExpansion,
                 out nonPublicStaticExpansion);
 
@@ -135,6 +139,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private static void GetPublicAndNonPublicMembers(
             ArrayBuilder<MemberAndDeclarationInfo> allMembers,
+            DynamicFlagsMap dynamicFlagsMap,
             out Expansion publicExpansion,
             out Expansion nonPublicExpansion)
         {
@@ -151,10 +156,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         case DkmClrDebuggerBrowsableAttributeState.RootHidden:
                             if (publicMembers.Count > 0)
                             {
-                                publicExpansions.Add(new MemberExpansion(publicMembers.ToArray()));
+                                publicExpansions.Add(new MemberExpansion(publicMembers.ToArray(), dynamicFlagsMap));
                                 publicMembers.Clear();
                             }
-                            publicExpansions.Add(new RootHiddenExpansion(member));
+                            publicExpansions.Add(new RootHiddenExpansion(member, dynamicFlagsMap));
                             continue;
                         case DkmClrDebuggerBrowsableAttributeState.Never:
                             continue;
@@ -173,7 +178,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             if (publicMembers.Count > 0)
             {
-                publicExpansions.Add(new MemberExpansion(publicMembers.ToArray()));
+                publicExpansions.Add(new MemberExpansion(publicMembers.ToArray(), dynamicFlagsMap));
             }
             publicMembers.Free();
 
@@ -182,20 +187,22 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             nonPublicExpansion = (nonPublicMembers.Count > 0) ?
                 new NonPublicMembersExpansion(
-                    declaredType: null,
-                    members: new MemberExpansion(nonPublicMembers.ToArray())) :
+                    members: new MemberExpansion(nonPublicMembers.ToArray(), dynamicFlagsMap)) :
                 null;
             nonPublicMembers.Free();
         }
 
         private readonly MemberAndDeclarationInfo[] _members;
+        private readonly DynamicFlagsMap _dynamicFlagsMap;
 
-        private MemberExpansion(MemberAndDeclarationInfo[] members)
+        private MemberExpansion(MemberAndDeclarationInfo[] members, DynamicFlagsMap dynamicFlagsMap)
         {
             Debug.Assert(members != null);
             Debug.Assert(members.Length > 0);
+            Debug.Assert(dynamicFlagsMap != null);
 
             _members = members;
+            _dynamicFlagsMap = dynamicFlagsMap;
         }
 
         internal override void GetRows(
@@ -216,7 +223,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             int offset = startIndex2 - index;
             for (int i = 0; i < count2; i++)
             {
-                rows.Add(GetMemberRow(resultProvider, inspectionContext, value, _members[i + offset], parent));
+                rows.Add(GetMemberRow(resultProvider, inspectionContext, value, _members[i + offset], parent, _dynamicFlagsMap));
             }
 
             index += _members.Length;
@@ -227,7 +234,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             DkmInspectionContext inspectionContext,
             DkmClrValue value,
             MemberAndDeclarationInfo member,
-            EvalResultDataItem parent)
+            EvalResultDataItem parent,
+            DynamicFlagsMap dynamicFlagsMap)
         {
             var memberValue = GetMemberValue(value, member, inspectionContext);
             return CreateMemberDataItem(
@@ -236,6 +244,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 member,
                 memberValue,
                 parent,
+                dynamicFlagsMap,
                 ExpansionFlags.All);
         }
 
@@ -249,10 +258,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private sealed class RootHiddenExpansion : Expansion
         {
             private readonly MemberAndDeclarationInfo _member;
+            private readonly DynamicFlagsMap _dynamicFlagsMap;
 
-            internal RootHiddenExpansion(MemberAndDeclarationInfo member)
+            internal RootHiddenExpansion(MemberAndDeclarationInfo member, DynamicFlagsMap dynamicFlagsMap)
             {
                 _member = member;
+                _dynamicFlagsMap = dynamicFlagsMap;
             }
 
             internal override void GetRows(
@@ -284,6 +295,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         _member,
                         memberValue,
                         parent,
+                        _dynamicFlagsMap,
                         ExpansionFlags.IncludeBaseMembers | ExpansionFlags.IncludeResultsView);
                     var expansion = parent.Expansion;
                     if (expansion != null)
@@ -300,12 +312,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// </summary>
         private sealed class NonPublicMembersExpansion : Expansion
         {
-            private readonly Type _declaredType;
             private readonly Expansion _members;
 
-            internal NonPublicMembersExpansion(Type declaredType, Expansion members)
+            internal NonPublicMembersExpansion(Expansion members)
             {
-                _declaredType = declaredType;
                 _members = members;
             }
 
@@ -325,7 +335,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     rows.Add(GetRow(
                         resultProvider,
                         inspectionContext,
-                        _declaredType,
                         value,
                         _members,
                         parent));
@@ -339,7 +348,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             private static EvalResultDataItem GetRow(
                 ResultProvider resultProvider,
                 DkmInspectionContext inspectionContext,
-                Type declaredType,
                 DkmClrValue value,
                 Expansion expansion,
                 EvalResultDataItem parent)
@@ -347,8 +355,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return new EvalResultDataItem(
                     ExpansionKind.NonPublicMembers,
                     name: Resources.NonPublicMembers,
-                    typeDeclaringMember: null,
-                    declaredType: declaredType,
+                    typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                    declaredTypeAndInfo: default(TypeAndCustomInfo),
                     parent: null,
                     value: value,
                     displayValue: null,
@@ -369,12 +377,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// </summary>
         private sealed class StaticMembersExpansion : Expansion
         {
-            private readonly Type _declaredType;
+            private readonly Type _runtimeType;
             private readonly Expansion _members;
 
-            internal StaticMembersExpansion(Type declaredType, Expansion members)
+            internal StaticMembersExpansion(Type runtimeType, Expansion members)
             {
-                _declaredType = declaredType;
+                _runtimeType = runtimeType;
                 _members = members;
             }
 
@@ -394,7 +402,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     rows.Add(GetRow(
                         resultProvider,
                         inspectionContext,
-                        _declaredType,
+                        new TypeAndCustomInfo(_runtimeType),
                         value,
                         _members));
                 }
@@ -405,17 +413,17 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             private static EvalResultDataItem GetRow(
                 ResultProvider resultProvider,
                 DkmInspectionContext inspectionContext,
-                Type declaredType,
+                TypeAndCustomInfo declaredTypeAndInfo,
                 DkmClrValue value,
                 Expansion expansion)
             {
                 var formatter = resultProvider.Formatter;
-                var fullName = formatter.GetTypeName(declaredType, escapeKeywordIdentifiers: true);
+                var fullName = formatter.GetTypeName(declaredTypeAndInfo, escapeKeywordIdentifiers: true);
                 return new EvalResultDataItem(
                     ExpansionKind.StaticMembers,
                     name: formatter.StaticMembersString,
-                    typeDeclaringMember: null,
-                    declaredType: declaredType,
+                    typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                    declaredTypeAndInfo: declaredTypeAndInfo,
                     parent: null,
                     value: value,
                     displayValue: null,
@@ -437,24 +445,31 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             MemberAndDeclarationInfo member,
             DkmClrValue memberValue,
             EvalResultDataItem parent,
+            DynamicFlagsMap dynamicFlagsMap,
             ExpansionFlags flags)
         {
-            var formatter = resultProvider.Formatter;
+            var declaredType = member.Type;
+            var declaredTypeInfo = dynamicFlagsMap.SubstituteDynamicFlags(member.OriginalDefinitionType, new DynamicFlagsCustomTypeInfo(member.TypeInfo)).GetCustomTypeInfo();
             string memberName;
+            // Considering, we're not handling the case of a member inherited from a generic base type.
             var typeDeclaringMember = member.GetExplicitlyImplementedInterface(out memberName) ?? member.DeclaringType;
+            var typeDeclaringMemberInfo = typeDeclaringMember.IsInterface
+                ? dynamicFlagsMap.SubstituteDynamicFlags(typeDeclaringMember.GetInterfaceListEntry(member.DeclaringType), originalDynamicFlags: default(DynamicFlagsCustomTypeInfo)).GetCustomTypeInfo()
+                : null;
+            var formatter = resultProvider.Formatter;
             memberName = formatter.GetIdentifierEscapingPotentialKeywords(memberName);
             var fullName = MakeFullName(
                 formatter,
                 memberName,
-                typeDeclaringMember,
+                new TypeAndCustomInfo(typeDeclaringMember, typeDeclaringMemberInfo), // Note: Won't include DynamicAttribute.
                 member.RequiresExplicitCast,
                 member.IsStatic,
                 parent);
             return resultProvider.CreateDataItem(
                 inspectionContext,
                 memberName,
-                typeDeclaringMember: (member.IncludeTypeInMemberName || typeDeclaringMember.IsInterface) ? typeDeclaringMember : null,
-                declaredType: member.Type,
+                typeDeclaringMemberAndInfo: (member.IncludeTypeInMemberName || typeDeclaringMember.IsInterface) ? new TypeAndCustomInfo(typeDeclaringMember, typeDeclaringMemberInfo) : default(TypeAndCustomInfo), // Note: Won't include DynamicAttribute.
+                declaredTypeAndInfo: new TypeAndCustomInfo(declaredType, declaredTypeInfo),
                 value: memberValue,
                 parent: parent,
                 expansionFlags: flags,
@@ -469,7 +484,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private static string MakeFullName(
             Formatter formatter,
             string name,
-            Type typeDeclaringMember,
+            TypeAndCustomInfo typeDeclaringMemberAndInfo,
             bool memberAccessRequiresExplicitCast,
             bool memberIsStatic,
             EvalResultDataItem parent)
@@ -492,16 +507,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 parentFullName = $"({parentFullName})";
             }
 
-            if (!typeDeclaringMember.IsInterface)
+            if (!typeDeclaringMemberAndInfo.Type.IsInterface)
             {
                 string qualifier;
                 if (memberIsStatic)
                 {
-                    qualifier = formatter.GetTypeName(typeDeclaringMember, escapeKeywordIdentifiers: false);
+                    qualifier = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: false);
                 }
                 else if (memberAccessRequiresExplicitCast)
                 {
-                    var typeName = formatter.GetTypeName(typeDeclaringMember, escapeKeywordIdentifiers: true);
+                    var typeName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
                     qualifier = formatter.GetCastExpression(
                         parentFullName,
                         typeName,
@@ -518,7 +533,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // NOTE: This should never interact with debugger proxy types:
                 //   1) Interfaces cannot have debugger proxy types.
                 //   2) Debugger proxy types cannot be interfaces.
-                if (typeDeclaringMember.Equals(parent.DeclaredType))
+                if (typeDeclaringMemberAndInfo.Type.Equals(parent.DeclaredTypeAndInfo.Type))
                 {
                     var memberAccessTemplate = parent.ChildShouldParenthesize
                         ? "({0}).{1}"
@@ -527,7 +542,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
                 else
                 {
-                    var interfaceName = formatter.GetTypeName(typeDeclaringMember, escapeKeywordIdentifiers: true);
+                    var interfaceName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
                     var memberAccessTemplate = parent.ChildShouldParenthesize
                         ? "(({0})({1})).{2}"
                         : "(({0}){1}).{2}";

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return new EvalResultDataItem(
                 ExpansionKind.NativeView,
                 name: name,
-                typeDeclaringMember: null,
-                declaredType: comObject.Type.GetLmrType(),
+                typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                declaredTypeAndInfo: new TypeAndCustomInfo(comObject.Type), // DkmClrValue types don't have attributes.
                 parent: null,
                 value: comObject,
                 displayValue: null,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -13,15 +14,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         /// <returns>The qualified name (i.e. including containing types and namespaces) of a named,
         /// pointer, or array type.</returns>
-        internal string GetTypeName(Type type, bool escapeKeywordIdentifiers = false)
+        internal string GetTypeName(TypeAndCustomInfo typeAndInfo, bool escapeKeywordIdentifiers = false)
         {
+            var type = typeAndInfo.Type;
             if (type == null)
             {
                 throw new ArgumentNullException("type");
             }
 
+            var dynamicFlags = new DynamicFlagsCustomTypeInfo(typeAndInfo.Info);
+            var index = 0;
             var pooled = PooledStringBuilder.GetInstance();
-            AppendQualifiedTypeName(pooled.Builder, type, escapeKeywordIdentifiers);
+            AppendQualifiedTypeName(pooled.Builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers);
             return pooled.ToStringAndFree();
         }
 
@@ -37,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// This is fortunate, since we don't have a good way to recognize them in metadata.
         /// Does not call itself (directly).
         /// </remarks>
-        protected void AppendQualifiedTypeName(StringBuilder builder, Type type, bool escapeKeywordIdentifiers)
+        protected void AppendQualifiedTypeName(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers)
         {
             Type originalType = type;
 
@@ -45,12 +49,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // We'll reconstruct this information later from originalType.
             while (type.IsArray)
             {
+                index++;
                 type = type.GetElementType();
             }
 
             int pointerCount = 0;
             while (type.IsPointer)
             {
+                index++;
                 pointerCount++;
                 type = type.GetElementType();
             }
@@ -59,6 +65,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Type typeArg;
             while ((typeArg = type.GetNullableTypeArgument()) != null)
             {
+                index++;
                 nullableCount++;
                 type = typeArg;
             }
@@ -67,7 +74,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Debug.Assert(pointerCount == 0 || nullableCount == 0, "Benign: pointer to nullable?");
 
             int oldLength = builder.Length;
-            AppendQualifiedTypeNameInternal(builder, type, escapeKeywordIdentifiers);
+            AppendQualifiedTypeNameInternal(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers);
             string name = builder.ToString(oldLength, builder.Length - oldLength);
 
             builder.Append('?', nullableCount);
@@ -92,12 +99,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// <remarks>
         /// Does not call itself or <see cref="AppendQualifiedTypeName"/> (directly).
         /// </remarks>
-        private void AppendQualifiedTypeNameInternal(StringBuilder builder, Type type, bool escapeKeywordIdentifiers)
+        private void AppendQualifiedTypeNameInternal(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers)
         {
-            if (AppendSpecialTypeName(builder, type, escapeKeywordIdentifiers))
+            var isDynamic = dynamicFlags[index++] && type.IsObject();
+            if (AppendSpecialTypeName(builder, type, isDynamic, escapeKeywordIdentifiers))
             {
                 return;
             }
+            Debug.Assert(!isDynamic, $"Dynamic should have been handled by {nameof(AppendSpecialTypeName)}");
 
             Debug.Assert(!IsPredefinedType(type));
 
@@ -137,7 +146,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     // ACASEY: I explored the type in the debugger and couldn't find the arity stored/exposed separately.
                     int arity = hasTypeArguments ? containingType.GetGenericArguments().Length - typeArgumentOffset : 0;
 
-                    AppendUnqualifiedTypeName(builder, containingType, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, arity);
+                    AppendUnqualifiedTypeName(builder, containingType, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, arity);
                     builder.Append('.');
 
                     typeArgumentOffset += arity;
@@ -145,12 +154,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 stack.Free();
 
-                AppendUnqualifiedTypeName(builder, type, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, numTypeArguments - typeArgumentOffset);
+                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, numTypeArguments - typeArgumentOffset);
             }
             else
             {
                 AppendNamespacePrefix(builder, type, escapeKeywordIdentifiers);
-                AppendUnqualifiedTypeName(builder, type, escapeKeywordIdentifiers, typeArguments, 0, numTypeArguments);
+                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, 0, numTypeArguments);
             }
         }
 
@@ -196,6 +205,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// </summary>
         /// <param name="builder">Builder to which the name will be appended.</param>
         /// <param name="type">Type, the name of which will be appended.</param>
+        /// <param name="dynamicFlags">Flags indicating which occurrences of &quot;object&quot; need to be replaced by &quot;dynamic&quot;.</param>
+        /// <param name="index">Current index into <paramref name="dynamicFlags"/>.</param>
         /// <param name="escapeKeywordIdentifiers">True if identifiers that are also keywords should be prefixed with '@'.</param>
         /// <param name="typeArguments">
         /// The type arguments of the type passed to <see cref="AppendQualifiedTypeNameInternal"/>, which might be nested
@@ -213,7 +224,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// We're passing the full array plus bounds, rather than a tailored array, to avoid creating a lot of short-lived
         /// temporary arrays.
         /// </remarks>
-        private void AppendUnqualifiedTypeName(StringBuilder builder, Type type, bool escapeKeywordIdentifiers, Type[] typeArguments, int typeArgumentOffset, int arity)
+        private void AppendUnqualifiedTypeName(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers, Type[] typeArguments, int typeArgumentOffset, int arity)
         {
             if (typeArguments == null || arity == 0)
             {
@@ -222,10 +233,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
 
             var mangledName = type.Name;
-            var index = mangledName.IndexOf('`');
-            AppendIdentifier(builder, escapeKeywordIdentifiers, mangledName, index);
+            var separatorIndex = mangledName.IndexOf('`');
+            AppendIdentifier(builder, escapeKeywordIdentifiers, mangledName, separatorIndex);
 
-            AppendGenericTypeArgumentList(builder, typeArguments, typeArgumentOffset, arity, escapeKeywordIdentifiers);
+            AppendGenericTypeArgumentList(builder, typeArguments, typeArgumentOffset, dynamicFlags, ref index, arity, escapeKeywordIdentifiers);
         }
 
         protected void AppendIdentifier(StringBuilder builder, bool escapeKeywordIdentifiers, string identifier, int length = -1)
@@ -263,11 +274,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         protected abstract void AppendIdentifierEscapingPotentialKeywords(StringBuilder builder, string identifier);
 
-        protected abstract void AppendGenericTypeArgumentList(StringBuilder builder, Type[] typeArguments, int typeArgumentOffset, int arity, bool escapeKeywordIdentifiers);
+        protected abstract void AppendGenericTypeArgumentList(
+            StringBuilder builder, 
+            Type[] typeArguments, 
+            int typeArgumentOffset,
+            DynamicFlagsCustomTypeInfo dynamicFlags,
+            ref int index,
+            int arity, 
+            bool escapeKeywordIdentifiers);
 
         protected abstract void AppendRankSpecifier(StringBuilder builder, int rank);
 
-        protected abstract bool AppendSpecialTypeName(StringBuilder builder, Type type, bool escapeKeywordIdentifiers);
+        protected abstract bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic, bool escapeKeywordIdentifiers);
 
         #endregion
     }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // (Tools > Options setting) and call "value.ToString()" if appropriate.
             return IncludeObjectId(
                 value,
-                string.Format(_defaultFormat, value.EvaluateToString(inspectionContext) ?? inspectionContext.GetTypeName(value.Type, Formatter.NoFormatSpecifiers, CustomTypeInfo: null)),
+                string.Format(_defaultFormat, value.EvaluateToString(inspectionContext) ?? inspectionContext.GetTypeName(value.Type, NoFormatSpecifiers, CustomTypeInfo: null)),
                 flags);
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.VisualStudio.Debugger.Metadata;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -36,9 +37,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return GetValueString(value, inspectionContext, options, GetValueFlags.IncludeObjectId);
         }
 
-        string IDkmClrFormatter.GetTypeName(DkmInspectionContext inspectionContext, DkmClrType type, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo CustomTypeInfo)
+        string IDkmClrFormatter.GetTypeName(DkmInspectionContext inspectionContext, DkmClrType type, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo typeInfo)
         {
-            return GetTypeName(type.GetLmrType());
+            return GetTypeName(new TypeAndCustomInfo(type.GetLmrType(), typeInfo));
         }
 
         bool IDkmClrFormatter.HasUnderlyingString(DkmClrValue value, DkmInspectionContext inspectionContext)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ArrayBuilder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ArrayBuilder.cs
@@ -53,6 +53,24 @@ namespace Microsoft.CodeAnalysis
             _items.AddRange(items);
         }
 
+        public T Peek()
+        {
+            return _items[_items.Count - 1];
+        }
+
+        public void Push(T item)
+        {
+            Add(item);
+        }
+
+        public T Pop()
+        {
+            var position = _items.Count - 1;
+            var result = _items[position];
+            _items.RemoveAt(position);
+            return result;
+        }
+
         public void Clear()
         {
             _items.Clear();

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsMap.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsMap.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Diagnostics;
+using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class DynamicFlagsMap
+    {
+        private static readonly DynamicFlagsMap Empty = new DynamicFlagsMap();
+
+        private readonly Type _typeDefinition;
+        private readonly DynamicFlagsCustomTypeInfo _dynamicFlags;
+        private readonly int[] _startIndices;
+
+        private DynamicFlagsMap()
+        {
+        }
+
+        private DynamicFlagsMap(
+            Type typeDefinition,
+            DynamicFlagsCustomTypeInfo dynamicFlagsArray,
+            int[] startIndices)
+        {
+            Debug.Assert(typeDefinition != null);
+            Debug.Assert(startIndices != null);
+
+            Debug.Assert(typeDefinition.IsGenericTypeDefinition);
+            Debug.Assert(startIndices.Length == typeDefinition.GetGenericArguments().Length + 1);
+
+            _typeDefinition = typeDefinition;
+            _dynamicFlags = dynamicFlagsArray;
+            _startIndices = startIndices;
+        }
+
+        internal static DynamicFlagsMap Create(TypeAndCustomInfo typeAndInfo)
+        {
+            var type = typeAndInfo.Type;
+            Debug.Assert(type != null);
+            if (!type.IsGenericType)
+            {
+                return Empty;
+            }
+
+            var dynamicFlags = new DynamicFlagsCustomTypeInfo(typeAndInfo.Info);
+            if (!dynamicFlags.Any())
+            {
+                return Empty;
+            }
+
+            var typeDefinition = type.GetGenericTypeDefinition();
+            Debug.Assert(typeDefinition != null);
+
+            var typeArgs = type.GetGenericArguments();
+            Debug.Assert(typeArgs.Length > 0);
+
+            int pos = 1; // Consider "type" to have already been consumed.
+            var startsBuilder = ArrayBuilder<int>.GetInstance();
+            foreach (var typeArg in typeArgs)
+            {
+                startsBuilder.Add(pos);
+
+                foreach (Type curr in new TypeWalker(typeArg))
+                {
+                    pos++;
+                }
+            }
+
+            Debug.Assert(pos > 1);
+            startsBuilder.Add(pos);
+
+            return new DynamicFlagsMap(typeDefinition, dynamicFlags, startsBuilder.ToArrayAndFree());
+        }
+
+        internal DynamicFlagsCustomTypeInfo SubstituteDynamicFlags(Type type, DynamicFlagsCustomTypeInfo originalDynamicFlags)
+        {
+            if (_typeDefinition == null)
+            {
+                return originalDynamicFlags;
+            }
+
+            var substitutedFlags = ArrayBuilder<bool>.GetInstance();
+            int f = 0;
+
+            foreach (Type curr in new TypeWalker(type))
+            {
+                if (curr.IsGenericParameter && curr.DeclaringType.Equals(_typeDefinition))
+                {
+                    AppendFlagsFor(curr, substitutedFlags);
+                }
+                else
+                {
+                    substitutedFlags.Add(originalDynamicFlags[f]);
+                }
+
+                f++;
+            }
+
+            return new DynamicFlagsCustomTypeInfo(new BitArray(substitutedFlags.ToArrayAndFree()));
+        }
+
+        private void AppendFlagsFor(Type type, ArrayBuilder<bool> builder)
+        {
+            Debug.Assert(type.IsGenericParameter);
+
+            var genericParameterPosition = type.GenericParameterPosition;
+            var start = _startIndices[genericParameterPosition];
+            var nextStart = _startIndices[genericParameterPosition + 1];
+            for (int i = start; i < nextStart; i++)
+            {
+                builder.Add(_dynamicFlags[i]);
+            }
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicHelpers.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.Debugger.Metadata;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal static class DynamicHelpers
+    {
+        private static readonly BitArray TrueArray = new BitArray(new[] { true });
+
+        public static DynamicFlagsCustomTypeInfo GetDynamicFlags(this IList<CustomAttributeData> attributes)
+        {
+            foreach (var attribute in attributes)
+            {
+                if (attribute.Constructor.DeclaringType.IsType("System.Runtime.CompilerServices", "DynamicAttribute"))
+                {
+                    var arguments = attribute.ConstructorArguments;
+                    if (arguments.Count == 0)
+                    {
+                        return new DynamicFlagsCustomTypeInfo(TrueArray);
+                    }
+                    else if (arguments.Count == 1)
+                    {
+                        var argumentType = arguments[0].ArgumentType;
+                        if (argumentType.IsArray && argumentType.GetElementType().IsBoolean())
+                        {
+                            // Per https://msdn.microsoft.com/en-us/library/system.reflection.customattributetypedargument.argumenttype(v=vs.110).aspx,
+                            // if ArgumentType indicates an array, then Value will actually be a ReadOnlyCollection.
+                            var collection = (ReadOnlyCollection<CustomAttributeTypedArgument>)arguments[0].Value;
+                            var numFlags = collection.Count;
+                            var array = new BitArray(numFlags);
+                            for (int i = 0; i < numFlags; i++)
+                            {
+                                array[i] = (bool)collection[i].Value;
+                            }
+                            return new DynamicFlagsCustomTypeInfo(array);
+                        }
+                    }
+                }
+            }
+
+            return default(DynamicFlagsCustomTypeInfo);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/EvalResultDataItem.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.VisualStudio.Debugger.Metadata;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -36,8 +37,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         public readonly ExpansionKind Kind;
         public readonly string Name;
-        public readonly Type TypeDeclaringMember;
-        public readonly Type DeclaredType;
+        public readonly TypeAndCustomInfo TypeDeclaringMemberAndInfo;
+        public readonly TypeAndCustomInfo DeclaredTypeAndInfo;
         public readonly EvalResultDataItem Parent;
         public readonly DkmClrValue Value;
         public readonly string DisplayValue; // overrides the "Value" text displayed for certain kinds of DataItems (errors, invalid pointer dereferences, etc)...not to be confused with DebuggerDisplayAttribute Value...
@@ -71,8 +72,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 ExpansionKind.Error,
                 inspectionContext: null,
                 name: name,
-                typeDeclaringMember: null,
-                declaredType: null,
+                typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                declaredTypeAndInfo: default(TypeAndCustomInfo),
                 parent: null,
                 value: null,
                 displayValue: errorMessage,
@@ -90,8 +91,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         public EvalResultDataItem(
             ExpansionKind kind,
             string name,
-            Type typeDeclaringMember,
-            Type declaredType,
+            TypeAndCustomInfo typeDeclaringMemberAndInfo,
+            TypeAndCustomInfo declaredTypeAndInfo,
             EvalResultDataItem parent,
             DkmClrValue value,
             string displayValue,
@@ -111,8 +112,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             this.Kind = kind;
             this.Name = name;
-            this.TypeDeclaringMember = typeDeclaringMember;
-            this.DeclaredType = declaredType;
+            this.TypeDeclaringMemberAndInfo = typeDeclaringMemberAndInfo;
+            this.DeclaredTypeAndInfo = declaredTypeAndInfo;
             this.Parent = parent;
             this.Value = value;
             this.DisplayValue = displayValue;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeAndCustomInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeAndCustomInfo.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.VisualStudio.Debugger.Metadata;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal struct TypeAndCustomInfo
+    {
+        public readonly Type Type;
+        public readonly DkmClrCustomTypeInfo Info;
+
+        public TypeAndCustomInfo(Type type, DkmClrCustomTypeInfo info)
+        {
+            Debug.Assert(type != null); // Can only be null in the default instance.
+            Type = type;
+            Info = info;
+        }
+
+        public TypeAndCustomInfo(Type type)
+            : this(type, null)
+        {
+        }
+
+        public TypeAndCustomInfo(DkmClrType type)
+            : this(type.GetLmrType(), null)
+        {
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeWalker.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeWalker.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal struct TypeWalker
+    {
+        private readonly Type _type;
+
+        public TypeWalker(Type type)
+        {
+            _type = type;
+        }
+
+        public TypeEnumerator GetEnumerator()
+        {
+            return new TypeEnumerator(_type);
+        }
+
+        internal struct TypeEnumerator : IDisposable
+        {
+            private bool _first;
+            private ArrayBuilder<Type> _stack;
+
+            public TypeEnumerator(Type type)
+            {
+                _first = true;
+                _stack = ArrayBuilder<Type>.GetInstance();
+                _stack.Push(type);
+            }
+
+            public Type Current => _stack.Peek();
+
+            public bool MoveNext()
+            {
+                if (_first)
+                {
+                    _first = false;
+                    return true;
+                }
+
+                if (_stack.Count == 0)
+                {
+                    return false;
+                }
+
+                var curr = _stack.Pop();
+
+                if (curr.HasElementType)
+                {
+                    _stack.Push(curr.GetElementType());
+                    return true;
+                }
+
+                // Push children in reverse order so they get popped in forward order.
+                var children = curr.GetGenericArguments();
+                var numChildren = children.Length;
+                for (int i = numChildren - 1; i >= 0; i--)
+                {
+                    _stack.Push(children[i]);
+                }
+
+                return _stack.Count > 0;
+            }
+
+            public void Reset()
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Dispose()
+            {
+                Debug.Assert(_stack != null);
+                _stack.Free();
+                _stack = null;
+            }
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return string.Format(
                 Resources.ExceptionThrown,
                 fullNameWithoutFormatSpecifiers,
-                formatter.GetTypeName(value.Type.GetLmrType()));
+                formatter.GetTypeName(new TypeAndCustomInfo(value.Type)));
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
@@ -61,6 +61,9 @@
     <Compile Include="..\..\..\..\..\Test\PdbUtilities\Shared\DateTimeUtilities.cs">
       <Link>Helpers\DateTimeUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs">
+      <Link>ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs</Link>
+    </Compile>
     <Compile Include="..\..\ExpressionCompiler\ExpressionEvaluatorFatalError.cs">
       <Link>ExpressionCompiler\ExpressionEvaluatorFatalError.cs</Link>
     </Compile>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/ResultProvider.Portable.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/ResultProvider.Portable.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\..\..\..\..\Test\PdbUtilities\Shared\DateTimeUtilities.cs">
       <Link>Helpers\DateTimeUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs">
+      <Link>ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs</Link>
+    </Compile>
     <Compile Include="..\..\ExpressionCompiler\ExpressionEvaluatorFatalError.cs">
       <Link>ExpressionCompiler\ExpressionEvaluatorFatalError.cs</Link>
     </Compile>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.VisualStudio.Debugger.Metadata;
 using Roslyn.Utilities;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             this.Formatter = formatter;
         }
 
-        void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo customTypeInfo, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)
+        void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo declaredTypeInfo, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)
         {
             // TODO: Use full name
             var wl = new WorkList(workList, e => completionRoutine(DkmEvaluationAsyncResult.CreateErrorResult(e)));
@@ -47,6 +48,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 value,
                 wl,
                 declaredType,
+                declaredTypeInfo,
                 inspectionContext,
                 resultName,
                 result => wl.ContinueWith(() => completionRoutine(new DkmEvaluationAsyncResult(result))));
@@ -271,7 +273,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     GetResultAndContinue(
                         dataItem,
                         workList,
-                        declaredType: DkmClrType.Create(dataItem.Value.Type.AppDomain, dataItem.DeclaredType),
+                        declaredType: DkmClrType.Create(dataItem.Value.Type.AppDomain, dataItem.DeclaredTypeAndInfo.Type),
+                        declaredTypeInfo: dataItem.DeclaredTypeAndInfo.Info,
                         inspectionContext: inspectionContext,
                         parent: dataItem.Parent,
                         completionRoutine: completionRoutine);
@@ -344,27 +347,28 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// The qualified name (i.e. including containing types and namespaces) of a named, pointer,
         /// or array type followed by the qualified name of the actual runtime type, if provided.
         /// </returns>
-        private static string GetTypeName(DkmInspectionContext inspectionContext, DkmClrValue value, DkmClrType declaredType, ExpansionKind kind)
+        private static string GetTypeName(DkmInspectionContext inspectionContext, DkmClrValue value, DkmClrType declaredType, DkmClrCustomTypeInfo declaredTypeInfo, ExpansionKind kind)
         {
             var declaredLmrType = declaredType.GetLmrType();
             var runtimeType = value.Type;
             var runtimeLmrType = runtimeType.GetLmrType();
+            var declaredTypeName = inspectionContext.GetTypeName(declaredType, Formatter.NoFormatSpecifiers, declaredTypeInfo);
+            var runtimeTypeName = inspectionContext.GetTypeName(runtimeType, Formatter.NoFormatSpecifiers, CustomTypeInfo: null);
             var includeRuntimeTypeName =
-                !declaredLmrType.Equals(runtimeLmrType) &&
+                !string.Equals(declaredTypeName, runtimeTypeName, StringComparison.OrdinalIgnoreCase) && // Names will reflect "dynamic", types will not.
                 !declaredLmrType.IsPointer &&
                 (kind != ExpansionKind.PointerDereference) &&
                 (!declaredLmrType.IsNullable() || value.EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown));
-            var declaredTypeName = inspectionContext.GetTypeName(declaredType, Formatter.NoFormatSpecifiers, CustomTypeInfo: null);
             return includeRuntimeTypeName ?
-                string.Format("{0} {{{1}}}", declaredTypeName, inspectionContext.GetTypeName(runtimeType, Formatter.NoFormatSpecifiers, CustomTypeInfo: null)) :
+                string.Format("{0} {{{1}}}", declaredTypeName, runtimeTypeName) : 
                 declaredTypeName;
         }
 
         internal EvalResultDataItem CreateDataItem(
             DkmInspectionContext inspectionContext,
             string name,
-            Type typeDeclaringMember,
-            Type declaredType,
+            TypeAndCustomInfo typeDeclaringMemberAndInfo,
+            TypeAndCustomInfo declaredTypeAndInfo,
             DkmClrValue value,
             EvalResultDataItem parent,
             ExpansionFlags expansionFlags,
@@ -383,6 +387,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Expansion expansion;
             // If the declared type is Nullable<T>, the value should
             // have no expansion if null, or be expanded as a T.
+            var declaredType = declaredTypeAndInfo.Type;
             var lmrNullableTypeArg = declaredType.GetNullableTypeArgument();
             if (lmrNullableTypeArg != null && !value.HasExceptionThrown())
             {
@@ -403,7 +408,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     value = nullableValue;
                     Debug.Assert(lmrNullableTypeArg.Equals(value.Type.GetLmrType())); // If this is not the case, add a test for includeRuntimeTypeIfNecessary.
-                    expansion = this.GetTypeExpansion(inspectionContext, lmrNullableTypeArg, value, ExpansionFlags.IncludeResultsView);
+                    // CONSIDER: The DynamicAttribute for the type argument should just be Skip(1) of the original flag array.
+                    expansion = this.GetTypeExpansion(inspectionContext, new TypeAndCustomInfo(lmrNullableTypeArg), value, ExpansionFlags.IncludeResultsView);
                 }
             }
             else if (value.IsError() || (inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoExpansion) != 0)
@@ -416,8 +422,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     this,
                     inspectionContext,
                     name,
-                    typeDeclaringMember,
-                    declaredType,
+                    typeDeclaringMemberAndInfo,
+                    declaredTypeAndInfo,
                     value,
                     childShouldParenthesize,
                     fullName,
@@ -427,16 +433,17 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     this.Formatter.GetEditableValue(value, inspectionContext));
                 if (expansion == null)
                 {
-                    var expansionType = value.HasExceptionThrown() ? value.Type.GetLmrType() : declaredType;
-                    expansion = this.GetTypeExpansion(inspectionContext, expansionType, value, expansionFlags);
+                    expansion = value.HasExceptionThrown()
+                        ? this.GetTypeExpansion(inspectionContext, new TypeAndCustomInfo(value.Type), value, expansionFlags)
+                        : this.GetTypeExpansion(inspectionContext, declaredTypeAndInfo, value, expansionFlags);
                 }
             }
 
             return new EvalResultDataItem(
                 ExpansionKind.Default,
                 name,
-                typeDeclaringMember,
-                declaredType,
+                typeDeclaringMemberAndInfo,
+                declaredTypeAndInfo,
                 parent: parent,
                 value: value,
                 displayValue: null,
@@ -451,17 +458,26 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 inspectionContext: inspectionContext);
         }
 
-        private void GetRootResultAndContinue(DkmClrValue value, WorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, string name, CompletionRoutine<DkmEvaluationResult> completionRoutine)
+        private void GetRootResultAndContinue(
+            DkmClrValue value, 
+            WorkList workList, 
+            DkmClrType declaredType,
+            DkmClrCustomTypeInfo declaredTypeInfo,
+            DkmInspectionContext inspectionContext, 
+            string name, 
+            CompletionRoutine<DkmEvaluationResult> completionRoutine)
         {
             var type = value.Type.GetLmrType();
             if (type.IsTypeVariables())
             {
-                var expansion = new TypeVariablesExpansion(type);
+                Debug.Assert(type.Equals(declaredType.GetLmrType()));
+                var declaredTypeAndInfo = new TypeAndCustomInfo(type, declaredTypeInfo);
+                var expansion = new TypeVariablesExpansion(declaredTypeAndInfo);
                 var dataItem = new EvalResultDataItem(
                     ExpansionKind.Default,
                     name,
-                    typeDeclaringMember: null,
-                    declaredType: type,
+                    typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                    declaredTypeAndInfo: declaredTypeAndInfo,
                     parent: null,
                     value: value,
                     displayValue: null,
@@ -499,8 +515,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else if ((inspectionContext.EvaluationFlags & DkmEvaluationFlags.ResultsOnly) != 0)
             {
+                var dataItem = ResultsViewExpansion.CreateResultsOnlyRow(
+                    inspectionContext, 
+                    name, 
+                    declaredType, 
+                    declaredTypeInfo, 
+                    value, 
+                    this.Formatter);
                 CreateEvaluationResultAndContinue(
-                    ResultsViewExpansion.CreateResultsOnlyRow(inspectionContext, name, declaredType, value, this.Formatter), 
+                    dataItem, 
                     workList,
                     inspectionContext,
                     value.StackFrame,
@@ -508,7 +531,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else
             {
-                var dataItem = ResultsViewExpansion.CreateResultsOnlyRowIfSynthesizedEnumerable(inspectionContext, name, declaredType, value, this.Formatter);
+                var dataItem = ResultsViewExpansion.CreateResultsOnlyRowIfSynthesizedEnumerable(
+                    inspectionContext, 
+                    name, 
+                    declaredType, 
+                    declaredTypeInfo, 
+                    value, 
+                    this.Formatter);
                 if (dataItem != null)
                 {
                     CreateEvaluationResultAndContinue(
@@ -525,8 +554,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     dataItem = CreateDataItem(
                         inspectionContext,
                         name,
-                        typeDeclaringMember: null,
-                        declaredType: declaredType.GetLmrType(),
+                        typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
+                        declaredTypeAndInfo: new TypeAndCustomInfo(declaredType.GetLmrType(), declaredTypeInfo),
                         value: value,
                         parent: null,
                         expansionFlags: ExpansionFlags.All,
@@ -536,12 +565,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         category: DkmEvaluationResultCategory.Other,
                         flags: value.EvalFlags,
                         evalFlags: inspectionContext.EvaluationFlags);
-                    GetResultAndContinue(dataItem, workList, declaredType, inspectionContext, parent: null, completionRoutine: completionRoutine);
+                    GetResultAndContinue(dataItem, workList, declaredType, declaredTypeInfo, inspectionContext, parent: null, completionRoutine: completionRoutine);
                 }
             }
         }
 
-        private void GetResultAndContinue(EvalResultDataItem dataItem, WorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, EvalResultDataItem parent, CompletionRoutine<DkmEvaluationResult> completionRoutine)
+        private void GetResultAndContinue(
+            EvalResultDataItem dataItem, 
+            WorkList workList, 
+            DkmClrType declaredType,
+            DkmClrCustomTypeInfo declaredTypeInfo,
+            DkmInspectionContext inspectionContext, 
+            EvalResultDataItem parent, 
+            CompletionRoutine<DkmEvaluationResult> completionRoutine)
         {
             var value = dataItem.Value; // Value may have been replaced (specifically, for Nullable<T>).
             DebuggerDisplayInfo displayInfo;
@@ -557,7 +593,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         displayValue => EvaluateDebuggerDisplayStringAndContinue(value, workList, inspectionContext, targetType, attribute.TypeName,
                             displayType =>
                             {
-                                completionRoutine(GetResult(inspectionContext, dataItem, declaredType, displayName.Result, displayValue.Result, displayType.Result, parent));
+                                completionRoutine(GetResult(inspectionContext, dataItem, declaredType, declaredTypeInfo, displayName.Result, displayValue.Result, displayType.Result, parent));
                                 workList.Execute();
                             },
                             onException),
@@ -566,7 +602,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else
             {
-                completionRoutine(GetResult(inspectionContext, dataItem, declaredType, displayName: null, displayValue: null, displayType: null, parent: parent));
+                completionRoutine(GetResult(inspectionContext, dataItem, declaredType, declaredTypeInfo, displayName: null, displayValue: null, displayType: null, parent: parent));
             }
         }
 
@@ -601,11 +637,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
         }
 
-        private DkmEvaluationResult GetResult(DkmInspectionContext inspectionContext, EvalResultDataItem dataItem, DkmClrType declaredType, string displayName, string displayValue, string displayType, EvalResultDataItem parent)
+        private DkmEvaluationResult GetResult(
+            DkmInspectionContext inspectionContext, 
+            EvalResultDataItem dataItem, 
+            DkmClrType declaredType,
+            DkmClrCustomTypeInfo declaredTypeInfo,
+            string displayName, 
+            string displayValue, 
+            string displayType, 
+            EvalResultDataItem parent)
         {
             var name = dataItem.Name;
             Debug.Assert(name != null);
-            var typeDeclaringMember = dataItem.TypeDeclaringMember;
+            var typeDeclaringMemberAndInfo = dataItem.TypeDeclaringMemberAndInfo;
 
             // Note: Don't respect the debugger display name on the root element:
             //   1) In the Watch window, that's where the user's text goes.
@@ -617,11 +661,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 name = displayName;
             }
-            else if (typeDeclaringMember != null)
+            else if (typeDeclaringMemberAndInfo.Type != null)
             {
-                if (typeDeclaringMember.IsInterface)
+                if (typeDeclaringMemberAndInfo.Type.IsInterface)
                 {
-                    var interfaceTypeName = this.Formatter.GetTypeName(typeDeclaringMember, escapeKeywordIdentifiers: true);
+                    var interfaceTypeName = this.Formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
                     name = string.Format("{0}.{1}", interfaceTypeName, name);
                 }
                 else
@@ -630,7 +674,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     var builder = pooled.Builder;
                     builder.Append(name);
                     builder.Append(" (");
-                    builder.Append(this.Formatter.GetTypeName(typeDeclaringMember));
+                    builder.Append(this.Formatter.GetTypeName(typeDeclaringMemberAndInfo));
                     builder.Append(')');
                     name = pooled.ToStringAndFree();
                 }
@@ -651,7 +695,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 display = value.GetValueString(inspectionContext, Formatter.NoFormatSpecifiers);
             }
 
-            var typeName = displayType ?? GetTypeName(inspectionContext, value, declaredType, dataItem.Kind);
+            var typeName = displayType ?? GetTypeName(inspectionContext, value, declaredType, declaredTypeInfo, dataItem.Kind);
 
             return CreateEvaluationResult(inspectionContext, value, name, typeName, display, dataItem);
         }
@@ -723,8 +767,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
         }
 
-        internal Expansion GetTypeExpansion(DkmInspectionContext inspectionContext, Type declaredType, DkmClrValue value, ExpansionFlags flags)
+        internal Expansion GetTypeExpansion(
+            DkmInspectionContext inspectionContext, 
+            TypeAndCustomInfo declaredTypeAndInfo,
+            DkmClrValue value, 
+            ExpansionFlags flags)
         {
+            var declaredType = declaredTypeAndInfo.Type;
             Debug.Assert(!declaredType.IsTypeVariables());
 
             if ((inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoExpansion) != 0)
@@ -744,7 +793,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     return null;
                 }
                 var lowerBounds = value.ArrayLowerBounds;
-                return ArrayExpansion.CreateExpansion(sizes, lowerBounds);
+
+                Type elementType;
+                DkmClrCustomTypeInfo elementTypeInfo;
+                if (declaredType.IsArray)
+                {
+                    elementType = declaredType.GetElementType();
+                    elementTypeInfo = new DynamicFlagsCustomTypeInfo(declaredTypeAndInfo.Info).SkipOne().GetCustomTypeInfo();
+                }
+                else
+                {
+                    elementType = runtimeType.GetElementType();
+                    elementTypeInfo = null;
+                }
+
+                return ArrayExpansion.CreateExpansion(new TypeAndCustomInfo(elementType, elementTypeInfo), sizes, lowerBounds);
             }
 
             if (this.Formatter.IsPredefinedType(runtimeType))
@@ -754,7 +817,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             if (declaredType.IsPointer)
             {
-                return !value.IsNull ? new PointerDereferenceExpansion(declaredType.GetElementType()) : null;
+                // If this ever happens, the element type info is just .SkipOne().
+                Debug.Assert(!new DynamicFlagsCustomTypeInfo(declaredTypeAndInfo.Info).Any());
+                return !value.IsNull ? new PointerDereferenceExpansion(new TypeAndCustomInfo(declaredType.GetElementType())) : null;
             }
 
             if (value.EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown) &&
@@ -767,7 +832,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 flags &= ~ExpansionFlags.IncludeBaseMembers;
             }
 
-            return MemberExpansion.CreateExpansion(inspectionContext, declaredType, value, flags, TypeHelpers.IsVisibleMember, this.Formatter);
+            return MemberExpansion.CreateExpansion(inspectionContext, declaredTypeAndInfo, value, flags, TypeHelpers.IsVisibleMember, this.Formatter);
         }
 
         private static DkmEvaluationResult CreateEvaluationResultFromException(Exception e, EvalResultDataItem dataItem, DkmInspectionContext inspectionContext)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
@@ -12,6 +12,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.TypeNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.Values.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeAndCustomInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeWalker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\DynamicFlagsMap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\DynamicHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ResultProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\AggregateExpansion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expansion\ArrayExpansion.cs" />

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrCustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrCustomTypeInfo.cs
@@ -5,18 +5,28 @@
 #endregion
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 {
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public class DkmClrCustomTypeInfo
     {
         public readonly Guid PayloadTypeId;
         public readonly ReadOnlyCollection<byte> Payload;
 
-        public DkmClrCustomTypeInfo(Guid payloadTypeId, ReadOnlyCollection<byte> payload)
+        private DkmClrCustomTypeInfo(Guid payloadTypeId, ReadOnlyCollection<byte> payload)
         {
             PayloadTypeId = payloadTypeId;
             Payload = payload;
         }
+
+        public static DkmClrCustomTypeInfo Create(Guid payloadTypeId, ReadOnlyCollection<byte> payload)
+        {
+            return new DkmClrCustomTypeInfo(payloadTypeId, payload);
+        }
+
+        private string DebuggerDisplay => $"[{string.Join(", ", Payload.Select(b => $"0x{b:x2}"))}] from {PayloadTypeId}";
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         public string GetTypeName(DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo CustomTypeInfo)
         {
             // The real version does some sort of dynamic dispatch that ultimately calls this method.
-            return _formatter.GetTypeName(this, clrType, formatSpecifiers, customTypeInfo: null);
+            return _formatter.GetTypeName(this, clrType, formatSpecifiers, CustomTypeInfo);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFormatter.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFormatter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
 {
     public interface IDkmClrFormatter
     {
-        string GetTypeName(DkmInspectionContext inspectionContext, DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo customTypeInfo);
+        string GetTypeName(DkmInspectionContext inspectionContext, DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo CustomTypeInfo);
         string GetUnderlyingString(DkmClrValue clrValue, DkmInspectionContext inspectionContext);
         string GetValueString(DkmClrValue clrValue, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers);
         bool HasUnderlyingString(DkmClrValue clrValue, DkmInspectionContext inspectionContext);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/CustomAttributeDataImpl.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/CustomAttributeDataImpl.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.VisualStudio.Debugger.Metadata;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -21,6 +24,27 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 return new ConstructorInfoImpl(CustomAttributeData.Constructor);
             }
+        }
+
+        public override IList<CustomAttributeTypedArgument> ConstructorArguments
+        {
+            get
+            {
+                return CustomAttributeData.ConstructorArguments.Select(MakeTypedArgument).ToList();
+            }
+        }
+
+        private static CustomAttributeTypedArgument MakeTypedArgument(System.Reflection.CustomAttributeTypedArgument a)
+        {
+            var argumentType = (TypeImpl)a.ArgumentType;
+            if (!argumentType.IsArray)
+            {
+                return new CustomAttributeTypedArgument(argumentType, a.Value);
+            }
+
+            var reflectionValue = (ReadOnlyCollection<System.Reflection.CustomAttributeTypedArgument>)a.Value;
+            var lmrValue = new ReadOnlyCollection<CustomAttributeTypedArgument>(reflectionValue.Select(MakeTypedArgument).ToList());
+            return new CustomAttributeTypedArgument(argumentType, lmrValue);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/TypeImpl.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/TypeImpl.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         protected override bool HasElementTypeImpl()
         {
-            throw new NotImplementedException();
+            return this.Type.HasElementType;
         }
 
         protected override bool IsArrayImpl()

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Xunit;
+using System.Collections;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
@@ -150,10 +151,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal DkmEvaluationResult FormatResult(string name, DkmClrValue value, DkmClrType declaredType = null, DkmInspectionContext inspectionContext = null)
         {
-            return FormatResult(name, name, value, declaredType, inspectionContext);
+            return FormatResult(name, name, value, declaredType, inspectionContext: inspectionContext);
         }
 
-        internal DkmEvaluationResult FormatResult(string name, string fullName, DkmClrValue value, DkmClrType declaredType = null, DkmInspectionContext inspectionContext = null)
+        internal DkmEvaluationResult FormatResult(string name, string fullName, DkmClrValue value, DkmClrType declaredType = null, bool[] declaredTypeInfo = null, DkmInspectionContext inspectionContext = null)
         {
             DkmEvaluationResult evaluationResult = null;
             var workList = new DkmWorkList();
@@ -161,9 +162,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 value,
                 workList,
                 declaredType: declaredType ?? value.Type,
+                customTypeInfo: new DynamicFlagsCustomTypeInfo(declaredTypeInfo == null ? null : new BitArray(declaredTypeInfo)).GetCustomTypeInfo(),
                 inspectionContext: inspectionContext ?? DefaultInspectionContext,
                 formatSpecifiers: Formatter.NoFormatSpecifiers,
-                customTypeInfo: null,
                 resultName: name,
                 resultFullName: null,
                 completionRoutine: asyncResult => evaluationResult = asyncResult.Result);
@@ -481,6 +482,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 throw new NotImplementedException();
             }
+        }
+
+        internal static DynamicFlagsCustomTypeInfo MakeDynamicFlagsCustomTypeInfo(params bool[] dynamicFlags)
+        {
+            return new DynamicFlagsCustomTypeInfo(dynamicFlags == null ? null : new BitArray(dynamicFlags));
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\..\..\..\Test\PdbUtilities\Shared\DateTimeUtilities.cs">
       <Link>DateTimeUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\Source\ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs">
+      <Link>ExpressionCompiler\DynamicFlagsCustomTypeInfo.cs</Link>
+    </Compile>
     <Compile Include="..\..\Source\ExpressionCompiler\ExpressionCompilerConstants.cs">
       <Link>ExpressionCompiler\ExpressionCompilerConstants.cs</Link>
     </Compile>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.TypeNames.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.TypeNames.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Text
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Type = Microsoft.VisualStudio.Debugger.Metadata.Type
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
@@ -22,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
         End Sub
 
-        Protected Overrides Sub AppendGenericTypeArgumentList(builder As StringBuilder, typeArguments() As Type, typeArgumentOffset As Integer, arity As Integer, escapeKeywordIdentifiers As Boolean)
+        Protected Overrides Sub AppendGenericTypeArgumentList(builder As StringBuilder, typeArguments() As Type, typeArgumentOffset As Integer, dynamicFlags As DynamicFlagsCustomTypeInfo, ByRef index As Integer, arity As Integer, escapeKeywordIdentifiers As Boolean)
             builder.Append("(Of ")
             For i = 0 To arity - 1
                 If i > 0 Then
@@ -30,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End If
 
                 Dim typeArgument As Type = typeArguments(typeArgumentOffset + i)
-                AppendQualifiedTypeName(builder, typeArgument, escapeKeywordIdentifiers)
+                AppendQualifiedTypeName(builder, typeArgument, dynamicFlags, index, escapeKeywordIdentifiers)
             Next
             builder.Append(")"c)
         End Sub
@@ -43,7 +44,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             builder.Append(")"c)
         End Sub
 
-        Protected Overrides Function AppendSpecialTypeName(builder As StringBuilder, type As Type, escapeKeywordIdentifiers As Boolean) As Boolean
+        Protected Overrides Function AppendSpecialTypeName(builder As StringBuilder, type As Type, isDynamic As Boolean, escapeKeywordIdentifiers As Boolean) As Boolean
+            ' NOTE: isDynamic is ignored in VB.
+
             If type.IsPredefinedType() Then
                 builder.Append(type.GetPredefinedTypeName()) ' Not an identifier, does not require escaping.
                 Return True

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
@@ -4,6 +4,7 @@ Imports System.Collections.ObjectModel
 Imports System.Globalization
 Imports System.Text
 Imports Microsoft.CodeAnalysis.Collections
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Roslyn.Utilities
 Imports Type = Microsoft.VisualStudio.Debugger.Metadata.Type
 
@@ -20,7 +21,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Sub AppendEnumTypeAndName(builder As StringBuilder, typeToDisplayOpt As Type, name As String)
             If typeToDisplayOpt IsNot Nothing Then
-                AppendQualifiedTypeName(builder, typeToDisplayOpt, escapeKeywordIdentifiers:=True)
+                Dim index As Integer = 0
+                AppendQualifiedTypeName(builder, typeToDisplayOpt, Nothing, index, escapeKeywordIdentifiers:=True)
                 builder.Append("."c)
             End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -26,8 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                        staticMembersString:=Resources.SharedMembers)
         End Sub
 
-        Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, formatSpecifiers As ReadOnlyCollection(Of String), customTypeInfo As DkmClrCustomTypeInfo) As String Implements IDkmClrFormatter.GetTypeName
-            Return GetTypeName(clrType.GetLmrType())
+        Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, formatSpecifiers As ReadOnlyCollection(Of String), clrTypeInfo As DkmClrCustomTypeInfo) As String Implements IDkmClrFormatter.GetTypeName
+            Return GetTypeName(New TypeAndCustomInfo(clrType.GetLmrType(), clrTypeInfo))
         End Function
 
         Private Function IDkmClrFormatter_GetUnderlyingString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext) As String Implements IDkmClrFormatter.GetUnderlyingString

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
@@ -2,14 +2,20 @@
 
 Imports System.Runtime.CompilerServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     Public Module TestTypeExtensions
 
         <Extension>
-        Public Function GetTypeName(type As Type, Optional escapeKeywordIdentifiers As Boolean = False) As String
-            Return VisualBasicFormatter.Instance.GetTypeName(CType(type, TypeImpl), escapeKeywordIdentifiers)
+        Public Function GetTypeName(type As System.Type, Optional dynamicFlags As Boolean() = Nothing, Optional escapeKeywordIdentifiers As Boolean = False) As String
+            Return type.GetTypeName(ResultProviderTestBase.MakeDynamicFlagsCustomTypeInfo(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers)
+        End Function
+
+        <Extension>
+        Public Function GetTypeName(type As System.Type, typeInfo As DkmClrCustomTypeInfo, Optional escapeKeywordIdentifiers As Boolean = False) As String
+            Return VisualBasicFormatter.Instance.GetTypeName(New TypeAndCustomInfo(CType(type, TypeImpl), typeInfo), escapeKeywordIdentifiers)
         End Function
 
     End Module

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeNameFormatterTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeNameFormatterTests.vb
@@ -2,7 +2,9 @@
 
 Imports System
 Imports System.Collections.Generic
+Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 Imports Type = Microsoft.VisualStudio.Debugger.Metadata.Type
@@ -262,6 +264,21 @@ End Namespace
             Assert.Equal("[Return].[From](Of [Async])", fromType.GetTypeName(escapeKeywordIdentifiers:=True))
             Assert.Equal("[Return].[From](Of [Return].[False].[Nothing])", constructedYieldType.GetTypeName(escapeKeywordIdentifiers:=True))
             Assert.Equal("[Return].[From](Of [Return].[False].[Nothing]).[Await]", constructedAwaitType.GetTypeName(escapeKeywordIdentifiers:=True))
+        End Sub
+
+        <WorkItem(1087216)>
+        <Fact>
+        Public Sub DynamicAttribute_ValidFlags()
+            Assert.Equal("Object", GetType(Object).GetTypeName({True}))
+            Assert.Equal("Object()", GetType(Object()).GetTypeName({False, True}))
+        End Sub
+
+        <WorkItem(1087216)>
+        <Fact>
+        Public Sub DynamicAttribute_OtherGuid()
+            Dim typeInfo = DkmClrCustomTypeInfo.Create(Guid.NewGuid(), New ReadOnlyCollection(Of Byte)({1}))
+            Assert.Equal("Object", GetType(Object).GetTypeName(typeInfo))
+            Assert.Equal("Object()", GetType(Object()).GetTypeName(typeInfo))
         End Sub
 
     End Class


### PR DESCRIPTION
This is the first of a sequence of changes.  We associate additional
information with each type that comes from the expression compiler.  For
now, it is the bool[] from the DynamicAttribute on the return type of a
method synthesized by the expression compiler.  Then, as we traverse the
type in the type name formatter, we consume the flags to determine which
occurrences of "object" should be replaced by "dynamic".

We don't show "dynamic" everywhere we could (e.g. in base type names in
disambiguators), but I believe we show "dynamic" everywhere the legacy EE
did.

TODO: The expression compiler doesn't call the new API to pass the
appropriate dynamic flags (API pending).

TODO: The expression compiler doesn't consume dynamic flags on
pseudo-locals (API pending).