### PR TITLE
Set correct checkmarks in "Set Rule Set Severity"

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -266,10 +266,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     foreach (var diagnosticItem in group)
                     {
                         ReportDiagnostic ruleSetSeverity;
-                        if (specificOptions.TryGetValue(diagnosticItem.Descriptor.Id, out ruleSetSeverity) &&
-                            ruleSetSeverity != ReportDiagnostic.Default)
+                        if (specificOptions.TryGetValue(diagnosticItem.Descriptor.Id, out ruleSetSeverity))
                         {
                             selectedItemSeverities.Add(ruleSetSeverity);
+                        }
+                        else
+                        {
+                            // The rule has no setting.
+                            selectedItemSeverities.Add(ReportDiagnostic.Default);
                         }
                     }
                 }


### PR DESCRIPTION
If you selected multiple diagnostic rules in the Solution Explorer,
right-click, and open the "Set Rule Set Severity" sub-menu, you should
see a check mark next to a single item (Error, Warning, Info, etc.) if
and only if all the rules have the same severity in the rule set file.
This does not currently work if some rules have one setting, and the
other rules have no setting--only the rules with a setting are
considered.

The fix here is to treat rules with no setting as if they had a setting
of "Default". Then we will see that the settings do not all match, and
no checkmark will be shown.

Fixes #1597.