### PR TITLE
Use `NameOf` instead of explicit string literals.

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -320,7 +320,7 @@ Public Module VerificationHelpers
     <Extension()>
     Public Function FindNodeOrTokenByKind(tree As SyntaxTree, kind As SyntaxKind, Optional occurrence As Integer = 1) As SyntaxNodeOrToken
         If Not occurrence > 0 Then
-            Throw New ArgumentException("Specified value must be greater than zero.", "occurrence")
+            Throw New ArgumentException("Specified value must be greater than zero.", NameOf(tree))
         End If
         Dim foundNode As SyntaxNodeOrToken = Nothing
         If TryFindNodeOrToken(tree.GetRoot(), kind, occurrence, foundNode) Then

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -320,7 +320,7 @@ Public Module VerificationHelpers
     <Extension()>
     Public Function FindNodeOrTokenByKind(tree As SyntaxTree, kind As SyntaxKind, Optional occurrence As Integer = 1) As SyntaxNodeOrToken
         If Not occurrence > 0 Then
-            Throw New ArgumentException("Specified value must be greater than zero.", NameOf(tree))
+            Throw New ArgumentException("Specified value must be greater than zero.", NameOf(occurrence))
         End If
         Dim foundNode As SyntaxNodeOrToken = Nothing
         If TryFindNodeOrToken(tree.GetRoot(), kind, occurrence, foundNode) Then

--- a/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
@@ -22,7 +22,7 @@ Public MustInherit Class SemanticModelTestBase : Inherits BasicTestBase
 
     Private Function GetAncestor(Of T As VisualBasicSyntaxNode)(node As VisualBasicSyntaxNode) As T
         If node Is Nothing Then
-            Throw New ArgumentNullException("node")
+            Throw New ArgumentNullException(NameOf(node))
         End If
 
         Dim parent = node.Parent

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -1525,7 +1525,7 @@ lVbRuntimePlus:
             Dim diagnosticBuilder = ArrayBuilder(Of Diagnostic).GetInstance()
             Dim parsedTokensAsString As New StringBuilder
 
-            Dim defines As ImmutableDictionary(Of String, InternalSyntax.CConst) = PublicSymbolsToInternalDefines(symbols, NameOf(symbolList))
+            Dim defines As ImmutableDictionary(Of String, InternalSyntax.CConst) = PublicSymbolsToInternalDefines(symbols, "symbols")
 
             ' remove quotes around the whole /define argument (incl. nested)
             Dim unquotedString As String

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -1525,7 +1525,7 @@ lVbRuntimePlus:
             Dim diagnosticBuilder = ArrayBuilder(Of Diagnostic).GetInstance()
             Dim parsedTokensAsString As New StringBuilder
 
-            Dim defines As ImmutableDictionary(Of String, InternalSyntax.CConst) = PublicSymbolsToInternalDefines(symbols, "symbols")
+            Dim defines As ImmutableDictionary(Of String, InternalSyntax.CConst) = PublicSymbolsToInternalDefines(symbols, NameOf(symbolList))
 
             ' remove quotes around the whole /define argument (incl. nested)
             Dim unquotedString As String

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -192,10 +192,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim isProperties As Boolean = (GetType(TMember) Is GetType(PropertySymbol))
             Dim isMethods As Boolean = (GetType(TMember) Is GetType(MethodSymbol))
             If Not (isProperties OrElse isMethods) Then
-                Throw New ArgumentException("Must resolve overloads on PropertySymbol or MethodSymbol", "TMember")
+                Throw New ArgumentException("Must resolve overloads on PropertySymbol or MethodSymbol", NameOf(TMember))
             End If
             If isProperties And Not typeArguments.IsEmpty Then
-                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, "typeArguments")
+                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, NameOf(typeArguments))
             End If
 
             Dim boundArguments As ImmutableArray(Of BoundExpression) = Nothing

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentException("Must resolve overloads on PropertySymbol or MethodSymbol", "TMember")
             End If
             If isProperties And Not typeArguments.IsEmpty Then
-                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, NameOf(members))
+                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, "typeArguments")
             End If
 
             Dim boundArguments As ImmutableArray(Of BoundExpression) = Nothing

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentException("Must resolve overloads on PropertySymbol or MethodSymbol", "TMember")
             End If
             If isProperties And Not typeArguments.IsEmpty Then
-                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, "typeArguments")
+                Throw New ArgumentException(VBResources.PropertiesCanNotHaveTypeArguments, NameOf(members))
             End If
 
             Dim boundArguments As ImmutableArray(Of BoundExpression) = Nothing

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -545,7 +545,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(identifierSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If identifierSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(identifierSyntax))
+                Throw New ArgumentNullException("identifierSyntax")
             End If
             If Not IsInTree(identifierSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -579,7 +579,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(anonymousObjectCreationExpressionSyntax As AnonymousObjectCreationExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
             If anonymousObjectCreationExpressionSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(anonymousObjectCreationExpressionSyntax))
+                Throw New ArgumentNullException("anonymousObjectCreationExpressionSyntax")
             End If
             If Not IsInTree(anonymousObjectCreationExpressionSyntax) Then
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
@@ -595,7 +595,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(fieldInitializerSyntax As FieldInitializerSyntax, Optional cancellationToken As System.Threading.CancellationToken = Nothing) As IPropertySymbol
             If fieldInitializerSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(fieldInitializerSyntax))
+                Throw New ArgumentNullException("fieldInitializerSyntax")
             End If
             If Not IsInTree(fieldInitializerSyntax) Then
                 Throw New ArgumentException(VBResources.FieldInitializerSyntaxNotWithinSyntaxTree)
@@ -630,7 +630,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As CollectionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -651,7 +651,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As ExpressionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -668,7 +668,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As AggregationRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -545,7 +545,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(identifierSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If identifierSyntax Is Nothing Then
-                Throw New ArgumentNullException("identifierSyntax")
+                Throw New ArgumentNullException(NameOf(identifierSyntax))
             End If
             If Not IsInTree(identifierSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -579,7 +579,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(anonymousObjectCreationExpressionSyntax As AnonymousObjectCreationExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
             If anonymousObjectCreationExpressionSyntax Is Nothing Then
-                Throw New ArgumentNullException("anonymousObjectCreationExpressionSyntax")
+                Throw New ArgumentNullException(NameOf(anonymousObjectCreationExpressionSyntax))
             End If
             If Not IsInTree(anonymousObjectCreationExpressionSyntax) Then
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
@@ -595,7 +595,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(fieldInitializerSyntax As FieldInitializerSyntax, Optional cancellationToken As System.Threading.CancellationToken = Nothing) As IPropertySymbol
             If fieldInitializerSyntax Is Nothing Then
-                Throw New ArgumentNullException("fieldInitializerSyntax")
+                Throw New ArgumentNullException(NameOf(fieldInitializerSyntax))
             End If
             If Not IsInTree(fieldInitializerSyntax) Then
                 Throw New ArgumentException(VBResources.FieldInitializerSyntaxNotWithinSyntaxTree)
@@ -630,7 +630,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As CollectionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -651,7 +651,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As ExpressionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -668,7 +668,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(rangeVariableSyntax As AggregationRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)

--- a/src/Compilers/VisualBasic/Portable/Compilation/QuerySymbolInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/QuerySymbolInfo.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional cancellationToken As CancellationToken = Nothing
         ) As CollectionRangeVariableSymbolInfo
             If variableSyntax Is Nothing Then
-                Throw New ArgumentNullException("variableSyntax")
+                Throw New ArgumentNullException(NameOf(variableSyntax))
             End If
             If Not IsInTree(variableSyntax) Then
                 Throw New ArgumentException(VBResources.VariableSyntaxNotWithinSyntaxTree)
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional cancellationToken As CancellationToken = Nothing
         ) As AggregateClauseSymbolInfo
             If aggregateSyntax Is Nothing Then
-                Throw New ArgumentNullException("aggregateSyntax")
+                Throw New ArgumentNullException(NameOf(aggregateSyntax))
             End If
             If Not IsInTree(aggregateSyntax) Then
                 Throw New ArgumentException(VBResources.AggregateSyntaxNotWithinSyntaxTree)

--- a/src/Compilers/VisualBasic/Portable/Compilation/QuerySymbolInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/QuerySymbolInfo.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional cancellationToken As CancellationToken = Nothing
         ) As CollectionRangeVariableSymbolInfo
             If variableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(variableSyntax))
+                Throw New ArgumentNullException("variableSyntax")
             End If
             If Not IsInTree(variableSyntax) Then
                 Throw New ArgumentException(VBResources.VariableSyntaxNotWithinSyntaxTree)
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional cancellationToken As CancellationToken = Nothing
         ) As AggregateClauseSymbolInfo
             If aggregateSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(aggregateSyntax))
+                Throw New ArgumentNullException("aggregateSyntax")
             End If
             If Not IsInTree(aggregateSyntax) Then
                 Throw New ArgumentException(VBResources.AggregateSyntaxNotWithinSyntaxTree)

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -562,7 +562,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Sub CheckSyntaxNode(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             If Not IsInTree(node) Then
@@ -572,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub CheckModelAndSyntaxNodeToSpeculate(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             If Me.IsSpeculativeSemanticModel Then
@@ -750,7 +750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                    bindingOption As SpeculativeBindingOption,
                                                    <Out> ByRef binder As Binder) As BoundNodeSummary
             If expression Is Nothing Then
-                Throw New ArgumentNullException(NameOf(position))
+                Throw New ArgumentNullException("expression")
             End If
 
             Dim standalone = SyntaxFactory.GetStandaloneExpression(expression)
@@ -833,7 +833,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function GetSpeculativelyBoundAttributeSummary(position As Integer, attribute As AttributeSyntax, <Out> ByRef binder As Binder) As BoundNodeSummary
             If attribute Is Nothing Then
-                Throw New ArgumentNullException(NameOf(position))
+                Throw New ArgumentNullException("attribute")
             End If
 
             Dim bnode = GetSpeculativelyBoundAttribute(position, attribute, binder)
@@ -1827,7 +1827,7 @@ _Default:
                 Dim containingType = binder.ContainingType
                 Dim baseType = If(containingType Is Nothing, Nothing, containingType.BaseTypeNoUseSiteDiagnostics)
                 If baseType Is Nothing Then
-                    Throw New ArgumentException(NameOf(position),
+                    Throw New ArgumentException("position",
                             "Not a valid position for a call to LookupBaseMembers (must be in a type with a base type)")
                 End If
                 container = baseType
@@ -2058,10 +2058,10 @@ _Default:
             CheckPosition(position)
 
             If symbol Is Nothing Then
-                Throw New ArgumentNullException(NameOf(position))
+                Throw New ArgumentNullException("symbol")
             End If
 
-            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(position))
+            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol")
 
             Dim binder = Me.GetEnclosingBinder(position)
             If binder IsNot Nothing Then
@@ -2311,10 +2311,10 @@ _Default:
         ''' type), use Compilation.ClassifyConversion.</remarks>
         Public Shadows Function ClassifyConversion(position As Integer, expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             If destination Is Nothing Then
-                Throw New ArgumentNullException(NameOf(position))
+                Throw New ArgumentNullException("destination")
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(position))
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
 
             CheckPosition(position)
             Dim binder = Me.GetEnclosingBinder(position)
@@ -2343,7 +2343,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(identifierSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If identifierSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(identifierSyntax))
+                Throw New ArgumentNullException("identifierSyntax")
             End If
             If Not IsInTree(identifierSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -2387,7 +2387,7 @@ _Default:
         ''' if the field initializer was not part of an anonymous type creation.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(fieldInitializerSyntax As FieldInitializerSyntax, Optional cancellationToken As CancellationToken = Nothing) As IPropertySymbol
             If fieldInitializerSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(fieldInitializerSyntax))
+                Throw New ArgumentNullException("fieldInitializerSyntax")
             End If
             If Not IsInTree(fieldInitializerSyntax) Then
                 Throw New ArgumentException(VBResources.FieldInitializerSyntaxNotWithinSyntaxTree)
@@ -2403,7 +2403,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(anonymousObjectCreationExpressionSyntax As AnonymousObjectCreationExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
             If anonymousObjectCreationExpressionSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(anonymousObjectCreationExpressionSyntax))
