### PR TITLE
Don't error when an assembly has no analyzers

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1538,7 +1538,7 @@ class C
             var csc = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", "/preferreduilang:en", "/t:library", "/a:" + typeof(object).Assembly.Location, "a.cs" });
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Equal("warning CS8033: The assembly " + typeof(object).Assembly.Location + " does not contain any analyzers.", outWriter.ToString().Trim());
+            Assert.DoesNotContain("warning", outWriter.ToString());
 
             CleanupAllGeneratedFiles(file.Path);
         }

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -181,8 +181,7 @@ Delta: Gamma: Beta: Test B
 
             File.Delete(alphaDll.Path);
 
-            Assert.Equal(1, errors.Count);
-            Assert.Equal(AnalyzerLoadFailureEventArgs.FailureErrorCode.NoAnalyzers, errors.First().ErrorCode);
+            Assert.Equal(0, errors.Count);
         }
 
         [Fact]

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
@@ -162,6 +162,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             try
             {
                 analyzerTypeNameMap = GetAnalyzerTypeNameMap();
+                if (analyzerTypeNameMap.Count == 0)
+                {
+                    return;
+                }
+
                 analyzerAssembly = GetAssembly();
             }
             catch (Exception e)
@@ -208,13 +213,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // If there are no analyzers, don't load the assembly at all.
                 if (!analyzerTypeNameMap.ContainsKey(language))
                 {
-                    this.AnalyzerLoadFailed?.Invoke(this, new AnalyzerLoadFailureEventArgs(AnalyzerLoadFailureEventArgs.FailureErrorCode.NoAnalyzers, null, null));
                     return;
                 }
 
                 analyzerAssembly = GetAssembly();
             }
-            catch (Exception e) when (e is IOException || e is BadImageFormatException || e is SecurityException || e is ArgumentException)
+            catch (Exception e)
             {
                 this.AnalyzerLoadFailed?.Invoke(this, new AnalyzerLoadFailureEventArgs(AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToLoadAnalyzer, e, null));
                 return;

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1795,8 +1795,7 @@ a.vb
             Dim vbc = New MockVisualBasicCompiler(Nothing, dir.Path, {"/nologo", "/preferreduilang:en", "/t:library", "/a:" + GetType(Object).Assembly.Location, "a.vb"})
             Dim exitCode = vbc.Run(outWriter, Nothing)
             Assert.Equal(0, exitCode)
-            Assert.Equal("vbc : warning BC42377: The assembly " + GetType(Object).Assembly.Location + " does not contain any analyzers.", outWriter.ToString().Trim())
-
+            Assert.DoesNotContain("warning", outWriter.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub


### PR DESCRIPTION
Currently we raise an error if an assembly is passed in as an analyzer
reference, but does not actually contain any analyzers. However, we're
going to start passing both analyzers and their dependencies through the
/analyzer switch, and this will become a common occurrence. As such we
should stop raising the error.