### PR TITLE
make persistent service not to support project k for now.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -72,6 +72,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
                 this.Folders = project.GetFolderNames(itemId);
 
+                // TODO: 
+                // this one doesn't work for asynchronous project load situation where shared projects is loaded after one uses shared file. 
+                // we need to figure out what to do on those case. but this works for project k case.
+                // opened an issue to track this issue - https://github.com/dotnet/roslyn/issues/1859
                 this.SharedHierarchy = project.Hierarchy == null ? null : LinkedFileUtilities.GetSharedHierarchyForItem(project.Hierarchy, itemId);
                 _documentProvider = documentProvider;
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/LinkedFileUtilities.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/LinkedFileUtilities.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -70,9 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return null;
             }
 
-            var sharedHierarchy = document.SharedHierarchy;
-            Contract.Requires(GetSharedHierarchyForItem(document.Project.Hierarchy, itemId) == sharedHierarchy);
-
+            var sharedHierarchy = GetSharedHierarchyForItem(document.Project.Hierarchy, itemId);
             if (sharedHierarchy == null)
             {
                 return null;
@@ -193,6 +192,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             itemIdInSharedHierarchy = (uint)VSConstants.VSITEMID.Nil;
             return false;
+        }
+
+        /// <summary>
+        /// Check whether given project is project k project.
+        /// </summary>
+        public static bool IsProjectKProject(Project project)
+        {
+            // TODO: we need better way to see whether a project is project k project or not.
+            if (project.FilePath == null)
+            {
+                return false;
+            }
+
+            return project.FilePath.EndsWith(".xproj", StringComparison.InvariantCultureIgnoreCase) ||
+                   project.FilePath.EndsWith(".kproj", StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -807,9 +807,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             var hierarchy = hostDocument.Project.Hierarchy;
-            var sharedHierarchy = hostDocument.SharedHierarchy;
-            Contract.Requires(LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId) == sharedHierarchy);
-
+            var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId);
             if (sharedHierarchy != null)
             {
                 if (sharedHierarchy.SetProperty(
@@ -897,9 +895,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             // If this is a regular document or a closed linked (non-shared) document, then use the
             // default logic for determining current context.
-            var sharedHierarchy = hostDocument.SharedHierarchy;
-            Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId));
-
+            var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId);
             if (sharedHierarchy == null)
             {
                 return base.GetDocumentIdInCurrentContext(documentId);
@@ -1101,8 +1097,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                var sharedHierarchy = hostDocument.SharedHierarchy;
-                Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId));
+                var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hierarchy, itemId);
                 if (sharedHierarchy != null)
                 {
                     uint cookie;
@@ -1126,9 +1121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                var sharedHierarchy = hostDocument.SharedHierarchy;
-                Contract.Requires(sharedHierarchy == LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId));
-
+                var sharedHierarchy = LinkedFileUtilities.GetSharedHierarchyForItem(hostDocument.Project.Hierarchy, itemId);
                 if (sharedHierarchy != null)
                 {
                     uint cookie;

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentPersistentStorage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentPersistentStorage.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.Isam.Esent;
 using Microsoft.Isam.Esent.Interop;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
@@ -102,6 +103,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
             Contract.ThrowIfTrue(string.IsNullOrWhiteSpace(name));
 
             if (!PersistenceEnabled)
+            {
+                return SpecializedTasks.Default<Stream>();
+            }
+
+            if (!IsSupported(project))
             {
                 return SpecializedTasks.Default<Stream>();
             }
@@ -210,6 +216,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
                 return SpecializedTasks.False;
             }
 
+            if (!IsSupported(project))
+            {
+                return SpecializedTasks.False;
+            }
+
             int projectId;
             int nameId;
             if (!TryGetUniqueFileId(project.FilePath, out projectId) ||
@@ -266,6 +277,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
         public override void Close()
         {
             _esentStorage.Close();
+        }
+
+        private bool IsSupported(Project project)
+        {
+            // TODO: figure out a proper way to support project K scenario where we can't use path as a unique key
+            // https://github.com/dotnet/roslyn/issues/1860
+            return !LinkedFileUtilities.IsProjectKProject(project);
         }
 
         private bool TryGetUniqueNameId(string name, out int id)
@@ -351,6 +369,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
         {
             projectId = default(int);
             documentId = default(int);
+
+            if (!IsSupported(document.Project))
+            {
+                return false;
+            }
 
             return TryGetUniqueFileId(document.Project.FilePath, out projectId) && TryGetUniqueFileId(document.FilePath, out documentId);
         }


### PR DESCRIPTION
also change to use cached IVsHierarchy only for error list filtering due to issue with caching it on shared projects