### PR TITLE
(Preview) Commit rename on save and debugging run mode

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -406,6 +406,7 @@
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_RenameHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_ReturnHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_SelectAllHandler.cs" />
+    <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_SaveHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_TabHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_OpenLineAboveHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_TypeCharHandler.cs" />

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -7,11 +7,14 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.Rename,
-       ContentTypeNames.RoslynContentType)]
+    // Line commit and rename are both executed on Save. Ensure any rename session is committed
+    // before line commit runs to ensure changes from both are correctly applied.
+    [Order(Before = PredefinedCommandHandlerNames.Commit)]
+    [ExportCommandHandler(PredefinedCommandHandlerNames.Rename, ContentTypeNames.RoslynContentType)]
     internal partial class RenameCommandHandler
     {
         private readonly InlineRenameService _renameService;

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_SaveHandler.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+{
+    internal partial class RenameCommandHandler : ICommandHandler<SaveCommandArgs>
+    {
+        public CommandState GetCommandState(SaveCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return GetCommandState(nextHandler);
+        }
+
+        public void ExecuteCommand(SaveCommandArgs args, Action nextHandler)
+        {
+            if (_renameService.ActiveSession != null)
+            {
+                _renameService.ActiveSession.Commit();
+                ((IWpfTextView)args.TextView).VisualElement.Focus();
+            }
+
+            nextHandler();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.SuggestionSupport;
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private readonly ITextBufferAssociatedViewService _textBufferAssociatedViewService;
         private readonly ITextBufferFactoryService _textBufferFactoryService;
         private readonly IEnumerable<IRefactorNotifyService> _refactorNotifyServices;
+        private readonly IEditAndContinueWorkspaceService _editAndContinueWorkspaceService;
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly Solution _baseSolution;
         private readonly Document _triggerDocument;
@@ -118,7 +120,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _baseSolution = _triggerDocument.Project.Solution;
             this.UndoManager = workspace.Services.GetService<IInlineRenameUndoManager>();
 
+            this._editAndContinueWorkspaceService = workspace.Services.GetService<IEditAndContinueWorkspaceService>();
+            this._editAndContinueWorkspaceService.BeforeDebuggingStateChanged += OnBeforeDebuggingStateChanged;
+
             InitializeOpenBuffers(triggerSpan);
+        }
+
+        private void OnBeforeDebuggingStateChanged(object sender, DebuggingStateChangedEventArgs args)
+        {
+            if (args.After == DebuggingState.Run)
+            {
+                Commit();
+            }
         }
 
         public string OriginalSymbolName
@@ -520,8 +533,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private void EndRenameSession()
         {
+            _editAndContinueWorkspaceService.BeforeDebuggingStateChanged -= OnBeforeDebuggingStateChanged;
             CancelAllOpenDocumentTrackingTasks();
-
             RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
             _inlineRenameSessionDurationLogBlock.Dispose();
         }
@@ -571,8 +584,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 LogRenameSession(RenameLogMessage.UserActionOutcome.Committed, previewChanges);
 
-                RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
-                _inlineRenameSessionDurationLogBlock.Dispose();
+                EndRenameSession();
             }
         }
 

--- a/src/Features/Core/EditAndContinue/DebuggingState.cs
+++ b/src/Features/Core/EditAndContinue/DebuggingState.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    internal enum DebuggingState
+    {
+        Design,
+        Run,
+        Break
+    }
+}

--- a/src/Features/Core/EditAndContinue/DebuggingStateChangedEventArgs.cs
+++ b/src/Features/Core/EditAndContinue/DebuggingStateChangedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    internal sealed class DebuggingStateChangedEventArgs
+    {
+        public DebuggingState Before { get; }
+        public DebuggingState After { get; }
+
+        public DebuggingStateChangedEventArgs(DebuggingState before, DebuggingState after)
+        {
+            Debug.Assert(before != after);
+
+            this.Before = before;
+            this.After = after;
+        }
+    }
+}

--- a/src/Features/Core/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private DebuggingSession _debuggingSession;
         private EditSession _editSession;
 
