### PR TITLE
CodeModel should use SyntaxNode instead of Symbols for Parameters

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements;
 using Microsoft.VisualStudio.Text;
 
@@ -175,6 +173,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         string GetParameterFullName(SyntaxNode node);
         EnvDTE80.vsCMParameterKind GetParameterKind(SyntaxNode node);
         SyntaxNode SetParameterKind(SyntaxNode node, EnvDTE80.vsCMParameterKind kind);
+        IEnumerable<SyntaxNode> GetParameterNodes(SyntaxNode parent);
 
         EnvDTE.vsCMFunction ValidateFunctionKind(SyntaxNode containerNode, EnvDTE.vsCMFunction kind, string name);
 

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeMember.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeMember.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        internal virtual ImmutableArray<IParameterSymbol> GetParameters()
+        internal virtual ImmutableArray<SyntaxNode> GetParameters()
         {
             throw Exceptions.ThrowEFail();
         }

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
@@ -64,9 +64,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return typeSymbol.DelegateInvokeMethod;
         }
 
-        internal override ImmutableArray<IParameterSymbol> GetParameters()
+        internal override ImmutableArray<SyntaxNode> GetParameters()
         {
-            return LookupInvokeMethod().Parameters;
+            return ImmutableArray.CreateRange(CodeModelService.GetParameterNodes(LookupNode()));
         }
 
         public override EnvDTE.vsCMElement Kind

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -73,9 +72,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             get { return (IMethodSymbol)LookupSymbol(); }
         }
 
-        internal override ImmutableArray<IParameterSymbol> GetParameters()
+        internal override ImmutableArray<SyntaxNode> GetParameters()
         {
-            return MethodSymbol.Parameters;
+            return ImmutableArray.CreateRange(CodeModelService.GetParameterNodes(LookupNode()));
         }
 
         protected override object GetExtenderNames()

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
@@ -70,9 +70,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return this.Attributes;
         }
 
-        internal override ImmutableArray<IParameterSymbol> GetParameters()
+        internal override ImmutableArray<SyntaxNode> GetParameters()
         {
-            return PropertySymbol.Parameters;
+            return ImmutableArray.CreateRange(CodeModelService.GetParameterNodes(LookupNode()));
         }
 
         protected override object GetExtenderNames()

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
@@ -64,6 +64,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return codeElement.AddParameter(data.Name, data.Type, data.Position)
         End Function
 
+        Protected Overrides Function GetParameters(codeElement As EnvDTE80.CodeDelegate2) As EnvDTE.CodeElements
+            Return codeElement.Parameters
+        End Function
+
         Protected Overrides Sub RemoveChild(codeElement As EnvDTE80.CodeDelegate2, child As Object)
             codeElement.RemoveParameter(child)
         End Sub

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         Protected ReadOnly NullTextPoint As PartAction =
             Sub(part, textPointGetter)
                 Dim tp As EnvDTE.TextPoint = Nothing
-                tp = textPointGetter(Part)
+                tp = textPointGetter(part)
                 Assert.Null(tp)
             End Sub
 
@@ -348,6 +348,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Overridable Function AddImplementedInterface(codeElement As TCodeElement, base As Object, position As Object) As EnvDTE.CodeInterface
+            Throw New NotSupportedException
+        End Function
+
+        Protected Overridable Function GetParameters(codeElement As TCodeElement) As EnvDTE.CodeElements
             Throw New NotSupportedException
         End Function
 
@@ -1246,5 +1250,33 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             End Using
         End Sub
 
