### PR TITLE
Fix the names of the resources in the MSBuild task.

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 if (null == pathToTool)
                 {
-                    Log.LogErrorWithCodeFromResources("General.FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
+                    Log.LogErrorWithCodeFromResources("General_FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
                 }
             }
 
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
                 else if (singleIdentifier.Length > 0)
                 {
-                    Log.LogWarningWithCodeFromResources("Csc.InvalidParameterWarning", "/define:", singleIdentifier);
+                    Log.LogWarningWithCodeFromResources("Csc_InvalidParameterWarning", "/define:", singleIdentifier);
                 }
             }
 
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // shelling out to the command-line compiler anyway.  That means the command-line
                     // compiler will log the error.  So here, we only log the error if we would've
                     // tried to use the host compiler.
-                    Log.LogErrorWithCodeFromResources("General.CouldNotSetHostObjectParameter", param, e.Message);
+                    Log.LogErrorWithCodeFromResources("General_CouldNotSetHostObjectParameter", param, e.Message);
                 }
                 return false;
             }
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // shelling out to the command-line compiler anyway.  That means the command-line
                     // compiler will log the error.  So here, we only log the error if we would've
                     // tried to use the host compiler.
-                    Log.LogErrorWithCodeFromResources("General.CouldNotSetHostObjectParameter", param, e.Message);
+                    Log.LogErrorWithCodeFromResources("General_CouldNotSetHostObjectParameter", param, e.Message);
                 }
                 return false;
             }
@@ -726,7 +726,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     }
                     else
                     {
-                        Log.LogErrorWithCodeFromResources("General.IncorrectHostObject", "Csc", "ICscHostObject");
+                        Log.LogErrorWithCodeFromResources("General_IncorrectHostObject", "Csc", "ICscHostObject");
                     }
                 }
             }