+        public event EventHandler<DebuggingStateChangedEventArgs> BeforeDebuggingStateChanged;
+
         internal EditAndContinueWorkspaceService(IDiagnosticAnalyzerService diagnosticService)
         {
             Debug.Assert(diagnosticService != null);
@@ -35,6 +37,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 return _editSession;
             }
+        }
+
+        public void OnBeforeDebuggingStateChanged(DebuggingState before, DebuggingState after)
+        {
+            BeforeDebuggingStateChanged?.Invoke(this, new DebuggingStateChangedEventArgs(before, after));
         }
 
         public void StartDebuggingSession(Solution currentSolution)

--- a/src/Features/Core/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         EditSession EditSession { get; }
         DebuggingSession DebuggingSession { get; }
 
+        event EventHandler<DebuggingStateChangedEventArgs> BeforeDebuggingStateChanged;
+        void OnBeforeDebuggingStateChanged(DebuggingState before, DebuggingState after);
+
         void StartDebuggingSession(Solution currentSolution);
 
         void StartEditSession(

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -217,6 +217,8 @@
     <Compile Include="Diagnostics\PredefinedDiagnosticProviderNames.cs" />
     <Compile Include="Diagnostics\UpdateArgsId.cs" />
     <Compile Include="Diagnostics\WorkspaceAnalyzerOptions.cs" />
+    <Compile Include="EditAndContinue\DebuggingState.cs" />
+    <Compile Include="EditAndContinue\DebuggingStateChangedEventArgs.cs" />
     <Compile Include="EditAndContinue\EncDebuggingSessionInfo.cs" />
     <Compile Include="EditAndContinue\EncEditSessionInfo.cs" />
     <Compile Include="EditAndContinue\BidirectionalMap.cs" />

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -220,6 +220,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     Debug.Assert(s_breakStateProjectCount == 0);
                     Debug.Assert(s_breakStateEnteredProjects.Count == 0);
 
+                    _encService.OnBeforeDebuggingStateChanged(DebuggingState.Design, DebuggingState.Run);
+
                     _encService.StartDebuggingSession(_vsProject.VisualStudioWorkspace.CurrentSolution);
                     s_encDebuggingSessionInfo = new EncDebuggingSessionInfo();
 
@@ -297,6 +299,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 // Avoid ending the debug session if it has already been ended.
                 if (_encService.DebuggingSession != null)
                 {
+                    _encService.OnBeforeDebuggingStateChanged(DebuggingState.Run, DebuggingState.Design);
+
                     _encService.EndDebuggingSession();
                     LogEncSession();
 
@@ -424,6 +428,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 using (NonReentrantContext)
                 {
                     log.Write("Enter {2}Break Mode: project '{0}', AS#: {1}", _vsProject.DisplayName, pActiveStatements != null ? pActiveStatements.Length : -1, encBreakReason == Interop.ENC_BREAKSTATE_REASON.ENC_BREAK_EXCEPTION ? "Exception " : "");
+
                     Debug.Assert(cActiveStatements == (pActiveStatements != null ? pActiveStatements.Length : 0));
                     Debug.Assert(s_breakStateProjectCount < s_debugStateProjectCount);
                     Debug.Assert(s_breakStateProjectCount > 0 || _exceptionRegions.Count == 0);
@@ -432,6 +437,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
                     if (s_breakStateEntrySolution == null)
                     {
+                        _encService.OnBeforeDebuggingStateChanged(DebuggingState.Run, DebuggingState.Break);
+
                         s_breakStateEntrySolution = _vsProject.VisualStudioWorkspace.CurrentSolution;
                     }
 
@@ -867,6 +874,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     if (_encService.EditSession != null)
                     {
                         Debug.Assert(s_breakStateProjectCount == s_debugStateProjectCount);
+
+                        _encService.OnBeforeDebuggingStateChanged(DebuggingState.Break, DebuggingState.Run);
 
                         _encService.EditSession.LogEditSession(s_encDebuggingSessionInfo);
                         _encService.EndEditSession();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;


### PR DESCRIPTION
Fixes internal TFS bug 1142095

Commit any existing rename session when a document is saved or when
debugging run mode is entered. This ensures rename sessions are
completed before Edit and Continue sets the buffers to readonly when
debugging begins or when break mode is exited.

Merging to preview branch with approval from Matt and Habib.