### PR TITLE
Fixed parsing logic for rsp file arguments to implement speced behavior.

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -4145,8 +4145,90 @@ class myClass
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
         }
-        [Fact]
 
+        [WorkItem(1784, "https://github.com/dotnet/roslyn/issues/1784")]
+        [Fact]
+        public void QuotedDefineInRespFile()
+        {
+            string source = Temp.CreateFile("a.cs").WriteAllText(@"
+#if NN
+class myClass
+{
+#endif
+    static int Main()
+#if DD
+    {
+        return 1;
+#endif
+
+#if AA
+    }
+#endif
+
+#if BB
+}
+#endif
+
+").Path;
+
+            string rsp = Temp.CreateFile().WriteAllText(@"
+/d:""DD""
+/d:""AA;BB""
+/d:""N""N
+").Path;
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            // csc errors_whitespace_008.cs @errors_whitespace_008.cs.rsp 
+            var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en"});
+            int exitCode = csc.Run(outWriter);
+            Assert.Equal(0, exitCode);
+
+            CleanupAllGeneratedFiles(source);
+            CleanupAllGeneratedFiles(rsp);
+        }
+
+        [WorkItem(1784, "https://github.com/dotnet/roslyn/issues/1784")]
+        [Fact]
+        public void QuotedDefineInRespFileErr()
+        {
+            string source = Temp.CreateFile("a.cs").WriteAllText(@"
+#if NN
+class myClass
+{
+#endif
+    static int Main()
+#if DD
+    {
+        return 1;
+#endif
+
+#if AA
+    }
+#endif
+
+#if BB
+}
+#endif
+
+").Path;
+
+            string rsp = Temp.CreateFile().WriteAllText(@"
+/d:""DD""""
+/d:""AA;BB""
+/d:""N"" ""N
+").Path;
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            // csc errors_whitespace_008.cs @errors_whitespace_008.cs.rsp 
+            var csc = new MockCSharpCompiler(rsp, _baseDirectory, new[] { source, "/preferreduilang:en" });
+            int exitCode = csc.Run(outWriter);
+            Assert.Equal(1, exitCode);
+
+            CleanupAllGeneratedFiles(source);
+            CleanupAllGeneratedFiles(rsp);
+        }
+
+        [Fact]
         private void ResponseFileSplitting()
         {
             string[] responseFile;
@@ -4184,17 +4266,17 @@ class myClass
                 @"a\""a b\\""b c\\\""c d\\\\""d e\\\\\""e f"" g""",
             };
             args = CSharpCommandLineParser.ParseResponseLines(responseFile);
-            AssertEx.Equal(new[] { @"a""a", @"b\""b c\""c d\\""d", @"e\\""e", @"f"" g""" }, args);
+            AssertEx.Equal(new[] { @"a""a", @"b\b c\""c d\\d", @"e\\""e", @"f g" }, args);
 
-            // Quoting inside argument.
+            // Quoting inside argument is valid.
             responseFile = new string[] {
                 @"  /o:""foo.cs"" /o:""abc def""\baz ""/o:baz bar""bing",
             };
             args = CSharpCommandLineParser.ParseResponseLines(responseFile);
-            AssertEx.Equal(new[] { @"/o:""foo.cs""", @"/o:""abc def""\baz", @"""/o:baz bar""bing" }, args);
+            AssertEx.Equal(new[] { @"/o:foo.cs", @"/o:abc def\baz", @"/o:baz barbing" }, args);
         }
-        [Fact]
 
+        [Fact]
         private void SourceFileQuoting()
         {
             string[] responseFile = new string[] {

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -86,13 +86,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyCommandLineSplitter("   \t   ", new string[0]);
             VerifyCommandLineSplitter("   abc\tdef baz    quuz   ", new[] { "abc", "def", "baz", "quuz" });
             VerifyCommandLineSplitter(@"  ""abc def""  fi""ddle dee de""e  ""hi there ""dude  he""llo there""  ",
-                                        new string[] { @"abc def", @"fi""ddle dee de""e", @"""hi there ""dude", @"he""llo there""" });
+                                        new string[] { @"abc def", @"fiddle dee dee", @"hi there dude", @"hello there" });
             VerifyCommandLineSplitter(@"  ""abc def \"" baz quuz"" ""\""straw berry"" fi\""zz \""buzz fizzbuzz",
                                         new string[] { @"abc def "" baz quuz", @"""straw berry", @"fi""zz", @"""buzz", @"fizzbuzz" });
             VerifyCommandLineSplitter(@"  \\""abc def""  \\\""abc def"" ",
-                                        new string[] { @"\""abc def""", @"\""abc", @"def""" });
+                                        new string[] { @"\abc def", @"\""abc", @"def" });
             VerifyCommandLineSplitter(@"  \\\\""abc def""  \\\\\""abc def"" ",
-                                        new string[] { @"\\""abc def""", @"\\""abc", @"def""" });
+                                        new string[] { @"\\abc def", @"\\""abc", @"def" });
+            VerifyCommandLineSplitter(@"  \\\\""abc def""  \\\\\""abc def"" q a r ",
+                                        new string[] { @"\\abc def", @"\\""abc", @"def q a r" });
             VerifyCommandLineSplitter(@"abc #Comment ignored",
                                         new string[] { @"abc" }, removeHashComments: true);
         }

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
@@ -554,6 +554,10 @@ namespace Microsoft.CodeAnalysis
             bool inQuotes = false;
             int backslashCount = 0;
 
+            // separate the line into multiple arguments on whitespaces. 
+            // we maintain the inQuotes state to ensure we do not break line while in a quoted text.
+            // we also need to count slashes since odd number of slashes before a quote 
+            // makes that quote just a regular char
             return Split(commandLine,
                 (c =>
                 {
@@ -578,8 +582,52 @@ namespace Microsoft.CodeAnalysis
                 }))
             .Select(arg => arg.Trim())                                                                  // Trim whitespace
             .TakeWhile(arg => (!removeHashComments || !arg.StartsWith("#", StringComparison.Ordinal)))  // If removeHashComments is true, skip all arguments after one that starts with '#'
-            .Select(arg => CondenseDoubledBackslashes(arg).Unquote())                                   // Remove quotes and handle backslashes.
+            .Select(arg => UnquoteAndUnescape(NormalizeBackslashes(arg)))                               // Remove quotes and handle backslashes.
             .Where(arg => !string.IsNullOrEmpty(arg));                        							// Don't produce empty strings.
+        }
+
+        // Once the line is split into arguments we need to remove quotes 
+        // that are not escaped, and need to remove slashes that are used for escaping
+        private static string UnquoteAndUnescape(string v)
+        {
+            if (v.IndexOf('"') < 0 && v.IndexOf('\\') < 0)
+            {
+                return v;
+            }
+
+            // split on " 
+            // except for preceded by \ like  \" 
+            // ignore pairs like \\
+            bool afterSingleBackslash = false;
+            var split = Split(v, c =>
+                {
+                    if (!afterSingleBackslash && c == '\"')
+                    {
+                        return true;
+                    }
+
+                    afterSingleBackslash = !afterSingleBackslash & c == '\\';
+                    return false;
+                }).ToArray();
+
+
+            // unescape escaped \"  and \\
+            for(int i = 0; i < split.Length; i++)
+            {
+                if (split[i].IndexOf('\\') >= 0)
+                {
+                    split[i] = split[i].Replace(@"\""", @"""");
+                    split[i] = split[i].Replace(@"\\", @"\");
+                }
+            }
+
+            // the behavior of unpaired quote seems to be not well defined
+            // Exprimentally I can see the following behaviors:
+            // 1) command arg parsing fails (Main is not called)
+            // 2) the text following the last quote is appended to the last argv as-is
+            // We will use strategy #2 for unpaired quote. 
+            // It is a broken and unlikely case but we have to do something.
+            return string.Join("", split);
         }
 
         private static bool IsCommandLineDelimiter(char c)
@@ -611,10 +659,15 @@ namespace Microsoft.CodeAnalysis
             yield return str.Substring(nextPiece);
         }
 
-        /// <summary>
-        /// Condense double backslashes that precede a quotation mark to single backslashes.
-        /// </summary>
-        private static string CondenseDoubledBackslashes(string input)
+        // In the input, the backslashes not preceding quotes are not escaped 
+        // (possibly to not force the user to type so many slashes). 
+        // That makes it hard to either unescape slashes after quotes are removed 
+        // or remove quotes after slashes are unescaped.
+        // NormalizeBackslashes makes the slashes that do not precede quotes to 
+        // be "escaped" the same way as the slashes that do. 
+        // This way we can later unescape all slashes in the same way and 
+        // not rely on presence of quotes.
+        private static string NormalizeBackslashes(string input)
         {
             int i = input.IndexOf('\\');
 
@@ -639,11 +692,11 @@ namespace Microsoft.CodeAnalysis
                     // Add right amount of pending backslashes.
                     if (c == '\"')
                     {
-                        AddBackslashes(builder, backslashCount / 2);
+                        AddBackslashes(builder, backslashCount);
                     }
                     else
                     {
-                        AddBackslashes(builder, backslashCount);
+                        AddBackslashes(builder, backslashCount * 2);
                     }
 
                     builder.Append(c);
@@ -651,7 +704,7 @@ namespace Microsoft.CodeAnalysis
                 }
             } while (++i < input.Length);
 
-            AddBackslashes(builder, backslashCount);
+            AddBackslashes(builder, backslashCount * 2);
             return pooledBuilder.ToStringAndFree();
         }
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -352,7 +352,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' Return the index within the trivia of what would be considered trailing
         ''' single-line trivia by the Scanner. This behavior must match ScanSingleLineTrivia.
         ''' In short, search walks backwards and stops at the second terminator
-        ''' (colon or EOL) from the end, ignoring EOLs preceeded by line continuations.
+        ''' (colon or EOL) from the end, ignoring EOLs preceded by line continuations.
         ''' </summary>
         <Extension()>
         Private Function GetIndexOfEndOfTrivia(trivia As SyntaxList(Of VisualBasicSyntaxNode)) As Integer

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             // 
             // 1) A label may be marked "tied to parent". Let x, y have both label l and l is "tied to parent".
             //    Then (x,y) can be in M only if (parent(x), parent(y)) in M.
-            //    Thus we require labels of children tied to a parent to be preceeded by all their possible parent labels.
+            //    Thus we require labels of children tied to a parent to be preceded by all their possible parent labels.
             //
             // 2) Rather than defining function equal in terms of constants f and t, which are hard to get right,
             //    we try to match multiple times with different threashold for node distance.

--- a/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
                 }
 
                 // now we have an interesting case where indentation block intersects with us.
-                // this can happen if code is splitted in two different script blocks or nuggets.
+                // this can happen if code is split in two different script blocks or nuggets.
                 // here, we will re-adjust block to be contained within our span.
                 if (operation.TextSpan.IntersectsWith(_span))
                 {


### PR DESCRIPTION
In particular, it is allowed for arguments to have embedded quoted portions like

/define:Unquoted"Quoted"Unquoted"Quoted"

wich means

/define:UnquotedQuotedUnquotedQuoted

when passed on command line, and should mean exactly the same when passed in an rsp file.

The change fixes #1784