### PR TITLE
Honor requested categories and spans specified by light bulb

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -148,49 +149,58 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     if (!documentAndSnapshot.HasValue)
                     {
                         // this is here to fail test and see why it is failed.
-                        System.Diagnostics.Trace.WriteLine("given range is not current");
+                        Trace.WriteLine("given range is not current");
                         return null;
                     }
 
                     var document = documentAndSnapshot.Value.Item1;
-                    var snapshot = documentAndSnapshot.Value.Item2;
-
                     var workspace = document.Project.Solution.Workspace;
-                    var optionService = workspace.Services.GetService<IOptionService>();
                     var supportSuggestion = workspace.Services.GetService<IDocumentSupportsSuggestionService>();
 
-                    IEnumerable<SuggestedActionSet> result = null;
-                    if (supportSuggestion.SupportsCodeFixes(document) && requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
-                    {
-                        var suggestions = Task.Run(
-                            async () => await _owner._codeFixService.GetFixesAsync(document, range.Span.ToTextSpan(), cancellationToken).ConfigureAwait(false), cancellationToken).WaitAndGetResult(cancellationToken);
+                    var fixes = GetCodeFixes(supportSuggestion, requestedActionCategories, workspace, document, range, cancellationToken);
+                    var refactorings = GetRefactorings(supportSuggestion, requestedActionCategories, workspace, document, range, cancellationToken);
 
-                        result = OrganizeFixes(workspace, suggestions);
-                    }
-
-                    if (supportSuggestion.SupportsRefactorings(document))
-                    {
-                        var refactoringResult = GetRefactorings(requestedActionCategories, document, snapshot, workspace, optionService, cancellationToken);
-
-                        result = result == null ? refactoringResult :
-                                    refactoringResult == null ? result :
-                                        result.Concat(refactoringResult);
-                    }
-
-                    return result;
+                    return (fixes == null) ? refactorings :
+                                (refactorings == null) ? fixes : fixes.Concat(refactorings);
                 }
+            }
+
+            private IEnumerable<SuggestedActionSet> GetCodeFixes(
+                IDocumentSupportsSuggestionService supportSuggestion,
+                ISuggestedActionCategorySet requestedActionCategories,
+                Workspace workspace,
+                Document document,
+                SnapshotSpan range,
+                CancellationToken cancellationToken)
+            {
+                if (_owner._codeFixService != null && supportSuggestion.SupportsCodeFixes(document) &&
+                    requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
+                {
+                    // We only include suppressions if lightbulb is asking for everything.
+                    // If the light bulb is only asking for code fixes, then we don't include suppressions.
+                    var includeSuppressionFixes = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Any);
+
+                    var fixes = Task.Run(
+                        async () => await _owner._codeFixService.GetFixesAsync(
+                            document, range.Span.ToTextSpan(), includeSuppressionFixes, cancellationToken).ConfigureAwait(false),
+                        cancellationToken).WaitAndGetResult(cancellationToken);
+
+                    return OrganizeFixes(workspace, fixes, hasSuppressionFixes: includeSuppressionFixes);
+                }
+
+                return null;
             }
 
             /// <summary>
             /// Arrange fixes into groups based on the issue (diagnostic being fixed) and prioritize these groups.
             /// </summary>
-            private IEnumerable<SuggestedActionSet> OrganizeFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections)
+            private IEnumerable<SuggestedActionSet> OrganizeFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, bool hasSuppressionFixes)
             {
                 var map = ImmutableDictionary.CreateBuilder<Diagnostic, IList<SuggestedAction>>();
                 var order = ImmutableArray.CreateBuilder<Diagnostic>();
 
                 // First group fixes by issue (diagnostic).
-                GroupFixes(workspace, fixCollections, map, order);
+                GroupFixes(workspace, fixCollections, map, order, hasSuppressionFixes);
 
                 // Then prioritize between the groups.
                 return PrioritizeFixGroups(map.ToImmutable(), order.ToImmutable());
@@ -199,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// <summary>
             /// Groups fixes by the diagnostic being addressed by each fix.
             /// </summary>
-            private void GroupFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, IDictionary<Diagnostic, IList<SuggestedAction>> map, IList<Diagnostic> order)
+            private void GroupFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, IDictionary<Diagnostic, IList<SuggestedAction>> map, IList<Diagnostic> order, bool hasSuppressionFixes)
             {
                 foreach (var fixCollection in fixCollections)
                 {
@@ -222,15 +232,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         }
                     }
 
