### PR TITLE
Fixes EnC function remapping of an active statement containing await expression

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -554,7 +554,7 @@ class Test
 
             v.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      478 (0x1de)
+  // Code size      481 (0x1e1)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -562,7 +562,8 @@ class Test
                 int V_3,
                 Test.<G>d__1 V_4,
                 object V_5,
-                System.Exception V_6)
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
+                System.Exception V_7)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<G>d__1.<>1__state""
   IL_0006:  stloc.0
@@ -576,7 +577,7 @@ class Test
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_002f
-    IL_0014:  br         IL_011f
+    IL_0014:  br         IL_0121
    -IL_0019:  nop
    -IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
@@ -598,7 +599,7 @@ class Test
      -IL_0038:  call       ""System.Threading.Tasks.Task<int> Test.F()""
       IL_003d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
       IL_0042:  stloc.2
-      IL_0043:  ldloca.s   V_2
+     ~IL_0043:  ldloca.s   V_2
       IL_0045:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
       IL_004a:  brtrue.s   IL_0090
       IL_004c:  ldarg.0
@@ -617,7 +618,7 @@ class Test
       IL_0067:  ldloca.s   V_4
       IL_0069:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
       IL_006e:  nop
-      IL_006f:  leave      IL_01dd
+      IL_006f:  leave      IL_01e0
      >IL_0074:  ldarg.0
       IL_0075:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
       IL_007a:  stloc.2
@@ -666,108 +667,108 @@ class Test
     IL_00de:  stfld      ""int Test.<G>d__1.<>s__6""
     IL_00e3:  call       ""System.Threading.Tasks.Task<int> Test.F()""
     IL_00e8:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00ed:  stloc.2