+        Protected Sub TestAllParameterNames(code As XElement, ParamArray expectedParameterNames() As String)
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
+                Assert.NotNull(codeElement)
+
+                Dim parameters = GetParameters(codeElement)
+                Assert.NotNull(parameters)
+
+                Assert.Equal(parameters.Count(), expectedParameterNames.Count())
+                If (expectedParameterNames.Any()) Then
+                    TestAllParameterNamesByIndex(parameters, expectedParameterNames)
+                    TestAllParameterNamesByName(parameters, expectedParameterNames)
+                End If
+            End Using
+        End Sub
+
+        Private Sub TestAllParameterNamesByName(parameters As EnvDTE.CodeElements, expectedParameterNames() As String)
+            For index = 0 To expectedParameterNames.Count() - 1
+                Assert.NotNull(parameters.Item(expectedParameterNames(index)))
+            Next
+        End Sub
+
+        Private Sub TestAllParameterNamesByIndex(parameters As EnvDTE.CodeElements, expectedParameterNames() As String)
+            For index = 0 To expectedParameterNames.Count() - 1
+                ' index + 1 for Item because Parameters are not zero indexed
+                Assert.Equal(expectedParameterNames(index), parameters.Item(index + 1).Name)
+            Next
+        End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
@@ -106,6 +106,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             codeElement.RemoveParameter(child)
         End Sub
 
+        Protected Overrides Function GetParameters(codeElement As EnvDTE80.CodeFunction2) As EnvDTE.CodeElements
+            Return codeElement.Parameters
+        End Function
+
         Protected Overridable Function ExtensionMethodExtender_GetIsExtension(codeElement As EnvDTE80.CodeFunction2) As Boolean
             Throw New NotSupportedException
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
@@ -88,6 +88,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return codeElement.AddParameter(data.Name, data.Type, data.Position)
         End Function
 