-                    // Add suppression fixes to the end of a given SuggestedActionSet so that they always show up last in a group.
-                    foreach (var fix in fixes)
+                    if (hasSuppressionFixes)
                     {
-                        if (fix.Action is SuppressionCodeAction)
+                        // Add suppression fixes to the end of a given SuggestedActionSet so that they always show up last in a group.
+                        foreach (var fix in fixes)
                         {
-                            var suggestedAction = new SuppressionSuggestedAction(workspace, _subjectBuffer, _owner._editHandler,
-                                fix, fixCollection.Provider);
+                            if (fix.Action is SuppressionCodeAction)
+                            {
+                                var suggestedAction = new SuppressionSuggestedAction(workspace, _subjectBuffer, _owner._editHandler,
+                                    fix, fixCollection.Provider);
 
-                            AddFix(fix, suggestedAction, map, order);
+                                AddFix(fix, suggestedAction, map, order);
+                            }
                         }
                     }
                 }
@@ -278,34 +291,33 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
 
             private IEnumerable<SuggestedActionSet> GetRefactorings(
+                IDocumentSupportsSuggestionService supportSuggestion,
                 ISuggestedActionCategorySet requestedActionCategories,
-                Document document,
-                ITextSnapshot snapshot,
                 Workspace workspace,
-                IOptionService optionService,
+                Document document,
+                SnapshotSpan range,
                 CancellationToken cancellationToken)
             {
-                // For Dev14 Preview, we also want to show refactorings in the CodeFix list when users press Ctrl+.
-                if (requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring) ||
-                    requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
-                {
-                    var refactoringsOn = optionService.GetOption(EditorComponentOnOffOptions.CodeRefactorings);
-                    if (!refactoringsOn)
-                    {
-                        return null;
-                    }
+                var optionService = workspace.Services.GetService<IOptionService>();
 
+                if (optionService.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                    _owner._codeRefactoringService != null &&
+                    supportSuggestion.SupportsRefactorings(document) &&
+                    requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
+                {
                     // Get the selection while on the UI thread.
-                    var selection = GetCodeRefactoringSelection(snapshot);
+                    var selection = TryGetCodeRefactoringSelection(range);
                     if (!selection.HasValue)
                     {
                         // this is here to fail test and see why it is failed.
-                        System.Diagnostics.Trace.WriteLine("given range is not current");
+                        Trace.WriteLine("given range is not current");
                         return null;
                     }
 
                     var refactorings = Task.Run(
-                        async () => await _owner._codeRefactoringService.GetRefactoringsAsync(document, selection.Value, cancellationToken).ConfigureAwait(false), cancellationToken).WaitAndGetResult(cancellationToken);
+                        async () => await _owner._codeRefactoringService.GetRefactoringsAsync(
+                            document, selection.Value, cancellationToken).ConfigureAwait(false),
+                        cancellationToken).WaitAndGetResult(cancellationToken);
 
                     return refactorings.Select(r => OrganizeRefactorings(workspace, r));
                 }
@@ -337,6 +349,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
             public async Task<bool> HasSuggestedActionsAsync(ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range, CancellationToken cancellationToken)
             {
+                // Explicitly hold onto below fields in locals and use these locals throughout this code path to avoid races
+                // if these fields happen to be cleared by Dispose() below. This is required since this code path involves
+                // code that runs asynchronously from background thread.
                 var view = _textView;
                 var buffer = _subjectBuffer;
                 var provider = _owner;
@@ -348,51 +363,109 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 using (var asyncToken = provider._listener.BeginAsyncOperation("HasSuggesetedActionsAsync"))
                 {
-                    var result = await HasSuggesetedActionCoreAsync(view, buffer, provider._codeFixService, range, cancellationToken).ConfigureAwait(false);
-                    if (!result.HasValue)
+                    var documentAndSnapshot = await GetMatchingDocumentAndSnapshotAsync(range.Snapshot, cancellationToken).ConfigureAwait(false);
+                    if (!documentAndSnapshot.HasValue)
                     {
+                        // this is here to fail test and see why it is failed.
+                        Trace.WriteLine("given range is not current");
                         return false;
                     }
 
-                    if (result.Value.HasFix)
+                    var document = documentAndSnapshot.Value.Item1;
+                    var workspace = document.Project.Solution.Workspace;
+                    var supportSuggestion = workspace.Services.GetService<IDocumentSupportsSuggestionService>();
+
+                    return
+                        await HasFixesAsync(
+                            supportSuggestion, requestedActionCategories, provider, document, range,
+                            cancellationToken).ConfigureAwait(false) ||
+                        await HasRefactoringsAsync(
+                            supportSuggestion, requestedActionCategories, provider, document, range,
+                            cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            private async Task<bool> HasFixesAsync(
+                IDocumentSupportsSuggestionService supportSuggestion,
+                ISuggestedActionCategorySet requestedActionCategories,
+                SuggestedActionsSourceProvider provider,
+                Document document, SnapshotSpan range,
+                CancellationToken cancellationToken)
+            {
+                if (provider._codeFixService != null && supportSuggestion.SupportsCodeFixes(document) &&
+                    requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
+                {
+                    // We only consider suppressions if lightbulb is asking for everything.
+                    // If the light bulb is only asking for code fixes, then we don't consider suppressions.
+                    var considerSuppressionFixes = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Any);
+                    var result = await Task.Run(
+                        async () => await provider._codeFixService.GetFirstDiagnosticWithFixAsync(
+                            document, range.Span.ToTextSpan(), considerSuppressionFixes, cancellationToken).ConfigureAwait(false),
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (result.HasFix)
                     {
                         Logger.Log(FunctionId.SuggestedActions_HasSuggestedActionsAsync);
                         return true;
                     }
 
-                    if (result.Value.PartialResult)
+                    if (result.PartialResult)
                     {
                         // reset solution version number so that we can raise suggested action changed event
                         Volatile.Write(ref _lastSolutionVersionReported, InvalidSolutionVersion);
                         return false;
                     }
-
-                    return false;
                 }
+
+                return false;
             }
 
-            private static async Task<FirstDiagnosticResult?> HasSuggesetedActionCoreAsync(
-                ITextView view, ITextBuffer buffer, ICodeFixService service, SnapshotSpan range, CancellationToken cancellationToken)
+            private async Task<bool> HasRefactoringsAsync(
+                IDocumentSupportsSuggestionService supportSuggestion,
+                ISuggestedActionCategorySet requestedActionCategories,
+                SuggestedActionsSourceProvider provider,
+                Document document, SnapshotSpan range,
+                CancellationToken cancellationToken)
             {
-                var documentAndSnapshot = await GetMatchingDocumentAndSnapshotAsync(range.Snapshot, cancellationToken).ConfigureAwait(false);
-                if (!documentAndSnapshot.HasValue)
+                var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
+
+                if (optionService.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                    provider._codeRefactoringService != null &&
+                    supportSuggestion.SupportsRefactorings(document) &&
+                    requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
                 {
-                    return null;
+                    TextSpan? selection = null;
+                    if (IsForeground())
+                    {
+                        // This operation needs to happen on UI thread because it needs to access textView.Selection.
+                        selection = TryGetCodeRefactoringSelection(range);
+                    }
+                    else
+                    {
+                        await InvokeBelowInputPriority(() =>
+                        {
+                            // This operation needs to happen on UI thread because it needs to access textView.Selection.
+                            selection = TryGetCodeRefactoringSelection(range);
+                        }).ConfigureAwait(false);
+                    }
+
+                    if (!selection.HasValue)
+                    {
+                        // this is here to fail test and see why it is failed.
+                        Trace.WriteLine("given range is not current");
+                        return false;
+                    }
+
+                    return await Task.Run(
+                        async () => await provider._codeRefactoringService.HasRefactoringsAsync(
+                            document, selection.Value, cancellationToken).ConfigureAwait(false),
+                        cancellationToken).ConfigureAwait(false);
                 }
 
-                var document = documentAndSnapshot.Value.Item1;
-
-                // make sure current document support codefix
-                var supportCodeFix = document.Project.Solution.Workspace.Services.GetService<IDocumentSupportsSuggestionService>();
-                if (!supportCodeFix.SupportsCodeFixes(document))
-                {
-                    return null;
-                }
-
-                return await service.GetFirstDiagnosticWithFixAsync(document, range.Span.ToTextSpan(), cancellationToken).ConfigureAwait(false);
+                return false;
             }
 
-            private TextSpan? GetCodeRefactoringSelection(ITextSnapshot snapshot)
+            private TextSpan? TryGetCodeRefactoringSelection(SnapshotSpan range)
             {
                 var selectedSpans = _textView.Selection.SelectedSpans
                     .SelectMany(ss => _textView.BufferGraph.MapDownToBuffer(ss, SpanTrackingMode.EdgeExclusive, _subjectBuffer))
@@ -405,8 +478,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     return null;
                 }
 
-                var selectedSpan = selectedSpans[0];
-                return selectedSpan.TranslateTo(snapshot, SpanTrackingMode.EdgeInclusive).Span.ToTextSpan();
+                var translatedSpan = selectedSpans[0].TranslateTo(range.Snapshot, SpanTrackingMode.EdgeInclusive);
+
+                // We only support refactorings when selected span intersects with the span that the light bulb is asking for.
+                if (!translatedSpan.IntersectsWith(range))
+                {
+                    return null;
+                }
+
+                return translatedSpan.Span.ToTextSpan();
             }
 
             private static async Task<ValueTuple<Document, ITextSnapshot>?> GetMatchingDocumentAndSnapshotAsync(ITextSnapshot givenSnapshot, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -46,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
                 var reference = new MockAnalyzerReference();
                 var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
                 var document = project.Documents.Single();
-                var unused = fixService.GetFirstDiagnosticWithFixAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None).Result;
+                var unused = fixService.GetFirstDiagnosticWithFixAsync(document, TextSpan.FromBounds(0, 0), considerSuppressionFixes: false, cancellationToken: CancellationToken.None).Result;
 
                 var fixer1 = fixers.Single().Value as MockFixer;
                 var fixer2 = reference.Fixer as MockFixer;
@@ -94,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
                 Document document;
                 EditorLayerExtensionManager.ExtensionManager extensionManager;
                 GetDocumentAndExtensionManager(diagnosticService, workspace, out document, out extensionManager);
-                var fixes = fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None).Result;
+                var fixes = fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeSuppressionFixes: true, cancellationToken: CancellationToken.None).Result;
                 Assert.True(((TestErrorLogger)errorLogger).Messages.Count == 1);
                 string message;
                 Assert.True(((TestErrorLogger)errorLogger).Messages.TryGetValue(codefix.GetType().Name, out message));
@@ -116,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
                 var reference = new MockAnalyzerReference(codefix);
                 var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
                 document = project.Documents.Single();
-                var fixes = fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None).Result;
+                var fixes = fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeSuppressionFixes: true, cancellationToken: CancellationToken.None).Result;
 
                 Assert.True(extensionManager.IsDisabled(codefix));
                 Assert.False(extensionManager.IsIgnored(codefix));
@@ -133,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
                 Document document;
                 EditorLayerExtensionManager.ExtensionManager extensionManager;
                 GetDocumentAndExtensionManager(diagnosticService, workspace, out document, out extensionManager);
-                var unused = fixService.GetFirstDiagnosticWithFixAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None).Result;
+                var unused = fixService.GetFirstDiagnosticWithFixAsync(document, TextSpan.FromBounds(0, 0), considerSuppressionFixes: false, cancellationToken: CancellationToken.None).Result;
                 Assert.True(extensionManager.IsDisabled(codefix));
                 Assert.False(extensionManager.IsIgnored(codefix));
             }