-    IL_00ee:  ldloca.s   V_2
-    IL_00f0:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_00f5:  brtrue.s   IL_013b
-    IL_00f7:  ldarg.0
-    IL_00f8:  ldc.i4.1
-    IL_00f9:  dup
-    IL_00fa:  stloc.0
-    IL_00fb:  stfld      ""int Test.<G>d__1.<>1__state""
-   <IL_0100:  ldarg.0
-    IL_0101:  ldloc.2
-    IL_0102:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0107:  ldarg.0
-    IL_0108:  stloc.s    V_4
-    IL_010a:  ldarg.0
-    IL_010b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_0110:  ldloca.s   V_2
-    IL_0112:  ldloca.s   V_4
-    IL_0114:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-    IL_0119:  nop
-    IL_011a:  leave      IL_01dd
-   >IL_011f:  ldarg.0
-    IL_0120:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0125:  stloc.2
-    IL_0126:  ldarg.0
-    IL_0127:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_012c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0132:  ldarg.0
-    IL_0133:  ldc.i4.m1
-    IL_0134:  dup
-    IL_0135:  stloc.0
-    IL_0136:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_013b:  ldloca.s   V_2
-    IL_013d:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0142:  stloc.3
-    IL_0143:  ldloca.s   V_2
-    IL_0145:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_014b:  ldarg.0
-    IL_014c:  ldloc.3
-    IL_014d:  stfld      ""int Test.<G>d__1.<>s__7""
-    IL_0152:  ldarg.0
-    IL_0153:  ldarg.0
-    IL_0154:  ldfld      ""int Test.<G>d__1.<>s__6""
-    IL_0159:  ldarg.0
-    IL_015a:  ldfld      ""int Test.<G>d__1.<>s__7""
-    IL_015f:  add
-    IL_0160:  stfld      ""int Test.<G>d__1.<x>5__1""
-   -IL_0165:  nop
-   ~IL_0166:  ldarg.0
-    IL_0167:  ldfld      ""object Test.<G>d__1.<>s__2""
-    IL_016c:  stloc.s    V_5
-    IL_016e:  ldloc.s    V_5
-    IL_0170:  brfalse.s  IL_018f
-    IL_0172:  ldloc.s    V_5
-    IL_0174:  isinst     ""System.Exception""
-    IL_0179:  stloc.s    V_6
-    IL_017b:  ldloc.s    V_6
-    IL_017d:  brtrue.s   IL_0182
-    IL_017f:  ldloc.s    V_5
-    IL_0181:  throw
-    IL_0182:  ldloc.s    V_6
-    IL_0184:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0189:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_018e:  nop
-    IL_018f:  ldarg.0
-    IL_0190:  ldfld      ""int Test.<G>d__1.<>s__3""
-    IL_0195:  stloc.3
-    IL_0196:  ldloc.3
-    IL_0197:  ldc.i4.1
-    IL_0198:  beq.s      IL_019c
-    IL_019a:  br.s       IL_01a5
-    IL_019c:  ldarg.0
-    IL_019d:  ldfld      ""int Test.<G>d__1.<>s__4""
-    IL_01a2:  stloc.1
-    IL_01a3:  leave.s    IL_01c8
-    IL_01a5:  ldarg.0
-    IL_01a6:  ldnull
-    IL_01a7:  stfld      ""object Test.<G>d__1.<>s__2""
-    IL_01ac:  leave.s    IL_01c8
+    IL_00ed:  stloc.s    V_6
+   ~IL_00ef:  ldloca.s   V_6
+    IL_00f1:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00f6:  brtrue.s   IL_013e
+    IL_00f8:  ldarg.0
+    IL_00f9:  ldc.i4.1
+    IL_00fa:  dup
+    IL_00fb:  stloc.0
+    IL_00fc:  stfld      ""int Test.<G>d__1.<>1__state""
+   <IL_0101:  ldarg.0
+    IL_0102:  ldloc.s    V_6
+    IL_0104:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_0109:  ldarg.0
+    IL_010a:  stloc.s    V_4
+    IL_010c:  ldarg.0
+    IL_010d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_0112:  ldloca.s   V_6
+    IL_0114:  ldloca.s   V_4
+    IL_0116:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
+    IL_011b:  nop
+    IL_011c:  leave      IL_01e0
+   >IL_0121:  ldarg.0
+    IL_0122:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_0127:  stloc.s    V_6
+    IL_0129:  ldarg.0
+    IL_012a:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_012f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0135:  ldarg.0
+    IL_0136:  ldc.i4.m1
+    IL_0137:  dup
+    IL_0138:  stloc.0
+    IL_0139:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_013e:  ldloca.s   V_6
+    IL_0140:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0145:  stloc.3
+    IL_0146:  ldloca.s   V_6
+    IL_0148:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_014e:  ldarg.0
+    IL_014f:  ldloc.3
+    IL_0150:  stfld      ""int Test.<G>d__1.<>s__7""
+    IL_0155:  ldarg.0
+    IL_0156:  ldarg.0
+    IL_0157:  ldfld      ""int Test.<G>d__1.<>s__6""
+    IL_015c:  ldarg.0
+    IL_015d:  ldfld      ""int Test.<G>d__1.<>s__7""
+    IL_0162:  add
+    IL_0163:  stfld      ""int Test.<G>d__1.<x>5__1""
+   -IL_0168:  nop
+   ~IL_0169:  ldarg.0
+    IL_016a:  ldfld      ""object Test.<G>d__1.<>s__2""
+    IL_016f:  stloc.s    V_5
+    IL_0171:  ldloc.s    V_5
+    IL_0173:  brfalse.s  IL_0192
+    IL_0175:  ldloc.s    V_5
+    IL_0177:  isinst     ""System.Exception""
+    IL_017c:  stloc.s    V_7
+    IL_017e:  ldloc.s    V_7
+    IL_0180:  brtrue.s   IL_0185
+    IL_0182:  ldloc.s    V_5
+    IL_0184:  throw
+    IL_0185:  ldloc.s    V_7
+    IL_0187:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_018c:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0191:  nop
+    IL_0192:  ldarg.0
+    IL_0193:  ldfld      ""int Test.<G>d__1.<>s__3""
+    IL_0198:  stloc.3
+    IL_0199:  ldloc.3
+    IL_019a:  ldc.i4.1
+    IL_019b:  beq.s      IL_019f
+    IL_019d:  br.s       IL_01a8
+    IL_019f:  ldarg.0
+    IL_01a0:  ldfld      ""int Test.<G>d__1.<>s__4""
+    IL_01a5:  stloc.1
+    IL_01a6:  leave.s    IL_01cb
+    IL_01a8:  ldarg.0
+    IL_01a9:  ldnull
+    IL_01aa:  stfld      ""object Test.<G>d__1.<>s__2""
+    IL_01af:  leave.s    IL_01cb
   }
   catch System.Exception
   {
-   ~IL_01ae:  stloc.s    V_6
-    IL_01b0:  ldarg.0
-    IL_01b1:  ldc.i4.s   -2
-    IL_01b3:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_01b8:  ldarg.0
-    IL_01b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_01be:  ldloc.s    V_6
-    IL_01c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_01c5:  nop
-    IL_01c6:  leave.s    IL_01dd
+   ~IL_01b1:  stloc.s    V_7
+    IL_01b3:  ldarg.0
+    IL_01b4:  ldc.i4.s   -2
+    IL_01b6:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_01bb:  ldarg.0
+    IL_01bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_01c1:  ldloc.s    V_7
+    IL_01c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_01c8:  nop
+    IL_01c9:  leave.s    IL_01e0
   }
