### PR TITLE
Set correct path to linked rule set file

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -63,6 +63,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return hierarchy.TryGetItemProperty(itemId, __VSHPROPID.VSHPROPID_Name, out name);
         }
 
+        public static bool TryGetCanonicalName(this IVsHierarchy hierarchy, uint itemId, out string name)
+        {
+            return ErrorHandler.Succeeded(hierarchy.GetCanonicalName(itemId, out name));
+        }
+
         public static bool TryGetParentHierarchy(this IVsHierarchy hierarchy, out IVsHierarchy parentHierarchy)
         {
             return hierarchy.TryGetProperty(__VSHPROPID.VSHPROPID_ParentHierarchy, out parentHierarchy);

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.LanguageServices.SolutionExplorer;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
 using VSLangProj140;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
@@ -485,11 +486,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private void SetActiveRuleSetHandler(object sender, EventArgs e)
         {
             EnvDTE.Project project;
-            string fileName;
+            string ruleSetFileFullPath;
             if (_tracker.SelectedHierarchy.TryGetProject(out project) &&
-                _tracker.SelectedHierarchy.TryGetItemName(_tracker.SelectedItemId, out fileName))
+                _tracker.SelectedHierarchy.TryGetCanonicalName(_tracker.SelectedItemId, out ruleSetFileFullPath))
             {
-                UpdateProjectConfigurationsToUseRuleSetFile(project, fileName);
+                string projectDirectoryFullPath = Path.GetDirectoryName(project.FullName);
+                string ruleSetFileRelativePath = FilePathUtilities.GetRelativePath(projectDirectoryFullPath, ruleSetFileFullPath);
+
+                UpdateProjectConfigurationsToUseRuleSetFile(project, ruleSetFileRelativePath);
             }
         }
 

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -34,6 +34,10 @@
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Workspaces\Core\Desktop\Workspaces.Desktop.csproj">
+      <Project>{2e87fa96-50bb-4607-8676-46521599f998}</Project>
+      <Name>Workspaces.Desktop</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Workspaces.csproj">
       <Project>{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}</Project>
       <Name>Workspaces</Name>

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -136,6 +136,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Implementation" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.SolutionExplorer" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Telemetry" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.VisualBasic" />
     <InternalsVisibleTo Include="Roslyn.InteractiveFeatures" />


### PR DESCRIPTION
When the user right-clicks on a rule set file in Solution Explorer and
chooses "Set as Active Rule Set", we ask the associated `IVsHierarchy`
for the name of the rule set file and use that to set the
`<CodeAnalysisRuleSet>` property in the project file. However, the name
returned by the `IVsHierarchy` does not include the full path, so this
only works if the rule set is immediately next to the project file.

For linked files this will generally not be the case. Instead, we need
to ask for the *canonical* name, which will give us the full path. We
then compute the relative path to that file from the project's
directory, and use that for the `<CodeAnalysisRuleSet>` property.

Fixes #1579.