+        Protected Overrides Function GetParameters(codeElement As EnvDTE80.CodeProperty2) As EnvDTE.CodeElements
+            Return codeElement.Parameters
+        End Function
+
         Protected Overrides Sub RemoveChild(codeElement As EnvDTE80.CodeProperty2, child As Object)
             codeElement.RemoveParameter(child)
         End Sub

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
@@ -276,6 +276,32 @@ public delegate int? D();
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+public delegate int $$M(int @int);
+</Code>
+
+            TestAllParameterNames(code, "@int")
+        End Sub
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters_2()
+            Dim code =
+<Code>
+public delegate int $$M(int @int, string @string);
+</Code>
+
+            TestAllParameterNames(code, "@int", "@string")
+        End Sub
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -2158,6 +2158,40 @@ class A
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+public class C
+{
+    public void $$Foo(int @int)
+    {
+    }
+}
+</Code>
+            TestAllParameterNames(code, "@int")
+        End Sub
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters_2()
+            Dim code =
+<Code>
+public class C
+{
+    public void $$Foo(int @int, string @string)
+    {
+    }
+}
+</Code>
+            TestAllParameterNames(code, "@int", "@string")
+        End Sub
+
+#End Region
+
         Private Function GetExtensionMethodExtender(codeElement As EnvDTE80.CodeFunction2) As ICSExtensionMethodExtender
             Return CType(codeElement.Extender(ExtenderNames.ExtensionMethod), ICSExtensionMethodExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -1076,6 +1076,28 @@ public interface I
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+class Program
+{
+    public int $$this[int @int]
+    {
+        get { return @int; }
+        set { }
+    }
+}
+</Code>
+
+            TestAllParameterNames(code, "@int")
+        End Sub
+
+#End Region
+
         Private Function GetAutoImplementedPropertyExtender(codeElement As EnvDTE80.CodeProperty2) As ICSAutoImplementedPropertyExtender
             Return CType(codeElement.Extender(ExtenderNames.AutoImplementedProperty), ICSAutoImplementedPropertyExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeDelegateTests.vb
@@ -495,6 +495,32 @@ Delegate Sub $$D()
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+Delegate Sub $$D([integer] as Integer)
+</Code>
+
+            TestAllParameterNames(code, "[integer]")
+        End Sub
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters_2()
+            Dim code =
+<Code>
+Delegate Sub $$D([integer] as Integer, [string] as String)
+</Code>
+
+            TestAllParameterNames(code, "[integer]", "[string]")
+        End Sub
+
+#End Region
+
         Private Function GetGenericExtender(codeElement As EnvDTE80.CodeDelegate2) As IVBGenericExtender
             Return CType(codeElement.Extender(ExtenderNames.VBGenericExtender), IVBGenericExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
@@ -2086,6 +2086,36 @@ End Class
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+Class C
+    Sub $$M1([integer] As Integer)
+    End Sub
+End Class
+</Code>
+            TestAllParameterNames(code, "[integer]")
+        End Sub
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters_2()
+            Dim code =
+<Code>
+Class C
+    Sub $$M1([integer] As Integer, [string] as String)
+    End Sub
+End Class
+</Code>
+            TestAllParameterNames(code, "[integer]", "[string]")
+        End Sub
+
+#End Region
+
         Private Function GetPartialMethodExtender(codeElement As EnvDTE80.CodeFunction2) As IVBPartialMethodExtender
             Return CType(codeElement.Extender(ExtenderNames.VBPartialMethodExtender), IVBPartialMethodExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -1344,6 +1344,56 @@ End Interface
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters()
+            Dim code =
+<Code>
+Class Program
+    Property $$P([integer] As Integer) As Integer
+        Get
+            Return [integer]
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+    Sub Main(args As String())
+
+    End Sub
+End Class
+</Code>
+
+            TestAllParameterNames(code, "[integer]")
+        End Sub
+
+        <WorkItem(1147885)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestParameterNameWithEscapeCharacters_2()
+            Dim code =
+<Code>
+Class Program
+    Property $$P([integer] As Integer, [string] as String) As Integer
+        Get
+            Return [integer]
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+    Sub Main(args As String())
+
+    End Sub
+End Class
+</Code>
+
+            TestAllParameterNames(code, "[integer]", "[string]")
+        End Sub
+
+#End Region
+
         Private Function GetAutoImplementedPropertyExtender(codeElement As EnvDTE80.CodeProperty2) As IVBAutoPropertyExtender
             Return CType(codeElement.Extender(ExtenderNames.VBAutoPropertyExtender), IVBAutoPropertyExtender)
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -1098,7 +1098,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
         Public Overrides Function TryGetParameterNode(parentNode As SyntaxNode, name As String, ByRef parameterNode As SyntaxNode) As Boolean
             For Each parameter As ParameterSyntax In GetParameterNodes(parentNode)
-                If String.Equals(parameter.Identifier.Identifier.ValueText, name, StringComparison.OrdinalIgnoreCase) Then
+                Dim parameterName = GetNameFromParameter(parameter)
+                If String.Equals(parameterName, name, StringComparison.OrdinalIgnoreCase) Then
                     parameterNode = parameter
                     Return True
                 End If
@@ -1865,10 +1866,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         Public Overrides Function GetParameterName(node As SyntaxNode) As String
             Dim parameter = TryCast(node, ParameterSyntax)
             If parameter IsNot Nothing Then
-                Return parameter.Identifier.Identifier.ValueText
+                Return GetNameFromParameter(parameter)
             End If
 
             Throw New InvalidOperationException()
+        End Function
+
+        Private Function GetNameFromParameter(parameter As ParameterSyntax) As String
+            Dim parameterName As String = parameter.Identifier.Identifier.ToString()
+            Return If(Not String.IsNullOrEmpty(parameterName) AndAlso SyntaxFactsService.IsTypeCharacter(parameterName.Last()),
+                parameterName.Substring(0, parameterName.Length - 1),
+                parameterName)
         End Function
 
         Public Overrides Function GetParameterFullName(node As SyntaxNode) As String


### PR DESCRIPTION
Fixes Internal TFS issue 1147885

CodeModel service should get the name of the parameter from the
SyntaxNode rather than the symbols since we need to get the fullname
used in the source code.