- -IL_01c8:  ldarg.0
-  IL_01c9:  ldc.i4.s   -2
-  IL_01cb:  stfld      ""int Test.<G>d__1.<>1__state""
- ~IL_01d0:  ldarg.0
-  IL_01d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_01d6:  ldloc.1
-  IL_01d7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_01dc:  nop
-  IL_01dd:  ret
+ -IL_01cb:  ldarg.0
+  IL_01cc:  ldc.i4.s   -2
+  IL_01ce:  stfld      ""int Test.<G>d__1.<>1__state""
+ ~IL_01d3:  ldarg.0
+  IL_01d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_01d9:  ldloc.1
+  IL_01da:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_01df:  nop
+  IL_01e0:  ret
 }", sequencePoints: "Test+<G>d__1.MoveNext");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -654,7 +654,7 @@ public class Test
     IL_0056:  call       ""System.Threading.Tasks.Task<int> Test.G()""
     IL_005b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_0060:  stloc.s    V_5
-    IL_0062:  ldloca.s   V_5
+   ~IL_0062:  ldloca.s   V_5
     IL_0064:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0069:  brtrue.s   IL_00b1
     IL_006b:  ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -2260,7 +2260,7 @@ class Test
     IL_0033:  callvirt   ""System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)""
     IL_0038:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_003d:  stloc.2
-    IL_003e:  ldloca.s   V_2
+   ~IL_003e:  ldloca.s   V_2
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -3214,7 +3214,7 @@ class Test
     IL_0035:  call       ""System.Threading.Tasks.Task<int> Test.G()""
     IL_003a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_003f:  stloc.3
-    IL_0040:  ldloca.s   V_3
+   ~IL_0040:  ldloca.s   V_3
     IL_0042:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0047:  brtrue.s   IL_008a
     IL_0049:  ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -1008,7 +1008,7 @@ class C
     IL_0010:  call       ""System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)""
     IL_0015:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_001a:  stloc.2
-    IL_001b:  ldloca.s   V_2
+   ~IL_001b:  ldloca.s   V_2
     IL_001d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0022:  brtrue.s   IL_0064
     IL_0024:  ldarg.0
@@ -1072,6 +1072,46 @@ class C
   IL_00a7:  ret
 }
 ", sequencePoints: "C+<F>d__0.MoveNext");
