### PR TITLE
Compiler/VisualBasic/Portable/Errors Cleaning

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Errors/CustomDiagnostics.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/CustomDiagnostics.vb
@@ -90,9 +90,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Get
                 Dim builder = ArrayBuilder(Of Location).GetInstance()
                 For Each sym In _symbols
-                    For Each l In sym.Locations
-                        builder.Add(l)
-                    Next
+                    builder.AddRange(sym.Locations)
                 Next
 
                 Return builder.ToImmutableAndFree()

--- a/src/Compilers/VisualBasic/Portable/Errors/DiagnosticBagExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/DiagnosticBagExtensions.vb
@@ -53,38 +53,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Appends diagnostics from useSiteDiagnostics into diagnostics and returns True if there were any errors.
         ''' </summary>
         <System.Runtime.CompilerServices.Extension()>
-        Friend Function Add(
-            diagnostics As DiagnosticBag,
-            node As VisualBasicSyntaxNode,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
-        ) As Boolean
+        Friend Function Add( diagnostics As DiagnosticBag,
+                             node As VisualBasicSyntaxNode,
+                             useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                           ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.GetLocation, useSiteDiagnostics)
         End Function
 
         <System.Runtime.CompilerServices.Extension()>
-        Friend Function Add(
-            diagnostics As DiagnosticBag,
-            node As BoundNode,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
-        ) As Boolean
+        Friend Function Add( diagnostics As DiagnosticBag,
+                             node As BoundNode,
+                             useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                           ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.Syntax.GetLocation, useSiteDiagnostics)
         End Function
 
         <System.Runtime.CompilerServices.Extension()>
-        Friend Function Add(
-            diagnostics As DiagnosticBag,
-            node As SyntaxNodeOrToken,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
-        ) As Boolean
+        Friend Function Add( diagnostics As DiagnosticBag,
+                             node As SyntaxNodeOrToken,
+                             useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                           ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.GetLocation, useSiteDiagnostics)
         End Function
 
         <System.Runtime.CompilerServices.Extension()>
-        Friend Function Add(
-            diagnostics As DiagnosticBag,
-            location As Location,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
-        ) As Boolean
+        Friend Function Add( diagnostics As DiagnosticBag,
+                             location As Location,
+                             useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                           ) As Boolean
 
             If useSiteDiagnostics.IsNullOrEmpty Then
                 Return False

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -102,14 +102,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' cases where we actually want fully qualified name
-            If errorCode = ERRID.ERR_AmbiguousAcrossInterfaces3 OrElse
-               errorCode = ERRID.ERR_TypeConflict6 OrElse
-               errorCode = ERRID.ERR_ExportedTypesConflict OrElse
-               errorCode = ERRID.ERR_ForwardedTypeConflictsWithDeclaration OrElse
-               errorCode = ERRID.ERR_ForwardedTypeConflictsWithExportedType OrElse
-               errorCode = ERRID.ERR_ForwardedTypesConflict Then
+            Select Case errorCode
+                Case ERRID.ERR_AmbiguousAcrossInterfaces3,
+                     ERRID.ERR_TypeConflict6,
+                     ERRID.ERR_ExportedTypesConflict,
+                     ERRID.ERR_ForwardedTypeConflictsWithDeclaration,
+                     ERRID.ERR_ForwardedTypeConflictsWithExportedType,
+                     ERRID.ERR_ForwardedTypesConflict
                 Return symbol.ToString()
-            End If
+            End Select
+
 
             ' show fully qualified name for missing special types
             If errorCode = ERRID.ERR_UnreferencedAssembly3 AndAlso
@@ -328,17 +330,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Public Overrides Sub ReportDuplicateMetadataReferenceStrong(diagnostics As DiagnosticBag, location As Location, reference As MetadataReference, identity As AssemblyIdentity, equivalentReference As MetadataReference, equivalentIdentity As AssemblyIdentity)
-            diagnostics.Add(ERRID.ERR_DuplicateReferenceStrong,
-                            DirectCast(location, Location),
-                            If(reference.Display, identity.GetDisplayName()),
-                            If(equivalentReference.Display, equivalentIdentity.GetDisplayName()))
+            diagnostics.Add(ERRID.ERR_DuplicateReferenceStrong, location,
+                            If(reference.Display, identity.GetDisplayName),
+                            If(equivalentReference.Display, equivalentIdentity.GetDisplayName))
         End Sub
 
         Public Overrides Sub ReportDuplicateMetadataReferenceWeak(diagnostics As DiagnosticBag, location As Location, reference As MetadataReference, identity As AssemblyIdentity, equivalentReference As MetadataReference, equivalentIdentity As AssemblyIdentity)
-            diagnostics.Add(ERRID.ERR_DuplicateReference2,
-                            DirectCast(location, Location),
-                            identity.Name,
-                            If(equivalentReference.Display, equivalentIdentity.GetDisplayName()))
+            diagnostics.Add(ERRID.ERR_DuplicateReference2, location, identity.Name,
+                            If(equivalentReference.Display, equivalentIdentity.GetDisplayName))
         End Sub
 
         ' signing:


### PR DESCRIPTION
`/Errors/CustomDiagnostics`
* Use .AddRange instead.
To add the locations for each symbol in one go, rather at one at a time.

`/Errors/DiagnosticBagExtension`
* Tidy up method signatures

`/Errors/MessageProvider`
* Remove Unnecessary casts
* Use `Select Case`
