### PR TITLE
handle mapped file path properly

### DIFF
--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
                 originalLine: originalLineInfo.StartLinePosition.Line,
                 mappedColumn: mappedLineInfo.StartLinePosition.Character,
                 originalColumn: originalLineInfo.StartLinePosition.Character,
-                mappedFilePath: mappedLineInfo.HasMappedPath ? mappedLineInfo.Path : null,
+                mappedFilePath: mappedLineInfo.GetMappedFilePathIfExist(),
                 originalFilePath: document.FilePath);
         }
 

--- a/src/Features/Core/Diagnostics/DiagnosticData.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticData.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -80,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     severity, severity, isEnabledByDefault, warningLevel,
                     ImmutableArray<string>.Empty, ImmutableDictionary<string, string>.Empty,
                     workspace, projectId, documentId, span,
-                    originalFilePath, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,
+                    null, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,
                     originalFilePath, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,
                     title, description, helpLink)
         {
@@ -360,7 +361,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 document.Project.Id,
                 document.Id,
                 sourceSpan,
-                mappedLineInfo.Path,
+                mappedLineInfo.GetMappedFilePathIfExist(),
                 mappedStartLine,
                 mappedStartColumn,
                 mappedEndLine,

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -684,7 +684,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 diagnostic.ProjectId,
                 diagnostic.DocumentId,
                 newSpan,
-                mappedFilePath: mappedLineInfo.HasMappedPath ? mappedLineInfo.Path : null,
+                mappedFilePath: mappedLineInfo.GetMappedFilePathIfExist(),
                 mappedStartLine: mappedLineInfo.StartLinePosition.Line,
                 mappedStartColumn: mappedLineInfo.StartLinePosition.Character,
                 mappedEndLine: mappedLineInfo.EndLinePosition.Line,

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
             var diagnostic = GetDiagnosticData(
                 hostDocument.Id, bstrErrorId, bstrErrorMessage, severity,
-                bstrFileName, iStartLine, iStartColumn, iEndLine, iEndColumn,
+                null, iStartLine, iStartColumn, iEndLine, iEndColumn,
                 bstrFileName, iStartLine, iStartColumn, iEndLine, iEndColumn);
 
             _diagnosticProvider.AddNewErrors(hostDocument.Id, diagnostic);
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 // right location on closed venus file.
                 return GetDiagnosticData(
                     id, GetErrorId(error), error.bstrText, GetDiagnosticSeverity(error),
-                    error.bstrFileName, error.iLine, error.iCol, error.iLine, error.iCol, error.bstrFileName, line, column, line, column);
+                    null, error.iLine, error.iCol, error.iLine, error.iCol, error.bstrFileName, line, column, line, column);
             }
 
             return GetDiagnosticData(

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim filename = Nothing
                 Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.DocumentName, filename))
-                Assert.Equal(Path.Combine(item.OriginalFilePath, item.OriginalFilePath), filename)
+                Assert.Equal(item.OriginalFilePath, filename)
 
                 Dim text = Nothing
                 Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.Text, text))
@@ -167,7 +167,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim filename = Nothing
                 Assert.True(snapshot1.TryGetValue(0, StandardTableKeyNames.DocumentName, filename))
-                Assert.Equal(Path.Combine(item.OriginalFilePath, item.OriginalFilePath), filename)
+                Assert.Equal(item.OriginalFilePath, filename)
 
                 Dim text = Nothing
                 Assert.True(snapshot1.TryGetValue(0, StandardTableKeyNames.Text, text))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/FileLinePositionSpanExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/FileLinePositionSpanExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Shared.Extensions
+{
+    internal static class FileLinePositionSpanExtensions
+    {
+        /// <summary>
+        /// Get mapped file path if exist, otherwise return null.
+        /// </summary>
+        public static string GetMappedFilePathIfExist(this FileLinePositionSpan fileLinePositionSpan)
+        {
+            return fileLinePositionSpan.HasMappedPath ? fileLinePositionSpan.Path : null;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Rename\TokenRenameInfo.cs" />
     <Compile Include="Serialization\AssemblySerializationInfoService.cs" />
     <Compile Include="Serialization\IAssemblySerializationInfoService.cs" />
+    <Compile Include="Shared\Extensions\FileLinePositionSpanExtensions.cs" />
     <Compile Include="Shared\Extensions\TextDocumentExtensions.cs" />
     <Compile Include="Shared\Extensions\ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs" />
     <Compile Include="Shared\Utilities\SymbolEquivalenceComparer.AssemblyComparers.cs" />


### PR DESCRIPTION
previously we had some cases where we saved mapped file path without actually checking whether mapped file path actually exist.

this fix that issue.

...

this fix an issue David Pugh reported where we always take expensive code path where we combine original and mapped file path when there is actually no mapped file path.