+
+                    v0.VerifyPdb("C+<F>d__0.MoveNext", @"
+<symbols>
+  <methods>
+    <method containingType=""C+&lt;F&gt;d__0"" name=""MoveNext"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""1"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""27"" offset=""0"" />
+          <slot kind=""20"" offset=""0"" />
+          <slot kind=""33"" offset=""11"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""0"" />
+        <entry offset=""0x7"" hidden=""true"" document=""0"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" document=""0"" />
+        <entry offset=""0x1b"" hidden=""true"" document=""0"" />
+        <entry offset=""0x74"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""0"" />
+        <entry offset=""0x78"" hidden=""true"" document=""0"" />
+        <entry offset=""0x92"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x9a"" hidden=""true"" document=""0"" />
+      </sequencePoints>
+      <locals />
+      <scope startOffset=""0x0"" endOffset=""0xa8"">
+        <namespace name=""System.Threading.Tasks"" />
+      </scope>
+      <asyncInfo>
+        <kickoffMethod declaringType=""C"" methodName=""F"" />
+        <await yield=""0x2d"" resume=""0x48"" declaringType=""C+&lt;F&gt;d__0"" methodName=""MoveNext"" />
+      </asyncInfo>
+    </method>
+  </methods>
+</symbols>
+");
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2978,7 +2978,7 @@ class C
     IL_0066:  callvirt   ""System.Threading.Tasks.Task<int> C.F()""
     IL_006b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_0070:  stloc.2
-    IL_0071:  ldloca.s   V_2
+   ~IL_0071:  ldloca.s   V_2
     IL_0073:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0078:  brtrue.s   IL_00ba
     IL_007a:  ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -445,7 +445,7 @@ namespace ConsoleApplication1
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""15"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -455,6 +455,7 @@ namespace ConsoleApplication1
         <entry offset=""0x7"" hidden=""true"" document=""0"" />
         <entry offset=""0xe"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
         <entry offset=""0xf"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" document=""0"" />
+        <entry offset=""0x20"" hidden=""true"" document=""0"" />
         <entry offset=""0x7b"" hidden=""true"" document=""0"" />
         <entry offset=""0x93"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""0"" />
         <entry offset=""0x9b"" hidden=""true"" document=""0"" />
@@ -479,7 +480,7 @@ namespace ConsoleApplication1
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
           <slot kind=""20"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""141"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
@@ -496,6 +497,7 @@ namespace ConsoleApplication1
         <entry offset=""0x41"" startLine=""22"" startColumn=""22"" endLine=""22"" endColumn=""27"" document=""0"" />
         <entry offset=""0x54"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" document=""0"" />
         <entry offset=""0x55"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" document=""0"" />
+        <entry offset=""0x6b"" hidden=""true"" document=""0"" />
         <entry offset=""0xdb"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" document=""0"" />
         <entry offset=""0xed"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""0"" />
         <entry offset=""0xee"" hidden=""true"" document=""0"" />
@@ -628,6 +630,7 @@ class C
         <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
         <entry offset=""0x25"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
         <entry offset=""0x36"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x55"" hidden=""true"" document=""0"" />
         <entry offset=""0xab"" hidden=""true"" document=""0"" />
         <entry offset=""0xc2"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
         <entry offset=""0xca"" hidden=""true"" document=""0"" />
@@ -718,7 +721,7 @@ class C
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""129"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -733,6 +736,7 @@ class C
         <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
         <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
         <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x86"" hidden=""true"" document=""0"" />
         <entry offset=""0xe1"" hidden=""true"" document=""0"" />
         <entry offset=""0xf9"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
         <entry offset=""0x101"" hidden=""true"" document=""0"" />
@@ -825,6 +829,7 @@ class C
         <entry offset=""0x2d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
         <entry offset=""0x39"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
         <entry offset=""0x4f"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""0"" />
         <entry offset=""0xaf"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""0"" />
         <entry offset=""0xc1"" hidden=""true"" document=""0"" />
         <entry offset=""0xd8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
@@ -908,7 +913,7 @@ class C
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""129"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -923,6 +928,7 @@ class C
         <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
         <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
         <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x64"" hidden=""true"" document=""0"" />
         <entry offset=""0xbd"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""0"" />
         <entry offset=""0xd0"" hidden=""true"" document=""0"" />
         <entry offset=""0xe8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
@@ -1003,7 +1009,7 @@ class C
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""35"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -1014,6 +1020,7 @@ class C
         <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
         <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x27"" hidden=""true"" document=""0"" />
         <entry offset=""0x83"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""0"" />
         <entry offset=""0xdd"" hidden=""true"" document=""0"" />
         <entry offset=""0xf5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
@@ -1093,6 +1100,7 @@ class C
         <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
         <entry offset=""0x14"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""0"" />
         <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x70"" hidden=""true"" document=""0"" />
         <entry offset=""0xc6"" hidden=""true"" document=""0"" />
         <entry offset=""0xdd"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
         <entry offset=""0xe5"" hidden=""true"" document=""0"" />
@@ -1172,7 +1180,7 @@ class C
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""58"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -1184,6 +1192,7 @@ class C
         <entry offset=""0x12"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
         <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""0"" />
         <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x82"" hidden=""true"" document=""0"" />
         <entry offset=""0xdd"" hidden=""true"" document=""0"" />
         <entry offset=""0xf5"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
         <entry offset=""0xfd"" hidden=""true"" document=""0"" />
@@ -1367,7 +1376,7 @@ class C
    -IL_0034:  call       ""System.Threading.Tasks.Task<int> C.G()""
     IL_0039:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_003e:  stloc.3
-    IL_003f:  ldloca.s   V_3
+   ~IL_003f:  ldloca.s   V_3
     IL_0041:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0046:  brtrue.s   IL_008c
     IL_0048:  ldarg.0
@@ -1476,7 +1485,7 @@ class C
           <slot kind=""27"" offset=""0"" />
           <slot kind=""20"" offset=""0"" />
           <slot kind=""temp"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""105"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
@@ -1494,6 +1503,7 @@ class C
         <entry offset=""0x29"" hidden=""true"" document=""0"" />
         <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
         <entry offset=""0x34"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x3f"" hidden=""true"" document=""0"" />
         <entry offset=""0xb1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""0"" />
         <entry offset=""0xb2"" hidden=""true"" document=""0"" />
         <entry offset=""0xe5"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" document=""0"" />

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -172,6 +172,22 @@ namespace Microsoft.CodeAnalysis
         XmlInExpressionLambda = 32,
 
         /// <summary>
+        /// Local variable that stores the result of an await expression (the awaiter object).
+        /// The variable is assigned the result of a call to await-expression.GetAwaiter() and subsequently used 
+        /// to check whether the task completed. Eventually the value is stored in an awaiter field.
+        /// 
+        /// The value assigned to the variable needs to be preserved when remapping the IL offset from old method body 
+        /// to new method body during EnC. If the awaiter expression is contained in an active statement and the 
+        /// containing MoveNext method changes the debugger finds the next sequence point that follows the await expression 
+        /// and transfers the execution to the new method version. This sequenec point is placed by the compiler at 
+        /// the immediately after the stloc instruction that stores the awaiter object to this variable.
+        /// The subsequent ldloc then restores it in the new method version.
+        /// 
+        /// (VB, C#).
+        /// </summary>
+        Awaiter = 33,
+
+        /// <summary>
         /// All values have to be less than or equal to <see cref="MaxValidValueForLocalVariableSerializedToDebugInformation"/> 
         /// (<see cref="EditAndContinueMethodDebugInformation"/>)
         /// </summary>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1502,21 +1502,22 @@ End Module
   // Code size      514 (0x202)
   .maxstack  8
   .locals init (Integer V_0,
-  Object V_1,
+                Object V_1,
                 Boolean V_2,
                 System.Runtime.CompilerServices.ICriticalNotifyCompletion V_3,
                 System.Runtime.CompilerServices.INotifyCompletion V_4,
                 Program.VB$StateMachine_0_Test2 V_5,
                 Object V_6,
-                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_7,
-                System.Runtime.CompilerServices.INotifyCompletion V_8,
-                System.Exception V_9)
-  IL_0000:  ldarg.0
+                Object V_7,
+                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_8,
+                System.Runtime.CompilerServices.INotifyCompletion V_9,
+                System.Exception V_10)
+ ~IL_0000:  ldarg.0
   IL_0001:  ldfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
   IL_0006:  stloc.0
   .try
