### PR TITLE
Fix a crash during IL generation for an Expression Tree involving an extension Add method used within a collection initializer

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -567,12 +567,21 @@ lSelect:
             For i = 0 To initializerCount - 1
                 Debug.Assert(initializers(i).Kind = BoundKind.Call)
                 Dim [call] = DirectCast(initializers(i), BoundCall)
+
+                ' Note, for extension methods we are dropping the "Me" parameter to remove
+                ' BoundCollectionInitializerExpression.PlaceholderOpt references from the tree.
+                ' Otherwise, IL generation fails because it doesn't know what to do with it.
+                ' At run-time, this code is going to throw because ElementInit API doesnt accept
+                ' shared methods. We don't fail compilation in this scenario due to backward
+                ' compatibility reasons.
                 newInitializers(i) = _factory.Convert(
                                             ElementInitType,
                                             ConvertRuntimeHelperToExpressionTree(
                                                     "ElementInit",
                                                     _factory.MethodInfo([call].Method),
-                                                    ConvertArgumentsIntoArray([call].Arguments)))
+                                                    ConvertArgumentsIntoArray(If([call].Method.IsShared AndAlso [call].Method.IsExtensionMethod,
+                                                                                 [call].Arguments.RemoveAt(0),
+                                                                                 [call].Arguments))))
             Next
 
             Return _factory.Array(ElementInitType, newInitializers.AsImmutableOrNull())


### PR DESCRIPTION
This change addresses issue #1190. Even though Expression Trees API doesn’t support extension methods as Add methods in a collection initializer, we still compile the code successfully and let it fail at run-time. The motivation is backward compatibility. 

Similar issue in C# has been addressed already, see #310.