@@ -198,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             public MockAnalyzerReference()
             {
-               Fixer = new MockFixer();
+                Fixer = new MockFixer();
             }
 
             public MockAnalyzerReference(CodeFixProvider codeFix)

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify available codefix with a global fixer
                 Dim fixes = codefixService.GetFixesAsync(document,
                                                          document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan,
-                                                         CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                                                         includeSuppressionFixes:=True, cancellationToken:=CancellationToken.None).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify available codefix with a global fixer + a project fixer
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = codefixService.GetFixesAsync(document,
                                                      document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan,
-                                                     CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                                                     includeSuppressionFixes:=True, cancellationToken:=CancellationToken.None).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(1, fixes.Count())
 
                 ' Remove a project analyzer
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = codefixService.GetFixesAsync(document,
                                                      document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan,
-                                                     CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                                                     includeSuppressionFixes:=True, cancellationToken:=CancellationToken.None).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
             End Using
         End Sub
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify no codefix with a global fixer
                 Dim fixes = codefixService.GetFixesAsync(document,
                                                          document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan,
-                                                         CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                                                         includeSuppressionFixes:=True, cancellationToken:=CancellationToken.None).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify no codefix with a global fixer + a project fixer
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = codefixService.GetFixesAsync(document,
                                                      document.GetSyntaxRootAsync().WaitAndGetResult(CancellationToken.None).FullSpan,
-                                                     CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                                                     includeSuppressionFixes:=True, cancellationToken:=CancellationToken.None).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
             End Using
         End Sub