-{
-  IL_0007:  ldloc.0
+  {
+   ~IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
@@ -1527,14 +1528,14 @@ End Module
     IL_0013:  br         IL_00bd
     IL_0018:  nop
     IL_0019:  br         IL_0191
-    IL_001e:  nop
-  IL_001f:  ldarg.0
+   -IL_001e:  nop
+   -IL_001f:  ldarg.0
     IL_0020:  newobj     "Sub MyTask(Of Integer)..ctor()"
     IL_0025:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-    IL_002a:  nop
+   -IL_002a:  nop
     IL_002b:  ldarg.0
     IL_002c:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-  IL_0031:  ldnull
+    IL_0031:  ldnull
     IL_0032:  ldstr      "GetAwaiter"
     IL_0037:  ldc.i4.0
     IL_0038:  newarr     "Object"
@@ -1543,8 +1544,8 @@ End Module
     IL_003f:  ldnull
     IL_0040:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
     IL_0045:  stloc.1
-    IL_0046:  ldloc.1
-  IL_0047:  ldnull
+   ~IL_0046:  ldloc.1
+    IL_0047:  ldnull
     IL_0048:  ldstr      "IsCompleted"
     IL_004d:  ldc.i4.0
     IL_004e:  newarr     "Object"
@@ -1564,7 +1565,7 @@ End Module
     IL_006b:  dup
     IL_006c:  stloc.0
     IL_006d:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_0072:  ldarg.0
+   <IL_0072:  ldarg.0
     IL_0073:  ldloc.1
     IL_0074:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
     IL_0079:  ldloc.1
@@ -1591,13 +1592,13 @@ End Module
     IL_00a5:  ldarg.0
     IL_00a6:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
     IL_00ab:  ldloca.s   V_4
-  IL_00ad:  ldarg.0
+    IL_00ad:  ldarg.0
     IL_00ae:  stloc.s    V_5
     IL_00b0:  ldloca.s   V_5
     IL_00b2:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
     IL_00b7:  nop
     IL_00b8:  leave      IL_0201
-    IL_00bd:  ldarg.0
+   >IL_00bd:  ldarg.0
     IL_00be:  ldc.i4.m1
     IL_00bf:  dup
     IL_00c0:  stloc.0
@@ -1615,8 +1616,8 @@ End Module
     IL_00dc:  ldc.i4.0
     IL_00dd:  newarr     "Object"
     IL_00e2:  ldnull
-  IL_00e3:  ldnull
-  IL_00e4:  ldnull
+    IL_00e3:  ldnull
+    IL_00e4:  ldnull
     IL_00e5:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
     IL_00ea:  stloc.s    V_6
     IL_00ec:  ldnull
@@ -1624,7 +1625,7 @@ End Module
     IL_00ee:  ldloc.s    V_6
     IL_00f0:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
     IL_00f5:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Object"
-    IL_00fa:  nop
+   -IL_00fa:  nop
     IL_00fb:  ldarg.0
     IL_00fc:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
     IL_0101:  ldnull
@@ -1635,8 +1636,8 @@ End Module
     IL_010e:  ldnull
     IL_010f:  ldnull
     IL_0110:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0115:  stloc.s    V_6
-    IL_0117:  ldloc.s    V_6
+    IL_0115:  stloc.s    V_7
+   ~IL_0117:  ldloc.s    V_7
     IL_0119:  ldnull
     IL_011a:  ldstr      "IsCompleted"
     IL_011f:  ldc.i4.0
@@ -1657,13 +1658,13 @@ End Module
     IL_013d:  dup
     IL_013e:  stloc.0
     IL_013f:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-  IL_0144:  ldarg.0
-    IL_0145:  ldloc.s    V_6
+   <IL_0144:  ldarg.0
+    IL_0145:  ldloc.s    V_7
     IL_0147:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_014c:  ldloc.s    V_6
+    IL_014c:  ldloc.s    V_7
     IL_014e:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
-    IL_0153:  stloc.s    V_7
-    IL_0155:  ldloc.s    V_7
+    IL_0153:  stloc.s    V_8
+    IL_0155:  ldloc.s    V_8
     IL_0157:  ldnull
     IL_0158:  ceq
     IL_015a:  stloc.2
@@ -1671,37 +1672,37 @@ End Module
     IL_015c:  brtrue.s   IL_0173
     IL_015e:  ldarg.0
     IL_015f:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_0164:  ldloca.s   V_7
+    IL_0164:  ldloca.s   V_8
     IL_0166:  ldarg.0
     IL_0167:  stloc.s    V_5
     IL_0169:  ldloca.s   V_5
     IL_016b:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
     IL_0170:  nop
     IL_0171:  br.s       IL_018f
-    IL_0173:  ldloc.s    V_6
+    IL_0173:  ldloc.s    V_7
     IL_0175:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
-    IL_017a:  stloc.s    V_8
+    IL_017a:  stloc.s    V_9
     IL_017c:  ldarg.0
     IL_017d:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_0182:  ldloca.s   V_8
+    IL_0182:  ldloca.s   V_9
     IL_0184:  ldarg.0
     IL_0185:  stloc.s    V_5
     IL_0187:  ldloca.s   V_5
     IL_0189:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
     IL_018e:  nop
     IL_018f:  leave.s    IL_0201
-    IL_0191:  ldarg.0
+   >IL_0191:  ldarg.0
     IL_0192:  ldc.i4.m1
     IL_0193:  dup
     IL_0194:  stloc.0
     IL_0195:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
     IL_019a:  ldarg.0
     IL_019b:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_01a0:  stloc.s    V_6
+    IL_01a0:  stloc.s    V_7
     IL_01a2:  ldarg.0
     IL_01a3:  ldnull
     IL_01a4:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_01a9:  ldloc.s    V_6
+    IL_01a9:  ldloc.s    V_7
     IL_01ab:  ldnull
     IL_01ac:  ldstr      "GetResult"
     IL_01b1:  ldc.i4.0
@@ -1713,37 +1714,38 @@ End Module
     IL_01bb:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object, System.Type, String, Object(), String(), System.Type(), Boolean(), Boolean) As Object"
     IL_01c0:  pop
     IL_01c1:  ldnull
-    IL_01c2:  stloc.s    V_6
-    IL_01c4:  leave.s    IL_01eb
-}
+    IL_01c2:  stloc.s    V_7
+   -IL_01c4:  leave.s    IL_01eb
+  }
   catch System.Exception
