### PR TITLE
Fix variable capturing for VB lambdas in EE...

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -520,7 +520,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Symbol oldInnermostFramePointer = _innermostFramePointer;
-
             _innermostFramePointer = framePointer;
             var addedLocals = ArrayBuilder<LocalSymbol>.GetInstance();
             addedLocals.Add(framePointer);

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            nextFreeHoistedLocalSlot As Integer,
                            Diagnostics As DiagnosticBag)
 
-                MyBase.New(slotAllocatorOpt, F.CompilationState, Diagnostics)
+                MyBase.New(slotAllocatorOpt, F.CompilationState, Diagnostics, preserveOriginalLocals:=False)
 
                 Debug.Assert(F IsNot Nothing)
                 Debug.Assert(stateField IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -747,6 +747,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </remarks>
         Friend MustOverride Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
 
+        ''' <summary>
+        ''' Specifies whether existing, "unused" locals (corresponding to proxies) are preserved during lambda rewriting.
+        ''' </summary>
+        ''' <remarks>
+        ''' This value will be checked by the <see cref="LambdaRewriter"/> and is needed so that existing locals aren't
+        ''' omitted in the EE (method symbols in the EE will override this property to return True).
+        ''' </remarks>
+        Friend Overridable ReadOnly Property PreserveOriginalLocals As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
 #Region "IMethodSymbol"
 
         Private ReadOnly Property IMethodSymbol_Arity As Integer Implements IMethodSymbol.Arity

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6096,5 +6096,46 @@ class C
   IL_0024:  ret
 }");
         }
+
+        [Fact]
+        public void CapturedLocalInLambda()
+        {
+            var source = @"
+using System;
+class C
+{
+    void M(Func<int> f)
+    {
+        int x = 42;
+        M(() => x);
+    }
+}";
+            var comp = CreateCompilationWithMscorlib45(source);
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
+
+            string error;
+            var testData = new CompilationTestData();
+            context.CompileExpression("M(() => x)", out error, testData);
+            Assert.Null(error);
+            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                <>x.<>c__DisplayClass0_0 V_1) //CS$<>8__locals0
+  IL_0000:  newobj     ""<>x.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  ldloc.0
+  IL_0008:  stfld      ""C.<>c__DisplayClass0_0 <>x.<>c__DisplayClass0_0.CS$<>8__locals0""
+  IL_000d:  ldarg.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldftn      ""int <>x.<>c__DisplayClass0_0.<<>m0>b__0()""
+  IL_0015:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
+  IL_001a:  callvirt   ""void C.M(System.Func<int>)""
+  IL_001f:  ret
+}");
+        }
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -505,6 +505,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             '     <2> = New <>c__DisplayClass0()
             '     <2>.<1> = <1>
             '     <2>.z = z
+            '
+            ' Note: The above behavior is actually implemented in the LambdaRewriter and
+            '       is triggered by overriding PreserveOriginalLocals to return "True".
 
             ' Create a map from variable name to display class field.
             Dim displayClassVariables = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
@@ -521,10 +524,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' Rewrite references to "Me" to refer to this method's "Me" parameter.
             ' Rewrite variables within body to reference existing display classes.
             newBody = DirectCast(CapturedVariableRewriter.Rewrite(
-                    If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
-                    displayClassVariables.ToImmutableDictionary(),
-                    newBody,
-                    diagnostics), BoundBlock)
+                If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
+                displayClassVariables.ToImmutableDictionary(),
+                newBody,
+                diagnostics), BoundBlock)
             displayClassVariables.Free()
 
             If diagnostics.HasAnyErrors() Then
@@ -560,5 +563,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
             Return localPosition
         End Function
+
+        Friend Overrides ReadOnly Property PreserveOriginalLocals As Boolean
+            Get
+                Return True
+            End Get
+        End Property
+
     End Class
+
 End Namespace


### PR DESCRIPTION
Variables may have been captured by lambdas in the original method
or in the expression, and we need to preserve the existing values of
those variables in the expression. This requires rewriting the variables
in the expression based on the closure classes from both the original
method and the expression, and generating a preamble that copies
values into the expression closure classes.

Consider the original method:
Shared Sub M()
    Dim x, y, z as Integer
    ...
    F(Function() x + y)
End Sub
and the expression in the EE: "F(Function() x + z)".
	                '
The expression is first rewritten using the closure class and the local
<1> from the original method: F(Function() <1>.x + z)
Then lambda rewriting introduces a new closure class that includes
the locals <1> and z, and a corresponding local
<2>: F(Function() <2>.<1>.x + <2>.z)
And a preamble is added to initialize the fields of <2>:
    <2> = New <>c__DisplayClass0()
    <2>.<1> = <1>
    <2>.z = z