### PR TITLE
Change to Directory.GetCurrentDirectory

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -2726,7 +2726,7 @@ System.Diagnostics.Process.GetCurrentProcess();
                 Diagnostic(ErrorCode.ERR_ReferenceDirectiveOnlyAllowedInScripts, @"#r ""System.Core"""));
         }
 
-        private static readonly string s_resolvedPath = Path.GetPathRoot(Environment.CurrentDirectory) + "RESOLVED";
+        private static readonly string s_resolvedPath = Path.GetPathRoot(Directory.GetCurrentDirectory()) + "RESOLVED";
 
         private class DummyFileProvider : MetadataFileReferenceProvider
         {

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             => BuildClient.RunWithConsoleOutput(
                 args,
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
-                workingDir: Environment.CurrentDirectory,
+                workingDir: Directory.GetCurrentDirectory(),
                 language: RequestLanguage.CSharpCompile,
                 fallbackCompiler: Csc.Run);
     }

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // if ToolTask didn't override. MSBuild uses the process directory.
             string workingDirectory = GetWorkingDirectory();
             if (string.IsNullOrEmpty(workingDirectory))
-                workingDirectory = Environment.CurrentDirectory;
+                workingDirectory = Directory.GetCurrentDirectory();
             return workingDirectory;
         }
 

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         private static string MSBuildExecutable { get; } = Path.Combine(MSBuildDirectory, "MSBuild.exe");
 
-        private static readonly string s_workingDirectory = Environment.CurrentDirectory;
+        private static readonly string s_workingDirectory = Directory.GetCurrentDirectory();
         private static string ResolveAssemblyPath(string exeName)
         {
             var path = Path.Combine(s_workingDirectory, exeName);
@@ -1949,7 +1949,7 @@ class Hello
             ProcessStartInfo processStartInfo = new ProcessStartInfo();
             processStartInfo.CreateNoWindow = true;
             processStartInfo.FileName = pathToProcDump;
-            processStartInfo.WorkingDirectory = Environment.CurrentDirectory;
+            processStartInfo.WorkingDirectory = Directory.GetCurrentDirectory();
             processStartInfo.UseShellExecute = false;
 
             processStartInfo.Arguments = " -accepteula -c 0 -ma " + pid.ToString();

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             => BuildClient.RunWithConsoleOutput(
                 args,
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
-                workingDir: Environment.CurrentDirectory,
+                workingDir: Directory.GetCurrentDirectory(),
                 language: RequestLanguage.VisualBasicCompile,
                 fallbackCompiler: Vbc.Run);
     }

--- a/src/EditorFeatures/CSharpTest/Completion/LoadDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/LoadDirectiveCompletionProviderTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
             // after so many ".." we should be at the root drive an should no longer suggest the parent.  we can determine
             // our current directory depth by counting the number of backslashes present in the current working directory
             // and after that many references to "..", we are at the root.
-            int depth = Environment.CurrentDirectory.Count(c => c == Path.DirectorySeparatorChar);
+            int depth = Directory.GetCurrentDirectory().Count(c => c == Path.DirectorySeparatorChar);
             var pathToRoot = string.Concat(Enumerable.Repeat(@"..\", depth));
 
             VerifyItemExistsInInteractive(

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 _hostObject = new InteractiveHostObject();
 
                 _options = _options
-                                   .WithBaseDirectory(Environment.CurrentDirectory)
+                                   .WithBaseDirectory(Directory.GetCurrentDirectory())
                                    .AddReferences(_hostObject.GetType().Assembly);
 
                 _hostObject.ReferencePaths.AddRange(_options.SearchPaths);
@@ -393,7 +393,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 // send any updates to the host object and current directory back to the client:
                 var newSourcePaths = _hostObject.SourcePaths.List.GetNewContent();
                 var newReferencePaths = _hostObject.ReferencePaths.List.GetNewContent();
-                var currentDirectory = Environment.CurrentDirectory;
+                var currentDirectory = Directory.GetCurrentDirectory();
                 var oldWorkingDirectory = _options.BaseDirectory;
                 var newWorkingDirectory = (oldWorkingDirectory != currentDirectory) ? currentDirectory : null;
 

--- a/src/Test/Utilities/CommonTestBase.cs
+++ b/src/Test/Utilities/CommonTestBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         static CommonTestBase()
         {
             var configFileName = Path.GetFileName(Assembly.GetExecutingAssembly().Location) + ".config";
-            var configFilePath = Path.Combine(Environment.CurrentDirectory, configFileName);
+            var configFilePath = Path.Combine(Directory.GetCurrentDirectory(), configFileName);
 
             if (File.Exists(configFilePath))
             {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             this.ClearSolution();
 
-            var absoluteSolutionPath = this.GetAbsoluteSolutionPath(solutionFilePath, Environment.CurrentDirectory);
+            var absoluteSolutionPath = this.GetAbsoluteSolutionPath(solutionFilePath, Directory.GetCurrentDirectory());
 
             using (_dataGuard.DisposableWait(cancellationToken))
             {
@@ -505,7 +505,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
 
             string fullPath;
-            if (this.TryGetAbsoluteProjectPath(projectFilePath, Environment.CurrentDirectory, ReportMode.Throw, out fullPath))
+            if (this.TryGetAbsoluteProjectPath(projectFilePath, Directory.GetCurrentDirectory(), ReportMode.Throw, out fullPath))
             {
                 IProjectFileLoader loader;
                 if (this.TryGetLoaderFromProjectPath(projectFilePath, ReportMode.Throw, out loader))


### PR DESCRIPTION
The API Environment.CurrentDirectory is not available on CoreFX.
Switching all uses to Directory.GetCurrentDirectory which is an
equivalent API (it is actually how Environment.CurrentDirectory is often
implemented).