-{
-    IL_01c6:  dup
+  {
+  ~$IL_01c6:  dup
     IL_01c7:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_01cc:  stloc.s    V_9
-    IL_01ce:  ldarg.0
+    IL_01cc:  stloc.s    V_10
+   ~IL_01ce:  ldarg.0
     IL_01cf:  ldc.i4.s   -2
     IL_01d1:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
     IL_01d6:  ldarg.0
     IL_01d7:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_01dc:  ldloc.s    V_9
+    IL_01dc:  ldloc.s    V_10
     IL_01de:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
     IL_01e3:  nop
     IL_01e4:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
     IL_01e9:  leave.s    IL_0201
-}
-  IL_01eb:  ldarg.0
+  }
+ -IL_01eb:  ldarg.0
   IL_01ec:  ldc.i4.s   -2
   IL_01ee:  dup
   IL_01ef:  stloc.0
   IL_01f0:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-  IL_01f5:  ldarg.0
+ ~IL_01f5:  ldarg.0
   IL_01f6:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
   IL_01fb:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
   IL_0200:  nop
   IL_0201:  ret
 }
-]]>)
+]]>,
+            sequencePoints:="Program+VB$StateMachine_0_Test2.MoveNext")
         End Sub
 
         <Fact, WorkItem(1002672)>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinueStateMachineTests.vb
