### PR TITLE
Fix variable capturing for VB lambdas in EE...

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -520,7 +520,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Symbol oldInnermostFramePointer = _innermostFramePointer;
-
             _innermostFramePointer = framePointer;
             var addedLocals = ArrayBuilder<LocalSymbol>.GetInstance();
             addedLocals.Add(framePointer);

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            nextFreeHoistedLocalSlot As Integer,
                            Diagnostics As DiagnosticBag)
 
-                MyBase.New(slotAllocatorOpt, F.CompilationState, Diagnostics)
+                MyBase.New(slotAllocatorOpt, F.CompilationState, Diagnostics, preserveOriginalLocals:=False)
 
                 Debug.Assert(F IsNot Nothing)
                 Debug.Assert(stateField IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -747,6 +747,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </remarks>
         Friend MustOverride Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
 
+        ''' <summary>
+        ''' Specifies whether existing, "unused" locals (corresponding to proxies) are preserved during lambda rewriting.
+        ''' </summary>
+        ''' <remarks>
+        ''' This value will be checked by the <see cref="LambdaRewriter"/> and is needed so that existing locals aren't
+        ''' omitted in the EE (method symbols in the EE will override this property to return True).
+        ''' </remarks>
+        Friend Overridable ReadOnly Property PreserveOriginalLocals As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
 #Region "IMethodSymbol"
 
         Private ReadOnly Property IMethodSymbol_Arity As Integer Implements IMethodSymbol.Arity

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -5944,5 +5944,46 @@ class C
   IL_0024:  ret
 }");
         }
+
+        [Fact]
+        public void CapturedLocalInLambda()
+        {
+            var source = @"
+using System;
+class C
+{
+    void M(Func<int> f)
+    {
+        int x = 42;
+        M(() => x);
+    }
+}";
+            var comp = CreateCompilationWithMscorlib45(source);
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
+
+            string error;
+            var testData = new CompilationTestData();
+            context.CompileExpression("M(() => x)", out error, testData);
+            Assert.Null(error);
+            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                <>x.<>c__DisplayClass0_0 V_1) //CS$<>8__locals0
+  IL_0000:  newobj     ""<>x.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  ldloc.0
+  IL_0008:  stfld      ""C.<>c__DisplayClass0_0 <>x.<>c__DisplayClass0_0.CS$<>8__locals0""
+  IL_000d:  ldarg.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldftn      ""int <>x.<>c__DisplayClass0_0.<<>m0>b__0()""
+  IL_0015:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
+  IL_001a:  callvirt   ""void C.M(System.Func<int>)""
+  IL_001f:  ret
+}");
+        }
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -505,6 +505,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             '     <2> = New <>c__DisplayClass0()
             '     <2>.<1> = <1>
             '     <2>.z = z
+            '
+            ' Note: The above behavior is actually implemented in the LambdaRewriter and
+            '       is triggered by overriding PreserveOriginalLocals to return "True".
 
             ' Create a map from variable name to display class field.
             Dim displayClassVariables = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
@@ -521,10 +524,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' Rewrite references to "Me" to refer to this method's "Me" parameter.
             ' Rewrite variables within body to reference existing display classes.
             newBody = DirectCast(CapturedVariableRewriter.Rewrite(
-                    If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
-                    displayClassVariables.ToImmutableDictionary(),
-                    newBody,
-                    diagnostics), BoundBlock)
+                If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
+                displayClassVariables.ToImmutableDictionary(),
+                newBody,
+                diagnostics), BoundBlock)
             displayClassVariables.Free()
 
             If diagnostics.HasAnyErrors() Then
@@ -560,5 +563,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
             Return localPosition
         End Function
+
+        Friend Overrides ReadOnly Property PreserveOriginalLocals As Boolean
+            Get
+                Return True
+            End Get
+        End Property
+
     End Class
+
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -4064,6 +4064,227 @@ End Module"
 }")
         End Sub
 
+        <WorkItem(1145125)>
+        <Fact>
+        Public Sub LocalInLambda()
+            Dim source = "
+Imports System
+Class C
+    Sub M(f As Func(Of Integer))
+        Dim x = 42
+    End Sub
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(MakeSources(source), options:=TestOptions.DebugDll)
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
+
+            Dim errorMessage As String = Nothing
+            Dim testData = New CompilationTestData()
+            context.CompileExpression("M(Function() x)", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (Integer V_0, //x
+                <>x._Closure$__0-0 V_1) //$VB$Closure_0
+  IL_0000:  newobj     ""Sub <>x._Closure$__0-0..ctor()""
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  ldloc.0
+  IL_0008:  stfld      ""<>x._Closure$__0-0.$VB$Local_x As Integer""
+  IL_000d:  ldarg.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldftn      ""Function <>x._Closure$__0-0._Lambda$__0() As Integer""
+  IL_0015:  newobj     ""Sub System.Func(Of Integer)..ctor(Object, System.IntPtr)""
+  IL_001a:  callvirt   ""Sub C.M(System.Func(Of Integer))""
+  IL_001f:  ret
+}")
+        End Sub
+
+        <WorkItem(1145125)>
+        <Fact>
+        Public Sub CapturedLocalInLambda()
+            Dim source = "
+Imports System
+Class C
+    Sub M(f As Func(Of Integer))
+        Dim x = 42
+        M(Function() x)
+    End Sub
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(MakeSources(source))
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
+
+            Dim errorMessage As String = Nothing
+            Dim testData = New CompilationTestData()
+            context.CompileExpression("M(Function() x)", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (C._Closure$__1-0 V_0, //$VB$Closure_0
+                <>x._Closure$__0-0 V_1) //$VB$Closure_0
+  IL_0000:  newobj     ""Sub <>x._Closure$__0-0..ctor()""
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  ldloc.0
+  IL_0008:  stfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Closure_0 As C._Closure$__1-0""
+  IL_000d:  ldarg.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldftn      ""Function <>x._Closure$__0-0._Lambda$__0() As Integer""
+  IL_0015:  newobj     ""Sub System.Func(Of Integer)..ctor(Object, System.IntPtr)""
+  IL_001a:  callvirt   ""Sub C.M(System.Func(Of Integer))""
+  IL_001f:  ret
+}")
+        End Sub
+
+        <WorkItem(1145125)>
+        <Fact>
+        Public Sub CapturedParameterAndLocalInLambda()
+            Dim source = "
+Imports System
+Class C
+    Sub M(x As Integer)
+        F(Function() x)
+        If True Then
+            Dim y = 42.0
+            F(Function() y)
+        End If
+    End Sub
+    Function F(p As Func(Of Integer)) As Integer
+        Return p()
+    End Function
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(MakeSources(source))
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M", atLineNumber:=6)
+
+            Dim errorMessage As String = Nothing
+            Dim testData = New CompilationTestData()
+            context.CompileExpression("F(Function() x + y)", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size       39 (0x27)
+  .maxstack  3
+  .locals init (C._Closure$__1-0 V_0, //$VB$Closure_0
+                C._Closure$__1-1 V_1, //$VB$Closure_1
+                <>x._Closure$__0-0 V_2) //$VB$Closure_0
+  IL_0000:  newobj     ""Sub <>x._Closure$__0-0..ctor()""
+  IL_0005:  stloc.2
+  IL_0006:  ldloc.2
+  IL_0007:  ldloc.0
+  IL_0008:  stfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Closure_0 As C._Closure$__1-0""
+  IL_000d:  ldloc.2
+  IL_000e:  ldloc.1
+  IL_000f:  stfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Closure_1 As C._Closure$__1-1""
+  IL_0014:  ldarg.0
+  IL_0015:  ldloc.2
+  IL_0016:  ldftn      ""Function <>x._Closure$__0-0._Lambda$__0() As Integer""
+  IL_001c:  newobj     ""Sub System.Func(Of Integer)..ctor(Object, System.IntPtr)""
+  IL_0021:  callvirt   ""Function C.F(System.Func(Of Integer)) As Integer""
+  IL_0026:  ret
+}")
+            testData.GetMethodData("<>x._Closure$__0-0._Lambda$__0").VerifyIL("
+{
+  // Code size       31 (0x1f)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Closure_0 As C._Closure$__1-0""
+  IL_0006:  ldfld      ""C._Closure$__1-0.$VB$Local_x As Integer""
+  IL_000b:  conv.r8
+  IL_000c:  ldarg.0
+  IL_000d:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Closure_1 As C._Closure$__1-1""
+  IL_0012:  ldfld      ""C._Closure$__1-1.$VB$Local_y As Double""
+  IL_0017:  add
+  IL_0018:  call       ""Function System.Math.Round(Double) As Double""
+  IL_001d:  conv.ovf.i4
+  IL_001e:  ret
+}")
+        End Sub
+
+        <WorkItem(1145125)>
+        <Fact>
+        Public Sub CapturedParameterAndLocalInNestedLambda()
+            Dim source = "
+Imports System
+Class C
+    Sub M(x As Integer)
+        F(Function() x)
+        If True Then
+            Dim y = 42.0
+            F(Function()
+                  Dim z = 2600
+                  Return F(Function() x + y + z)
+              End Function)
+        End If
+    End Sub
+    Function F(p As Func(Of Integer)) As Integer
+        Return p()
+    End Function
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(MakeSources(source))
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C._Closure$__1-2._Lambda$__2")
+
+            Dim errorMessage As String = Nothing
+            Dim testData = New CompilationTestData()
+            context.CompileExpression("F(Function() x + y + z)", errorMessage, testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL("
+{
+  // Code size       52 (0x34)
+  .maxstack  3
+  .locals init (<>x._Closure$__0-0 V_0) //$VB$Closure_0
+  IL_0000:  newobj     ""Sub <>x._Closure$__0-0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Me As C._Closure$__1-2""
+  IL_000d:  ldloc.0
+  IL_000e:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Me As C._Closure$__1-2""
+  IL_0013:  ldfld      ""C._Closure$__1-2.$VB$NonLocal_$VB$Closure_3 As C._Closure$__1-1""
+  IL_0018:  ldfld      ""C._Closure$__1-1.$VB$NonLocal_$VB$Closure_2 As C._Closure$__1-0""
+  IL_001d:  ldfld      ""C._Closure$__1-0.$VB$Me As C""
+  IL_0022:  ldloc.0
+  IL_0023:  ldftn      ""Function <>x._Closure$__0-0._Lambda$__0() As Integer""
+  IL_0029:  newobj     ""Sub System.Func(Of Integer)..ctor(Object, System.IntPtr)""
+  IL_002e:  callvirt   ""Function C.F(System.Func(Of Integer)) As Integer""
+  IL_0033:  ret
+}")
+            testData.GetMethodData("<>x._Closure$__0-0._Lambda$__0").VerifyIL("
+{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Me As C._Closure$__1-2""
+  IL_0006:  ldfld      ""C._Closure$__1-2.$VB$NonLocal_$VB$Closure_3 As C._Closure$__1-1""
+  IL_000b:  ldfld      ""C._Closure$__1-1.$VB$NonLocal_$VB$Closure_2 As C._Closure$__1-0""
+  IL_0010:  ldfld      ""C._Closure$__1-0.$VB$Local_x As Integer""
+  IL_0015:  conv.r8
+  IL_0016:  ldarg.0
+  IL_0017:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Me As C._Closure$__1-2""
+  IL_001c:  ldfld      ""C._Closure$__1-2.$VB$NonLocal_$VB$Closure_3 As C._Closure$__1-1""
+  IL_0021:  ldfld      ""C._Closure$__1-1.$VB$Local_y As Double""
+  IL_0026:  add
+  IL_0027:  ldarg.0
+  IL_0028:  ldfld      ""<>x._Closure$__0-0.$VB$Local_$VB$Me As C._Closure$__1-2""
+  IL_002d:  ldfld      ""C._Closure$__1-2.$VB$Local_z As Integer""
+  IL_0032:  conv.r8
+  IL_0033:  add
+  IL_0034:  call       ""Function System.Math.Round(Double) As Double""
+  IL_0039:  conv.ovf.i4
+  IL_003a:  ret
+}")
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Variables may have been captured by lambdas in the original method
or in the expression, and we need to preserve the existing values of
those variables in the expression. This requires rewriting the variables
in the expression based on the closure classes from both the original
method and the expression, and generating a preamble that copies
values into the expression closure classes.

Consider the original method:
```
Shared Sub M()
    Dim x, y, z as Integer
    ...
    F(Function() x + y)
End Sub
```
and the expression in the EE: "F(Function() x + z)".
The expression is first rewritten using the closure class and the local
`<1>` from the original method: F(Function() `<1>`.x + z)
Then lambda rewriting introduces a new closure class that includes
the locals `<1>` and z, and a corresponding local
`<2>`: F(Function() `<2>`.`<1>`.x + `<2>`.z)
And a preamble is added to initialize the fields of `<2>`:
```
    <2> = New <>c__DisplayClass0()
    <2>.<1> = <1>
    <2>.z = z
```