+                Throw New ArgumentNullException("anonymousObjectCreationExpressionSyntax")
             End If
             If Not IsInTree(anonymousObjectCreationExpressionSyntax) Then
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
@@ -2419,7 +2419,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As ExpressionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2435,7 +2435,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As CollectionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2451,7 +2451,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As AggregationRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
+                Throw New ArgumentNullException("rangeVariableSyntax")
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2467,7 +2467,7 @@ _Default:
         ''' <returns>The label symbol, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(declarationSyntax As LabelStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As ILabelSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(declarationSyntax))
+                Throw New ArgumentNullException("declarationSyntax")
             End If
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinSyntaxTree)
@@ -3025,7 +3025,7 @@ _Default:
 
         Private Function GetSymbolInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As SymbolInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3068,7 +3068,7 @@ _Default:
 
         Private Function GetTypeInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As VisualBasicTypeInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3086,7 +3086,7 @@ _Default:
 
         Private Function GetMemberGroupForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3130,7 +3130,7 @@ _Default:
 
         Protected NotOverridable Overrides Function GetAliasInfoCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             Dim nameSyntax = TryCast(node, IdentifierNameSyntax)
@@ -3181,7 +3181,7 @@ _Default:
 
             Dim result = TryCast(container, NamespaceOrTypeSymbol)
             If result Is Nothing Then
-                Throw New ArgumentException(VBResources.NotAVbSymbol, NameOf(container))
+                Throw New ArgumentException(VBResources.NotAVbSymbol, "container")
             End If
             Return result
         End Function
@@ -3311,14 +3311,14 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As DataFlowAnalysis
-            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
-                                                SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
+            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
+                                                SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(statementOrExpression As SyntaxNode) As DataFlowAnalysis
 
             If statementOrExpression Is Nothing Then
-                Throw New ArgumentNullException(NameOf(statementOrExpression))
+                Throw New ArgumentNullException("statementOrExpression")
             End If
 
             If TypeOf statementOrExpression Is ExecutableStatementSyntax Then
@@ -3337,12 +3337,12 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
-                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
+                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(statement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, NameOf(statement)))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, "statement"))
         End Function
 
         Private Shared Function SafeCastArgument(Of T As Class)(node As SyntaxNode, argName As String) As T
@@ -3359,7 +3359,7 @@ _Default:
         Protected NotOverridable Overrides Function GetConstantValueCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As [Optional](Of Object)
 
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             If TypeOf node Is ExpressionSyntax Then
@@ -3374,7 +3374,7 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function IsAccessibleCore(position As Integer, symbol As ISymbol) As Boolean
-            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(position)))
+            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol"))
         End Function
 
         Protected NotOverridable Overrides Function IsEventUsableAsFieldCore(position As Integer, symbol As IEventSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -562,7 +562,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Sub CheckSyntaxNode(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Not IsInTree(node) Then
@@ -572,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub CheckModelAndSyntaxNodeToSpeculate(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Me.IsSpeculativeSemanticModel Then
@@ -750,7 +750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                    bindingOption As SpeculativeBindingOption,
                                                    <Out> ByRef binder As Binder) As BoundNodeSummary
             If expression Is Nothing Then
-                Throw New ArgumentNullException("expression")
+                Throw New ArgumentNullException(NameOf(expression))
             End If
 
             Dim standalone = SyntaxFactory.GetStandaloneExpression(expression)
@@ -833,7 +833,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function GetSpeculativelyBoundAttributeSummary(position As Integer, attribute As AttributeSyntax, <Out> ByRef binder As Binder) As BoundNodeSummary
             If attribute Is Nothing Then
-                Throw New ArgumentNullException("attribute")
+                Throw New ArgumentNullException(NameOf(attribute))
             End If
 
             Dim bnode = GetSpeculativelyBoundAttribute(position, attribute, binder)
@@ -1827,7 +1827,7 @@ _Default:
                 Dim containingType = binder.ContainingType
                 Dim baseType = If(containingType Is Nothing, Nothing, containingType.BaseTypeNoUseSiteDiagnostics)
                 If baseType Is Nothing Then
-                    Throw New ArgumentException("position",
+                    Throw New ArgumentException(NameOf(position),
                             "Not a valid position for a call to LookupBaseMembers (must be in a type with a base type)")
                 End If
                 container = baseType
@@ -2058,10 +2058,10 @@ _Default:
             CheckPosition(position)
 
             If symbol Is Nothing Then
-                Throw New ArgumentNullException("symbol")
+                Throw New ArgumentNullException(NameOf(symbol))
             End If
 
-            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol")
+            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(position))
 
             Dim binder = Me.GetEnclosingBinder(position)
             If binder IsNot Nothing Then
@@ -2311,10 +2311,10 @@ _Default:
         ''' type), use Compilation.ClassifyConversion.</remarks>
         Public Shadows Function ClassifyConversion(position As Integer, expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(destination))
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(destination))
 
             CheckPosition(position)
             Dim binder = Me.GetEnclosingBinder(position)
@@ -2343,7 +2343,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(identifierSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If identifierSyntax Is Nothing Then
-                Throw New ArgumentNullException("identifierSyntax")
+                Throw New ArgumentNullException(NameOf(identifierSyntax))
             End If
             If Not IsInTree(identifierSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -2387,7 +2387,7 @@ _Default:
         ''' if the field initializer was not part of an anonymous type creation.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(fieldInitializerSyntax As FieldInitializerSyntax, Optional cancellationToken As CancellationToken = Nothing) As IPropertySymbol
             If fieldInitializerSyntax Is Nothing Then
-                Throw New ArgumentNullException("fieldInitializerSyntax")
+                Throw New ArgumentNullException(NameOf(fieldInitializerSyntax))
             End If
             If Not IsInTree(fieldInitializerSyntax) Then
                 Throw New ArgumentException(VBResources.FieldInitializerSyntaxNotWithinSyntaxTree)
@@ -2403,7 +2403,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(anonymousObjectCreationExpressionSyntax As AnonymousObjectCreationExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
             If anonymousObjectCreationExpressionSyntax Is Nothing Then
-                Throw New ArgumentNullException("anonymousObjectCreationExpressionSyntax")
+                Throw New ArgumentNullException(NameOf(anonymousObjectCreationExpressionSyntax))
             End If
             If Not IsInTree(anonymousObjectCreationExpressionSyntax) Then
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
@@ -2419,7 +2419,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As ExpressionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2435,7 +2435,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As CollectionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2451,7 +2451,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As AggregationRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2467,7 +2467,7 @@ _Default:
         ''' <returns>The label symbol, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(declarationSyntax As LabelStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As ILabelSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinSyntaxTree)
@@ -3025,7 +3025,7 @@ _Default:
 
         Private Function GetSymbolInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As SymbolInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3068,7 +3068,7 @@ _Default:
 
         Private Function GetTypeInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As VisualBasicTypeInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3086,7 +3086,7 @@ _Default:
 
         Private Function GetMemberGroupForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3130,7 +3130,7 @@ _Default:
 
         Protected NotOverridable Overrides Function GetAliasInfoCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim nameSyntax = TryCast(node, IdentifierNameSyntax)
@@ -3181,7 +3181,7 @@ _Default:
 
             Dim result = TryCast(container, NamespaceOrTypeSymbol)
             If result Is Nothing Then
-                Throw New ArgumentException(VBResources.NotAVbSymbol, "container")
+                Throw New ArgumentException(VBResources.NotAVbSymbol, NameOf(container))
             End If
             Return result
         End Function
@@ -3311,14 +3311,14 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As DataFlowAnalysis
-            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
-                                                SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
+            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
+                                                SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(statementOrExpression As SyntaxNode) As DataFlowAnalysis
 
             If statementOrExpression Is Nothing Then
-                Throw New ArgumentNullException("statementOrExpression")
+                Throw New ArgumentNullException(NameOf(statementOrExpression))
             End If
 
             If TypeOf statementOrExpression Is ExecutableStatementSyntax Then
@@ -3337,12 +3337,12 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
-                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
+                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(statement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, "statement"))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, NameOf(statement)))
         End Function
 
         Private Shared Function SafeCastArgument(Of T As Class)(node As SyntaxNode, argName As String) As T
@@ -3359,7 +3359,7 @@ _Default:
         Protected NotOverridable Overrides Function GetConstantValueCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As [Optional](Of Object)
 
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If TypeOf node Is ExpressionSyntax Then
@@ -3374,7 +3374,7 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function IsAccessibleCore(position As Integer, symbol As ISymbol) As Boolean
-            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol"))
+            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(symbol)))
         End Function
 
         Protected NotOverridable Overrides Function IsEventUsableAsFieldCore(position As Integer, symbol As IEventSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -562,7 +562,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Sub CheckSyntaxNode(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Not IsInTree(node) Then
@@ -572,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub CheckModelAndSyntaxNodeToSpeculate(node As VisualBasicSyntaxNode)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Me.IsSpeculativeSemanticModel Then
@@ -750,7 +750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                    bindingOption As SpeculativeBindingOption,
                                                    <Out> ByRef binder As Binder) As BoundNodeSummary
             If expression Is Nothing Then
-                Throw New ArgumentNullException("expression")
+                Throw New ArgumentNullException(NameOf(position))
             End If
 
             Dim standalone = SyntaxFactory.GetStandaloneExpression(expression)
@@ -833,7 +833,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function GetSpeculativelyBoundAttributeSummary(position As Integer, attribute As AttributeSyntax, <Out> ByRef binder As Binder) As BoundNodeSummary
             If attribute Is Nothing Then
-                Throw New ArgumentNullException("attribute")
+                Throw New ArgumentNullException(NameOf(position))
             End If
 
             Dim bnode = GetSpeculativelyBoundAttribute(position, attribute, binder)
@@ -1827,7 +1827,7 @@ _Default:
                 Dim containingType = binder.ContainingType
                 Dim baseType = If(containingType Is Nothing, Nothing, containingType.BaseTypeNoUseSiteDiagnostics)
                 If baseType Is Nothing Then
-                    Throw New ArgumentException("position",
+                    Throw New ArgumentException(NameOf(position),
                             "Not a valid position for a call to LookupBaseMembers (must be in a type with a base type)")
                 End If
                 container = baseType
@@ -2058,10 +2058,10 @@ _Default:
             CheckPosition(position)
 
             If symbol Is Nothing Then
-                Throw New ArgumentNullException("symbol")
+                Throw New ArgumentNullException(NameOf(position))
             End If
 
-            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol")
+            Dim vbsymbol = symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(position))
 
             Dim binder = Me.GetEnclosingBinder(position)
             If binder IsNot Nothing Then
@@ -2311,10 +2311,10 @@ _Default:
         ''' type), use Compilation.ClassifyConversion.</remarks>
         Public Shadows Function ClassifyConversion(position As Integer, expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(position))
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(position))
 
             CheckPosition(position)
             Dim binder = Me.GetEnclosingBinder(position)
@@ -2343,7 +2343,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(identifierSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If identifierSyntax Is Nothing Then
-                Throw New ArgumentNullException("identifierSyntax")
+                Throw New ArgumentNullException(NameOf(identifierSyntax))
             End If
             If Not IsInTree(identifierSyntax) Then
                 Throw New ArgumentException(VBResources.IdentifierSyntaxNotWithinSyntaxTree)
@@ -2387,7 +2387,7 @@ _Default:
         ''' if the field initializer was not part of an anonymous type creation.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(fieldInitializerSyntax As FieldInitializerSyntax, Optional cancellationToken As CancellationToken = Nothing) As IPropertySymbol
             If fieldInitializerSyntax Is Nothing Then
-                Throw New ArgumentNullException("fieldInitializerSyntax")
+                Throw New ArgumentNullException(NameOf(fieldInitializerSyntax))
             End If
             If Not IsInTree(fieldInitializerSyntax) Then
                 Throw New ArgumentException(VBResources.FieldInitializerSyntaxNotWithinSyntaxTree)
@@ -2403,7 +2403,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(anonymousObjectCreationExpressionSyntax As AnonymousObjectCreationExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
             If anonymousObjectCreationExpressionSyntax Is Nothing Then
-                Throw New ArgumentNullException("anonymousObjectCreationExpressionSyntax")
+                Throw New ArgumentNullException(NameOf(anonymousObjectCreationExpressionSyntax))
             End If
             If Not IsInTree(anonymousObjectCreationExpressionSyntax) Then
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
@@ -2419,7 +2419,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As ExpressionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2435,7 +2435,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As CollectionRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2451,7 +2451,7 @@ _Default:
         ''' <returns>The symbol that was declared, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(rangeVariableSyntax As AggregationRangeVariableSyntax, Optional cancellationToken As CancellationToken = Nothing) As IRangeVariableSymbol
             If rangeVariableSyntax Is Nothing Then
-                Throw New ArgumentNullException("rangeVariableSyntax")
+                Throw New ArgumentNullException(NameOf(rangeVariableSyntax))
             End If
             If Not IsInTree(rangeVariableSyntax) Then
                 Throw New ArgumentException(VBResources.RangeVariableSyntaxNotWithinSyntaxTree)
@@ -2467,7 +2467,7 @@ _Default:
         ''' <returns>The label symbol, or Nothing if no such symbol exists.</returns>
         Public Overridable Overloads Function GetDeclaredSymbol(declarationSyntax As LabelStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As ILabelSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinSyntaxTree)
@@ -3025,7 +3025,7 @@ _Default:
 
         Private Function GetSymbolInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As SymbolInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3068,7 +3068,7 @@ _Default:
 
         Private Function GetTypeInfoForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As VisualBasicTypeInfo
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3086,7 +3086,7 @@ _Default:
 
         Private Function GetMemberGroupForNode(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim expressionSyntax = TryCast(node, expressionSyntax)
@@ -3130,7 +3130,7 @@ _Default:
 
         Protected NotOverridable Overrides Function GetAliasInfoCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim nameSyntax = TryCast(node, IdentifierNameSyntax)
@@ -3181,7 +3181,7 @@ _Default:
 
             Dim result = TryCast(container, NamespaceOrTypeSymbol)
             If result Is Nothing Then
-                Throw New ArgumentException(VBResources.NotAVbSymbol, "container")
+                Throw New ArgumentException(VBResources.NotAVbSymbol, NameOf(container))
             End If
             Return result
         End Function
@@ -3311,14 +3311,14 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As DataFlowAnalysis
-            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
-                                                SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
+            Return Me.AnalyzeDataFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
+                                                SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeDataFlowCore(statementOrExpression As SyntaxNode) As DataFlowAnalysis
 
             If statementOrExpression Is Nothing Then
-                Throw New ArgumentNullException("statementOrExpression")
+                Throw New ArgumentNullException(NameOf(statementOrExpression))
             End If
 
             If TypeOf statementOrExpression Is ExecutableStatementSyntax Then
@@ -3337,12 +3337,12 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(firstStatement As SyntaxNode, lastStatement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, "firstStatement"),
-                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, "lastStatement"))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(firstStatement, NameOf(firstStatement)),
+                                                   SafeCastArgument(Of StatementSyntax)(lastStatement, NameOf(firstStatement)))
         End Function
 
         Protected NotOverridable Overrides Function AnalyzeControlFlowCore(statement As SyntaxNode) As ControlFlowAnalysis