@@ -669,6 +669,7 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0xf" startLine="3" startColumn="5" endLine="3" endColumn="43" document="1"/>
                 <entry offset="0x10" startLine="4" startColumn="9" endLine="4" endColumn="33" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
                 <entry offset="0x7d" startLine="5" startColumn="9" endLine="5" endColumn="17" document="1"/>
                 <entry offset="0x81" hidden="true" document="1"/>
                 <entry offset="0x89" hidden="true" document="1"/>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/LocalSlotMappingTests.vb
@@ -993,7 +993,7 @@ End Class
           <slot kind=""27"" offset=""-1"" />
           <slot kind=""0"" offset=""-1"" />
           <slot kind=""temp"" />
-          <slot kind=""temp"" />
+          <slot kind=""33"" offset=""38"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -1008,6 +1008,7 @@ End Class
         <entry offset=""0x2f"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
         <entry offset=""0x4b"" hidden=""true"" document=""1"" />
         <entry offset=""0x4c"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
         <entry offset=""0xbb"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""17"" document=""1"" />
         <entry offset=""0xbf"" hidden=""true"" document=""1"" />
         <entry offset=""0xc7"" hidden=""true"" document=""1"" />

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -68,7 +68,7 @@ End Module
                     <slot kind="20" offset="-1"/>
                     <slot kind="27" offset="-1"/>
                     <slot kind="0" offset="-1"/>
-                    <slot kind="temp"/>
+                    <slot kind="33" offset="0"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
@@ -80,6 +80,7 @@ End Module
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0xf" startLine="11" startColumn="5" endLine="11" endColumn="68" document="0"/>
                 <entry offset="0x10" startLine="12" startColumn="9" endLine="12" endColumn="25" document="0"/>
+                <entry offset="0x20" hidden="true" document="0"/>
                 <entry offset="0x7f" startLine="13" startColumn="9" endLine="13" endColumn="17" document="0"/>
                 <entry offset="0x83" hidden="true" document="0"/>
                 <entry offset="0x8b" hidden="true" document="0"/>
@@ -118,18 +119,18 @@ End Module
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="27" offset="-1"/>
+                    <slot kind="33" offset="0"/>
+                    <slot kind="33" offset="8"/>
+                    <slot kind="33" offset="125"/>
+                    <slot kind="33" offset="38"/>
+                    <slot kind="33" offset="94"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
+                    <slot kind="33" offset="155"/>
+                    <slot kind="33" offset="205"/>
+                    <slot kind="33" offset="163"/>
+                    <slot kind="33" offset="171"/>
                     <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
@@ -140,12 +141,21 @@ End Module
                 <entry offset="0x67" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
                 <entry offset="0x68" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
                 <entry offset="0x69" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
+                <entry offset="0x7c" hidden="true" document="0"/>
                 <entry offset="0xea" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
+                <entry offset="0x102" hidden="true" document="0"/>
+                <entry offset="0x18b" hidden="true" document="0"/>
                 <entry offset="0x1f7" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
                 <entry offset="0x1f8" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
                 <entry offset="0x1f9" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
                 <entry offset="0x1fa" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
+                <entry offset="0x20d" hidden="true" document="0"/>
+                <entry offset="0x28a" hidden="true" document="0"/>
+                <entry offset="0x307" hidden="true" document="0"/>
                 <entry offset="0x375" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
+                <entry offset="0x38d" hidden="true" document="0"/>
+                <entry offset="0x412" hidden="true" document="0"/>
+                <entry offset="0x495" hidden="true" document="0"/>
                 <entry offset="0x4f5" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
                 <entry offset="0x4f7" hidden="true" document="0"/>
                 <entry offset="0x4ff" hidden="true" document="0"/>
@@ -192,7 +202,7 @@ End Module
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="27" offset="-1"/>
-                    <slot kind="temp"/>
+                    <slot kind="33" offset="0"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
@@ -204,6 +214,7 @@ End Module
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0xf" startLine="26" startColumn="5" endLine="26" endColumn="18" document="0"/>
                 <entry offset="0x10" startLine="27" startColumn="9" endLine="27" endColumn="25" document="0"/>
