### PR TITLE
Attribute changes to each declarator in Field Declaration

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.CodeModelEventCollector.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.CodeModelEventCollector.cs
@@ -893,18 +893,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 {
                     foreach (var attribute in ((AttributeListSyntax)node).Attributes)
                     {
-                        if (parent is BaseFieldDeclarationSyntax)
-                        {
-                            foreach (var variableDeclarator in ((BaseFieldDeclarationSyntax)parent).Declaration.Variables)
-                            {
-                                eventQueue.EnqueueAddEvent(attribute, variableDeclarator);
-                            }
-                        }
-                        else
-                        {
-                            eventQueue.EnqueueAddEvent(attribute, parent);
-                        }
+                        AddEventToEventQueueForAttributes(attribute, parent, eventQueue.EnqueueAddEvent);
                     }
+                }
+                else if (node is AttributeSyntax)
+                {
+                    AddEventToEventQueueForAttributes((AttributeSyntax)node, parent, eventQueue.EnqueueAddEvent);
                 }
                 else
                 {
@@ -935,22 +929,31 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 {
                     foreach (var attribute in ((AttributeListSyntax)node).Attributes)
                     {
-                        if (parent is BaseFieldDeclarationSyntax)
-                        {
-                            foreach (var variableDeclarator in ((BaseFieldDeclarationSyntax)parent).Declaration.Variables)
-                            {
-                                eventQueue.EnqueueChangeEvent(attribute, variableDeclarator, eventType);
-                            }
-                        }
-                        else
-                        {
-                            eventQueue.EnqueueChangeEvent(attribute, parent, eventType);
-                        }
+                        ChangeEventQueueForAttributes(attribute, parent, eventType, eventQueue);
                     }
+                }
+                else if (node is AttributeSyntax)
+                {
+                    ChangeEventQueueForAttributes((AttributeSyntax)node, parent, eventType, eventQueue);
                 }
                 else
                 {
                     eventQueue.EnqueueChangeEvent(node, parent, eventType);
+                }
+            }
+
+            private static void ChangeEventQueueForAttributes(AttributeSyntax attribute, SyntaxNode parent, CodeModelEventType eventType, CodeModelEventQueue eventQueue)
+            {
+                if (parent is BaseFieldDeclarationSyntax)
+                {
+                    foreach (var variableDeclarator in ((BaseFieldDeclarationSyntax)parent).Declaration.Variables)
+                    {
+                        eventQueue.EnqueueChangeEvent(attribute, variableDeclarator, eventType);
+                    }
+                }
+                else
+                {
+                    eventQueue.EnqueueChangeEvent(attribute, parent, eventType);
                 }
             }
 