-            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, "statement"))
+            Return Me.AnalyzeControlFlow(SafeCastArgument(Of StatementSyntax)(statement, NameOf(statement)))
         End Function
 
         Private Shared Function SafeCastArgument(Of T As Class)(node As SyntaxNode, argName As String) As T
@@ -3359,7 +3359,7 @@ _Default:
         Protected NotOverridable Overrides Function GetConstantValueCore(node As SyntaxNode, Optional cancellationToken As CancellationToken = Nothing) As [Optional](Of Object)
 
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If TypeOf node Is ExpressionSyntax Then
@@ -3374,7 +3374,7 @@ _Default:
         End Function
 
         Protected NotOverridable Overrides Function IsAccessibleCore(position As Integer, symbol As ISymbol) As Boolean
-            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)("symbol"))
+            Return Me.IsAccessible(position, symbol.EnsureVbSymbolOrNothing(Of symbol)(NameOf(position)))
         End Function
 
         Protected NotOverridable Overrides Function IsEventUsableAsFieldCore(position As Integer, symbol As IEventSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -868,7 +868,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Function GetDeclaredSymbol(declarationSyntax As DelegateStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As NamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -888,7 +888,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As TypeStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -907,7 +907,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares an enum.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As EnumStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -926,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a namespace.</param>
         ''' <returns>The namespace symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As NamespaceStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamespaceSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             Dim parentBlock = TryCast(declarationSyntax.Parent, NamespaceBlockSyntax)
@@ -948,7 +948,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a method, property, or event.</param>
         ''' <returns>The method, property, or event symbol that was declared.</returns>
         Friend Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As MethodBaseSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
             End If
@@ -1041,7 +1041,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(parameter As ParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As IParameterSymbol
             If parameter Is Nothing Then
-                Throw New ArgumentNullException("parameter")
+                Throw New ArgumentNullException(NameOf(parameter))
             End If
 
             Dim paramList As ParameterListSyntax = TryCast(parameter.Parent, ParameterListSyntax)
@@ -1087,7 +1087,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The type parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(typeParameter As TypeParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As ITypeParameterSymbol
             If typeParameter Is Nothing Then
-                Throw New ArgumentNullException("typeParameter")
+                Throw New ArgumentNullException(NameOf(typeParameter))
             End If
             If Not IsInTree(typeParameter) Then
                 Throw New ArgumentException(VBResources.TypeParameterNotWithinTree)
@@ -1135,7 +1135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As EnumMemberDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As IFieldSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1161,7 +1161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The symbol that was declared.</returns>
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1287,7 +1287,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The alias symbol that was declared or Nothing if no alias symbol was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As SimpleImportsClauseSyntax, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1336,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The field symbols that were declared.</returns>
         Friend Overrides Function GetDeclaredSymbols(declarationSyntax As FieldDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1372,10 +1372,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function ClassifyConversion(expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             CheckSyntaxNode(expression)
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(expression))
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(expression))
 
             ' TODO(cyrusn): Check arguments.  This is a public entrypoint, so we must do appropriate
             ' checks here.  However, no other methods in this type do any checking currently.  SO i'm
@@ -1698,7 +1698,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Function ValidateRegionDefiningExpression(expression As ExpressionSyntax) As Boolean
-            AssertNodeInTree(expression, "expression")
+            AssertNodeInTree(expression, NameOf(expression))
 
             If expression.Kind = SyntaxKind.PredefinedType OrElse SyntaxFacts.IsInNamespaceOrTypeContext(expression) Then
                 Return False
@@ -1760,8 +1760,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function ValidateRegionDefiningStatementsRange(firstStatement As StatementSyntax, lastStatement As StatementSyntax) As Boolean
-            AssertNodeInTree(firstStatement, "firstStatement")
-            AssertNodeInTree(lastStatement, "lastStatement")
+            AssertNodeInTree(firstStatement, NameOf(firstStatement))
+            AssertNodeInTree(lastStatement, NameOf(firstStatement))
 
             If firstStatement.Parent Is Nothing OrElse firstStatement.Parent IsNot lastStatement.Parent Then
                 Throw New ArgumentException("statements not within the same statement list")

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -868,7 +868,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Function GetDeclaredSymbol(declarationSyntax As DelegateStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As NamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -888,7 +888,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As TypeStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -907,7 +907,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares an enum.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As EnumStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -926,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a namespace.</param>
         ''' <returns>The namespace symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As NamespaceStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamespaceSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             Dim parentBlock = TryCast(declarationSyntax.Parent, NamespaceBlockSyntax)
@@ -948,7 +948,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a method, property, or event.</param>
         ''' <returns>The method, property, or event symbol that was declared.</returns>
         Friend Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As MethodBaseSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
             End If
@@ -1041,7 +1041,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(parameter As ParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As IParameterSymbol
             If parameter Is Nothing Then
-                Throw New ArgumentNullException("parameter")
+                Throw New ArgumentNullException(NameOf(parameter))
             End If
 
             Dim paramList As ParameterListSyntax = TryCast(parameter.Parent, ParameterListSyntax)
@@ -1087,7 +1087,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The type parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(typeParameter As TypeParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As ITypeParameterSymbol
             If typeParameter Is Nothing Then
-                Throw New ArgumentNullException("typeParameter")
+                Throw New ArgumentNullException(NameOf(typeParameter))
             End If
             If Not IsInTree(typeParameter) Then
                 Throw New ArgumentException(VBResources.TypeParameterNotWithinTree)
@@ -1135,7 +1135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As EnumMemberDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As IFieldSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1161,7 +1161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The symbol that was declared.</returns>
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1287,7 +1287,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The alias symbol that was declared or Nothing if no alias symbol was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As SimpleImportsClauseSyntax, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1336,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The field symbols that were declared.</returns>
         Friend Overrides Function GetDeclaredSymbols(declarationSyntax As FieldDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException("declarationSyntax")
+                Throw New ArgumentNullException(NameOf(declarationSyntax))
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1372,10 +1372,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function ClassifyConversion(expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             CheckSyntaxNode(expression)
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(destination))
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(expression))
 
             ' TODO(cyrusn): Check arguments.  This is a public entrypoint, so we must do appropriate
             ' checks here.  However, no other methods in this type do any checking currently.  SO i'm
@@ -1698,7 +1698,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Function ValidateRegionDefiningExpression(expression As ExpressionSyntax) As Boolean
-            AssertNodeInTree(expression, "expression")
+            AssertNodeInTree(expression, NameOf(expression))
 
             If expression.Kind = SyntaxKind.PredefinedType OrElse SyntaxFacts.IsInNamespaceOrTypeContext(expression) Then
                 Return False
@@ -1760,8 +1760,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function ValidateRegionDefiningStatementsRange(firstStatement As StatementSyntax, lastStatement As StatementSyntax) As Boolean
-            AssertNodeInTree(firstStatement, "firstStatement")
-            AssertNodeInTree(lastStatement, "lastStatement")
+            AssertNodeInTree(firstStatement, NameOf(firstStatement))
+            AssertNodeInTree(lastStatement, NameOf(lastStatement))
 
             If firstStatement.Parent Is Nothing OrElse firstStatement.Parent IsNot lastStatement.Parent Then
                 Throw New ArgumentException("statements not within the same statement list")

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -868,7 +868,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Function GetDeclaredSymbol(declarationSyntax As DelegateStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As NamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -888,7 +888,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a type.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As TypeStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -907,7 +907,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares an enum.</param>
         ''' <returns>The type symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As EnumStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamedTypeSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             ' Don't need to wrap in a SemanticModelBinder, since we're not binding.
@@ -926,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a namespace.</param>
         ''' <returns>The namespace symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As NamespaceStatementSyntax, Optional cancellationToken As CancellationToken = Nothing) As INamespaceSymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
             If Not IsInTree(declarationSyntax) Then Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
 
             Dim parentBlock = TryCast(declarationSyntax.Parent, NamespaceBlockSyntax)
@@ -948,7 +948,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="declarationSyntax">The syntax node that declares a method, property, or event.</param>
         ''' <returns>The method, property, or event symbol that was declared.</returns>
         Friend Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As MethodBaseSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
-            If declarationSyntax Is Nothing Then Throw New ArgumentNullException(NameOf(declarationSyntax))
+            If declarationSyntax Is Nothing Then Throw New ArgumentNullException("declarationSyntax")
             If Not IsInTree(declarationSyntax) Then
                 Throw New ArgumentException(VBResources.DeclarationSyntaxNotWithinTree)
             End If
@@ -1041,7 +1041,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(parameter As ParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As IParameterSymbol
             If parameter Is Nothing Then
-                Throw New ArgumentNullException(NameOf(parameter))
+                Throw New ArgumentNullException("parameter")
             End If
 
             Dim paramList As ParameterListSyntax = TryCast(parameter.Parent, ParameterListSyntax)
@@ -1087,7 +1087,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The type parameter symbol that was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(typeParameter As TypeParameterSyntax, Optional cancellationToken As CancellationToken = Nothing) As ITypeParameterSymbol
             If typeParameter Is Nothing Then
-                Throw New ArgumentNullException(NameOf(typeParameter))
+                Throw New ArgumentNullException("typeParameter")
             End If
             If Not IsInTree(typeParameter) Then
                 Throw New ArgumentException(VBResources.TypeParameterNotWithinTree)
@@ -1135,7 +1135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As EnumMemberDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As IFieldSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(declarationSyntax))
+                Throw New ArgumentNullException("declarationSyntax")
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1161,7 +1161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The symbol that was declared.</returns>
         Public Overrides Function GetDeclaredSymbol(declarationSyntax As ModifiedIdentifierSyntax, Optional cancellationToken As CancellationToken = Nothing) As ISymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(declarationSyntax))
+                Throw New ArgumentNullException("declarationSyntax")
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1287,7 +1287,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The alias symbol that was declared or Nothing if no alias symbol was declared.</returns>
         Public Overloads Overrides Function GetDeclaredSymbol(declarationSyntax As SimpleImportsClauseSyntax, Optional cancellationToken As CancellationToken = Nothing) As IAliasSymbol
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(declarationSyntax))
+                Throw New ArgumentNullException("declarationSyntax")
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1336,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The field symbols that were declared.</returns>
         Friend Overrides Function GetDeclaredSymbols(declarationSyntax As FieldDeclarationSyntax, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of ISymbol)
             If declarationSyntax Is Nothing Then
-                Throw New ArgumentNullException(NameOf(declarationSyntax))
+                Throw New ArgumentNullException("declarationSyntax")
             End If
 
             If Not IsInTree(declarationSyntax) Then
@@ -1372,10 +1372,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function ClassifyConversion(expression As ExpressionSyntax, destination As ITypeSymbol) As Conversion
             CheckSyntaxNode(expression)
             If destination Is Nothing Then
-                Throw New ArgumentNullException(NameOf(expression))
+                Throw New ArgumentNullException("destination")
             End If
 
-            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(expression))
+            Dim vbdestination = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
 
             ' TODO(cyrusn): Check arguments.  This is a public entrypoint, so we must do appropriate
             ' checks here.  However, no other methods in this type do any checking currently.  SO i'm
@@ -1698,7 +1698,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Function ValidateRegionDefiningExpression(expression As ExpressionSyntax) As Boolean
-            AssertNodeInTree(expression, NameOf(expression))
+            AssertNodeInTree(expression, "expression")
 
             If expression.Kind = SyntaxKind.PredefinedType OrElse SyntaxFacts.IsInNamespaceOrTypeContext(expression) Then
                 Return False
@@ -1760,8 +1760,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function ValidateRegionDefiningStatementsRange(firstStatement As StatementSyntax, lastStatement As StatementSyntax) As Boolean
-            AssertNodeInTree(firstStatement, NameOf(firstStatement))
-            AssertNodeInTree(lastStatement, NameOf(firstStatement))
+            AssertNodeInTree(firstStatement, "firstStatement")
+            AssertNodeInTree(lastStatement, "lastStatement")
 
             If firstStatement.Parent Is Nothing OrElse firstStatement.Parent IsNot lastStatement.Parent Then
                 Throw New ArgumentException("statements not within the same statement list")

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If result Is Nothing Then
                     result = version
                 ElseIf result <> version Then
-                    Throw New ArgumentException("inconsistent language versions", NameOf(syntaxTrees))
+                    Throw New ArgumentException("inconsistent language versions", "syntaxTrees")
                 End If
             Next
 
@@ -797,7 +797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ContainsSyntaxTree(syntaxTree As SyntaxTree) As Boolean
             If syntaxTree Is Nothing Then
-                Throw New ArgumentNullException(NameOf(syntaxTree))
+                Throw New ArgumentNullException("syntaxTree")
             End If
 
             Dim vbtree = syntaxTree
@@ -810,7 +810,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function AddSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException(NameOf(trees))
+                Throw New ArgumentNullException("trees")
             End If
 
             If Not trees.Any() Then
@@ -858,7 +858,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 If IsSubmission AndAlso declMap.Count > 1 Then
-                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, NameOf(trees))
+                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, "trees")
                 End If
 
                 Return UpdateSyntaxTrees(builder.ToImmutable(), ordinalMap, declMap, declTable, referenceDirectivesChanged)
@@ -892,7 +892,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function RemoveSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException(NameOf(trees))
+                Throw New ArgumentNullException("trees")
             End If
 
             If Not trees.Any() Then
@@ -974,7 +974,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not newTree.HasCompilationUnitRoot Then
-                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, NameOf(oldTree))
+                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, "newTree")
             End If
 
             Dim vbOldTree = oldTree
@@ -1182,7 +1182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Friend Shadows Function GetAssemblyOrModuleSymbol(reference As MetadataReference) As Symbol
             If (reference Is Nothing) Then
-                Throw New ArgumentNullException(NameOf(reference))
+                Throw New ArgumentNullException("reference")
             End If
 
             If reference.Properties.Kind = MetadataImageKind.Assembly Then
@@ -1321,7 +1321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Shadows Function GetCompilationNamespace(namespaceSymbol As INamespaceSymbol) As NamespaceSymbol
             If namespaceSymbol Is Nothing Then
-                Throw New ArgumentNullException(NameOf(namespaceSymbol))
+                Throw New ArgumentNullException("namespaceSymbol")
             End If
 
             Dim vbNs = TryCast(namespaceSymbol, NamespaceSymbol)
@@ -1707,15 +1707,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ClassifyConversion(source As ITypeSymbol, destination As ITypeSymbol) As Conversion
             If source Is Nothing Then
-                Throw New ArgumentNullException(NameOf(source))
+                Throw New ArgumentNullException("source")
             End If
 
             If destination Is Nothing Then
-                Throw New ArgumentNullException(NameOf(source))
+                Throw New ArgumentNullException("destination")
             End If
 
-            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(source))
-            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(source))
+            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)("source")
+            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
 
             If vbsource.IsErrorType() OrElse vbdest.IsErrorType() Then
                 Return New Conversion(Nothing) ' No conversion
@@ -1801,7 +1801,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shadows Function CreateArrayTypeSymbol(elementType As TypeSymbol, Optional rank As Integer = 1) As ArrayTypeSymbol
             If elementType Is Nothing Then
-                Throw New ArgumentNullException(NameOf(elementType))
+                Throw New ArgumentNullException("elementType")
             End If
 
             Return New ArrayTypeSymbol(elementType, Nothing, rank, Me)
@@ -1961,7 +1961,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                               includeEarlierStages As Boolean,
                                               Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of Diagnostic)
             If Not SyntaxTrees.Contains(tree) Then
-                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", NameOf(stage))
+                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", "tree")
             End If
 
             Dim builder = DiagnosticBag.GetInstance()
@@ -2506,7 +2506,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException(NameOf(trees))
+                Throw New ArgumentNullException("trees")
             End If
 
             Return Me.AddSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2519,7 +2519,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException(NameOf(trees))
+                Throw New ArgumentNullException("trees")
             End If
 
             Return Me.RemoveSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2582,7 +2582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Protected Overrides Function CommonCreateArrayTypeSymbol(elementType As ITypeSymbol, rank As Integer) As IArrayTypeSymbol
-            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(elementType)), rank)
+            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)("elementType"), rank)
         End Function
 
         Protected Overrides Function CommonCreatePointerTypeSymbol(elementType As ITypeSymbol) As IPointerTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If result Is Nothing Then
                     result = version
                 ElseIf result <> version Then
-                    Throw New ArgumentException("inconsistent language versions", "syntaxTrees")
+                    Throw New ArgumentException("inconsistent language versions", NameOf(syntaxTrees))
                 End If
             Next
 
@@ -797,7 +797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ContainsSyntaxTree(syntaxTree As SyntaxTree) As Boolean
             If syntaxTree Is Nothing Then
-                Throw New ArgumentNullException("syntaxTree")
+                Throw New ArgumentNullException(NameOf(syntaxTree))
             End If
 
             Dim vbtree = syntaxTree
@@ -810,7 +810,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function AddSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             If Not trees.Any() Then
@@ -858,7 +858,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 If IsSubmission AndAlso declMap.Count > 1 Then
-                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, "trees")
+                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, NameOf(trees))
                 End If
 
                 Return UpdateSyntaxTrees(builder.ToImmutable(), ordinalMap, declMap, declTable, referenceDirectivesChanged)
@@ -892,7 +892,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function RemoveSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             If Not trees.Any() Then
@@ -974,7 +974,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not newTree.HasCompilationUnitRoot Then
-                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, "newTree")
+                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, NameOf(oldTree))
             End If
 
             Dim vbOldTree = oldTree
@@ -1182,7 +1182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Friend Shadows Function GetAssemblyOrModuleSymbol(reference As MetadataReference) As Symbol
             If (reference Is Nothing) Then
-                Throw New ArgumentNullException("reference")
+                Throw New ArgumentNullException(NameOf(reference))
             End If
 
             If reference.Properties.Kind = MetadataImageKind.Assembly Then
@@ -1321,7 +1321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Shadows Function GetCompilationNamespace(namespaceSymbol As INamespaceSymbol) As NamespaceSymbol
             If namespaceSymbol Is Nothing Then
-                Throw New ArgumentNullException("namespaceSymbol")
+                Throw New ArgumentNullException(NameOf(namespaceSymbol))
             End If
 
             Dim vbNs = TryCast(namespaceSymbol, NamespaceSymbol)
@@ -1707,15 +1707,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ClassifyConversion(source As ITypeSymbol, destination As ITypeSymbol) As Conversion
             If source Is Nothing Then
-                Throw New ArgumentNullException("source")
+                Throw New ArgumentNullException(NameOf(source))
             End If
 
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(source))
             End If
 
-            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)("source")
-            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(source))
+            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(source))
 
             If vbsource.IsErrorType() OrElse vbdest.IsErrorType() Then
                 Return New Conversion(Nothing) ' No conversion
@@ -1801,7 +1801,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shadows Function CreateArrayTypeSymbol(elementType As TypeSymbol, Optional rank As Integer = 1) As ArrayTypeSymbol
             If elementType Is Nothing Then
-                Throw New ArgumentNullException("elementType")
+                Throw New ArgumentNullException(NameOf(elementType))
             End If
 
             Return New ArrayTypeSymbol(elementType, Nothing, rank, Me)
@@ -1961,7 +1961,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                               includeEarlierStages As Boolean,
                                               Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of Diagnostic)
             If Not SyntaxTrees.Contains(tree) Then
-                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", "tree")
+                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", NameOf(stage))
             End If
 
             Dim builder = DiagnosticBag.GetInstance()
@@ -2506,7 +2506,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             Return Me.AddSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2519,7 +2519,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             Return Me.RemoveSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2582,7 +2582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Protected Overrides Function CommonCreateArrayTypeSymbol(elementType As ITypeSymbol, rank As Integer) As IArrayTypeSymbol
-            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)("elementType"), rank)
+            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(elementType)), rank)
         End Function
 
         Protected Overrides Function CommonCreatePointerTypeSymbol(elementType As ITypeSymbol) As IPointerTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If result Is Nothing Then
                     result = version
                 ElseIf result <> version Then
-                    Throw New ArgumentException("inconsistent language versions", "syntaxTrees")
+                    Throw New ArgumentException("inconsistent language versions", NameOf(syntaxTrees))
                 End If
             Next
 
@@ -797,7 +797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ContainsSyntaxTree(syntaxTree As SyntaxTree) As Boolean
             If syntaxTree Is Nothing Then
-                Throw New ArgumentNullException("syntaxTree")
+                Throw New ArgumentNullException(NameOf(syntaxTree))
             End If
 
             Dim vbtree = syntaxTree
@@ -810,7 +810,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function AddSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             If Not trees.Any() Then
@@ -858,7 +858,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 If IsSubmission AndAlso declMap.Count > 1 Then
-                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, "trees")
+                    Throw New ArgumentException(VBResources.SubmissionCanHaveAtMostOneSyntaxTree, NameOf(trees))
                 End If
 
                 Return UpdateSyntaxTrees(builder.ToImmutable(), ordinalMap, declMap, declTable, referenceDirectivesChanged)
@@ -892,7 +892,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function RemoveSyntaxTrees(trees As IEnumerable(Of SyntaxTree)) As VisualBasicCompilation
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             If Not trees.Any() Then
@@ -974,7 +974,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not newTree.HasCompilationUnitRoot Then
-                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, "newTree")
+                Throw New ArgumentException(VBResources.TreeMustHaveARootNodeWithCompilationUnit, NameOf(newTree))
             End If
 
             Dim vbOldTree = oldTree
@@ -1182,7 +1182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Friend Shadows Function GetAssemblyOrModuleSymbol(reference As MetadataReference) As Symbol
             If (reference Is Nothing) Then
-                Throw New ArgumentNullException("reference")
+                Throw New ArgumentNullException(NameOf(reference))
             End If
 
             If reference.Properties.Kind = MetadataImageKind.Assembly Then
@@ -1321,7 +1321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Shadows Function GetCompilationNamespace(namespaceSymbol As INamespaceSymbol) As NamespaceSymbol
             If namespaceSymbol Is Nothing Then
-                Throw New ArgumentNullException("namespaceSymbol")
+                Throw New ArgumentNullException(NameOf(namespaceSymbol))
             End If
 
             Dim vbNs = TryCast(namespaceSymbol, NamespaceSymbol)
@@ -1707,15 +1707,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function ClassifyConversion(source As ITypeSymbol, destination As ITypeSymbol) As Conversion
             If source Is Nothing Then
-                Throw New ArgumentNullException("source")
+                Throw New ArgumentNullException(NameOf(source))
             End If
 
             If destination Is Nothing Then
-                Throw New ArgumentNullException("destination")
+                Throw New ArgumentNullException(NameOf(destination))
             End If
 
-            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)("source")
-            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)("destination")
+            Dim vbsource = source.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(source))
+            Dim vbdest = destination.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(destination))
 
             If vbsource.IsErrorType() OrElse vbdest.IsErrorType() Then
                 Return New Conversion(Nothing) ' No conversion
@@ -1801,7 +1801,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shadows Function CreateArrayTypeSymbol(elementType As TypeSymbol, Optional rank As Integer = 1) As ArrayTypeSymbol
             If elementType Is Nothing Then
-                Throw New ArgumentNullException("elementType")
+                Throw New ArgumentNullException(NameOf(elementType))
             End If
 
             Return New ArrayTypeSymbol(elementType, Nothing, rank, Me)
@@ -1961,7 +1961,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                               includeEarlierStages As Boolean,
                                               Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of Diagnostic)
             If Not SyntaxTrees.Contains(tree) Then
-                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", "tree")
+                Throw New ArgumentException("Cannot GetDiagnosticsForSyntax for a tree that is not part of the compilation", NameOf(tree))
             End If
 
             Dim builder = DiagnosticBag.GetInstance()
@@ -2506,7 +2506,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             Return Me.AddSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2519,7 +2519,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If trees Is Nothing Then
-                Throw New ArgumentNullException("trees")
+                Throw New ArgumentNullException(NameOf(trees))
             End If
 
             Return Me.RemoveSyntaxTrees(trees.Cast(Of SyntaxTree)())
@@ -2582,7 +2582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Protected Overrides Function CommonCreateArrayTypeSymbol(elementType As ITypeSymbol, rank As Integer) As IArrayTypeSymbol
-            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)("elementType"), rank)
+            Return CreateArrayTypeSymbol(elementType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(elementType)), rank)
         End Function
 
         Protected Overrides Function CommonCreatePointerTypeSymbol(elementType As ITypeSymbol) As IPointerTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Errors/VBDiagnostic.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/VBDiagnostic.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Overrides Function WithLocation(location As Location) As Diagnostic
             If location Is Nothing Then
-                Throw New ArgumentNullException("location")
+                Throw New ArgumentNullException(NameOf(location))
             End If
 
             If location IsNot Me.Location Then

--- a/src/Compilers/VisualBasic/Portable/Errors/VBDiagnostic.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/VBDiagnostic.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Overrides Function WithLocation(location As Location) As Diagnostic
             If location Is Nothing Then
-                Throw New ArgumentNullException(NameOf(location))
+                Throw New ArgumentNullException("location")
             End If
 
             If location IsNot Me.Location Then

--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>Array of symbols that include VBC_VER and TARGET.</returns>
         Public Function AddPredefinedPreprocessorSymbols(kind As OutputKind, symbols As ImmutableArray(Of KeyValuePair(Of String, Object))) As ImmutableArray(Of KeyValuePair(Of String, Object))
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException("kind")
+                Throw New ArgumentOutOfRangeException(NameOf(kind))
             End If
 
             Const CompilerVersionSymbol = "VBC_VER"

--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>Array of symbols that include VBC_VER and TARGET.</returns>
         Public Function AddPredefinedPreprocessorSymbols(kind As OutputKind, symbols As ImmutableArray(Of KeyValuePair(Of String, Object))) As ImmutableArray(Of KeyValuePair(Of String, Object))
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException(NameOf(kind))
+                Throw New ArgumentOutOfRangeException("kind")
             End If
 
             Const CompilerVersionSymbol = "VBC_VER"

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -335,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End If
 
             ' TODO: should this be a Require?
-            Throw New ArgumentOutOfRangeException("span")
+            Throw New ArgumentOutOfRangeException(NameOf(span))
         End Function
 #End Region
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -335,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End If
 
             ' TODO: should this be a Require?
-            Throw New ArgumentOutOfRangeException(NameOf(span))
+            Throw New ArgumentOutOfRangeException("span")
         End Function
 #End Region
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/SemanticFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/SemanticFacts.vb
@@ -38,11 +38,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                   within As NamedTypeSymbol,
                                                   Optional throughTypeOpt As NamedTypeSymbol = Nothing) As Boolean
             If symbol Is Nothing Then
-                Throw New ArgumentNullException("symbol")
+                Throw New ArgumentNullException(NameOf(symbol))
             End If
 
             If within Is Nothing Then
-                Throw New ArgumentNullException("within")
+                Throw New ArgumentNullException(NameOf(within))
             End If
 
             Return AccessCheck.IsSymbolAccessible(symbol, within, throughTypeOpt, useSiteDiagnostics:=Nothing)
@@ -58,11 +58,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function IsSymbolAccessible(symbol As Symbol,
                                                   within As AssemblySymbol) As Boolean
             If symbol Is Nothing Then
-                Throw New ArgumentNullException("symbol")
+                Throw New ArgumentNullException(NameOf(symbol))
             End If
 
             If within Is Nothing Then
-                Throw New ArgumentNullException("within")
+                Throw New ArgumentNullException(NameOf(within))
             End If
 
             Return AccessCheck.IsSymbolAccessible(symbol, within, useSiteDiagnostics:=Nothing)

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 Return If(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers), "ChrW(&H" & codepoint.ToString("X"), "ChrW(" & codepoint.ToString()) & ")"
             End If
 
-            Return """"c & EscapeQuote(c) & """"c & NameOf(c)
+            Return """"c & EscapeQuote(c) & """"c & "c"
         End Function
 
         Private Function EscapeQuote(c As Char) As String

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -1,5 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
+﻿
 Imports System.Globalization
 Imports System.Reflection
 Imports Microsoft.CodeAnalysis.Collections

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 Return If(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers), "ChrW(&H" & codepoint.ToString("X"), "ChrW(" & codepoint.ToString()) & ")"
             End If
 
-            Return """"c & EscapeQuote(c) & """"c & "c"
+            Return """"c & EscapeQuote(c) & """"c & NameOf(c)
         End Function
 
         Private Function EscapeQuote(c As Char) As String

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -1,4 +1,5 @@
-﻿
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 Imports System.Globalization
 Imports System.Reflection
 Imports Microsoft.CodeAnalysis.Collections

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        format As SymbolDisplayFormat,
                                        minimal As Boolean) As ImmutableArray(Of SymbolDisplayPart)
             If symbol Is Nothing Then
-                Throw New ArgumentNullException(NameOf(symbol))
+                Throw New ArgumentNullException("symbol")
             End If
 
             If minimal Then

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        format As SymbolDisplayFormat,
                                        minimal As Boolean) As ImmutableArray(Of SymbolDisplayPart)
             If symbol Is Nothing Then
-                Throw New ArgumentNullException("symbol")
+                Throw New ArgumentNullException(NameOf(symbol))
             End If
 
             If minimal Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public Function ResolveForwardedType(fullyQualifiedMetadataName As String) As NamedTypeSymbol
             If fullyQualifiedMetadataName Is Nothing Then
-                Throw New ArgumentNullException(NameOf(fullyQualifiedMetadataName))
+                Throw New ArgumentNullException("fullyQualifiedMetadataName")
             End If
 
             Dim emittedName = MetadataTypeName.FromFullName(fullyQualifiedMetadataName)
@@ -433,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function GetTypeByMetadataName(metadataName As String, includeReferences As Boolean, isWellKnownType As Boolean, Optional useCLSCompliantNameArityEncoding As Boolean = False) As NamedTypeSymbol
 
             If metadataName Is Nothing Then
-                Throw New ArgumentNullException(NameOf(metadataName))
+                Throw New ArgumentNullException("metadataName")
             End If
 
             Dim type As NamedTypeSymbol = Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public Function ResolveForwardedType(fullyQualifiedMetadataName As String) As NamedTypeSymbol
             If fullyQualifiedMetadataName Is Nothing Then
-                Throw New ArgumentNullException("fullyQualifiedMetadataName")
+                Throw New ArgumentNullException(NameOf(fullyQualifiedMetadataName))
             End If
 
             Dim emittedName = MetadataTypeName.FromFullName(fullyQualifiedMetadataName)
@@ -433,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function GetTypeByMetadataName(metadataName As String, includeReferences As Boolean, isWellKnownType As Boolean, Optional useCLSCompliantNameArityEncoding As Boolean = False) As NamedTypeSymbol
 
             If metadataName Is Nothing Then
-                Throw New ArgumentNullException("metadataName")
+                Throw New ArgumentNullException(NameOf(metadataName))
             End If
 
             Dim type As NamedTypeSymbol = Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -811,7 +811,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Private Function IMethodSymbol_GetTypeInferredDuringReduction(reducedFromTypeParameter As ITypeParameterSymbol) As ITypeSymbol Implements IMethodSymbol.GetTypeInferredDuringReduction
-            Return Me.GetTypeInferredDuringReduction(reducedFromTypeParameter.EnsureVbSymbolOrNothing(Of TypeParameterSymbol)("reducedFromTypeParameter"))
+            Return Me.GetTypeInferredDuringReduction(reducedFromTypeParameter.EnsureVbSymbolOrNothing(Of TypeParameterSymbol)(NameOf(reducedFromTypeParameter)))
         End Function
 
         Private ReadOnly Property IMethodSymbol_ReducedFrom As IMethodSymbol Implements IMethodSymbol.ReducedFrom
@@ -822,10 +822,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function IMethodSymbol_ReduceExtensionMethod(receiverType As ITypeSymbol) As IMethodSymbol Implements IMethodSymbol.ReduceExtensionMethod
             If receiverType Is Nothing Then
-                Throw New ArgumentNullException("receiverType")
+                Throw New ArgumentNullException(NameOf(receiverType))
             End If
 
-            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)("receiverType"))
+            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(receiverType)))
         End Function
 
         Private ReadOnly Property IMethodSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IMethodSymbol.Parameters

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -811,7 +811,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Private Function IMethodSymbol_GetTypeInferredDuringReduction(reducedFromTypeParameter As ITypeParameterSymbol) As ITypeSymbol Implements IMethodSymbol.GetTypeInferredDuringReduction
-            Return Me.GetTypeInferredDuringReduction(reducedFromTypeParameter.EnsureVbSymbolOrNothing(Of TypeParameterSymbol)(NameOf(reducedFromTypeParameter)))
+            Return Me.GetTypeInferredDuringReduction(reducedFromTypeParameter.EnsureVbSymbolOrNothing(Of TypeParameterSymbol)("reducedFromTypeParameter"))
         End Function
 
         Private ReadOnly Property IMethodSymbol_ReducedFrom As IMethodSymbol Implements IMethodSymbol.ReducedFrom
@@ -822,10 +822,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function IMethodSymbol_ReduceExtensionMethod(receiverType As ITypeSymbol) As IMethodSymbol Implements IMethodSymbol.ReduceExtensionMethod
             If receiverType Is Nothing Then
-                Throw New ArgumentNullException(NameOf(receiverType))
+                Throw New ArgumentNullException("receiverType")
             End If
 
-            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(receiverType)))
+            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)("receiverType"))
         End Function
 
         Private ReadOnly Property IMethodSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IMethodSymbol.Parameters

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -232,7 +232,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public Function GetModuleNamespace(namespaceSymbol As INamespaceSymbol) As NamespaceSymbol
             If namespaceSymbol Is Nothing Then
-                Throw New ArgumentNullException("namespaceSymbol")
+                Throw New ArgumentNullException(NameOf(namespaceSymbol))
             End If
 
             Dim moduleNs = TryCast(namespaceSymbol, NamespaceSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -232,7 +232,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public Function GetModuleNamespace(namespaceSymbol As INamespaceSymbol) As NamespaceSymbol
             If namespaceSymbol Is Nothing Then
-                Throw New ArgumentNullException(NameOf(namespaceSymbol))
+                Throw New ArgumentNullException("namespaceSymbol")
             End If
 
             Dim moduleNs = TryCast(namespaceSymbol, NamespaceSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -470,7 +470,7 @@ Done:
         Public Function FindImplementationForInterfaceMember(interfaceMember As Symbol) As Symbol
             ' This layer handles caching, ComputeImplementationForInterfaceMember does the work.
             If interfaceMember Is Nothing Then
-                Throw New ArgumentNullException(NameOf(interfaceMember))
+                Throw New ArgumentNullException("interfaceMember")
             End If
 
             If Not interfaceMember.ContainingType.IsInterfaceType() OrElse

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -470,7 +470,7 @@ Done:
         Public Function FindImplementationForInterfaceMember(interfaceMember As Symbol) As Symbol
             ' This layer handles caching, ComputeImplementationForInterfaceMember does the work.
             If interfaceMember Is Nothing Then
-                Throw New ArgumentNullException("interfaceMember")
+                Throw New ArgumentNullException(NameOf(interfaceMember))
             End If
 
             If Not interfaceMember.ContainingType.IsInterfaceType() OrElse

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -869,17 +869,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         <Extension()>
         Friend Sub CheckTypeArguments(typeArguments As ImmutableArray(Of TypeSymbol), expectedCount As Integer)
             If typeArguments.IsDefault Then
-                Throw New Global.System.ArgumentNullException(NameOf(typeArguments))
+                Throw New Global.System.ArgumentNullException("typeArguments")
             End If
 
             For Each typeArg In typeArguments
                 If typeArg Is Nothing Then
-                    Throw New ArgumentException(VBResources.TypeArgumentCannotBeNothing, NameOf(typeArguments))
+                    Throw New ArgumentException(VBResources.TypeArgumentCannotBeNothing, "typeArguments")
                 End If
             Next
 
             If typeArguments.Length = 0 OrElse typeArguments.Length <> expectedCount Then
-                Throw New ArgumentException(VBResources.WrongNumberOfTypeArguments, NameOf(typeArguments))
+                Throw New ArgumentException(VBResources.WrongNumberOfTypeArguments, "typeArguments")
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -869,17 +869,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         <Extension()>
         Friend Sub CheckTypeArguments(typeArguments As ImmutableArray(Of TypeSymbol), expectedCount As Integer)
             If typeArguments.IsDefault Then
-                Throw New Global.System.ArgumentNullException("typeArguments")
+                Throw New Global.System.ArgumentNullException(NameOf(typeArguments))
             End If
 
             For Each typeArg In typeArguments
                 If typeArg Is Nothing Then
-                    Throw New ArgumentException(VBResources.TypeArgumentCannotBeNothing, "typeArguments")
+                    Throw New ArgumentException(VBResources.TypeArgumentCannotBeNothing, NameOf(typeArguments))
                 End If
             Next
 
             If typeArguments.Length = 0 OrElse typeArguments.Length <> expectedCount Then
-                Throw New ArgumentException(VBResources.WrongNumberOfTypeArguments, "typeArguments")
+                Throw New ArgumentException(VBResources.WrongNumberOfTypeArguments, NameOf(typeArguments))
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -15,13 +15,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         <Extension()>
         Public Function WithAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
+            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(node))
             Return CType(node.SetAnnotations(annotations), TNode)
         End Function
 
         <Extension()>
         Public Function WithAdditionalAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
+            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(node))
             Return CType(node.SetAnnotations(node.GetAnnotations().Concat(annotations).ToArray()), TNode)
         End Function
 
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Private Function AddLeadingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Not trivia.Any Then
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Friend Function AddTrailingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim tk = TryCast(node, SyntaxToken)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -15,13 +15,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         <Extension()>
         Public Function WithAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(node))
+            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
             Return CType(node.SetAnnotations(annotations), TNode)
         End Function
 
         <Extension()>
         Public Function WithAdditionalAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(node))
+            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
             Return CType(node.SetAnnotations(node.GetAnnotations().Concat(annotations).ToArray()), TNode)
         End Function
 
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Private Function AddLeadingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             If Not trivia.Any Then
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Friend Function AddTrailingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException(NameOf(node))
+                Throw New ArgumentNullException("node")
             End If
 
             Dim tk = TryCast(node, SyntaxToken)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -15,13 +15,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         <Extension()>
         Public Function WithAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
+            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(annotations))
             Return CType(node.SetAnnotations(annotations), TNode)
         End Function
 
         <Extension()>
         Public Function WithAdditionalAnnotations(Of TNode As VisualBasicSyntaxNode)(node As TNode, ParamArray annotations() As SyntaxAnnotation) As TNode
-            If annotations Is Nothing Then Throw New ArgumentNullException("annotations")
+            If annotations Is Nothing Then Throw New ArgumentNullException(NameOf(annotations))
             Return CType(node.SetAnnotations(node.GetAnnotations().Concat(annotations).ToArray()), TNode)
         End Function
 
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Private Function AddLeadingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If Not trivia.Any Then
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         <Extension()>
         Friend Function AddTrailingTrivia(Of TSyntax As VisualBasicSyntaxNode)(node As TSyntax, trivia As SyntaxList(Of VisualBasicSyntaxNode)) As TSyntax
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim tk = TryCast(node, SyntaxToken)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                 Case Else
-                    Throw New ArgumentException("typeSuffix")
+                    Throw New ArgumentException(NameOf(text))
             End Select
         End Function
 
@@ -62,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case TypeCharacter.SingleLiteral, TypeCharacter.Single
                     Return New FloatingLiteralTokenSyntax(Of Single)(SyntaxKind.FloatingLiteralToken, text, leadingTrivia, trailingTrivia, typeSuffix, CSng(value))
                 Case Else
-                    Throw New ArgumentException("typeSuffix")
+                    Throw New ArgumentException(NameOf(text))
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                 Case Else
-                    Throw New ArgumentException("typeSuffix")
+                    Throw New ArgumentException(NameOf(typeSuffix))
             End Select
         End Function
 
@@ -62,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case TypeCharacter.SingleLiteral, TypeCharacter.Single
                     Return New FloatingLiteralTokenSyntax(Of Single)(SyntaxKind.FloatingLiteralToken, text, leadingTrivia, trailingTrivia, typeSuffix, CSng(value))
                 Case Else
-                    Throw New ArgumentException("typeSuffix")
+                    Throw New ArgumentException(NameOf(typeSuffix))
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                 Case Else
-                    Throw New ArgumentException(NameOf(text))
+                    Throw New ArgumentException("typeSuffix")
             End Select
         End Function
 
@@ -62,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case TypeCharacter.SingleLiteral, TypeCharacter.Single
                     Return New FloatingLiteralTokenSyntax(Of Single)(SyntaxKind.FloatingLiteralToken, text, leadingTrivia, trailingTrivia, typeSuffix, CSng(value))
                 Case Else
-                    Throw New ArgumentException(NameOf(text))
+                    Throw New ArgumentException("typeSuffix")
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      SyntaxKind.EndOfInterpolatedStringToken
 
                 Case Else
-                    Throw New ArgumentOutOfRangeException("kind")
+                    Throw New ArgumentOutOfRangeException(NameOf(kind))
             End Select
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      SyntaxKind.EndOfInterpolatedStringToken
 
                 Case Else
-                    Throw New ArgumentOutOfRangeException(NameOf(kind))
+                    Throw New ArgumentOutOfRangeException("kind")
             End Select
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
@@ -745,7 +745,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return "Finally"
 
                 Case Else
-                    Throw New ArgumentOutOfRangeException(NameOf(kind))
+                    Throw New ArgumentOutOfRangeException("kind")
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
@@ -745,7 +745,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return "Finally"
 
                 Case Else
-                    Throw New ArgumentOutOfRangeException("kind")
+                    Throw New ArgumentOutOfRangeException(NameOf(kind))
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
@@ -263,7 +263,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function IntegerLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, base As LiteralBase, typeSuffix As TypeCharacter, value As ULong, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(text))
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, base, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -275,7 +275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function FloatingLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, typeSuffix As TypeCharacter, value As Double, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(text))
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.FloatingLiteralToken(text, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, isBracketed As Boolean, identifierText As String, typeCharacter As TypeCharacter, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(text))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, isBracketed, identifierText, typeCharacter), 0, 0)
@@ -307,7 +307,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(text))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, False, text, TypeCharacter.None), 0, 0)
@@ -325,11 +325,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function BracketedIdentifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(text))
             End If
 
             If MakeHalfWidthIdentifier(text.First) = "[" AndAlso MakeHalfWidthIdentifier(text.Last) = "]" Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(text))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, "[" + text + "]", DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, True, text, TypeCharacter.None), 0, 0)
@@ -695,7 +695,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function BadToken(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(text))
             End If
             Return New SyntaxToken(Nothing, New InternalSyntax.BadTokenSyntax(SyntaxKind.BadToken, InternalSyntax.SyntaxSubKind.None, Nothing, Nothing, text,
                     DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -998,7 +998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="nodesAndTokens">A sequence of nodes and tokens.</param>
         Public Shared Function NodeOrTokenList(nodesAndTokens As IEnumerable(Of SyntaxNodeOrToken)) As SyntaxNodeOrTokenList
             If nodesAndTokens Is Nothing Then
-                Throw New ArgumentNullException("nodesAndTokens")
+                Throw New ArgumentNullException(NameOf(nodesAndTokens))
             End If
 
             Dim builder = New SyntaxNodeOrTokenListBuilder(8)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
@@ -263,7 +263,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function IntegerLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, base As LiteralBase, typeSuffix As TypeCharacter, value As ULong, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(leadingTrivia))
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, base, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -275,7 +275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function FloatingLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, typeSuffix As TypeCharacter, value As Double, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(leadingTrivia))
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.FloatingLiteralToken(text, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, isBracketed As Boolean, identifierText As String, typeCharacter As TypeCharacter, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(leadingTrivia))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, isBracketed, identifierText, typeCharacter), 0, 0)
@@ -307,7 +307,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(leadingTrivia))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, False, text, TypeCharacter.None), 0, 0)
@@ -325,11 +325,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function BracketedIdentifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(leadingTrivia))
             End If
 
             If MakeHalfWidthIdentifier(text.First) = "[" AndAlso MakeHalfWidthIdentifier(text.Last) = "]" Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(leadingTrivia))
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, "[" + text + "]", DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, True, text, TypeCharacter.None), 0, 0)
@@ -695,7 +695,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function BadToken(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException("text")
+                Throw New ArgumentException(NameOf(leadingTrivia))
             End If
             Return New SyntaxToken(Nothing, New InternalSyntax.BadTokenSyntax(SyntaxKind.BadToken, InternalSyntax.SyntaxSubKind.None, Nothing, Nothing, text,
                     DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -998,7 +998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="nodesAndTokens">A sequence of nodes and tokens.</param>
         Public Shared Function NodeOrTokenList(nodesAndTokens As IEnumerable(Of SyntaxNodeOrToken)) As SyntaxNodeOrTokenList
             If nodesAndTokens Is Nothing Then
-                Throw New ArgumentNullException("nodesAndTokens")
+                Throw New ArgumentNullException(NameOf(nodesAndTokens))
             End If
 
             Dim builder = New SyntaxNodeOrTokenListBuilder(8)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
@@ -263,7 +263,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function IntegerLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, base As LiteralBase, typeSuffix As TypeCharacter, value As ULong, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException(NameOf(leadingTrivia))
+                Throw New ArgumentNullException("text")
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, base, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -275,7 +275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function FloatingLiteralToken(leadingTrivia As SyntaxTriviaList, text As String, typeSuffix As TypeCharacter, value As Double, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentNullException(NameOf(leadingTrivia))
+                Throw New ArgumentNullException("text")
             End If
 
             Return New SyntaxToken(Nothing, InternalSyntax.SyntaxFactory.FloatingLiteralToken(text, typeSuffix, value, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, isBracketed As Boolean, identifierText As String, typeCharacter As TypeCharacter, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException(NameOf(leadingTrivia))
+                Throw New ArgumentException("text")
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, isBracketed, identifierText, typeCharacter), 0, 0)
@@ -307,7 +307,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function Identifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException(NameOf(leadingTrivia))
+                Throw New ArgumentException("text")
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, text, DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, False, text, TypeCharacter.None), 0, 0)
@@ -325,11 +325,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function BracketedIdentifier(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException(NameOf(leadingTrivia))
+                Throw New ArgumentException("text")
             End If
 
             If MakeHalfWidthIdentifier(text.First) = "[" AndAlso MakeHalfWidthIdentifier(text.Last) = "]" Then
-                Throw New ArgumentException(NameOf(leadingTrivia))
+                Throw New ArgumentException("text")
             End If
 
             Return New SyntaxToken(Nothing, New InternalSyntax.ComplexIdentifierSyntax(SyntaxKind.IdentifierToken, Nothing, Nothing, "[" + text + "]", DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), SyntaxKind.IdentifierToken, True, text, TypeCharacter.None), 0, 0)
@@ -695,7 +695,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared Function BadToken(leadingTrivia As SyntaxTriviaList, text As String, trailingTrivia As SyntaxTriviaList) As SyntaxToken
             If text Is Nothing Then
-                Throw New ArgumentException(NameOf(leadingTrivia))
+                Throw New ArgumentException("text")
             End If
             Return New SyntaxToken(Nothing, New InternalSyntax.BadTokenSyntax(SyntaxKind.BadToken, InternalSyntax.SyntaxSubKind.None, Nothing, Nothing, text,
                     DirectCast(leadingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailingTrivia.Node, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
@@ -998,7 +998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="nodesAndTokens">A sequence of nodes and tokens.</param>
         Public Shared Function NodeOrTokenList(nodesAndTokens As IEnumerable(Of SyntaxNodeOrToken)) As SyntaxNodeOrTokenList
             If nodesAndTokens Is Nothing Then
-                Throw New ArgumentNullException(NameOf(nodesAndTokens))
+                Throw New ArgumentNullException("nodesAndTokens")
             End If
 
             Dim builder = New SyntaxNodeOrTokenListBuilder(8)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -566,7 +566,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             'PERF: it is very important to keep this method fast.
 
             If Not FullSpan.Contains(position) Then
-                Throw New ArgumentOutOfRangeException("position")
+                Throw New ArgumentOutOfRangeException(NameOf(position))
             End If
 
             Dim childNodeOrToken = ChildSyntaxList.ChildThatContainsPosition(Me, position)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -566,7 +566,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             'PERF: it is very important to keep this method fast.
 
             If Not FullSpan.Contains(position) Then
-                Throw New ArgumentOutOfRangeException(NameOf(position))
+                Throw New ArgumentOutOfRangeException("position")
             End If
 
             Dim childNodeOrToken = ChildSyntaxList.ChildThatContainsPosition(Me, position)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Not Me.FullSpan.Contains(position) Then
-                    Throw New IndexOutOfRangeException("position")
+                    Throw New IndexOutOfRangeException(NameOf(position))
                 End If
 
                 Return FindTokenInternal(position)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Not Me.FullSpan.Contains(position) Then
-                    Throw New IndexOutOfRangeException(NameOf(position))
+                    Throw New IndexOutOfRangeException("position")
                 End If
 
                 Return FindTokenInternal(position)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function WithChanges(newText As SourceText, changes As TextChangeRange()) As SyntaxTree
             If changes Is Nothing Then
-                Throw New ArgumentNullException("changes")
+                Throw New ArgumentNullException(NameOf(newText))
             End If
 
             Dim scanner As scanner
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       Optional path As String = "",
                                       Optional encoding As Encoding = Nothing) As SyntaxTree
             If root Is Nothing Then
-                Throw New ArgumentNullException("root")
+                Throw New ArgumentNullException(NameOf(root))
             End If
 
             Return New ParsedSyntaxTree(
@@ -217,11 +217,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          Optional cancellationToken As CancellationToken = Nothing) As SyntaxTree
 
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(text))
             End If
 
             If path Is Nothing Then
-                Throw New ArgumentNullException("path")
+                Throw New ArgumentNullException(NameOf(text))
             End If
 
             options = If(options, VisualBasicParseOptions.Default)
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This method does not filter diagnostics based on compiler options like /nowarn, /warnaserror etc.
         ''' </remarks>
         Public Overrides Function GetDiagnostics(node As SyntaxNode) As IEnumerable(Of Diagnostic)
-            If node Is Nothing Then Throw New ArgumentNullException("node")
+            If node Is Nothing Then Throw New ArgumentNullException(NameOf(node))
 
             Return Me.GetDiagnostics(DirectCast(node.Green, InternalSyntax.VisualBasicSyntaxNode), DirectCast(node, VisualBasicSyntaxNode).Position, InDocumentationComment(node))
         End Function
@@ -451,7 +451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list is pessimistic because it may claim more or larger regions than actually changed.</remarks>
         Public Overrides Function GetChangedSpans(oldTree As SyntaxTree) As IList(Of TextSpan)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException("oldTree")
+                Throw New ArgumentNullException(NameOf(oldTree))
             End If
 
             Return SyntaxDiffer.GetPossiblyDifferentTextSpans(oldTree.GetRoot(), Me.GetRoot())
@@ -464,7 +464,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list of changes may be different than the original changes that produced this tree.</remarks>
         Public Overrides Function GetChanges(oldTree As SyntaxTree) As IList(Of TextChange)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException("oldTree")
+                Throw New ArgumentNullException(NameOf(oldTree))
             End If
 
             Return SyntaxDiffer.GetTextChanges(oldTree, Me)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function WithChanges(newText As SourceText, changes As TextChangeRange()) As SyntaxTree
             If changes Is Nothing Then
-                Throw New ArgumentNullException("changes")
+                Throw New ArgumentNullException(NameOf(changes))
             End If
 
             Dim scanner As scanner
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       Optional path As String = "",
                                       Optional encoding As Encoding = Nothing) As SyntaxTree
             If root Is Nothing Then
-                Throw New ArgumentNullException("root")
+                Throw New ArgumentNullException(NameOf(root))
             End If
 
             Return New ParsedSyntaxTree(
@@ -217,11 +217,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          Optional cancellationToken As CancellationToken = Nothing) As SyntaxTree
 
             If text Is Nothing Then
-                Throw New ArgumentNullException("text")
+                Throw New ArgumentNullException(NameOf(text))
             End If
 
             If path Is Nothing Then
-                Throw New ArgumentNullException("path")
+                Throw New ArgumentNullException(NameOf(path))
             End If
 
             options = If(options, VisualBasicParseOptions.Default)
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This method does not filter diagnostics based on compiler options like /nowarn, /warnaserror etc.
         ''' </remarks>
         Public Overrides Function GetDiagnostics(node As SyntaxNode) As IEnumerable(Of Diagnostic)
-            If node Is Nothing Then Throw New ArgumentNullException("node")
+            If node Is Nothing Then Throw New ArgumentNullException(NameOf(node))
 
             Return Me.GetDiagnostics(DirectCast(node.Green, InternalSyntax.VisualBasicSyntaxNode), DirectCast(node, VisualBasicSyntaxNode).Position, InDocumentationComment(node))
         End Function
@@ -451,7 +451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list is pessimistic because it may claim more or larger regions than actually changed.</remarks>
         Public Overrides Function GetChangedSpans(oldTree As SyntaxTree) As IList(Of TextSpan)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException("oldTree")
+                Throw New ArgumentNullException(NameOf(oldTree))
             End If
 
             Return SyntaxDiffer.GetPossiblyDifferentTextSpans(oldTree.GetRoot(), Me.GetRoot())
@@ -464,7 +464,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list of changes may be different than the original changes that produced this tree.</remarks>
         Public Overrides Function GetChanges(oldTree As SyntaxTree) As IList(Of TextChange)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException("oldTree")
+                Throw New ArgumentNullException(NameOf(oldTree))
             End If
 
             Return SyntaxDiffer.GetTextChanges(oldTree, Me)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function WithChanges(newText As SourceText, changes As TextChangeRange()) As SyntaxTree
             If changes Is Nothing Then
-                Throw New ArgumentNullException(NameOf(newText))
+                Throw New ArgumentNullException("changes")
             End If
 
             Dim scanner As scanner
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       Optional path As String = "",
                                       Optional encoding As Encoding = Nothing) As SyntaxTree
             If root Is Nothing Then
-                Throw New ArgumentNullException(NameOf(root))
+                Throw New ArgumentNullException("root")
             End If
 
             Return New ParsedSyntaxTree(
@@ -217,11 +217,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          Optional cancellationToken As CancellationToken = Nothing) As SyntaxTree
 
             If text Is Nothing Then
-                Throw New ArgumentNullException(NameOf(text))
+                Throw New ArgumentNullException("text")
             End If
 
             If path Is Nothing Then
-                Throw New ArgumentNullException(NameOf(text))
+                Throw New ArgumentNullException("path")
             End If
 
             options = If(options, VisualBasicParseOptions.Default)
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This method does not filter diagnostics based on compiler options like /nowarn, /warnaserror etc.
         ''' </remarks>
         Public Overrides Function GetDiagnostics(node As SyntaxNode) As IEnumerable(Of Diagnostic)
-            If node Is Nothing Then Throw New ArgumentNullException(NameOf(node))
+            If node Is Nothing Then Throw New ArgumentNullException("node")
 
             Return Me.GetDiagnostics(DirectCast(node.Green, InternalSyntax.VisualBasicSyntaxNode), DirectCast(node, VisualBasicSyntaxNode).Position, InDocumentationComment(node))
         End Function
@@ -451,7 +451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list is pessimistic because it may claim more or larger regions than actually changed.</remarks>
         Public Overrides Function GetChangedSpans(oldTree As SyntaxTree) As IList(Of TextSpan)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException(NameOf(oldTree))
+                Throw New ArgumentNullException("oldTree")
             End If
 
             Return SyntaxDiffer.GetPossiblyDifferentTextSpans(oldTree.GetRoot(), Me.GetRoot())
@@ -464,7 +464,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks>The list of changes may be different than the original changes that produced this tree.</remarks>
         Public Overrides Function GetChanges(oldTree As SyntaxTree) As IList(Of TextChange)
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException(NameOf(oldTree))
+                Throw New ArgumentNullException("oldTree")
             End If
 
             Return SyntaxDiffer.GetTextChanges(oldTree, Me)

--- a/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
@@ -386,11 +386,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         <Extension>
         Public Function Insert(list As SyntaxTokenList, index As Integer, ParamArray items As SyntaxToken()) As SyntaxTokenList
             If index < 0 OrElse index > list.Count Then
-                Throw New ArgumentOutOfRangeException(NameOf(list))
+                Throw New ArgumentOutOfRangeException("index")
             End If
 
             If items Is Nothing Then
-                Throw New ArgumentNullException(NameOf(list))
+                Throw New ArgumentNullException("items")
             End If
 
             If list.Count = 0 Then

--- a/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
@@ -386,11 +386,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         <Extension>
         Public Function Insert(list As SyntaxTokenList, index As Integer, ParamArray items As SyntaxToken()) As SyntaxTokenList
             If index < 0 OrElse index > list.Count Then
-                Throw New ArgumentOutOfRangeException("index")
+                Throw New ArgumentOutOfRangeException(NameOf(list))
             End If
 
             If items Is Nothing Then
-                Throw New ArgumentNullException("items")
+                Throw New ArgumentNullException(NameOf(list))
             End If
 
             If list.Count = 0 Then

--- a/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicExtensions.vb
@@ -386,11 +386,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         <Extension>
         Public Function Insert(list As SyntaxTokenList, index As Integer, ParamArray items As SyntaxToken()) As SyntaxTokenList
             If index < 0 OrElse index > list.Count Then
-                Throw New ArgumentOutOfRangeException("index")
+                Throw New ArgumentOutOfRangeException(NameOf(index))
             End If
 
             If items Is Nothing Then
-                Throw New ArgumentNullException("items")
+                Throw New ArgumentNullException(NameOf(items))
             End If
 
             If list.Count = 0 Then

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -38,14 +38,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If(preprocessorSymbols Is Nothing, DefaultPreprocessorSymbols, ImmutableArray.CreateRange(preprocessorSymbols)))
 
             If Not languageVersion.IsValid Then
-                Throw New ArgumentOutOfRangeException("languageVersion")
+                Throw New ArgumentOutOfRangeException(NameOf(languageVersion))
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException("kind")
+                Throw New ArgumentOutOfRangeException(NameOf(languageVersion))
             End If
 
-            ValidatePreprocessorSymbols(preprocessorSymbols, "preprocessorSymbols")
+            ValidatePreprocessorSymbols(preprocessorSymbols, NameOf(languageVersion))
         End Sub
 
         Private Shared Sub ValidatePreprocessorSymbols(preprocessorSymbols As IEnumerable(Of KeyValuePair(Of String, Object)),
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not version.IsValid Then
-                Throw New ArgumentOutOfRangeException("version")
+                Throw New ArgumentOutOfRangeException(NameOf(version))
             End If
 
             Return New VisualBasicParseOptions(Me) With {._languageVersion = version}
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException("kind")
+                Throw New ArgumentOutOfRangeException(NameOf(kind))
             End If
 
             Return New VisualBasicParseOptions(Me) With {.Kind = kind}
@@ -177,7 +177,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not documentationMode.IsValid() Then
-                Throw New ArgumentOutOfRangeException("documentationMode")
+                Throw New ArgumentOutOfRangeException(NameOf(documentationMode))
             End If
 
             Return New VisualBasicParseOptions(Me) With {.DocumentationMode = documentationMode}
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            ValidatePreprocessorSymbols(symbols, "symbols")
+            ValidatePreprocessorSymbols(symbols, NameOf(symbols))
 
             Return New VisualBasicParseOptions(Me) With {._preprocessorSymbols = symbols}
         End Function

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -38,14 +38,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If(preprocessorSymbols Is Nothing, DefaultPreprocessorSymbols, ImmutableArray.CreateRange(preprocessorSymbols)))
 
             If Not languageVersion.IsValid Then
-                Throw New ArgumentOutOfRangeException(NameOf(languageVersion))
+                Throw New ArgumentOutOfRangeException("languageVersion")
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException(NameOf(languageVersion))
+                Throw New ArgumentOutOfRangeException("kind")
             End If
 
-            ValidatePreprocessorSymbols(preprocessorSymbols, NameOf(languageVersion))
+            ValidatePreprocessorSymbols(preprocessorSymbols, "preprocessorSymbols")
         End Sub
 
         Private Shared Sub ValidatePreprocessorSymbols(preprocessorSymbols As IEnumerable(Of KeyValuePair(Of String, Object)),
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not version.IsValid Then
-                Throw New ArgumentOutOfRangeException(NameOf(version))
+                Throw New ArgumentOutOfRangeException("version")
             End If
 
             Return New VisualBasicParseOptions(Me) With {._languageVersion = version}
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException(NameOf(kind))
+                Throw New ArgumentOutOfRangeException("kind")
             End If
 
             Return New VisualBasicParseOptions(Me) With {.Kind = kind}
@@ -177,7 +177,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not documentationMode.IsValid() Then
-                Throw New ArgumentOutOfRangeException(NameOf(documentationMode))
+                Throw New ArgumentOutOfRangeException("documentationMode")
             End If
 
             Return New VisualBasicParseOptions(Me) With {.DocumentationMode = documentationMode}
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            ValidatePreprocessorSymbols(symbols, NameOf(symbols))
+            ValidatePreprocessorSymbols(symbols, "symbols")
 
             Return New VisualBasicParseOptions(Me) With {._preprocessorSymbols = symbols}
         End Function

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -38,14 +38,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If(preprocessorSymbols Is Nothing, DefaultPreprocessorSymbols, ImmutableArray.CreateRange(preprocessorSymbols)))
 
             If Not languageVersion.IsValid Then
-                Throw New ArgumentOutOfRangeException("languageVersion")
+                Throw New ArgumentOutOfRangeException(NameOf(languageVersion))
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException("kind")
+                Throw New ArgumentOutOfRangeException(NameOf(kind))
             End If
 
-            ValidatePreprocessorSymbols(preprocessorSymbols, "preprocessorSymbols")
+            ValidatePreprocessorSymbols(preprocessorSymbols, NameOf(preprocessorSymbols))
         End Sub
 
         Private Shared Sub ValidatePreprocessorSymbols(preprocessorSymbols As IEnumerable(Of KeyValuePair(Of String, Object)),
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not version.IsValid Then
-                Throw New ArgumentOutOfRangeException("version")
+                Throw New ArgumentOutOfRangeException(NameOf(version))
             End If
 
             Return New VisualBasicParseOptions(Me) With {._languageVersion = version}
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not kind.IsValid Then
-                Throw New ArgumentOutOfRangeException("kind")
+                Throw New ArgumentOutOfRangeException(NameOf(kind))
             End If
 
             Return New VisualBasicParseOptions(Me) With {.Kind = kind}
@@ -177,7 +177,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not documentationMode.IsValid() Then
-                Throw New ArgumentOutOfRangeException("documentationMode")
+                Throw New ArgumentOutOfRangeException(NameOf(documentationMode))
             End If
 
             Return New VisualBasicParseOptions(Me) With {.DocumentationMode = documentationMode}
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            ValidatePreprocessorSymbols(symbols, "symbols")
+            ValidatePreprocessorSymbols(symbols, NameOf(symbols))
 
             Return New VisualBasicParseOptions(Me) With {._preprocessorSymbols = symbols}
         End Function

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -347,7 +347,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             If nameSyntax.LocalName.ValueText = name Then
                 Return startTag.Attributes.OfType(Of XmlNameAttributeSyntax)() _
-                    .Where(Function(a) a.Name.ToString() = "name") _
+                    .Where(Function(a) a.Name.ToString() = NameOf(name)) _
                     .Select(Function(a) a.Reference.Identifier.ValueText) _
                     .FirstOrDefault()
             End If

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructExtensions.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructExtensions.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
         <Extension()>
         Public Function GetAligningWhitespace(snapshot As ITextSnapshot, position As Integer) As String
             If snapshot Is Nothing Then
-                Throw New ArgumentNullException("snapshot")
+                Throw New ArgumentNullException(NameOf(snapshot))
             End If
             Dim line = snapshot.GetLineFromPosition(position)
             Dim precedingText = snapshot.GetText(Span.FromBounds(line.Start, position))

--- a/src/EditorFeatures/VisualBasic/Outlining/VisualBasicOutliningHelpers.vb
+++ b/src/EditorFeatures/VisualBasic/Outlining/VisualBasicOutliningHelpers.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Outlining
 
         Friend Sub CollectCommentsRegions(node As SyntaxNode, spans As List(Of OutliningSpan))
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim triviaList = node.GetLeadingTrivia()

--- a/src/EditorFeatures/VisualBasicTest/Utils.vb
+++ b/src/EditorFeatures/VisualBasicTest/Utils.vb
@@ -332,7 +332,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests
                     Return String.Join(vbCrLf, lines)
 
                 Case Else
-                    Throw New ArgumentException("Unexpected testSource XML tag.", "testSource")
+                    Throw New ArgumentException("Unexpected testSource XML tag.", NameOf(testSource))
             End Select
         End Function
     End Module

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/WriteCsvNames.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/WriteCsvNames.vb
@@ -63,7 +63,7 @@ Friend Class WriteCsvNames
     End Sub
 
     Private Sub WriteEnumeratorVariable(enumerator As ParseEnumerator, enumeration As ParseEnumeration)
-        WriteCsvLine("enumerator", EnumerationTypeName(enumeration), enumerator.Name)
+        WriteCsvLine(NameOf(enumerator), EnumerationTypeName(enumeration), enumerator.Name)
     End Sub
 
     Private Sub WriteNodeStructure(nodeStructure As ParseNodeStructure)
@@ -87,15 +87,15 @@ Friend Class WriteCsvNames
     End Sub
 
     Private Sub WriteKind(kind As ParseNodeKind)
-        WriteCsvLine("kind", StructureTypeName(kind.NodeStructure), Ident(kind.Name))
+        WriteCsvLine(NameOf(kind), StructureTypeName(kind.NodeStructure), Ident(kind.Name))
     End Sub
 
     Private Sub WriteField(field As ParseNodeField)
-        WriteCsvLine("field", StructureTypeName(field.ContainingStructure), FieldPropertyName(field))
+        WriteCsvLine(NameOf(field), StructureTypeName(field.ContainingStructure), FieldPropertyName(field))
     End Sub
 
     Private Sub WriteChild(child As ParseNodeChild)
-        WriteCsvLine("child", StructureTypeName(child.ContainingStructure), ChildPropertyName(child))
+        WriteCsvLine(NameOf(child), StructureTypeName(child.ContainingStructure), ChildPropertyName(child))
     End Sub
 
     Private Sub WriteFactories()

--- a/src/VisualStudio/Core/Test/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CodeModelTestState.vb
@@ -23,11 +23,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         )
 
             If workspace Is Nothing Then
-                Throw New ArgumentNullException("workspace")
+                Throw New ArgumentNullException(NameOf(workspace))
             End If
 
             If codeModelService Is Nothing Then
-                Throw New ArgumentNullException("codeModelService")
+                Throw New ArgumentNullException(NameOf(workspace))
             End If
 
             _workspace = workspace

--- a/src/VisualStudio/Core/Test/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CodeModelTestState.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             End If
 
             If codeModelService Is Nothing Then
-                Throw New ArgumentNullException(NameOf(workspace))
+                Throw New ArgumentNullException(NameOf(codeModelService))
             End If
 
             _workspace = workspace

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -831,7 +831,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
         Public Overrides Function GetName(node As SyntaxNode) As String
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Debug.Assert(TypeOf node Is SyntaxNode)
@@ -906,7 +906,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
         Public Overrides Function SetName(node As SyntaxNode, name As String) As SyntaxNode
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim identifier As SyntaxToken = SyntaxFactory.Identifier(name)
@@ -953,7 +953,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
         Public Overrides Function GetNodeWithName(node As SyntaxNode) As SyntaxNode
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             If node.Kind = SyntaxKind.OperatorBlock Then

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicProjectCodeModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicProjectCodeModel.vb
@@ -37,28 +37,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
             ' Because the VB project system lacks these hooks, we simulate the same operations that those hooks perform.
             Dim document = _project.GetCurrentDocumentFromPath(fileName)
             If document Is Nothing Then
-                Throw New ArgumentException("fileName")
+                Throw New ArgumentException(NameOf(fileName))
             End If
 
             Dim itemId = document.GetItemId()
             If itemId = VSConstants.VSITEMID.Nil Then
-                Throw New ArgumentException("fileName")
+                Throw New ArgumentException(NameOf(fileName))
                 Return Nothing
             End If
 
             Dim pvar As Object = Nothing
             If ErrorHandler.Failed(_project.Hierarchy.GetProperty(itemId, __VSHPROPID.VSHPROPID_ExtObject, pvar)) Then
-                Throw New ArgumentException("fileName")
+                Throw New ArgumentException(NameOf(fileName))
             End If
 
             Dim projectItem = TryCast(pvar, EnvDTE.ProjectItem)
             If projectItem Is Nothing Then
-                Throw New ArgumentException("fileName")
+                Throw New ArgumentException(NameOf(fileName))
             End If
 
             Dim fileCodeModel As EnvDTE.FileCodeModel = Nothing
             If ErrorHandler.Failed(_project.CreateFileCodeModel(projectItem.ContainingProject, projectItem, fileCodeModel)) Then
-                Throw New ArgumentException("fileName")
+                Throw New ArgumentException(NameOf(fileName))
             End If
 
             Return fileCodeModel

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 If project Is Nothing Then
                     ' Hmm, we got a project which isn't from ourselves. That's somewhat odd, and we really can't do anything
                     ' with it.
-                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", "pReferencedCompilerProject")
+                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
                 End If
 
                 MyBase.AddProjectReference(New ProjectReference(project.Id, embedInteropTypes:=True))
@@ -140,7 +140,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 If project Is Nothing Then
                     ' Hmm, we got a project which isn't from ourselves. That's somewhat odd, and we really can't do anything
                     ' with it.
-                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", "pReferencedCompilerProject")
+                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
                 End If
 
                 MyBase.AddProjectReference(New ProjectReference(project.Id))
@@ -328,11 +328,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 If project Is Nothing Then
                     ' Hmm, we got a project which isn't from ourselves. That's somewhat odd, and we really can't do anything
                     ' with it.
-                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", "pReferencedCompilerProject")
+                    Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
                 End If
 
                 If Not Me.CurrentProjectReferencesContains(project.Id) Then
-                    Throw New ArgumentException("Project reference to remove is not referenced by this project.", "pReferencedCompilerProject")
+                    Throw New ArgumentException("Project reference to remove is not referenced by this project.", NameOf(pReferencedCompilerProject))
                 End If
 
                 Dim projectReference = GetCurrentProjectReferences().Single(Function(r) r.ProjectId Is project.Id)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/OperatorGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/OperatorGenerator.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                                                 options As CodeGenerationOptions) As StatementSyntax
             Dim operatorSyntaxKind = SyntaxFacts.GetOperatorKind(method.MetadataName)
             If operatorSyntaxKind = SyntaxKind.None Then
-                Throw New ArgumentException(String.Format(WorkspacesResources.CannotCodeGenUnsupportedOperator, method.Name), "method")
+                Throw New ArgumentException(String.Format(WorkspacesResources.CannotCodeGenUnsupportedOperator, method.Name), NameOf(method))
             End If
 
             Dim begin = SyntaxFactory.OperatorStatement(

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
@@ -298,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     cancellationToken As CancellationToken) As TDeclarationNode
 
             If target.HasValue AndAlso Not target.Value.IsValidAttributeTarget() Then
-                Throw New ArgumentException(NameOf(destination))
+                Throw New ArgumentException(NameOf(target))
             End If
 
             Dim attributeSyntaxList = AttributeGenerator.GenerateAttributeBlocks(attributes.ToImmutableArray(), options, target)
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function RemoveAttribute(Of TDeclarationNode As SyntaxNode)(destination As TDeclarationNode, attributeToRemove As AttributeData, options As CodeGenerationOptions, cancellationToken As CancellationToken) As TDeclarationNode
             If attributeToRemove.ApplicationSyntaxReference Is Nothing Then
-                Throw New ArgumentException(NameOf(destination))
+                Throw New ArgumentException(NameOf(attributeToRemove))
             End If
 
             Dim attributeSyntaxToRemove = attributeToRemove.ApplicationSyntaxReference.GetSyntax(cancellationToken)
@@ -335,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function RemoveAttribute(Of TDeclarationNode As SyntaxNode)(destination As TDeclarationNode, attributeToRemove As SyntaxNode, options As CodeGenerationOptions, cancellationToken As CancellationToken) As TDeclarationNode
             If attributeToRemove Is Nothing Then
-                Throw New ArgumentException(NameOf(destination))
+                Throw New ArgumentException(NameOf(attributeToRemove))
             End If
 
             ' Removed node could be AttributeSyntax or AttributeListSyntax.

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
@@ -298,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     cancellationToken As CancellationToken) As TDeclarationNode
 
             If target.HasValue AndAlso Not target.Value.IsValidAttributeTarget() Then
-                Throw New ArgumentException("target")
+                Throw New ArgumentException(NameOf(destination))
             End If
 
             Dim attributeSyntaxList = AttributeGenerator.GenerateAttributeBlocks(attributes.ToImmutableArray(), options, target)
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function RemoveAttribute(Of TDeclarationNode As SyntaxNode)(destination As TDeclarationNode, attributeToRemove As AttributeData, options As CodeGenerationOptions, cancellationToken As CancellationToken) As TDeclarationNode
             If attributeToRemove.ApplicationSyntaxReference Is Nothing Then
-                Throw New ArgumentException("attributeToRemove")
+                Throw New ArgumentException(NameOf(destination))
             End If
 
             Dim attributeSyntaxToRemove = attributeToRemove.ApplicationSyntaxReference.GetSyntax(cancellationToken)
@@ -335,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function RemoveAttribute(Of TDeclarationNode As SyntaxNode)(destination As TDeclarationNode, attributeToRemove As SyntaxNode, options As CodeGenerationOptions, cancellationToken As CancellationToken) As TDeclarationNode
             If attributeToRemove Is Nothing Then
-                Throw New ArgumentException("attributeToRemove")
+                Throw New ArgumentException(NameOf(destination))
             End If
 
             ' Removed node could be AttributeSyntax or AttributeListSyntax.

--- a/src/Workspaces/VisualBasic/Portable/Extensions/DirectiveSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/DirectiveSyntaxExtensions.vb
@@ -102,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         Public Function GetMatchingStartOrEndDirective(directive As DirectiveTriviaSyntax,
                                                        cancellationToken As CancellationToken) As DirectiveTriviaSyntax
             If directive Is Nothing Then
-                Throw New ArgumentNullException("directive")
+                Throw New ArgumentNullException(NameOf(directive))
             End If
 
             If directive.Kind = SyntaxKind.ElseIfDirectiveTrivia OrElse directive.Kind = SyntaxKind.ElseDirectiveTrivia Then
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         Public Function GetMatchingConditionalDirectives(directive As DirectiveTriviaSyntax,
                                                          cancellationToken As CancellationToken) As IEnumerable(Of DirectiveTriviaSyntax)
             If directive Is Nothing Then
-                Throw New ArgumentNullException("directive")
+                Throw New ArgumentNullException(NameOf(directive))
             End If
 
             Dim result As IEnumerable(Of DirectiveTriviaSyntax) = Nothing

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -724,7 +724,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             End While
 
             Debug.Assert(Not self.FullSpan.Contains(position), "Position is valid. How could we not find a child?")
-            Throw New ArgumentOutOfRangeException(NameOf(self))
+            Throw New ArgumentOutOfRangeException(NameOf(position))
         End Function
 
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Case TypeCharacter.String
                     Return "$"
                 Case Else
-                    Throw New ArgumentException("Unexpected TypeCharacter.", "type")
+                    Throw New ArgumentException("Unexpected TypeCharacter.", NameOf(type))
             End Select
         End Function
 
@@ -724,7 +724,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             End While
 
             Debug.Assert(Not self.FullSpan.Contains(position), "Position is valid. How could we not find a child?")
-            Throw New ArgumentOutOfRangeException("position")
+            Throw New ArgumentOutOfRangeException(NameOf(self))
         End Function
 
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -492,11 +492,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function GetContainingTypeDeclaration(root As SyntaxNode, position As Integer) As SyntaxNode Implements ISyntaxFactsService.GetContainingTypeDeclaration
             If root Is Nothing Then
-                Throw New ArgumentNullException("root")
+                Throw New ArgumentNullException(NameOf(root))
             End If
 
             If position < 0 OrElse position > root.Span.End Then
-                Throw New ArgumentOutOfRangeException("position")
+                Throw New ArgumentOutOfRangeException(NameOf(root))
             End If
 
             Return root.
@@ -507,7 +507,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function GetContainingVariableDeclaratorOfFieldDeclaration(node As SyntaxNode) As SyntaxNode Implements ISyntaxFactsService.GetContainingVariableDeclaratorOfFieldDeclaration
             If node Is Nothing Then
-                Throw New ArgumentNullException("node")
+                Throw New ArgumentNullException(NameOf(node))
             End If
 
             Dim parent = node.Parent
@@ -579,8 +579,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function GetContainingMemberDeclaration(root As SyntaxNode, position As Integer) As SyntaxNode Implements ISyntaxFactsService.GetContainingMemberDeclaration
-            Contract.ThrowIfNull(root, "root")
-            Contract.ThrowIfTrue(position < 0 OrElse position > root.FullSpan.End, "position")
+            Contract.ThrowIfNull(root, NameOf(root))
+            Contract.ThrowIfTrue(position < 0 OrElse position > root.FullSpan.End, NameOf(root))
 
             Dim [end] = root.FullSpan.End
             If [end] = 0 Then

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -496,7 +496,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If position < 0 OrElse position > root.Span.End Then
-                Throw New ArgumentOutOfRangeException(NameOf(root))
+                Throw New ArgumentOutOfRangeException(NameOf(position))
             End If
 
             Return root.
@@ -580,7 +580,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function GetContainingMemberDeclaration(root As SyntaxNode, position As Integer) As SyntaxNode Implements ISyntaxFactsService.GetContainingMemberDeclaration
             Contract.ThrowIfNull(root, NameOf(root))
-            Contract.ThrowIfTrue(position < 0 OrElse position > root.FullSpan.End, NameOf(root))
+            Contract.ThrowIfTrue(position < 0 OrElse position > root.FullSpan.End, NameOf(position))
 
             Dim [end] = root.FullSpan.End
             If [end] = 0 Then

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 Else
                     Throw New ArgumentException(
                         VBWorkspaceResources.CannotMakeExplicit,
-                        paramName:="node")
+                        paramName:=NameOf(node))
                 End If
             End Using
         End Function

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractAddRemoveHandlerStatementDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractAddRemoveHandlerStatementDocumentation.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.Handler
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractCastExpressionDocumentation.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.NameOfTypeToConvert
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.Typename
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AddHandlerStatementDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AddHandlerStatementDocumentation.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.EventHandlerToAssociate
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/BinaryConditionalExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/BinaryConditionalExpressionDocumentation.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.ReturnedIfNothing
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.ExpressionIfNothing
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetTypeExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetTypeExpressionDocumentation.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.TypeToReturnObjectFor
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.Typename
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetXmlNamespaceExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetXmlNamespaceExpressionDocumentation.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                         New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "]")
                    }
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.XMLNSToReturnObjectFor
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.XmlNamespacePrefix
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/MidAssignmentDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/MidAssignmentDocumentation.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 2
                     Return VBWorkspaceResources.NumberOfCharsToReplace
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 2
                     Return VBWorkspaceResources.Length
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/NameOfExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/NameOfExpressionDocumentation.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.TypeOrMemberNameToReturn
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.TypeOrMember
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/PredefinedCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/PredefinedCastExpressionDocumentation.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.ExpressionToConvert
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 0
                     Return VBWorkspaceResources.Expression1
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/RemoveHandlerStatementDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/RemoveHandlerStatementDocumentation.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 1
                     Return VBWorkspaceResources.EventHandlerToDisassociate
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TernaryConditionalExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TernaryConditionalExpressionDocumentation.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 2
                     Return VBWorkspaceResources.EvaluatedAndReturnedIfFalse
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                 Case 2
                     Return VBWorkspaceResources.ExpressionIfFalse
                 Case Else
-                    Throw New ArgumentException("index")
+                    Throw New ArgumentException(NameOf(index))
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/NameSyntaxIterator.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/NameSyntaxIterator.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
 
         Public Sub New(name As NameSyntax)
             If name Is Nothing Then
-                Throw New ArgumentNullException("name")
+                Throw New ArgumentNullException(NameOf(name))
             End If
 
             Me._name = name


### PR DESCRIPTION
Change to use VB.net's `NameOf` operator, instead of explicit strings.