### PR TITLE
Remove check that was causing light bulb to not be offered on empty lines

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -144,11 +144,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 using (Logger.LogBlock(FunctionId.SuggestedActions_GetSuggestedActions, cancellationToken))
                 {
-                    if (range.IsEmpty)
-                    {
-                        return null;
-                    }
-
                     var documentAndSnapshot = GetMatchingDocumentAndSnapshotAsync(range.Snapshot, cancellationToken).WaitAndGetResult(cancellationToken);
                     if (!documentAndSnapshot.HasValue)
                     {


### PR DESCRIPTION
Fixes #1353.

Without this fix, we display light bulb in the margin on empty lines that have fixes but clicking on the light bulb / Ctrl + . does not offer any fixes.