### PR TITLE
Fix intermittently failing unit test SuppressDuplicateAnalyzerExceptionD...

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
@@ -529,6 +529,26 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
+        internal static bool AreEquivalentAnalyzerExceptionDiagnostics(Diagnostic exceptionDiagnostic, Diagnostic other)
+        {
+            // We need to have custom de-duplication logic for diagnostics generated for analyzer exceptions.
+            // We create a new descriptor instance per each analyzer exception diagnostic instance (see comments in method "GetAnalyzerExceptionDiagnostic" above).
+            // This is primarily to allow us to embed exception stack trace in the diagnostic description.
+            // However, this might mean that two exception diagnostics which are equivalent in terms of ID and Message, might not have equal description strings.
+            // We want to classify such diagnostics as equal for de-duplication purpose to reduce the noise in output.
+
+            Debug.Assert(IsAnalyzerExceptionDiagnostic(exceptionDiagnostic));
+
+            if (!IsAnalyzerExceptionDiagnostic(other))
+            {
+                return false;
+            }
+
+            return exceptionDiagnostic.Id == other.Id && 
+                exceptionDiagnostic.Severity == other.Severity &&
+                exceptionDiagnostic.GetMessage() == other.GetMessage();
+        }
+
         private bool IsSupportedDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic)
         {
             Debug.Assert(_isCompilerAnalyzer != null);

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -130,8 +131,18 @@ namespace Microsoft.CodeAnalysis
             public override bool Equals(Diagnostic obj)
             {
                 var other = obj as SimpleDiagnostic;
-                return other != null
-                    && _descriptor.Equals(other._descriptor)
+                if (other == null)
+                {
+                    return false;
+                }
+
+                if (AnalyzerExecutor.IsAnalyzerExceptionDiagnostic(this))
+                {
+                    // We have custom Equals logic for diagnostics generated for analyzer exceptions.
+                    return AnalyzerExecutor.AreEquivalentAnalyzerExceptionDiagnostics(this, other);
+                }
+
+                return _descriptor.Equals(other._descriptor)
                     && _messageArgs.SequenceEqual(other._messageArgs, (a, b) => a == b)
                     && _location == other._location
                     && _severity == other._severity


### PR DESCRIPTION
...iagnostics.

Since we added support to "add the complete exception stack trace to description field of analyzer exception diagnostics" (see #1742), the test verifying duplicate analyzer exception diagnostics has failed intermittently. Although we don't have a concrete repro, its pretty likely that is due to the fact that the stack trace of the exceptions generated by the analyzer used by this test (http://source.roslyn.io/#Roslyn.Compilers.UnitTests/Diagnostics/SuppressMessageAttributeTests.DiagnosticAnalyzers.cs,272) differs slightly, causing this behavior.

We should deem a pair of analyzer exception diagnostics which have same ID and message, but may have different exception trace, to be equivalent to reduce noise in the error-list output.