--- a/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSB3883: Unexpected exception: .
+        /// </summary>
+        internal static string Compiler_UnexpectedException {
+            get {
+                return ResourceManager.GetString("Compiler_UnexpectedException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MSB3053: The assembly alias &quot;{1}&quot; on reference &quot;{0}&quot; contains illegal characters..
         /// </summary>
         internal static string Csc_AssemblyAliasContainsIllegalCharacters {
@@ -97,11 +106,92 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSB3081: A problem occurred while trying to set the &quot;{0}&quot; parameter for the IDE&apos;s in-process compiler. {1}.
+        /// </summary>
+        internal static string General_CouldNotSetHostObjectParameter {
+            get {
+                return ResourceManager.GetString("General_CouldNotSetHostObjectParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3105: The item &quot;{0}&quot; was specified more than once in the &quot;{1}&quot; parameter.  Duplicate items are not supported by the &quot;{1}&quot; parameter..
+        /// </summary>
+        internal static string General_DuplicateItemsNotSupported {
+            get {
+                return ResourceManager.GetString("General_DuplicateItemsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3083: The item &quot;{0}&quot; was specified more than once in the &quot;{1}&quot; parameter and both items had the same value &quot;{2}&quot; for the &quot;{3}&quot; metadata.  Duplicate items are not supported by the &quot;{1}&quot; parameter unless they have different values for the &quot;{3}&quot; metadata..
+        /// </summary>
+        internal static string General_DuplicateItemsNotSupportedWithMetadata {
+            get {
+                return ResourceManager.GetString("General_DuplicateItemsNotSupportedWithMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected file &quot;{0}&quot; does not exist..
+        /// </summary>
+        internal static string General_ExpectedFileMissing {
+            get {
+                return ResourceManager.GetString("General_ExpectedFileMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3082: Task failed because &quot;{0}&quot; was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}..
+        /// </summary>
+        internal static string General_FrameworksFileNotFound {
+            get {
+                return ResourceManager.GetString("General_FrameworksFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3087: An incompatible host object was passed into the &quot;{0}&quot; task.  The host object for this task must implement the &quot;{1}&quot; interface..
+        /// </summary>
+        internal static string General_IncorrectHostObject {
+            get {
+                return ResourceManager.GetString("General_IncorrectHostObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Item &quot;{0}&quot; has attribute &quot;{1}&quot; with value &quot;{2}&quot; that could not be converted to &quot;{3}&quot;..
         /// </summary>
         internal static string General_InvalidAttributeMetadata {
             get {
                 return ResourceManager.GetString("General_InvalidAttributeMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The IDE&apos;s in-process compiler does not support the specified values for the &quot;{0}&quot; parameter.  Therefore, this task will fallback to using the command-line compiler..
+        /// </summary>
+        internal static string General_ParameterUnsupportedOnHostCompiler {
+            get {
+                return ResourceManager.GetString("General_ParameterUnsupportedOnHostCompiler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3104: The referenced assembly &quot;{0}&quot; was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one..
+        /// </summary>
+        internal static string General_ReferenceDoesNotExist {
+            get {
+                return ResourceManager.GetString("General_ReferenceDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3401: &quot;{1}&quot; is an invalid value for the &quot;{0}&quot; parameter.  The valid values are: {2}.
+        /// </summary>
+        internal static string Vbc_EnumParameterHasInvalidValue {
+            get {
+                return ResourceManager.GetString("Vbc_EnumParameterHasInvalidValue", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/MSBuildTask/ErrorString.resx
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Compiler_UnexpectedException" xml:space="preserve">
+    <value>MSB3883: Unexpected exception: </value>
+    <comment>{StrBegin="MSB3883: "}</comment>
+  </data>
   <data name="Csc_AssemblyAliasContainsIllegalCharacters" xml:space="preserve">
     <value>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</value>
     <comment>{StrBegin="MSB3053: "}</comment>
@@ -132,8 +136,42 @@
   <data name="General_CannotConvertStringToBool" xml:space="preserve">
     <value>The string "{0}" cannot be converted to a boolean (true/false) value.</value>
   </data>
+  <data name="General_CouldNotSetHostObjectParameter" xml:space="preserve">
+    <value>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</value>
+    <comment>{StrBegin="MSB3081: "}</comment>
+  </data>
+  <data name="General_DuplicateItemsNotSupported" xml:space="preserve">
+    <value>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</value>
+    <comment>{StrBegin="MSB3105: "}</comment>
+  </data>
+  <data name="General_DuplicateItemsNotSupportedWithMetadata" xml:space="preserve">
+    <value>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</value>
+    <comment>{StrBegin="MSB3083: "}</comment>
+  </data>
+  <data name="General_ExpectedFileMissing" xml:space="preserve">
+    <value>Expected file "{0}" does not exist.</value>
+  </data>
+  <data name="General_FrameworksFileNotFound" xml:space="preserve">
+    <value>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</value>
+    <comment>{StrBegin="MSB3082: "}</comment>
+  </data>
+  <data name="General_IncorrectHostObject" xml:space="preserve">
+    <value>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</value>
+    <comment>{StrBegin="MSB3087: "}</comment>
+  </data>
   <data name="General_InvalidAttributeMetadata" xml:space="preserve">
     <value>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</value>
+  </data>
+  <data name="General_ParameterUnsupportedOnHostCompiler" xml:space="preserve">
+    <value>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</value>
+  </data>
+  <data name="General_ReferenceDoesNotExist" xml:space="preserve">
+    <value>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</value>
+    <comment>{StrBegin="MSB3104: "}</comment>
+  </data>
+  <data name="Vbc_EnumParameterHasInvalidValue" xml:space="preserve">
+    <value>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</value>
+    <comment>{StrBegin="MSB3401: "}</comment>
   </data>
   <data name="Vbc_ParameterHasInvalidValue" xml:space="preserve">
     <value>"{1}" is an invalid value for the "{0}" parameter.</value>

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
                 catch (Exception e)
                 {
-                    Log.LogErrorWithCodeFromResources("Compiler.UnexpectedException");
+                    Log.LogErrorWithCodeFromResources("Compiler_UnexpectedException");
                     LogErrorOutput(e.ToString());
                     ExitCode = -1;
                 }
@@ -722,11 +722,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 {
                     if (disambiguatingMetadataName == null || String.IsNullOrEmpty(disambiguatingMetadataValue))
                     {
-                        Log.LogErrorWithCodeFromResources("General.DuplicateItemsNotSupported", item.ItemSpec, parameterName);
+                        Log.LogErrorWithCodeFromResources("General_DuplicateItemsNotSupported", item.ItemSpec, parameterName);
                     }
                     else
                     {
-                        Log.LogErrorWithCodeFromResources("General.DuplicateItemsNotSupportedWithMetadata", item.ItemSpec, parameterName, disambiguatingMetadataValue, disambiguatingMetadataName);
+                        Log.LogErrorWithCodeFromResources("General_DuplicateItemsNotSupportedWithMetadata", item.ItemSpec, parameterName, disambiguatingMetadataValue, disambiguatingMetadataName);
                     }
                     return false;
                 }
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             if (!resultFromHostObjectSetOperation)
             {
-                Log.LogMessageFromResources(MessageImportance.Normal, "General.ParameterUnsupportedOnHostCompiler", parameterName);
+                Log.LogMessageFromResources(MessageImportance.Normal, "General_ParameterUnsupportedOnHostCompiler", parameterName);
                 _hostCompilerSupportsAllParameters = false;
             }
         }
@@ -829,7 +829,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 if (!File.Exists(reference.ItemSpec))
                 {
                     success = false;
-                    Log.LogErrorWithCodeFromResources("General.ReferenceDoesNotExist", reference.ItemSpec);
+                    Log.LogErrorWithCodeFromResources("General_ReferenceDoesNotExist", reference.ItemSpec);
                 }
             }
 
@@ -881,7 +881,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                             // So just a message is fine.
                             Log.LogMessageFromResources
                             (
-                                "General.ExpectedFileMissing",
+                                "General_ExpectedFileMissing",
                                 "default.win32manifest"
                             );
                         }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
             catch (Exception e) when (Utilities.IsIoRelatedException(e))
             {
-                Log.LogErrorWithCodeFromResources("VBC.RenamePDB", PdbFile, e.Message);
+                Log.LogErrorWithCodeFromResources("VBC_RenamePDB", PdbFile, e.Message);
             }
         }
 
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 if (null == pathToTool)
                 {
-                    Log.LogErrorWithCodeFromResources("General.FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
+                    Log.LogErrorWithCodeFromResources("General_FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
                 }
             }
 
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     (0 != String.Compare(Verbosity, "quiet", StringComparison.OrdinalIgnoreCase)) &&
                     (0 != String.Compare(Verbosity, "verbose", StringComparison.OrdinalIgnoreCase)))
                 {
-                    Log.LogErrorWithCodeFromResources("Vbc.EnumParameterHasInvalidValue", "Verbosity", this.Verbosity, "Quiet, Normal, Verbose");
+                    Log.LogErrorWithCodeFromResources("Vbc_EnumParameterHasInvalidValue", "Verbosity", this.Verbosity, "Quiet, Normal, Verbose");
                     return false;
                 }
             }
@@ -974,7 +974,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // shelling out to the command-line compiler anyway.  That means the command-line
                     // compiler will log the error.  So here, we only log the error if we would've
                     // tried to use the host compiler.
-                    Log.LogErrorWithCodeFromResources("General.CouldNotSetHostObjectParameter", param, e.Message);
+                    Log.LogErrorWithCodeFromResources("General_CouldNotSetHostObjectParameter", param, e.Message);
                 }
 
                 return false;
@@ -1056,7 +1056,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     }
                     else
                     {
-                        Log.LogErrorWithCodeFromResources("General.IncorrectHostObject", "Vbc", "IVbcHostObject");
+                        Log.LogErrorWithCodeFromResources("General_IncorrectHostObject", "Vbc", "IVbcHostObject");
                     }
                 }
             }


### PR DESCRIPTION
Some of the build task names where still set to their old values from
when they were in MSBuild. This changes the names to the proper names
and also ports any missing resources to the resource files in the current
build task assembly.