### PR TITLE
VisualBasicCodeModelService should handle Constructor case for Function ...

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
@@ -349,6 +349,22 @@ End Class
 
 #Region "FunctionKind tests"
 
+        <WorkItem(1843, "https://github.com/dotnet/roslyn/issues/1843")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FunctionKind_Constructor()
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub $$New()
+   End Sub
+
+End Clas
+</Code>
+
+            TestFunctionKind(code, EnvDTE.vsCMFunction.vsCMFunctionConstructor)
+        End Sub
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub FunctionKind_Destructor()
             Dim code =

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -2428,8 +2428,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                      MethodKind.DeclareMethod
                     Return If(symbol.ReturnsVoid, EnvDTE.vsCMFunction.vsCMFunctionSub, EnvDTE.vsCMFunction.vsCMFunctionFunction)
 
-                Case MethodKind.Constructor
-                Case MethodKind.StaticConstructor
+                Case MethodKind.Constructor,
+                     MethodKind.StaticConstructor
                     Return EnvDTE.vsCMFunction.vsCMFunctionConstructor
 
                 Case MethodKind.UserDefinedOperator


### PR DESCRIPTION
...Kind Properly

Fix #1843 VisualBasicCodeModelService to get the function kind for Constructor had
a syntactic blunder where the case was not allowed to fall through