@@ -977,22 +980,31 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 {
                     foreach (var attribute in ((AttributeListSyntax)node).Attributes)
                     {
-                        if (parent is BaseFieldDeclarationSyntax)
-                        {
-                            foreach (var variableDeclarator in ((BaseFieldDeclarationSyntax)parent).Declaration.Variables)
-                            {
-                                eventQueue.EnqueueRemoveEvent(attribute, variableDeclarator);
-                            }
-                        }
-                        else
-                        {
-                            eventQueue.EnqueueRemoveEvent(attribute, parent);
-                        }
+                        AddEventToEventQueueForAttributes(attribute, parent, eventQueue.EnqueueRemoveEvent);
                     }
+                }
+                else if (node is AttributeSyntax)
+                {
+                    AddEventToEventQueueForAttributes((AttributeSyntax)node, parent, eventQueue.EnqueueRemoveEvent);
                 }
                 else
                 {
                     eventQueue.EnqueueRemoveEvent(node, parent);
+                }
+            }
+
+            private void AddEventToEventQueueForAttributes(AttributeSyntax attribute, SyntaxNode parent, Action<SyntaxNode, SyntaxNode> enqueueAddOrRemoveEvent)
+            {
+                if (parent is BaseFieldDeclarationSyntax)
+                {
+                    foreach (var variableDeclarator in ((BaseFieldDeclarationSyntax)parent).Declaration.Variables)
+                    {
+                        enqueueAddOrRemoveEvent(attribute, variableDeclarator);
+                    }
+                }
+                else
+                {
+                    enqueueAddOrRemoveEvent(attribute, parent);
                 }
             }
         }

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelEventQueue.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelEventQueue.cs
@@ -35,6 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             {
                 var priorEvent = _eventQueue.Peek();
                 if (priorEvent.Node == @event.Node &&
+                    priorEvent.ParentNode == @event.ParentNode &&
                     priorEvent.Type.IsChange() &&
                     @event.Type.IsChange())
                 {

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractEventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractEventCollectorTests.vb
@@ -15,23 +15,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
                        Assert.Equal(CodeModelEventType.Add, codeModelEvent.Type)
 
-                       If node IsNot Nothing Then
-                           Assert.NotNull(codeModelEvent.Node)
-                           Assert.Equal(node, codeModelService.GetName(codeModelEvent.Node))
-                       Else
-                           Assert.Null(codeModelEvent.Node)
-                       End If
-
-                       If parent IsNot Nothing Then
-                           Assert.NotNull(codeModelEvent.ParentNode)
-                           Assert.Equal(parent, codeModelService.GetName(codeModelEvent.ParentNode))
-                       Else
-                           Assert.Null(codeModelEvent.ParentNode)
-                       End If
+                       CheckCodeModelEvents(codeModelEvent, codeModelService, node, parent)
                    End Sub
         End Function
 
-        Friend Function Change(type As CodeModelEventType, node As String) As Action(Of CodeModelEvent, ICodeModelService)
+        Friend Function Change(type As CodeModelEventType, node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
             Return Sub(codeModelEvent, codeModelService)
                        Assert.NotNull(codeModelEvent)
 
@@ -43,27 +31,32 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                        Else
                            Assert.Null(codeModelEvent.Node)
                        End If
+
+                       If parent IsNot Nothing Then
+                           Assert.NotNull(codeModelEvent.ParentNode)
+                           Assert.Equal(parent, codeModelService.GetName(codeModelEvent.ParentNode))
+                       End If
                    End Sub
         End Function
 
-        Friend Function ArgChange(node As String) As Action(Of CodeModelEvent, ICodeModelService)
-            Return Change(CodeModelEventType.ArgChange, node)
+        Friend Function ArgChange(node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
+            Return Change(CodeModelEventType.ArgChange, node, parent)
         End Function
 
-        Friend Function BaseChange(node As String) As Action(Of CodeModelEvent, ICodeModelService)
-            Return Change(CodeModelEventType.BaseChange, node)
+        Friend Function BaseChange(node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
+            Return Change(CodeModelEventType.BaseChange, node, parent)
         End Function
 
-        Friend Function TypeRefChange(node As String) As Action(Of CodeModelEvent, ICodeModelService)
-            Return Change(CodeModelEventType.TypeRefChange, node)
+        Friend Function TypeRefChange(node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
+            Return Change(CodeModelEventType.TypeRefChange, node, parent)
         End Function
 
-        Friend Function Rename(node As String) As Action(Of CodeModelEvent, ICodeModelService)
-            Return Change(CodeModelEventType.Rename, node)
+        Friend Function Rename(node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
+            Return Change(CodeModelEventType.Rename, node, parent)
         End Function
 
-        Friend Function Unknown(node As String) As Action(Of CodeModelEvent, ICodeModelService)
-            Return Change(CodeModelEventType.Unknown, node)
+        Friend Function Unknown(node As String, Optional parent As String = Nothing) As Action(Of CodeModelEvent, ICodeModelService)
+            Return Change(CodeModelEventType.Unknown, node, parent)
         End Function
 
         Friend Function Remove(node As String, parent As String) As Action(Of CodeModelEvent, ICodeModelService)
@@ -72,21 +65,25 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
                        Assert.Equal(CodeModelEventType.Remove, codeModelEvent.Type)
 
-                       If node IsNot Nothing Then
-                           Assert.NotNull(codeModelEvent.Node)
-                           Assert.Equal(node, codeModelService.GetName(codeModelEvent.Node))
-                       Else
-                           Assert.Null(codeModelEvent.Node)
-                       End If
-
-                       If parent IsNot Nothing Then
-                           Assert.NotNull(codeModelEvent.ParentNode)
-                           Assert.Equal(parent, codeModelService.GetName(codeModelEvent.ParentNode))
-                       Else
-                           Assert.Null(codeModelEvent.ParentNode)
-                       End If
+                       CheckCodeModelEvents(codeModelEvent, codeModelService, node, parent)
                    End Sub
         End Function
+
+        Private Sub CheckCodeModelEvents(codeModelEvent As CodeModelEvent, codeModelService As ICodeModelService, node As String, parent As String)
+            If node IsNot Nothing Then
+                Assert.NotNull(codeModelEvent.Node)
+                Assert.Equal(node, codeModelService.GetName(codeModelEvent.Node))
+            Else
+                Assert.Null(codeModelEvent.Node)
+            End If
+
+            If parent IsNot Nothing Then
+                Assert.NotNull(codeModelEvent.ParentNode)
+                Assert.Equal(parent, codeModelService.GetName(codeModelEvent.ParentNode))
+            Else
+                Assert.Null(codeModelEvent.ParentNode)
+            End If
+        End Sub
 
         Friend Sub Test(code As XElement, change As XElement, ParamArray expectedEvents As Action(Of CodeModelEvent, ICodeModelService)())
             Dim definition =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/EventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/EventCollectorTests.vb
@@ -786,9 +786,10 @@ class C
 </Code>
 
             Test(code, changedCode,
-                 ArgChange("System.CLSCompliant"))
+                 ArgChange("System.CLSCompliant", "foo"))
         End Sub
 
+        <WorkItem(1147865)>
         <WorkItem(844611)>
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
         Public Sub TestField_ChangeAttributeOnTwoFields()
@@ -811,7 +812,66 @@ class C
 </Code>
 
             Test(code, changedCode,
-                 ArgChange("System.CLSCompliant"))
+                 ArgChange("System.CLSCompliant", "foo"),
+                 ArgChange("System.CLSCompliant", "bar"))
+        End Sub
+
+        <WorkItem(1147865)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestField_AddOneMoreAttribute()
+            Dim code =
+<Code>
+using System;
+
+class Program
+{
+    [System.NonSerialized()]
+    public int bar;
+}
+</Code>
+
+            Dim changedCode =
+<Code>
+using System;
+
+class Program
+{
+    [System.NonSerialized(), System.CLSCompliant(true)]
+    public int bar;
+}
+</Code>
+
+            Test(code, changedCode,
+                 Add("System.CLSCompliant", "bar"))
+        End Sub
+
+        <WorkItem(1147865)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestField_RemoveOneAttribute()
+            Dim code =
+<Code>
+using System;
+
+class Program
+{
+    [System.NonSerialized(), System.CLSCompliant(true)]
+    public int bar;
+}
+</Code>
+
+            Dim changedCode =
+<Code>
+using System;
+
+class Program
+{
+    [System.NonSerialized()]
+    public int bar;
+}
+</Code>
+
+            Test(code, changedCode,
+                 Remove("System.CLSCompliant", "bar"))
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
@@ -1522,6 +1522,7 @@ End Class
                  ArgChange("System.CLSCompliant"))
         End Sub
 
+        <WorkItem(1147865)>
         <WorkItem(844611)>
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
         Public Sub TestField_ChangeAttributeOnTwoFields()
@@ -1545,8 +1546,53 @@ End Class
 
             Test(code, changedCode,
                  Unknown(""),
-                 ArgChange("System.CLSCompliant"),
-                 ArgChange("System.CLSCompliant"))
+                 ArgChange("System.CLSCompliant", "foo"),
+                 ArgChange("System.CLSCompliant", "bar"))
+        End Sub
+
+        <WorkItem(1147865)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestField_AddOneMoreAttribute()
+            Dim code =
+<Code>
+Class C
+    &lt;System.CLSCompliant(False)&gt;
+    Dim foo, bar As Integer
+End Class
+</Code>
+
+            Dim changedCode =
+<Code>
+Class C
+    &lt;System.CLSCompliant(False), System.NonSerialized()&gt;
+    Dim foo, bar As Integer
+End Class
+</Code>
+            Test(code, changedCode,
+                 Add("System.NonSerialized", "foo"),
+                 Add("System.NonSerialized", "bar"))
+        End Sub
+
+        <WorkItem(1147865)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestField_RemoveOneAttribute()
+            Dim code =
+<Code>
+Class C
+    &lt;System.CLSCompliant(False), System.NonSerialized()&gt;
+    Dim foo, bar As Integer
+End Class
+</Code>
+            Dim changedCode =
+<Code>
+Class C
+    &lt;System.CLSCompliant(False)&gt;
+    Dim foo, bar As Integer
+End Class
+</Code>
+            Test(code, changedCode,
+                 Remove("System.NonSerialized", "foo"),
+                 Remove("System.NonSerialized", "bar"))
         End Sub
 
 #End Region


### PR DESCRIPTION
Fixes Internal Issue 1147865 : When adding, removing or changing an
attribute to field declarator, apply the corresponding changes to the
declarators in the field declaration rather than the field declaration
itself