### PR TITLE
[For discussion] Use a true native IStream when constructing a PDB

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -2726,7 +2726,8 @@ class C
 
             Assert.Equal((int)ErrorCode.FTL_DebugEmitFailure, err.Code);
             Assert.Equal(1, err.Arguments.Count);
-            Assert.True(((string)err.Arguments[0]).EndsWith(" HRESULT: 0x806D0004", StringComparison.Ordinal));
+            var ioExceptionMessage = new IOException().Message;
+            Assert.Equal(ioExceptionMessage, (string)err.Arguments[0]);
 
             pdb.Dispose();
             result = compilation.Emit(output, pdb);
@@ -2736,7 +2737,7 @@ class C
 
             Assert.Equal((int)ErrorCode.FTL_DebugEmitFailure, err.Code);
             Assert.Equal(1, err.Arguments.Count);
-            Assert.True(((string)err.Arguments[0]).EndsWith(" HRESULT: 0x806D0004", StringComparison.Ordinal));
+            Assert.Equal(ioExceptionMessage, (string)err.Arguments[0]);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1709,6 +1709,10 @@ namespace Microsoft.CodeAnalysis
                         peTempStream.Position = 0;
                         peTempStream.CopyTo(peStream);
                     }
+
+                    // Note: Native PDB writer may operate on the underlying stream during disposal.
+                    // So close it here before we read data from the underlying stream.
+                    nativePdbWriter?.WritePdbToOutput();
                 }
                 catch (Cci.PdbWritingException ex)
                 {

--- a/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
@@ -113,14 +113,19 @@ namespace Microsoft.Cci
 
                         stream.Flush();
                     }
-
-                    Marshal.ReleaseComObject(_nativeStream);
-                    _nativeStream = null;
                 }
             }
             catch (Exception ex)
             {
                 throw new PdbWritingException(ex);
+            }
+            finally
+            {
+                if (_nativeStream != null)
+                {
+                    Marshal.ReleaseComObject(_nativeStream);
+                    _nativeStream = null;
+                }
             }
         }
 


### PR DESCRIPTION
This is for discussion only at the moment. I haven't done full analysis of the resultant performance.

This is a performance fix for PDB writing. We see large byte array allocations during PDB writing, coming from the native stream writer. This is because each interop call from diasymreader into the ComStreamWrapper allocates a byte[] for interop. By letting the bytes accumulate in native memory, we avoid GC pressure. The native stream is copied into the destination stream in 4KB chunks, using a shared byte[] buffer at the end.