### PR TITLE
Avoid opening PDB writer on existing PDB file

### DIFF
--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
@@ -20,15 +20,13 @@ namespace Microsoft.CodeAnalysis
 
             private readonly CommonCompiler _compiler;
             private readonly string _filePath;
-            private readonly bool _streamCreatedByNativePdbWriter;
 
             private Stream _lazyStream;
 
-            internal CompilerEmitStreamProvider(CommonCompiler compiler, string filePath, bool streamCreatedByNativePdbWriter)
+            internal CompilerEmitStreamProvider(CommonCompiler compiler, string filePath)
             {
                 _compiler = compiler;
                 _filePath = filePath;
-                _streamCreatedByNativePdbWriter = streamCreatedByNativePdbWriter;
                 _lazyStream = s_uninitialized;
             }
 
@@ -45,7 +43,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (_lazyStream == s_uninitialized)
                 {
-                    _lazyStream = _streamCreatedByNativePdbWriter ? null : OpenFile(_filePath, diagnostics);
+                    _lazyStream = OpenFile(_filePath, diagnostics);
                 }
 
                 return _lazyStream;

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -416,8 +416,8 @@ namespace Microsoft.CodeAnalysis
                         WithOutputNameOverride(outputName).
                         WithPdbFilePath(finalPdbFilePath);
 
-                    using (var peStreamProvider = new CompilerEmitStreamProvider(this, finalOutputPath, streamCreatedByNativePdbWriter: false))
-                    using (var pdbStreamProviderOpt = Arguments.EmitPdb ? new CompilerEmitStreamProvider(this, finalOutputPath, streamCreatedByNativePdbWriter: true) : null)
+                    using (var peStreamProvider = new CompilerEmitStreamProvider(this, finalOutputPath))
+                    using (var pdbStreamProviderOpt = Arguments.EmitPdb ? new CompilerEmitStreamProvider(this, finalPdbFilePath) : null)
                     {
                         emitResult = compilation.Emit(
                             peStreamProvider,

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1641,6 +1641,7 @@ namespace Microsoft.CodeAnalysis
                         pdbStream = pdbStreamProvider.GetStream(diagnostics);
                         if (pdbStream == null)
                         {
+                            Debug.Assert(diagnostics.HasAnyErrors());
                             return null;
                         }
 
@@ -1648,8 +1649,8 @@ namespace Microsoft.CodeAnalysis
 
                         // Native PDB writer is able to update an existing stream.
                         // It checks for length to determine whether the given stream has existing data to be updated,
-                        // or whether it should start writing PDB data from scratch. Thus if not writing to a seekable empty stream ,
-                        // let's create an in-memory temp stream for the PDB writer and copy all data to the actual stream at once at the end.
+                        // or whether it should start writing PDB data from scratch. Thus if not writing to a seekable empty stream,
+                        // we have to create an in-memory temp stream for the PDB writer and copy all data to the actual stream at once at the end.
                         if (!retStream.CanSeek || retStream.Length != 0)
                         {
                             retStream = pdbTempStream = new MemoryStream();
@@ -1725,7 +1726,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         // Note: Native PDB writer may operate on the underlying stream during disposal.
                         // So close it here before we read data from the underlying stream.
-                        nativePdbWriter.WritePdbToOutput();
+                        nativePdbWriter?.WritePdbToOutput();
 
                         pdbTempStream.Position = 0;
                         pdbTempStream.CopyTo(pdbStream);

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.Cci
             // characteristics:
             writer.WriteUint(0);
 
-            // timestamp from NT headers
+            // PDB stamp
             timestampOffset = writer.BaseStream.Position + peStream.Position;
             writer.WriteUint(pdbStamp);
 

--- a/src/Test/Utilities/SharedCompilationUtils.cs
+++ b/src/Test/Utilities/SharedCompilationUtils.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return actual;
         }
 
-        private static void ValidateDebugDirectory(MemoryStream peStream, string pdbPath)
+        public static void ValidateDebugDirectory(Stream peStream, string pdbPath)
         {
             peStream.Seek(0, SeekOrigin.Begin);
             PEReader peReader = new PEReader(peStream);


### PR DESCRIPTION
When SymWriter is open on an existing file/stream it merges the data written into the PDB with the existing data. The compiler should never do that.