### PR TITLE
guard ourshelves from being called after package close at VS shutdown

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     internal abstract partial class AbstractEncProject : AbstractProject
     {
-        internal readonly VsENCRebuildableProjectImpl EditAndContinueImplOpt;
+        internal VsENCRebuildableProjectImpl EditAndContinueImplOpt;
 
         public AbstractEncProject(
             VisualStudioProjectTracker projectTracker,
@@ -27,6 +27,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 this.EditAndContinueImplOpt = new VsENCRebuildableProjectImpl(this);
             }
+        }
+
+        public override void Disconnect()
+        {
+            // project is going away
+            this.EditAndContinueImplOpt = null;
+
+            base.Disconnect();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject_IVsENCRebuildableProjectCfg.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractEncProject_IVsENCRebuildableProjectCfg.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio;
 using EncInterop = Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.Interop;
 using ShellInterop = Microsoft.VisualStudio.Shell.Interop;
 using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
@@ -20,57 +19,58 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public int StartDebuggingPE()
         {
-            return EditAndContinueImplOpt.StartDebuggingPE();
+            return EditAndContinueImplOpt?.StartDebuggingPE() ?? VSConstants.S_OK;
         }
 
         public int StopDebuggingPE()
         {
-            return EditAndContinueImplOpt.StopDebuggingPE();
+            return EditAndContinueImplOpt?.StopDebuggingPE() ?? VSConstants.S_OK;
         }
 
         public int GetPEidentity(Guid[] pMVID, string[] pbstrPEName)
         {
-            return EditAndContinueImplOpt.GetPEidentity(pMVID, pbstrPEName);
+            return EditAndContinueImplOpt?.GetPEidentity(pMVID, pbstrPEName) ?? VSConstants.E_FAIL;
         }
 
         public int EnterBreakStateOnPE(EncInterop.ENC_BREAKSTATE_REASON encBreakReason, ShellInterop.ENC_ACTIVE_STATEMENT[] pActiveStatements, uint cActiveStatements)
         {
-            return EditAndContinueImplOpt.EnterBreakStateOnPE(encBreakReason, pActiveStatements, cActiveStatements);
+            return EditAndContinueImplOpt?.EnterBreakStateOnPE(encBreakReason, pActiveStatements, cActiveStatements) ?? VSConstants.S_OK;
         }
 
         public int GetExceptionSpanCount(out uint pcExceptionSpan)
         {
-            return EditAndContinueImplOpt.GetExceptionSpanCount(out pcExceptionSpan);
+            pcExceptionSpan = default(uint);
+            return EditAndContinueImplOpt?.GetExceptionSpanCount(out pcExceptionSpan) ?? VSConstants.E_FAIL;
         }
 
         public int GetExceptionSpans(uint celt, ShellInterop.ENC_EXCEPTION_SPAN[] rgelt, ref uint pceltFetched)
         {
-            return EditAndContinueImplOpt.GetExceptionSpans(celt, rgelt, ref pceltFetched);
+            return EditAndContinueImplOpt?.GetExceptionSpans(celt, rgelt, ref pceltFetched) ?? VSConstants.E_FAIL;
         }
 
         public int GetCurrentExceptionSpanPosition(uint id, VsTextSpan[] ptsNewPosition)
         {
-            return EditAndContinueImplOpt.GetCurrentExceptionSpanPosition(id, ptsNewPosition);
+            return EditAndContinueImplOpt?.GetCurrentExceptionSpanPosition(id, ptsNewPosition) ?? VSConstants.E_FAIL;
         }
 
         public int GetENCBuildState(ShellInterop.ENC_BUILD_STATE[] pENCBuildState)
         {
-            return EditAndContinueImplOpt.GetENCBuildState(pENCBuildState);
+            return EditAndContinueImplOpt?.GetENCBuildState(pENCBuildState) ?? VSConstants.E_FAIL;
         }
 
         public int ExitBreakStateOnPE()
         {
-            return EditAndContinueImplOpt.ExitBreakStateOnPE();
+            return EditAndContinueImplOpt?.ExitBreakStateOnPE() ?? VSConstants.S_OK;
         }
 
         public int GetCurrentActiveStatementPosition(uint id, VsTextSpan[] ptsNewPosition)
         {
-            return EditAndContinueImplOpt.GetCurrentActiveStatementPosition(id, ptsNewPosition);
+            return EditAndContinueImplOpt?.GetCurrentActiveStatementPosition(id, ptsNewPosition) ?? VSConstants.E_FAIL;
         }
 
         public int EncApplySucceeded(int hrApplyResult)
         {
-            return EditAndContinueImplOpt.EncApplySucceeded(hrApplyResult);
+            return EditAndContinueImplOpt?.EncApplySucceeded(hrApplyResult) ?? VSConstants.S_OK;
         }
 
         public int GetPEBuildTimeStamp(Microsoft.VisualStudio.OLE.Interop.FILETIME[] pTimeStamp)
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public int BuildForEnc(object pUpdatePE)
         {
-            return EditAndContinueImplOpt.BuildForEnc(pUpdatePE);
+            return EditAndContinueImplOpt?.BuildForEnc(pUpdatePE) ?? VSConstants.S_OK;
         }
     }
 }


### PR DESCRIPTION
contract is vs package should not call other component on vs shutdown. but we should guard ourselves from other package violating that contract.