### PR TITLE
Fix issues in the compiler related to rewriting existing files

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5945,6 +5945,90 @@ class Program
         }
 
         [Fact]
+        public void ExistingPdb()
+        {
+            var dir = Temp.CreateDirectory();
+
+            var source1 = dir.CreateFile("program1.cs").WriteAllText(@"
+class " + new string('a', 10000) + @"
+{
+    public static void Main()
+    { 
+    }
+}");
+            var source2 = dir.CreateFile("program2.cs").WriteAllText(@"
+class Program2
+{
+        public static void Main() { }
+}");
+            var source3 = dir.CreateFile("program3.cs").WriteAllText(@"
+class Program3
+{
+        public static void Main() { }
+}");
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+
+            int oldSize = 16 * 1024;
+
+            var exe = dir.CreateFile("Program.exe");
+            using (var stream = File.OpenWrite(exe.Path))
+            {
+                byte[] buffer = new byte[oldSize];
+                stream.Write(buffer, 0, buffer.Length);
+            }
+
+            var pdb = dir.CreateFile("Program.pdb");
+            using (var stream = File.OpenWrite(pdb.Path))
+            {
+                byte[] buffer = new byte[oldSize];
+                stream.Write(buffer, 0, buffer.Length);
+            }
+
+            int exitCode1 = new MockCSharpCompiler(null, dir.Path, new[] { "/debug:full", "/out:Program.exe", source1.Path }).Run(outWriter);
+            Assert.NotEqual(0, exitCode1);
+
+            ValidateZeroes(exe.Path, oldSize);
+            ValidateZeroes(pdb.Path, oldSize);
+
+            int exitCode2 = new MockCSharpCompiler(null, dir.Path, new[] { "/debug:full", "/out:Program.exe", source2.Path }).Run(outWriter);
+            Assert.Equal(0, exitCode2);
+
+            using (var peFile = File.OpenRead(exe.Path))
+            {
+                SharedCompilationUtils.ValidateDebugDirectory(peFile, pdb.Path);
+            }
+
+            Assert.True(new FileInfo(exe.Path).Length < oldSize);
+            Assert.True(new FileInfo(pdb.Path).Length < oldSize);
+
+            int exitCode3 = new MockCSharpCompiler(null, dir.Path, new[] { "/debug:full", "/out:Program.exe", source3.Path }).Run(outWriter);
+            Assert.Equal(0, exitCode3);
+
+            using (var peFile = File.OpenRead(exe.Path))
+            {
+                SharedCompilationUtils.ValidateDebugDirectory(peFile, pdb.Path);
+            }
+        }
+
+        private static void ValidateZeroes(string path, int count)
+        {
+            using (var stream = File.OpenRead(path))
+            {
+                byte[] buffer = new byte[count];
+                stream.Read(buffer, 0, buffer.Length);
+
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    if (buffer[i] != 0)
+                    {
+                        Assert.True(false);
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void IOFailure_OpenOutputFile()
         {
             string sourcePath = MakeTrivialExe();

--- a/src/Test/Utilities/SharedCompilationUtils.cs
+++ b/src/Test/Utilities/SharedCompilationUtils.cs
@@ -10,7 +10,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
@@ -131,9 +133,67 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                     actual = PdbToXmlConverter.ToXml(pdbbits, exebits, PdbToXmlOptions.ResolveTokens | PdbToXmlOptions.ThrowOnError, methodName: qualifiedMethodName);
                 }
+
+                ValidateDebugDirectory(exebits, compilation.AssemblyName + ".pdb");
             }
 
             return actual;
+        }
+
+        public static void ValidateDebugDirectory(Stream peStream, string pdbPath)
+        {
+            peStream.Seek(0, SeekOrigin.Begin);
+            PEReader peReader = new PEReader(peStream);
+
+            var debugDirectory = peReader.PEHeaders.PEHeader.DebugTableDirectory;
+
+            int position;
+            Assert.True(peReader.PEHeaders.TryGetDirectoryOffset(debugDirectory, out position));
+            Assert.Equal(0x1c, debugDirectory.Size);
+
+            byte[] buffer = new byte[debugDirectory.Size];
+            peStream.Read(buffer, 0, buffer.Length);
+
+            peStream.Position = position;
+            var reader = new BinaryReader(peStream);
+
+            int characteristics = reader.ReadInt32();
+            Assert.Equal(0, characteristics);
+
+            uint timeDateStamp = reader.ReadUInt32();
+
+            uint version = reader.ReadUInt32();
+            Assert.Equal(0u, version);
+
+            int type = reader.ReadInt32();
+            Assert.Equal(2, type);
+
+            int sizeOfData = reader.ReadInt32();
+            int rvaOfRawData = reader.ReadInt32();
+
+            int section = peReader.PEHeaders.GetContainingSectionIndex(rvaOfRawData);
+            var sectionHeader = peReader.PEHeaders.SectionHeaders[section];
+
+            int pointerToRawData = reader.ReadInt32();
+            Assert.Equal(pointerToRawData, sectionHeader.PointerToRawData + rvaOfRawData - sectionHeader.VirtualAddress);
+
+            peStream.Position = pointerToRawData;
+
+            Assert.Equal((byte)'R', reader.ReadByte());
+            Assert.Equal((byte)'S', reader.ReadByte());
+            Assert.Equal((byte)'D', reader.ReadByte());
+            Assert.Equal((byte)'S', reader.ReadByte());
+
+            byte[] guidBlob = new byte[16];
+            reader.Read(guidBlob, 0, guidBlob.Length);
+
+            Assert.Equal(1u, reader.ReadUInt32());
+
+            byte[] pathBlob = new byte[sizeOfData - 24 - 1];
+            reader.Read(pathBlob, 0, pathBlob.Length);
+            var actualPath = Encoding.UTF8.GetString(pathBlob);
+            Assert.Equal(pdbPath, actualPath);
+            Assert.Equal(0, reader.ReadByte());
         }
 
         internal static string GetMethodIL(this CompilationTestData.MethodData method)


### PR DESCRIPTION
When writing PDB avoid merging with the existing one.
When encountering an error during emit don't write to the output files. 