### PR TITLE
Call nextHandler from completion

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SelectAll.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SelectAll.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             AssertIsForeground();
             DismissSessionIfActive();
+            nextHandler();
         }
     }
 }


### PR DESCRIPTION
Apparently you can get select-all in ETA without calling nextHandler, but in a way that breaks tests that depend on it. 

@Pilchie @dpoeschl @jasonmalinowski @balajikris @brettfo @basoundr 