### PR TITLE
Add null checks for properties of Dkm*AsyncResult...

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
@@ -95,7 +95,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     {
                         try
                         {
-                            var typeArguments = _instructionDecoder.GetTypeSymbols(compilation, method, result.ParameterTypeNames);
+                            // DkmGetClrGenericParametersAsyncResult.ParameterTypeNames will throw if ErrorCode != 0.
+                            var serializedTypeNames = (result.ErrorCode == 0) ? result.ParameterTypeNames : null;
+                            var typeArguments = _instructionDecoder.GetTypeSymbols(compilation, method, serializedTypeNames);
                             if (!typeArguments.IsEmpty)
                             {
                                 method = _instructionDecoder.ConstructMethod(method, typeParameters, typeArguments);
@@ -150,20 +152,25 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     frame,
                     result =>
                     {
-                        var argumentValues = result.Arguments;
+                        // DkmGetFrameArgumentsAsyncResult.Arguments will throw if ErrorCode != 0.
+                        var argumentValues = (result.ErrorCode == 0) ? result.Arguments : null;
                         try
                         {
-                            var builder = ArrayBuilder<string>.GetInstance();
-                            foreach (var argument in argumentValues)
+                            ArrayBuilder<string> builder = null;
+                            if (argumentValues != null)
                             {
-                                var formattedArgument = argument as DkmSuccessEvaluationResult;
-                                // Not expecting Expandable bit, at least not from this EE.
-                                Debug.Assert((formattedArgument == null) || (formattedArgument.Flags & DkmEvaluationResultFlags.Expandable) == 0);
-                                builder.Add(formattedArgument?.Value);
+                                builder = ArrayBuilder<string>.GetInstance();
+                                foreach (var argument in argumentValues)
+                                {
+                                    var formattedArgument = argument as DkmSuccessEvaluationResult;
+                                    // Not expecting Expandable bit, at least not from this EE.
+                                    Debug.Assert((formattedArgument == null) || (formattedArgument.Flags & DkmEvaluationResultFlags.Expandable) == 0);
+                                    builder.Add(formattedArgument?.Value);
+                                }
                             }
 
-                            var frameName = _instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, builder);
-                            builder.Free();
+                            var frameName = _instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, argumentValues: builder);
+                            builder?.Free();
                             completionRoutine(new DkmGetFrameNameAsyncResult(frameName));
                         }
                         catch (Exception e) when (ExpressionEvaluatorFatalError.ReportNonFatalException(e, DkmComponentManager.ReportCurrentNonFatalException))
@@ -172,16 +179,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         }
                         finally
                         {
-                            foreach (var argument in argumentValues)
+                            if (argumentValues != null)
                             {
-                                argument.Close();
+                                foreach (var argument in argumentValues)
+                                {
+                                    argument.Close();
+                                }
                             }
                         }
                     });
             }
             else
             {
-                var frameName = _instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, null);
+                var frameName = _instructionDecoder.GetName(method, includeParameterTypes, includeParameterNames, argumentValues: null);
                 completionRoutine(new DkmGetFrameNameAsyncResult(frameName));
             }
         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -108,6 +108,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal ImmutableArray<TTypeSymbol> GetTypeSymbols(TCompilation compilation, TMethodSymbol method, string[] serializedTypeNames)
         {
+            if (serializedTypeNames == null)
+            {
+                return ImmutableArray<TTypeSymbol>.Empty;
+            }
+
             var builder = ArrayBuilder<TTypeSymbol>.GetInstance();
             foreach (var name in serializedTypeNames)
             {


### PR DESCRIPTION
It appears that DkmGetFrameArgumentsAsyncResult.Arguments may be null in some cases (rather than an empty array).  We should be resiliant to that and behave as though there are no argument values available.

I threw in a similar check for generic type arguments as well (just for good measure).