--- a/src/Features/Core/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/CodeFixes/ICodeFixService.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        Task<FirstDiagnosticResult> GetFirstDiagnosticWithFixAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+        Task<FirstDiagnosticResult> GetFirstDiagnosticWithFixAsync(Document document, TextSpan textSpan, bool considerSuppressionFixes, CancellationToken cancellationToken);
 
-        Task<IEnumerable<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+        Task<IEnumerable<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/CodeRefactorings/ICodeRefactoringService.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
     internal interface ICodeRefactoringService
     {
+        Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+
         Task<IEnumerable<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
1. When light bulb asks us for suggestions (i.e. in HasSuggestedActionsAsync() and GetSuggestedActions()), it also specifies the category of suggestions that it is looking for (code fixes, refactorings, anything etc.). So far, we were completely ignoring the requested categories. HasSuggestedActionsAsync() would always return true so long as we had a code fix (that is not a suppression fix) and GetSuggestedActions() would always return all types of suggestions (fixes, suppressions and refactorings) regardless of what the light bulb is asking for. This led to strange bugs where we would return refactorings even when light bulb didn't ask for them. In other cases, HasSuggestedActionsAsync() and GetSuggestedActions() would disagree for the same requested categories. This change makes things consistent so that we always honor the suggestion categories that the light bulb is requesting.

2. When computing refactorings we were completely ignoring the span specified by light bulb and only considering selection specified by user. This led to incorrect behavior in some cases - for example, on mouse hover over a squiggle, we would return the code fixes corresponding to the squiggle along with refactorings for completely unrelated portions of the code that the user may have previously selected.

Fixes #1030, #1595, #1631

TODO: Add tests - I'm working on this.