### PR TITLE
Quick fix to unblock integration - get the PDB age from SymWriter and wr...

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Cci
             }
         }
 
-        public unsafe void GetDebugDirectoryGuidAndStamp(out Guid guid, out uint stamp)
+        public unsafe void GetDebugDirectoryGuidAndStampAndAge(out Guid guid, out uint stamp, out uint age)
         {
             // See symwrite.cpp - the data byte[] doesn't depend on the content of metadata tables or IL.
             // The writer only sets two values of the ImageDebugDirectory struct.
@@ -619,7 +619,7 @@ namespace Microsoft.Cci
             // {
             //     DWORD dwSig;                 // "RSDS"
             //     GUID guidSig;                // GUID
-            //     DWORD age;                   // always 1
+            //     DWORD age;                   // age
             //     char szPDB[0];               // zero-terminated UTF8 file name passed to the writer
             // };
             const int GuidSize = 16;
@@ -631,7 +631,6 @@ namespace Microsoft.Cci
             // Retrieve the timestamp the PDB writer generates when creating a new PDB stream.
             // Note that ImageDebugDirectory.TimeDateStamp is not set by GetDebugInfo, 
             // we need to go thru IPdbWriter interface to get it.
-            uint age;
             ((IPdbWriter)_symWriter).GetSignatureAge(out stamp, out age);
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -1444,14 +1444,16 @@ namespace Microsoft.Cci
 
             Guid pdbId;
             uint pdbStamp;
+            uint age;
             if (_nativePdbWriterOpt != null)
             {
-                _nativePdbWriterOpt.GetDebugDirectoryGuidAndStamp(out pdbId, out pdbStamp);
+                _nativePdbWriterOpt.GetDebugDirectoryGuidAndStampAndAge(out pdbId, out pdbStamp, out age);
             }
             else
             {
                 pdbId = Guid.NewGuid();
                 pdbStamp = 0;
+                age = 1;
             } 
 
             // characteristics:
@@ -1484,11 +1486,11 @@ namespace Microsoft.Cci
             writer.WriteByte((byte)'D');
             writer.WriteByte((byte)'S');
 
+            // PDB id:
             writer.WriteBytes(pdbId.ToByteArray());
 
-            // Age (EnC generation + 1): always 0x00000001.
-            // We don't emit PE files when emitting EnC deltas.
-            writer.WriteUint(1);
+            // age
+            writer.WriteUint(age);
 
             // UTF-8 encoded zero-terminated path to PDB
             writer.WriteString(_pdbPathOpt, emitNullTerminator: true);


### PR DESCRIPTION
...ite it to the Debug Directory.

The age should always be 1. We shouldn't be adding data to an existing PDB. Will investigate more.