### PR TITLE
Activating a previously failed testcase

### DIFF
--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -672,7 +672,7 @@ class C1
         }
 
         [WorkItem(985906)]
-        [Fact(Skip = "Issue #317"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void HandleSolutionProjectTypeSolutionFolder()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()


### PR DESCRIPTION
Fixes #317 : This HandleSolutionProjectTypeSolutionFolder was failing
because the msbuild bits in Jenkins were older bits. Now the bits should
have been updated. Hence enabling the test.