### PR TITLE
don't assume that a constructor's parent is a TypeBlockSyntax

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -551,6 +551,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             End Using
         End Sub
 
+        <WorkItem(1834, "https://github.com/dotnet/roslyn/issues/1834")>
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
+        Public Sub ConstructorNotParentedByTypeBlock()
+            Using worker = SetupWorkspace("Module Program", "End Module", "Public Sub New()", "End Sub")
+                SetupVerifableGlyph(StandardGlyphGroup.GlyphGroupModule, StandardGlyphItem.GlyphItemFriend)
+                Assert.Equal(0, _aggregator.GetItems("New").Count)
+                Dim item = _aggregator.GetItems("Program").Single
+                VerifyNavigateToResultItem(item, "Program", MatchKind.Exact, NavigateToItemKind.Module, displayName:="Program")
+            End Using
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Sub StartStopSanity()
             ' Verify that mutliple calls to start/stop don't blow up

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -961,6 +961,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static string GetContainer(SyntaxNode node, bool immediate)
         {
+            if (node == null)
+            {
+                return string.Empty;
+            }
+
             var name = GetNodeName(node, includeTypeParameters: immediate);
             var names = new List<string> { name };
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -722,15 +722,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return True
                 Case SyntaxKind.ConstructorBlock
                     Dim constructor = CType(node, ConstructorBlockSyntax)
-                    Dim typeBlock = CType(constructor.Parent, TypeBlockSyntax)
-                    declaredSymbolInfo = New DeclaredSymbolInfo(
-                        typeBlock.BlockStatement.Identifier.ValueText,
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
-                        DeclaredSymbolInfoKind.Constructor,
-                        constructor.SubNewStatement.NewKeyword.Span,
-                        parameterCount:=CType(If(constructor.SubNewStatement.ParameterList?.Parameters.Count, 0), UShort))
-                    Return True
+                    Dim typeBlock = TryCast(constructor.Parent, TypeBlockSyntax)
+                    If typeBlock IsNot Nothing Then
+                        declaredSymbolInfo = New DeclaredSymbolInfo(
+                            typeBlock.BlockStatement.Identifier.ValueText,
+                            GetContainerDisplayName(node.Parent),
+                            GetFullyQualifiedContainerName(node.Parent),
+                            DeclaredSymbolInfoKind.Constructor,
+                            constructor.SubNewStatement.NewKeyword.Span,
+                            parameterCount:=CType(If(constructor.SubNewStatement.ParameterList?.Parameters.Count, 0), UShort))
+
+                        Return True
+                    End If
                 Case SyntaxKind.DelegateFunctionStatement, SyntaxKind.DelegateSubStatement
                     Dim delegateDecl = CType(node, DelegateStatementSyntax)
                     declaredSymbolInfo = New DeclaredSymbolInfo(delegateDecl.Identifier.ValueText,

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -832,6 +832,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function GetContainer(node As SyntaxNode, immediate As Boolean) As String
+            If node Is Nothing Then
+                Return String.Empty
+            End If
+
             Dim name = GetNodeName(node, includeTypeParameters:=immediate)
             Dim names = New List(Of String) From {name}
 


### PR DESCRIPTION
In an error parsing or script scenario, a VB constructor won't necessarily be parented by a TypeBlockSyntax.

Fixes #1834.