+                <entry offset="0x1f" hidden="true" document="0"/>
                 <entry offset="0x7c" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
                 <entry offset="0x7e" hidden="true" document="0"/>
                 <entry offset="0x86" hidden="true" document="0"/>
@@ -260,7 +271,7 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="27" offset="-1"/>
-                    <slot kind="temp"/>
+                    <slot kind="33" offset="118"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
@@ -276,6 +287,7 @@ End Class
                 <entry offset="0x2a" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x36" startLine="9" startColumn="13" endLine="9" endColumn="53" document="0"/>
                 <entry offset="0x4d" startLine="11" startColumn="9" endLine="11" endColumn="55" document="0"/>
+                <entry offset="0x7d" hidden="true" document="0"/>
                 <entry offset="0xdd" startLine="12" startColumn="9" endLine="12" endColumn="21" document="0"/>
                 <entry offset="0xee" startLine="13" startColumn="9" endLine="13" endColumn="21" document="0"/>
                 <entry offset="0xff" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
@@ -344,6 +356,7 @@ End Class
                 <entry offset="0x15" startLine="6" startColumn="13" endLine="6" endColumn="29" document="0"/>
                 <entry offset="0x21" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="55" document="0"/>
+                <entry offset="0x5c" hidden="true" document="0"/>
                 <entry offset="0xb3" startLine="12" startColumn="9" endLine="12" endColumn="21" document="0"/>
                 <entry offset="0xc4" startLine="13" startColumn="9" endLine="13" endColumn="21" document="0"/>
                 <entry offset="0xd5" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
@@ -404,7 +417,7 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="27" offset="-1"/>
-                    <slot kind="temp"/>
+                    <slot kind="33" offset="62"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
                     <slot kind="temp"/>
@@ -418,6 +431,7 @@ End Class
                 <entry offset="0x10" startLine="6" startColumn="13" endLine="6" endColumn="29" document="0"/>
                 <entry offset="0x17" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x1e" startLine="9" startColumn="9" endLine="9" endColumn="55" document="0"/>
+                <entry offset="0x44" hidden="true" document="0"/>
                 <entry offset="0xa4" startLine="10" startColumn="9" endLine="10" endColumn="21" document="0"/>
                 <entry offset="0xb0" startLine="11" startColumn="9" endLine="11" endColumn="21" document="0"/>
                 <entry offset="0xbc" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
@@ -485,6 +499,7 @@ End Class
                 <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="29" document="0"/>
                 <entry offset="0x11" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x18" startLine="9" startColumn="9" endLine="9" endColumn="55" document="0"/>
+                <entry offset="0x3d" hidden="true" document="0"/>
                 <entry offset="0x91" startLine="10" startColumn="9" endLine="10" endColumn="21" document="0"/>
                 <entry offset="0x9d" startLine="11" startColumn="9" endLine="11" endColumn="21" document="0"/>
                 <entry offset="0xa9" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -203,7 +203,8 @@ class C
                 System.Runtime.CompilerServices.TaskAwaiter V_1,
                 C.<M>d__0 V_2,
                 int V_3,
-                System.Exception V_4)
+                System.Runtime.CompilerServices.TaskAwaiter V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__0.{0}""
   IL_0006:  ret

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1395,7 +1395,8 @@ class C
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
                 object V_2,
                 C.<M>d__1 V_3,
-                System.Exception V_4)
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.x""
   IL_0006:  ret
@@ -1408,7 +1409,8 @@ class C
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
                 object V_2,
                 C.<M>d__1 V_3,
-                System.Exception V_4)
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.<y>5__1""
   IL_0006:  ret


### PR DESCRIPTION
Fixes internal bug 1120376: Unexpected method re-evaluation.

The debugger needs a hidden breakpoint following each await expression in order to perform remapping correctly.

We also need to preserve the value of a local variable that stores the result of an await expression (the awaiter object) during remapping, hence this temp must be long-lived.

The variable is assigned the result of a call to await-expression.GetAwaiter() and subsequently used 
to check whether the task completed. Eventually the value is stored in an awaiter field.

The value assigned to the variable needs to be preserved when remapping the IL offset from old method body to new method body during EnC. If the awaiter expression is contained in an active statement and the containing MoveNext method changes the debugger finds the next sequence point that follows the await expression and transfers the execution to the new method version. This sequenec point is placed by the compiler at the immediately after the stloc instruction that stores the awaiter object to this variable. The subsequent ldloc then restores it in the new method version.

