### PR TITLE
Clean up local scopes produced by PdbToXml and update tests accordingly

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -546,7 +546,6 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -288,7 +288,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -249,7 +249,6 @@ class C
         <entry offset=""0x34"" hidden=""true"" document=""1"" />
         <entry offset=""0x3b"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x3f"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
@@ -1100,7 +1099,6 @@ class C
         <entry offset=""0x92"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
         <entry offset=""0x9a"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xa8"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -1642,9 +1642,6 @@ class C
         <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""40"" document=""1"" />
         <entry offset=""0x18"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
       </scope>
@@ -3184,11 +3181,6 @@ class B : A<B>
         <entry offset=""0x1c"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""14"" document=""0"" />
         <entry offset=""0x23"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""z"" il_index=""3"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
-        <local name=""y"" il_index=""1"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
-        <local name=""w"" il_index=""4"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x24"">
         <local name=""z"" il_index=""3"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
         <local name=""y"" il_index=""1"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
@@ -3242,10 +3234,6 @@ class B : A<B>
         <entry offset=""0x16"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""14"" document=""0"" />
         <entry offset=""0x1d"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""5"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
-        <local name=""z"" il_index=""3"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x1e"">
         <local name=""x"" il_index=""5"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
         <local name=""z"" il_index=""3"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
@@ -3300,10 +3288,6 @@ class B : A<B>
         <entry offset=""0x14"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" document=""0"" />
         <entry offset=""0x1b"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""2"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
-        <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <local name=""c"" il_index=""2"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
         <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
@@ -3388,10 +3372,6 @@ class B : A<B>
         <entry offset=""0x3"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""30"" document=""0"" />
         <entry offset=""0x9"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""2"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
-        <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <local name=""a"" il_index=""2"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
         <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -227,11 +227,6 @@ public class C
         <entry offset=""0x50"" hidden=""true"" document=""0"" />
         <entry offset=""0x54"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""j"" il_index=""0"" il_start=""0x0"" il_end=""0x55"" attributes=""0"" />
-        <local name=""i"" il_index=""1"" il_start=""0x1"" il_end=""0x1a"" attributes=""0"" />
-        <local name=""i"" il_index=""4"" il_start=""0x1a"" il_end=""0x39"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x55"">
         <namespace name=""System"" />
         <local name=""j"" il_index=""0"" il_start=""0x0"" il_end=""0x55"" attributes=""0"" />
@@ -378,7 +373,6 @@ public class C
         <entry offset=""0x2b"" hidden=""true"" document=""0"" />
         <entry offset=""0x36"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -399,7 +393,6 @@ public class C
         <entry offset=""0x24"" hidden=""true"" document=""0"" />
         <entry offset=""0x2e"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -2243,7 +2236,6 @@ class C
         <entry offset=""0x23"" startLine=""10"" startColumn=""50"" endLine=""10"" endColumn=""56"" document=""0"" />
         <entry offset=""0x25"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2357,7 +2349,6 @@ class C
         <entry offset=""0x12"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
         <entry offset=""0x13"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2464,7 +2455,6 @@ class C
         <entry offset=""0x12"" hidden=""true"" document=""0"" />
         <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2571,7 +2561,6 @@ class C
         <entry offset=""0x10"" hidden=""true"" document=""0"" />
         <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
@@ -50,7 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
         <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""30"" document=""1"" />
         <entry offset=""0x6"" startLine=""1"" startColumn=""33"" endLine=""1"" endColumn=""34"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C256"" name="".ctor"">
       <customDebugInfo>
@@ -60,7 +59,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
         <entry offset=""0x0"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""34"" document=""2"" />
         <entry offset=""0x6"" startLine=""1"" startColumn=""37"" endLine=""1"" endColumn=""38"" document=""2"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -256,7 +254,6 @@ int y = 1;
         <entry offset=""0x6"" startLine=""112"" startColumn=""9"" endLine=""112"" endColumn=""24"" document=""2"" />
         <entry offset=""0xc"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""3"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -297,7 +294,6 @@ class C
         <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -338,7 +334,6 @@ class C { void M() { } }
         <entry offset=""0x0"" startLine=""10"" startColumn=""20"" endLine=""10"" endColumn=""21"" document=""1"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""22"" endLine=""10"" endColumn=""23"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -399,7 +394,6 @@ class C
         <entry offset=""0x24"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""13"" document=""3"" />
         <entry offset=""0x2b"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""3"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -468,7 +462,6 @@ class C
         <entry offset=""0x24"" startLine=""1"" startColumn=""9"" endLine=""1"" endColumn=""13"" document=""6"" />
         <entry offset=""0x2b"" startLine=""2"" startColumn=""5"" endLine=""2"" endColumn=""6"" document=""6"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";
@@ -525,7 +518,6 @@ class C
         <entry offset=""0x16"" startLine=""1"" startColumn=""9"" endLine=""1"" endColumn=""13"" document=""4"" />
         <entry offset=""0x1d"" startLine=""2"" startColumn=""5"" endLine=""2"" endColumn=""6"" document=""4"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>";

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -195,13 +195,11 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <sequencePoints>
         <entry offset=""0x0"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""DynamicMembers"" name=""set_Prop"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""8"" startColumn=""40"" endLine=""8"" endColumn=""44"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""TestCase"" name="".cctor"">
       <customDebugInfo>
@@ -212,7 +210,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <sequencePoints>
         <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""33"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
         <namespace name=""System.Threading"" />
@@ -233,7 +230,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Driver"" name="".cctor"">
       <customDebugInfo>
@@ -243,7 +239,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0x0"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""35"" document=""0"" />
         <entry offset=""0x6"" startLine=""28"" startColumn=""5"" endLine=""28"" endColumn=""78"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Driver"" name=""Main"">
       <customDebugInfo>
@@ -261,9 +256,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0x19"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""30"" document=""0"" />
         <entry offset=""0x21"" startLine=""36"" startColumn=""5"" endLine=""36"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
       </scope>
@@ -300,7 +292,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0x11a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""0"" />
         <entry offset=""0x122"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <catchHandler offset=""0x100"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Run"" />
@@ -327,7 +318,6 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0x96"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""0"" />
         <entry offset=""0x9e"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
         <await yield=""0x31"" resume=""0x4c"" declaringType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" methodName=""MoveNext"" />
@@ -391,7 +381,6 @@ namespace ConsoleApplication1
         <entry offset=""0x1"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""34"" document=""0"" />
         <entry offset=""0xc"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xd"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -403,7 +392,6 @@ namespace ConsoleApplication1
         <forwardIterator name=""&lt;QBar&gt;d__2"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""ConsoleApplication1.Program"" name=""ZBar"">
       <customDebugInfo>
@@ -418,7 +406,6 @@ namespace ConsoleApplication1
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""ConsoleApplication1.Program"" name=""GetNextInt"" parameterNames=""random"">
       <customDebugInfo>
@@ -429,7 +416,6 @@ namespace ConsoleApplication1
         <entry offset=""0x1"" startLine=""31"" startColumn=""13"" endLine=""31"" endColumn=""51"" document=""0"" />
         <entry offset=""0xf"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""ConsoleApplication1.Program"" name="".cctor"">
       <customDebugInfo>
@@ -438,7 +424,6 @@ namespace ConsoleApplication1
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""53"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""ConsoleApplication1.Program+&lt;QBar&gt;d__2"" name=""MoveNext"">
       <customDebugInfo>
@@ -460,7 +445,6 @@ namespace ConsoleApplication1
         <entry offset=""0x93"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""0"" />
         <entry offset=""0x9b"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <catchHandler offset=""0x7b"" />
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""QBar"" />
@@ -507,7 +491,6 @@ namespace ConsoleApplication1
         <entry offset=""0x139"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""0"" />
         <entry offset=""0x141"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""ZBar"" />
         <await yield=""0x7d"" resume=""0x9c"" declaringType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" methodName=""MoveNext"" />
@@ -565,7 +548,6 @@ class TestCase
         <entry offset=""0x24d"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x255"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <catchHandler offset=""0x233"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Await"" parameterNames=""d"" />
@@ -635,9 +617,6 @@ class C
         <entry offset=""0xc2"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
         <entry offset=""0xca"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xa"" il_end=""0xab"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xd6"">
         <scope startOffset=""0xa"" endOffset=""0xab"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xa"" il_end=""0xab"" attributes=""0"" />
@@ -664,7 +643,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -741,7 +719,6 @@ class C
         <entry offset=""0xf9"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
         <entry offset=""0x101"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
         <await yield=""0x98"" resume=""0xb3"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
@@ -766,7 +743,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -835,7 +811,6 @@ class C
         <entry offset=""0xd8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
         <entry offset=""0xe0"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
         <await yield=""0x6d"" resume=""0x84"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
@@ -857,7 +832,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -934,7 +908,6 @@ class C
         <entry offset=""0xe8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
         <entry offset=""0xf0"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
         <await yield=""0x76"" resume=""0x91"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
@@ -959,7 +932,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1026,7 +998,6 @@ class C
         <entry offset=""0xf5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
         <entry offset=""0xfd"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" />
         <await yield=""0x39"" resume=""0x57"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
@@ -1046,7 +1017,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -1105,9 +1075,6 @@ class C
         <entry offset=""0xdd"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
         <entry offset=""0xe5"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""1"" il_start=""0xd"" il_end=""0xc6"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xf1"">
         <scope startOffset=""0xd"" endOffset=""0xc6"">
           <local name=""d"" il_index=""1"" il_start=""0xd"" il_end=""0xc6"" attributes=""0"" />
@@ -1129,7 +1096,6 @@ class C
         <forwardIterator name=""&lt;M&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -1197,7 +1163,6 @@ class C
         <entry offset=""0xf5"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
         <entry offset=""0xfd"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" />
         <await yield=""0x94"" resume=""0xaf"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
@@ -1217,7 +1182,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -1323,7 +1287,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1511,7 +1474,6 @@ class C
         <entry offset=""0x108"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
         <entry offset=""0x110"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""G"" />
         <await yield=""0x51"" resume=""0x70"" declaringType=""C+&lt;G&gt;d__0"" methodName=""MoveNext"" />
@@ -1591,7 +1553,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -42,10 +42,6 @@ class C
         <entry offset=""0x2"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
         <entry offset=""0x3"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""x"" value=""1"" type=""Int32"" />
-        <constant name=""y"" value=""2"" type=""Int32"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <constant name=""x"" value=""1"" type=""Int32"" />
         <scope startOffset=""0x1"" endOffset=""0x3"">
@@ -97,9 +93,6 @@ class C
         <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""15"" endColumn=""12"" document=""0"" />
         <entry offset=""0x27"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""x"" value=""1"" type=""Int32"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <namespace name=""System"" />
         <constant name=""x"" value=""1"" type=""Int32"" />
@@ -115,10 +108,6 @@ class C
         <entry offset=""0x2"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" document=""0"" />
         <entry offset=""0x5"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""y"" value=""2"" type=""Int32"" />
-        <constant name=""z"" value=""3"" type=""Int32"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <constant name=""y"" value=""2"" type=""Int32"" />
         <scope startOffset=""0x1"" endOffset=""0x3"">
@@ -198,10 +187,6 @@ class C
         <entry offset=""0x68"" hidden=""true"" document=""0"" />
         <entry offset=""0x6b"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""x"" value=""1"" type=""Int32"" />
-        <constant name=""y"" value=""2"" type=""Int32"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x6f"">
         <namespace name=""System.Collections.Generic"" />
         <scope startOffset=""0x21"" endOffset=""0x6f"">
@@ -246,12 +231,6 @@ class C
         <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""o"" value=""null"" type=""Object"" />
-        <constant name=""s"" value=""hello"" type=""String"" />
-        <constant name=""f"" value=""-3.402823E+38"" type=""Single"" />
-        <constant name=""d"" value=""1.79769313486232E+308"" type=""Double"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""o"" value=""null"" type=""Object"" />
         <constant name=""s"" value=""hello"" type=""String"" />
@@ -325,7 +304,6 @@ this is a string constant that is too long to fit into the PDB"";
         <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""43"" startColumn=""5"" endLine=""43"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -358,9 +336,6 @@ class C
         <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""d"" value=""1.5"" type=""Decimal"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""d"" value=""1.5"" type=""Decimal"" />
       </scope>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -51,7 +51,6 @@ class Test
         <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Helper"" name="".ctor"">
       <customDebugInfo>
@@ -62,7 +61,6 @@ class Test
         <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Helper"" name="".ctor"" parameterNames=""x"">
       <customDebugInfo>
@@ -73,7 +71,6 @@ class Test
         <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""0"" />
         <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -98,12 +95,6 @@ class Test
         <entry offset=""0xb1"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""30"" document=""0"" />
         <entry offset=""0x10f"" startLine=""24"" startColumn=""3"" endLine=""24"" endColumn=""4"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
-        <local name=""d2"" il_index=""1"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
-        <local name=""d4"" il_index=""2"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
-        <local name=""d5"" il_index=""3"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x110"">
         <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
         <local name=""d2"" il_index=""1"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
@@ -164,10 +155,6 @@ class Test
         <entry offset=""0x21"" startLine=""8"" startColumn=""28"" endLine=""8"" endColumn=""30"" document=""0"" />
         <entry offset=""0x27"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""arrDynamic"" il_index=""0"" il_start=""0x0"" il_end=""0x28"" attributes=""0"" />
-        <local name=""d"" il_index=""3"" il_start=""0x17"" il_end=""0x1d"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <namespace name=""System"" />
         <local name=""arrDynamic"" il_index=""0"" il_start=""0x0"" il_end=""0x28"" attributes=""0"" />
@@ -208,9 +195,6 @@ class Test
         <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""0"" />
         <entry offset=""0x1"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""3"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""d"" value=""null"" type=""Object"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""d"" value=""null"" type=""Object"" />
       </scope>
@@ -265,11 +249,6 @@ class Test
         <entry offset=""0x11"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""39"" document=""0"" />
         <entry offset=""0x18"" startLine=""13"" startColumn=""3"" endLine=""13"" endColumn=""4"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""arr"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-        <local name=""arrdim"" il_index=""1"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-        <local name=""arrobj"" il_index=""2"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <local name=""arr"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
         <local name=""arrdim"" il_index=""1"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
@@ -329,13 +308,6 @@ class Test
         <entry offset=""0x19"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""42"" document=""0"" />
         <entry offset=""0x20"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""4"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""l1"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-        <local name=""l2"" il_index=""1"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-        <local name=""l3"" il_index=""2"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-        <local name=""d1"" il_index=""3"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-        <local name=""d2"" il_index=""4"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <namespace name=""System.Collections.Generic"" />
         <local name=""l1"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
@@ -390,7 +362,6 @@ class Test
         <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Helper"" name="".ctor"">
       <customDebugInfo>
@@ -401,7 +372,6 @@ class Test
         <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Helper"" name="".ctor"" parameterNames=""x"">
       <customDebugInfo>
@@ -412,7 +382,6 @@ class Test
         <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""0"" />
         <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -434,11 +403,6 @@ class Test
         <entry offset=""0xd"" startLine=""21"" startColumn=""3"" endLine=""21"" endColumn=""37"" document=""0"" />
         <entry offset=""0x1a"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""4"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""staticObj"" il_index=""0"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
-        <local name=""d1"" il_index=""1"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
-        <local name=""d3"" il_index=""2"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x1b"">
         <local name=""staticObj"" il_index=""0"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
         <local name=""d1"" il_index=""1"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
@@ -484,9 +448,6 @@ class Test
         <entry offset=""0x7"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""0"" />
         <entry offset=""0x8"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""3"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x7"" il_end=""0x8"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <scope startOffset=""0x7"" endOffset=""0x8"">
           <local name=""d"" il_index=""0"" il_start=""0x7"" il_end=""0x8"" attributes=""0"" />
@@ -501,7 +462,6 @@ class Test
         <entry offset=""0x0"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -554,9 +514,6 @@ class Test
         <entry offset=""0x13"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" document=""0"" />
         <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
       </scope>
@@ -576,9 +533,6 @@ class Test
         <entry offset=""0x1"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" document=""0"" />
         <entry offset=""0x3"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
       </scope>
@@ -591,7 +545,6 @@ class Test
         <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -640,7 +593,6 @@ class Test
         <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""36"" document=""0"" />
         <entry offset=""0x16"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Complex"" name=""op_Addition"" parameterNames=""c1, c2"">
       <customDebugInfo>
@@ -659,9 +611,6 @@ class Test
         <entry offset=""0x21"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""18"" document=""0"" />
         <entry offset=""0x25"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
       </scope>
@@ -674,7 +623,6 @@ class Test
         <entry offset=""0x0"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -728,9 +676,6 @@ class Test
         <entry offset=""0xa"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" document=""0"" />
         <entry offset=""0xe"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x10"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x10"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x10"" attributes=""0"" />
       </scope>
@@ -751,9 +696,6 @@ class Test
         <entry offset=""0x3"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
         <entry offset=""0xc"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xd"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
       </scope>
@@ -766,7 +708,6 @@ class Test
         <entry offset=""0x0"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -810,9 +751,6 @@ class Sample
         <entry offset=""0x7"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""76"" document=""0"" />
         <entry offset=""0x19"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""cki"" il_index=""0"" il_start=""0x0"" il_end=""0x1a"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x1a"">
         <namespace name=""System"" />
         <local name=""cki"" il_index=""0"" il_start=""0x0"" il_end=""0x1a"" attributes=""0"" />
@@ -832,9 +770,6 @@ class Sample
         <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
       </scope>
@@ -901,9 +836,6 @@ struct Test
         <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""0"" />
         <entry offset=""0x8"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
         <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
@@ -925,9 +857,6 @@ struct Test
         <entry offset=""0x1"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""22"" document=""0"" />
         <entry offset=""0xa"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d2"" il_index=""0"" il_start=""0x0"" il_end=""0xc"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xc"">
         <local name=""d2"" il_index=""0"" il_start=""0x0"" il_end=""0xc"" attributes=""0"" />
       </scope>
@@ -947,9 +876,6 @@ struct Test
         <entry offset=""0x1"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""23"" document=""0"" />
         <entry offset=""0x8"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d3"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""d3"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
       </scope>
@@ -970,9 +896,6 @@ struct Test
         <entry offset=""0x1"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""38"" document=""0"" />
         <entry offset=""0x16"" startLine=""29"" startColumn=""5"" endLine=""29"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d4"" il_index=""0"" il_start=""0x0"" il_end=""0x18"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x18"">
         <local name=""d4"" il_index=""0"" il_start=""0x0"" il_end=""0x18"" attributes=""0"" />
       </scope>
@@ -991,9 +914,6 @@ struct Test
         <entry offset=""0x0"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
       </scope>
@@ -1046,11 +966,6 @@ class Test
         <entry offset=""0x41"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""50"" document=""0"" />
         <entry offset=""0x61"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""obj1"" il_index=""0"" il_start=""0x0"" il_end=""0x62"" attributes=""0"" />
-        <local name=""obj2"" il_index=""1"" il_start=""0x0"" il_end=""0x62"" attributes=""0"" />
-        <local name=""obj3"" il_index=""2"" il_start=""0x0"" il_end=""0x62"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x62"">
         <namespace name=""System"" />
         <local name=""obj1"" il_index=""0"" il_start=""0x0"" il_end=""0x62"" attributes=""0"" />
@@ -1065,7 +980,6 @@ class Test
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__2_1"" parameterNames=""d4"">
       <customDebugInfo>
@@ -1082,9 +996,6 @@ class Test
         <entry offset=""0x1"" startLine=""10"" startColumn=""46"" endLine=""10"" endColumn=""54"" document=""0"" />
         <entry offset=""0x5"" startLine=""10"" startColumn=""55"" endLine=""10"" endColumn=""56"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x6"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x6"" attributes=""0"" />
       </scope>
@@ -1098,7 +1009,6 @@ class Test
         <entry offset=""0x1"" startLine=""11"" startColumn=""37"" endLine=""11"" endColumn=""47"" document=""0"" />
         <entry offset=""0x5"" startLine=""11"" startColumn=""48"" endLine=""11"" endColumn=""49"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1266,21 +1176,6 @@ class Test
         <entry offset=""0xcb"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" document=""0"" />
         <entry offset=""0xcc"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""arrInt"" il_index=""1"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""scores"" il_index=""2"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""arrDynamic"" il_index=""3"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""scoreQuery1"" il_index=""4"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""scoreQuery2"" il_index=""5"" il_start=""0x0"" il_end=""0xce"" attributes=""0"" />
-        <local name=""dInWhile"" il_index=""6"" il_start=""0x5d"" il_end=""0x67"" attributes=""0"" />
-        <local name=""dInDoWhile"" il_index=""9"" il_start=""0x71"" il_end=""0x7b"" attributes=""0"" />
-        <local name=""d"" il_index=""13"" il_start=""0x8e"" il_end=""0x97"" attributes=""0"" />
-        <local name=""dInForEach"" il_index=""14"" il_start=""0x95"" il_end=""0x97"" attributes=""0"" />
-        <local name=""i"" il_index=""15"" il_start=""0xa5"" il_end=""0xc1"" attributes=""0"" />
-        <local name=""dInFor"" il_index=""16"" il_start=""0xaa"" il_end=""0xac"" attributes=""0"" />
-        <local name=""d"" il_index=""18"" il_start=""0xc1"" il_end=""0xce"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xce"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1321,7 +1216,6 @@ class Test
       <sequencePoints>
         <entry offset=""0x0"" startLine=""58"" startColumn=""20"" endLine=""58"" endColumn=""25"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__0_1"" parameterNames=""score"">
       <customDebugInfo>
@@ -1330,7 +1224,6 @@ class Test
       <sequencePoints>
         <entry offset=""0x0"" startLine=""61"" startColumn=""20"" endLine=""61"" endColumn=""25"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1373,10 +1266,6 @@ class Test
         <entry offset=""0x7"" startLine=""8"" startColumn=""3"" endLine=""8"" endColumn=""13"" document=""0"" />
         <entry offset=""0x9"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
-        <local name=""v"" il_index=""1"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <namespace name=""System"" />
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
@@ -1426,9 +1315,6 @@ class Test
         <entry offset=""0x7"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""19"" document=""0"" />
         <entry offset=""0x12"" startLine=""13"" startColumn=""2"" endLine=""13"" endColumn=""3"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""obj"" il_index=""0"" il_start=""0x0"" il_end=""0x13"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x13"">
         <namespace name=""System"" />
         <local name=""obj"" il_index=""0"" il_start=""0x0"" il_end=""0x13"" attributes=""0"" />
@@ -1476,10 +1362,6 @@ class Program
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""yyy"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""zzz"" il_index=""1"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1535,10 +1417,6 @@ class Foo<T>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""yyy"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""zzz"" il_index=""1"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1594,10 +1472,6 @@ class Foo<T,V>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""yyy"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""zzz"" il_index=""1"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1656,11 +1530,6 @@ class Foo<T,V>
         <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""23"" document=""0"" />
         <entry offset=""0x3"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""yyy"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-        <local name=""dummy"" il_index=""1"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-        <local name=""zzz"" il_index=""2"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1714,9 +1583,6 @@ class F<T,V>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""zzz"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1768,9 +1634,6 @@ class F<T,V>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""zzz"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1834,13 +1697,6 @@ class F<T,V>
         <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" document=""0"" />
         <entry offset=""0x6"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""z1"" il_index=""0"" il_start=""0x0"" il_end=""0x7"" attributes=""0"" />
-        <local name=""dummy1"" il_index=""1"" il_start=""0x0"" il_end=""0x7"" attributes=""0"" />
-        <local name=""z2"" il_index=""2"" il_start=""0x0"" il_end=""0x7"" attributes=""0"" />
-        <local name=""z3"" il_index=""3"" il_start=""0x0"" il_end=""0x7"" attributes=""0"" />
-        <local name=""dummy2"" il_index=""4"" il_start=""0x0"" il_end=""0x7"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1905,12 +1761,6 @@ class F<T,V>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""z3"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""www"" il_index=""1"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""length63length63length63length63length63length63length63length6"" il_index=""2"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""length64length64length64length64length64length64length64length64"" il_index=""3"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1970,11 +1820,6 @@ class F<T>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""yes"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""no"" il_index=""1"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-        <local name=""www"" il_index=""2"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -2041,11 +1886,6 @@ class Program
         <entry offset=""0x14"" hidden=""true"" document=""0"" />
         <entry offset=""0x18"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""simple"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
-        <local name=""x"" il_index=""1"" il_start=""0x1"" il_end=""0x18"" attributes=""0"" />
-        <local name=""inner"" il_index=""2"" il_start=""0x5"" il_end=""0x7"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -2072,9 +1912,6 @@ class Program
         <entry offset=""0x0"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""localInner"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""localInner"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
       </scope>
@@ -2116,7 +1953,6 @@ class C
         <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""34"" document=""0"" />
         <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""GetDynamic"">
       <customDebugInfo>
@@ -2125,7 +1961,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""20"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -35,7 +35,6 @@ class Program
         <forwardIterator name=""&lt;Foo&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Program"" name=""F"">
       <customDebugInfo>
@@ -47,7 +46,6 @@ class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""22"" document=""0"" />
         <entry offset=""0x1"" startLine=""9"" startColumn=""23"" endLine=""9"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Program+&lt;Foo&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -62,7 +60,6 @@ class Program
         <entry offset=""0x19"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -93,7 +90,6 @@ class Program
         <forwardIterator name=""&lt;Foo&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Program"" name=""F"">
       <customDebugInfo>
@@ -105,7 +101,6 @@ class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""22"" document=""0"" />
         <entry offset=""0x1"" startLine=""9"" startColumn=""23"" endLine=""9"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Program+&lt;Foo&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -120,7 +115,6 @@ class Program
         <entry offset=""0x19"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -151,7 +145,6 @@ class Program
         <forwardIterator name=""&lt;Foo&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Program"" name=""F"">
       <customDebugInfo>
@@ -163,7 +156,6 @@ class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""22"" document=""0"" />
         <entry offset=""0x1"" startLine=""9"" startColumn=""23"" endLine=""9"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Program+&lt;Foo&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -180,7 +172,6 @@ class Program
         <entry offset=""0x34"" hidden=""true"" document=""0"" />
         <entry offset=""0x3b"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -217,7 +208,6 @@ class Program
         <forwardIterator name=""&lt;IEI&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Program"" name=""F"">
       <customDebugInfo>
@@ -228,7 +218,6 @@ class Program
       <sequencePoints>
         <entry offset=""0x0"" startLine=""17"" startColumn=""23"" endLine=""17"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Program+&lt;IEI&gt;d__0`1"" name=""MoveNext"">
       <customDebugInfo>
@@ -252,7 +241,6 @@ class Program
         <entry offset=""0xab"" hidden=""true"" document=""0"" />
         <entry offset=""0xb2"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -293,7 +281,6 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Program"" name=""F"">
       <customDebugInfo>
@@ -305,7 +292,6 @@ class Program
         <entry offset=""0x0"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""0"" />
         <entry offset=""0x1"" startLine=""17"" startColumn=""23"" endLine=""17"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Program+&lt;IEI&gt;d__0`1"" name=""MoveNext"">
       <customDebugInfo>
@@ -336,7 +322,6 @@ class Program
         <entry offset=""0xd0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
         <entry offset=""0xd1"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -380,7 +365,6 @@ class Test<T>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Test`1"" name=""F"">
       <customDebugInfo>
@@ -392,7 +376,6 @@ class Test<T>
         <entry offset=""0x0"" startLine=""19"" startColumn=""21"" endLine=""19"" endColumn=""22"" document=""0"" />
         <entry offset=""0x1"" startLine=""19"" startColumn=""23"" endLine=""19"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -431,7 +414,6 @@ class Test<T>
         <entry offset=""0xde"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
         <entry offset=""0xe2"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -480,7 +462,6 @@ class C
         <forwardIterator name=""&lt;M&gt;d__0"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -497,7 +478,6 @@ class C
         <entry offset=""0x27"" hidden=""true"" document=""0"" />
         <entry offset=""0x31"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x32"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
@@ -516,11 +496,6 @@ class C
         <entry offset=""0x80"" hidden=""true"" document=""0"" />
         <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""d1"" value=""0.1"" type=""Decimal"" />
-        <constant name=""dx"" value=""1.23"" type=""Decimal"" />
-        <constant name=""d2"" value=""0.2"" type=""Decimal"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x89"">
         <scope startOffset=""0x26"" endOffset=""0x89"">
           <constant name=""d1"" value=""0.1"" type=""Decimal"" />
@@ -605,7 +580,6 @@ public class Test
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""32"" document=""0"" />
         <entry offset=""0xa"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xc"">
         <namespace name=""System"" />
         <namespace name=""System.Collections"" />
@@ -623,21 +597,18 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Test`1"" name=""get_IterProp"">
       <customDebugInfo>
         <forwardIterator name=""&lt;get_IterProp&gt;d__3"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Test`1"" name=""IterMethod"">
       <customDebugInfo>
         <forwardIterator name=""&lt;IterMethod&gt;d__4"" />
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -659,9 +630,6 @@ public class Test
         <entry offset=""0x22"" hidden=""true"" document=""0"" />
         <entry offset=""0x2d"" startLine=""47"" startColumn=""5"" endLine=""47"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""v"" il_index=""1"" il_start=""0xf"" il_end=""0x18"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2e"">
         <scope startOffset=""0xf"" endOffset=""0x18"">
           <local name=""v"" il_index=""1"" il_start=""0xf"" il_end=""0x18"" attributes=""0"" />
@@ -707,7 +675,6 @@ public class Test
         <entry offset=""0x12a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""0"" />
         <entry offset=""0x12e"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test`1+&lt;get_IterProp&gt;d__3"" name=""MoveNext"">
       <customDebugInfo>
@@ -726,7 +693,6 @@ public class Test
         <entry offset=""0x62"" hidden=""true"" document=""0"" />
         <entry offset=""0x69"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Test`1+&lt;IterMethod&gt;d__4"" name=""MoveNext"">
       <customDebugInfo>
@@ -745,7 +711,6 @@ public class Test
         <entry offset=""0x62"" hidden=""true"" document=""0"" />
         <entry offset=""0x69"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -809,7 +774,6 @@ class C
         <entry offset=""0x80"" hidden=""true"" document=""0"" />
         <entry offset=""0x87"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x8b"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
@@ -924,7 +888,6 @@ class C
         <entry offset=""0x45"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
         <entry offset=""0x46"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x4a"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
@@ -1029,7 +992,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1099,7 +1061,6 @@ class C
         <entry offset=""0xee"" hidden=""true"" document=""0"" />
         <entry offset=""0xf5"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1209,7 +1170,6 @@ class C
         <entry offset=""0x51"" hidden=""true"" document=""0"" />
         <entry offset=""0x58"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1227,7 +1187,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1364,7 +1323,6 @@ class C
         <entry offset=""0x7a"" hidden=""true"" document=""0"" />
         <entry offset=""0x81"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1385,7 +1343,6 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1447,7 +1404,6 @@ class C
         <entry offset=""0x8d"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""0"" />
         <entry offset=""0xe5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1463,7 +1419,6 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints />
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -1517,9 +1472,6 @@ class C
         <entry offset=""0x6d"" hidden=""true"" document=""0"" />
         <entry offset=""0x74"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""1"" il_start=""0x17"" il_end=""0x76"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x76"">
         <scope startOffset=""0x17"" endOffset=""0x76"">
           <local name=""d"" il_index=""1"" il_start=""0x17"" il_end=""0x76"" attributes=""0"" />
@@ -1584,7 +1536,6 @@ class C
         <entry offset=""0x86"" hidden=""true"" document=""0"" />
         <entry offset=""0x8d"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1629,7 +1580,6 @@ class C
         <entry offset=""0x19"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -49,9 +49,6 @@ class C
         <entry offset=""0x21"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""13"" document=""0"" />
         <entry offset=""0x28"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x29"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x29"">
         <namespace name=""System"" />
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x29"" attributes=""0"" />
@@ -64,7 +61,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""8"" startColumn=""21"" endLine=""8"" endColumn=""37"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -122,7 +118,6 @@ class Test
         <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""0"" />
         <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <namespace name=""System"" />
       </scope>
@@ -150,10 +145,6 @@ class Test
         <entry offset=""0x1b"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""22"" document=""0"" />
         <entry offset=""0x25"" startLine=""24"" startColumn=""5"" endLine=""24"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
         <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
@@ -176,10 +167,6 @@ class Test
         <entry offset=""0x29"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""26"" document=""0"" />
         <entry offset=""0x33"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
         <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -194,7 +181,6 @@ class Test
         <entry offset=""0x1"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""38"" document=""0"" />
         <entry offset=""0x1f"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""14"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -240,10 +226,6 @@ class Test
         <entry offset=""0x1b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""14"" document=""0"" />
         <entry offset=""0x22"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
         <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
@@ -256,7 +238,6 @@ class Test
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""38"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -311,7 +292,6 @@ class Test
         <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""0"" />
         <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <namespace name=""System"" />
       </scope>
@@ -339,10 +319,6 @@ class Test
         <entry offset=""0x1b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""22"" document=""0"" />
         <entry offset=""0x25"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
         <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
@@ -365,10 +341,6 @@ class Test
         <entry offset=""0x29"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""26"" document=""0"" />
         <entry offset=""0x33"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
         <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -383,7 +355,6 @@ class Test
         <entry offset=""0x1"" startLine=""17"" startColumn=""42"" endLine=""17"" endColumn=""63"" document=""0"" />
         <entry offset=""0x1f"" startLine=""17"" startColumn=""64"" endLine=""17"" endColumn=""65"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -426,7 +397,6 @@ class C : B
         <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
       </scope>
@@ -435,7 +405,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -454,7 +423,6 @@ class C : B
         <entry offset=""0x70"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""33"" document=""0"" />
         <entry offset=""0x71"" startLine=""14"" startColumn=""33"" endLine=""14"" endColumn=""34"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name="".cctor"">
       <customDebugInfo>
@@ -467,7 +435,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""35"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_0"">
       <customDebugInfo>
@@ -476,7 +443,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""14"" startColumn=""29"" endLine=""14"" endColumn=""30"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_1"">
       <customDebugInfo>
@@ -485,7 +451,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""26"" endLine=""11"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_2"">
       <customDebugInfo>
@@ -494,7 +459,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""13"" startColumn=""34"" endLine=""13"" endColumn=""38"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__6_0"">
       <customDebugInfo>
@@ -503,7 +467,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""12"" startColumn=""33"" endLine=""12"" endColumn=""34"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -551,7 +514,6 @@ class C : B
         <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
       </scope>
@@ -583,10 +545,6 @@ class C : B
         <entry offset=""0x59"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""21"" document=""0"" />
         <entry offset=""0x6b"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x6c"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x27"" il_end=""0x6b"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x6c"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x6c"" attributes=""0"" />
         <scope startOffset=""0x27"" endOffset=""0x6b"">
@@ -601,7 +559,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_0"" name=""&lt;.ctor&gt;b__0"">
       <customDebugInfo>
@@ -610,7 +567,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""13"" startColumn=""41"" endLine=""13"" endColumn=""42"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_0"" name=""&lt;.ctor&gt;b__1"">
       <customDebugInfo>
@@ -619,7 +575,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""16"" startColumn=""19"" endLine=""16"" endColumn=""20"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_1"" name=""&lt;.ctor&gt;b__3"">
       <customDebugInfo>
@@ -628,7 +583,6 @@ class C : B
       <sequencePoints>
         <entry offset=""0x0"" startLine=""18"" startColumn=""19"" endLine=""18"" endColumn=""20"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -683,10 +637,6 @@ class C
         <entry offset=""0xe"" startLine=""9"" startColumn=""9"" endLine=""12"" endColumn=""31"" document=""0"" />
         <entry offset=""0x79"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
-        <local name=""x"" il_index=""1"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x7a"">
         <namespace name=""System.Linq"" />
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
@@ -700,7 +650,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""30"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_1"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
       <customDebugInfo>
@@ -709,7 +658,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""23"" endLine=""11"" endColumn=""29"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_2"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
       <customDebugInfo>
@@ -718,7 +666,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -771,9 +718,6 @@ class C
         <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""11"" endColumn=""40"" document=""0"" />
         <entry offset=""0xe6"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""result"" il_index=""0"" il_start=""0x0"" il_end=""0xe7"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xe7"">
         <namespace name=""System.Linq"" />
         <local name=""result"" il_index=""0"" il_start=""0x0"" il_end=""0xe7"" attributes=""0"" />
@@ -786,7 +730,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""52"" endLine=""9"" endColumn=""57"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_1"" parameterNames=""b"">
       <customDebugInfo>
@@ -795,7 +738,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""65"" endLine=""9"" endColumn=""70"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_2"" parameterNames=""a, b"">
       <customDebugInfo>
@@ -804,7 +746,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""70"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_3"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
       <customDebugInfo>
@@ -813,7 +754,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""57"" endLine=""10"" endColumn=""74"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_4"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
       <customDebugInfo>
@@ -822,7 +762,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""33"" endLine=""10"" endColumn=""53"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_5"" parameterNames=""d"">
       <customDebugInfo>
@@ -831,7 +770,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""34"" endLine=""11"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -899,10 +837,6 @@ class C
         <entry offset=""0x59"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
         <entry offset=""0x5f"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0x11"" il_end=""0x55"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x20"" il_end=""0x55"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x60"">
         <scope startOffset=""0x11"" endOffset=""0x55"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0x11"" il_end=""0x55"" attributes=""0"" />
@@ -985,10 +919,6 @@ class C
         <entry offset=""0x97"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
         <entry offset=""0x9b"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""5"" il_start=""0x38"" il_end=""0x88"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""6"" il_start=""0x4f"" il_end=""0x88"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9c"">
         <scope startOffset=""0x38"" endOffset=""0x88"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""5"" il_start=""0x38"" il_end=""0x88"" attributes=""0"" />
@@ -1065,10 +995,6 @@ class C
         <entry offset=""0x58"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
         <entry offset=""0x61"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0xc"" il_end=""0x54"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x1f"" il_end=""0x54"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x62"">
         <scope startOffset=""0xc"" endOffset=""0x54"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0xc"" il_end=""0x54"" attributes=""0"" />
@@ -1145,10 +1071,6 @@ class C
         <entry offset=""0x62"" hidden=""true"" document=""0"" />
         <entry offset=""0x71"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xf"" il_end=""0x57"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""2"" il_start=""0x22"" il_end=""0x57"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x72"">
         <scope startOffset=""0xf"" endOffset=""0x57"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xf"" il_end=""0x57"" attributes=""0"" />
@@ -1223,10 +1145,6 @@ class C
         <entry offset=""0x63"" hidden=""true"" document=""0"" />
         <entry offset=""0x66"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x66"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x17"" il_end=""0x39"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x67"">
         <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x66"">
@@ -1314,10 +1232,6 @@ class C
         <entry offset=""0x70"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""0"" />
         <entry offset=""0x72"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x21"" il_end=""0x72"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x73"">
         <namespace name=""System"" />
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
@@ -1366,7 +1280,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""41"" endLine=""7"" endColumn=""42"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -1403,10 +1316,6 @@ class C
         <entry offset=""0x7b"" hidden=""true"" document=""0"" />
         <entry offset=""0x90"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x90"" attributes=""0"" />
-        <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x1d"" il_end=""0x62"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x91"">
         <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x90"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
@@ -47,9 +47,6 @@ class Program
         <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""35"" document=""0"" />
         <entry offset=""0x7"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""p"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <local name=""p"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
       </scope>
@@ -117,11 +114,6 @@ class C
         <entry offset=""0x4a"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" document=""0"" />
         <entry offset=""0x4b"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""version"" il_index=""0"" il_start=""0x0"" il_end=""0x4c"" attributes=""0"" />
-        <local name=""foob"" il_index=""1"" il_start=""0x15"" il_end=""0x2a"" attributes=""0"" />
-        <local name=""foob1"" il_index=""2"" il_start=""0x2a"" il_end=""0x3f"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4c"">
         <local name=""version"" il_index=""0"" il_start=""0x0"" il_end=""0x4c"" attributes=""0"" />
         <scope startOffset=""0x15"" endOffset=""0x2a"">
@@ -196,9 +188,6 @@ class Program
         <entry offset=""0x3"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""30"" document=""0"" />
         <entry offset=""0xa"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <namespace name=""System"" />
         <namespace name=""System.Diagnostics"" />
@@ -218,9 +207,6 @@ class Program
         <entry offset=""0x3"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""30"" document=""0"" />
         <entry offset=""0xa"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""y"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <local name=""y"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
       </scope>
@@ -238,9 +224,6 @@ class Program
         <entry offset=""0x3"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""30"" document=""0"" />
         <entry offset=""0xa"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
       </scope>
@@ -290,7 +273,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""9"" endColumn=""7"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x16"">
         <namespace name=""System"" />
       </scope>
@@ -302,7 +284,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""66"" endLine=""7"" endColumn=""70"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__2_0"" parameterNames=""x"">
       <customDebugInfo>
@@ -320,10 +301,6 @@ class C
         <entry offset=""0x41"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""27"" document=""0"" />
         <entry offset=""0x51"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""f"" il_index=""0"" il_start=""0x0"" il_end=""0x53"" attributes=""0"" />
-        <local name=""g"" il_index=""1"" il_start=""0x0"" il_end=""0x53"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x53"">
         <local name=""f"" il_index=""0"" il_start=""0x0"" il_end=""0x53"" attributes=""0"" />
         <local name=""g"" il_index=""1"" il_start=""0x0"" il_end=""0x53"" attributes=""0"" />
@@ -336,7 +313,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""36"" endLine=""6"" endColumn=""37"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__2_2"" parameterNames=""h"">
       <customDebugInfo>
@@ -350,9 +326,6 @@ class C
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
         <entry offset=""0xd"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x1e"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
       </scope>
@@ -393,9 +366,6 @@ class C
         <entry offset=""0x1"" startLine=""4"" startColumn=""57"" endLine=""4"" endColumn=""67"" document=""0"" />
         <entry offset=""0x3"" startLine=""4"" startColumn=""79"" endLine=""4"" endColumn=""80"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
       </scope>
@@ -412,9 +382,6 @@ class C
         <entry offset=""0x1"" startLine=""5"" startColumn=""45"" endLine=""5"" endColumn=""55"" document=""0"" />
         <entry offset=""0x3"" startLine=""5"" startColumn=""67"" endLine=""5"" endColumn=""68"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
       </scope>
@@ -467,7 +434,6 @@ class C2
         <entry offset=""0x15"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""63"" document=""0"" />
         <entry offset=""0x2a"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
       </scope>
@@ -493,7 +459,6 @@ class C2
         <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""51"" document=""0"" />
         <entry offset=""0x2a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -579,14 +544,6 @@ class C
         <entry offset=""0x4f"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" document=""0"" />
         <entry offset=""0x50"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""b"" il_index=""0"" il_start=""0x0"" il_end=""0x51"" attributes=""0"" />
-        <local name=""s"" il_index=""2"" il_start=""0x8"" il_end=""0x17"" attributes=""0"" />
-        <local name=""s"" il_index=""3"" il_start=""0x19"" il_end=""0x50"" attributes=""0"" />
-        <local name=""i"" il_index=""4"" il_start=""0x19"" il_end=""0x50"" attributes=""0"" />
-        <local name=""j"" il_index=""5"" il_start=""0x25"" il_end=""0x3d"" attributes=""0"" />
-        <local name=""k"" il_index=""6"" il_start=""0x25"" il_end=""0x3d"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x51"">
         <local name=""b"" il_index=""0"" il_start=""0x0"" il_end=""0x51"" attributes=""0"" />
         <scope startOffset=""0x8"" endOffset=""0x17"">
@@ -675,7 +632,6 @@ public class SeqPointForWhile
         <entry offset=""0x5"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""0"" />
         <entry offset=""0xf"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x10"">
         <namespace name=""System"" />
       </scope>
@@ -699,9 +655,6 @@ public class SeqPointForWhile
         <entry offset=""0x28"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""20"" document=""0"" />
         <entry offset=""0x2f"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""0"" il_start=""0x11"" il_end=""0x1a"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x30"">
         <scope startOffset=""0x11"" endOffset=""0x1a"">
           <local name=""x"" il_index=""0"" il_start=""0x11"" il_end=""0x1a"" attributes=""0"" />
@@ -757,9 +710,6 @@ class C
         <entry offset=""0x1c"" hidden=""true"" document=""0"" />
         <entry offset=""0x1f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""i"" il_index=""0"" il_start=""0x1"" il_end=""0x1f"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x20"">
         <scope startOffset=""0x1"" endOffset=""0x1f"">
           <local name=""i"" il_index=""0"" il_start=""0x1"" il_end=""0x1f"" attributes=""0"" />
@@ -802,7 +752,6 @@ class C
         <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
         <entry offset=""0xc"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>
@@ -848,9 +797,6 @@ class C
         <entry offset=""0xe"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""19"" document=""0"" />
         <entry offset=""0x14"" hidden=""true"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x16"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x16"">
         <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x16"" attributes=""0"" />
       </scope>
@@ -913,7 +859,6 @@ public class C
         <entry offset=""0x1a"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" document=""0"" />
         <entry offset=""0x23"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -977,9 +922,6 @@ public class C
         <entry offset=""0x1e"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" document=""0"" />
         <entry offset=""0x24"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""2"" il_start=""0xd"" il_end=""0x1a"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x25"">
         <scope startOffset=""0xd"" endOffset=""0x1a"">
           <local name=""x"" il_index=""2"" il_start=""0xd"" il_end=""0x1a"" attributes=""0"" />
@@ -1361,9 +1303,6 @@ class Program
         <entry offset=""0x47"" hidden=""true"" document=""0"" />
         <entry offset=""0x52"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""i"" il_index=""1"" il_start=""0x14"" il_end=""0x3d"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x53"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -1441,9 +1380,6 @@ public class SeqPointForWhile
         <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""0"" />
         <entry offset=""0x13"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""obj"" il_index=""0"" il_start=""0x0"" il_end=""0x14"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <namespace name=""System"" />
         <local name=""obj"" il_index=""0"" il_start=""0x0"" il_end=""0x14"" attributes=""0"" />
@@ -1479,7 +1415,6 @@ public class SeqPointForWhile
         <entry offset=""0x33"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""20"" document=""0"" />
         <entry offset=""0x3a"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1563,7 +1498,6 @@ public class SeqPointForWhile
         <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""27"" document=""0"" />
         <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""NS.MyClass"" name="".ctor"" parameterNames=""values"">
       <customDebugInfo>
@@ -1575,7 +1509,6 @@ public class SeqPointForWhile
         <entry offset=""0x8"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""57"" document=""0"" />
         <entry offset=""0x19"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""NS.MyClass"" name=""Main"">
       <customDebugInfo>
@@ -1598,12 +1531,6 @@ public class SeqPointForWhile
         <entry offset=""0x25"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""36"" document=""0"" />
         <entry offset=""0x32"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""intI"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""intJ"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""intK"" il_index=""2"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""mc"" il_index=""3"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""intI"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
         <local name=""intJ"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -1718,7 +1645,6 @@ public class Derived : Base
         <entry offset=""0xa"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
         <entry offset=""0x12"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x13"">
         <namespace name=""System"" />
       </scope>
@@ -1734,7 +1660,6 @@ public class Derived : Base
         <entry offset=""0xa"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
         <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1785,7 +1710,6 @@ public partial class C
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""15"" document=""2"" />
         <entry offset=""0x7"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""15"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1886,7 +1810,6 @@ public partial class C
         <entry offset=""0x9e"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""33"" document=""1"" />
         <entry offset=""0xa9"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xaa"">
         <namespace name=""System"" />
       </scope>
@@ -1921,7 +1844,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""50"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__1_0"" parameterNames=""z"">
       <customDebugInfo>
@@ -1930,7 +1852,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""43"" endLine=""4"" endColumn=""44"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1959,7 +1880,6 @@ class C
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""14"" document=""0"" />
         <entry offset=""0x7"" startLine=""4"" startColumn=""16"" endLine=""4"" endColumn=""21"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1990,37 +1910,31 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""35"" endLine=""4"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""set_AutoProp1"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""40"" endLine=""4"" endColumn=""52"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""get_AutoProp2"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""5"" startColumn=""33"" endLine=""5"" endColumn=""37"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""set_AutoProp2"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""5"" startColumn=""38"" endLine=""5"" endColumn=""42"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""get_AutoProp3"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""38"" endLine=""6"" endColumn=""51"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""set_AutoProp3"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""52"" endLine=""6"" endColumn=""56"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2091,7 +2005,6 @@ public class C
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2124,7 +2037,6 @@ public class C
         <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" document=""0"" />
         <entry offset=""0x3"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2236,10 +2148,6 @@ public class SeqPointAfterReturn
         <entry offset=""0x79"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""20"" document=""0"" />
         <entry offset=""0x7e"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""ret"" il_index=""0"" il_start=""0x0"" il_end=""0x81"" attributes=""0"" />
-        <local name=""rets"" il_index=""1"" il_start=""0x0"" il_end=""0x81"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x81"">
         <namespace name=""System"" />
         <local name=""ret"" il_index=""0"" il_start=""0x0"" il_end=""0x81"" attributes=""0"" />
@@ -2267,9 +2175,6 @@ public class SeqPointAfterReturn
         <entry offset=""0x26"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" document=""0"" />
         <entry offset=""0x27"" startLine=""39"" startColumn=""5"" endLine=""39"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x28"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x28"" attributes=""0"" />
       </scope>
@@ -2294,9 +2199,6 @@ public class SeqPointAfterReturn
         <entry offset=""0x17"" startLine=""50"" startColumn=""13"" endLine=""50"" endColumn=""26"" document=""0"" />
         <entry offset=""0x1f"" startLine=""52"" startColumn=""5"" endLine=""52"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
       </scope>
@@ -2376,10 +2278,6 @@ class Test
         <entry offset=""0x1b"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""24"" document=""0"" />
         <entry offset=""0x1f"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""ret"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
-        <local name=""e"" il_index=""1"" il_start=""0xa"" il_end=""0x11"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <local name=""ret"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
         <scope startOffset=""0xa"" endOffset=""0x11"">
@@ -2435,9 +2333,6 @@ class Test
         <entry offset=""0x2b"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
         <entry offset=""0x2e"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""e"" il_index=""0"" il_start=""0x8"" il_end=""0x2e"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2f"">
         <scope startOffset=""0x8"" endOffset=""0x2e"">
           <local name=""e"" il_index=""0"" il_start=""0x8"" il_end=""0x2e"" attributes=""0"" />
@@ -2494,7 +2389,6 @@ class Test
         <entry offset=""0x27"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
         <entry offset=""0x2a"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -2562,10 +2456,6 @@ class Program
         <entry offset=""0x26"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""0"" />
         <entry offset=""0x29"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""str"" il_index=""0"" il_start=""0x0"" il_end=""0x2a"" attributes=""0"" />
-        <local name=""isEmpty"" il_index=""1"" il_start=""0x0"" il_end=""0x2a"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2a"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -2654,12 +2544,6 @@ class C
         <entry offset=""0x7a"" startLine=""33"" startColumn=""9"" endLine=""33"" endColumn=""10"" document=""0"" />
         <entry offset=""0x7b"" startLine=""34"" startColumn=""5"" endLine=""34"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x1"" il_end=""0x3c"" attributes=""0"" />
-        <local name=""b"" il_index=""1"" il_start=""0x1"" il_end=""0x3c"" attributes=""0"" />
-        <local name=""c"" il_index=""2"" il_start=""0x3c"" il_end=""0x79"" attributes=""0"" />
-        <local name=""d"" il_index=""3"" il_start=""0x3c"" il_end=""0x79"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x7c"">
         <scope startOffset=""0x1"" endOffset=""0x3c"">
           <local name=""a"" il_index=""0"" il_start=""0x1"" il_end=""0x3c"" attributes=""0"" />
@@ -2711,9 +2595,6 @@ class Program
         <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""0"" />
         <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
       </scope>
@@ -2752,9 +2633,6 @@ class Program
         <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""31"" document=""0"" />
         <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
       </scope>
@@ -2814,10 +2692,6 @@ unsafe class C
         <entry offset=""0x17"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""32"" document=""0"" />
         <entry offset=""0x23"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
-        <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x17"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x24"">
         <namespace name=""System"" />
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
@@ -2870,9 +2744,6 @@ unsafe class C
         <entry offset=""0x1f"" hidden=""true"" document=""0"" />
         <entry offset=""0x21"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""p"" il_index=""0"" il_start=""0x1"" il_end=""0x21"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x22"">
         <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x21"">
@@ -2936,10 +2807,6 @@ unsafe class C
         <entry offset=""0x43"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""0"" />
         <entry offset=""0x51"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x52"" attributes=""0"" />
-        <local name=""p"" il_index=""1"" il_start=""0x15"" il_end=""0x43"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x52"">
         <namespace name=""System"" />
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x52"" attributes=""0"" />
@@ -2955,7 +2822,6 @@ unsafe class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3014,11 +2880,6 @@ unsafe class C
         <entry offset=""0x25"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""38"" document=""0"" />
         <entry offset=""0x38"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x39"" attributes=""0"" />
-        <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x25"" attributes=""0"" />
-        <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x25"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x39"">
         <namespace name=""System"" />
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x39"" attributes=""0"" />
@@ -3078,10 +2939,6 @@ unsafe class C
         <entry offset=""0x3b"" hidden=""true"" document=""0"" />
         <entry offset=""0x3f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""p"" il_index=""0"" il_start=""0x1"" il_end=""0x3f"" attributes=""0"" />
-        <local name=""q"" il_index=""1"" il_start=""0x1"" il_end=""0x3f"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x3f"">
@@ -3154,11 +3011,6 @@ unsafe class C
         <entry offset=""0x7c"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""31"" document=""0"" />
         <entry offset=""0x8a"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x8b"" attributes=""0"" />
-        <local name=""p"" il_index=""1"" il_start=""0x23"" il_end=""0x6e"" attributes=""0"" />
-        <local name=""q"" il_index=""2"" il_start=""0x23"" il_end=""0x6e"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x8b"">
         <namespace name=""System"" />
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x8b"" attributes=""0"" />
@@ -3176,7 +3028,6 @@ unsafe class C
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""0"" />
         <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""26"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3237,12 +3088,6 @@ unsafe class C
         <entry offset=""0x5f"" hidden=""true"" document=""0"" />
         <entry offset=""0x68"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x69"" attributes=""0"" />
-        <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
-        <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
-        <local name=""r"" il_index=""3"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x69"">
         <namespace name=""System"" />
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x69"" attributes=""0"" />
@@ -3261,7 +3106,6 @@ unsafe class C
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""18"" document=""0"" />
         <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""28"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3306,7 +3150,6 @@ unsafe class C
         <entry offset=""0x1"" startLine=""57"" startColumn=""9"" endLine=""57"" endColumn=""26"" document=""1"" />
         <entry offset=""0x8"" startLine=""58"" startColumn=""5"" endLine=""58"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
       </scope>
@@ -3350,7 +3193,6 @@ unsafe class C
         <entry offset=""0x1"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""26"" document=""0"" />
         <entry offset=""0x8"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
       </scope>
@@ -3440,11 +3282,6 @@ public class C
         <entry offset=""0x94"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" document=""0"" />
         <entry offset=""0x9c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""x"" il_index=""2"" il_start=""0x18"" il_end=""0x25"" attributes=""0"" />
-        <local name=""x"" il_index=""5"" il_start=""0x47"" il_end=""0x57"" attributes=""0"" />
-        <local name=""x"" il_index=""8"" il_start=""0x7d"" il_end=""0x8e"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9d"">
         <namespace name=""System"" />
         <scope startOffset=""0x18"" endOffset=""0x25"">
@@ -3500,11 +3337,6 @@ public class T
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""HighSurrogateCharacter"" value=""{0}"" type=""String"" />
-        <constant name=""LowSurrogateCharacter"" value=""{0}"" type=""String"" />
-        <constant name=""MatchedSurrogateCharacters"" value=""{1}"" type=""String"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <constant name=""HighSurrogateCharacter"" value=""{0}"" type=""String"" />
@@ -3548,9 +3380,6 @@ public class T
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""invalidUnicodeString"" value=""{0}"" type=""String"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <constant name=""invalidUnicodeString"" value=""{0}"" type=""String"" />
@@ -3684,37 +3513,6 @@ public class C<S>
         <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""53"" startColumn=""5"" endLine=""53"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <constant name=""B"" value=""0"" type=""Boolean"" />
-        <constant name=""C"" value=""0"" type=""Char"" />
-        <constant name=""I1"" value=""0"" type=""SByte"" />
-        <constant name=""U1"" value=""0"" type=""Byte"" />
-        <constant name=""I2"" value=""0"" type=""Int16"" />
-        <constant name=""U2"" value=""0"" type=""UInt16"" />
-        <constant name=""I4"" value=""0"" type=""Int32"" />
-        <constant name=""U4"" value=""0"" type=""UInt32"" />
-        <constant name=""I8"" value=""0"" type=""Int64"" />
-        <constant name=""U8"" value=""0"" type=""UInt64"" />
-        <constant name=""R4"" value=""0"" type=""Single"" />
-        <constant name=""R8"" value=""0"" type=""Double"" />
-        <constant name=""EI1"" value=""0"" signature=""15-11-10-01-08"" />
-        <constant name=""EU1"" value=""0"" signature=""15-11-14-01-08"" />
-        <constant name=""EI2"" value=""0"" signature=""15-11-18-01-08"" />
-        <constant name=""EU2"" value=""0"" signature=""15-11-1C-01-08"" />
-        <constant name=""EI4"" value=""null"" signature=""15-11-20-01-08"" />
-        <constant name=""EU4"" value=""0"" signature=""15-11-24-01-08"" />
-        <constant name=""EI8"" value=""0"" signature=""15-11-28-01-08"" />
-        <constant name=""EU8"" value=""0"" signature=""15-11-2C-01-08"" />
-        <constant name=""StrWithNul"" value=""U+0000"" type=""String"" />
-        <constant name=""EmptyStr"" value="""" type=""String"" />
-        <constant name=""NullStr"" value=""null"" type=""String"" />
-        <constant name=""NullObject"" value=""null"" type=""Object"" />
-        <constant name=""NullDynamic"" value=""null"" type=""Object"" />
-        <constant name=""NullTypeDef"" value=""null"" signature=""12-08"" />
-        <constant name=""NullTypeRef"" value=""null"" signature=""12-1D"" />
-        <constant name=""NullTypeSpec"" value=""null"" signature=""15-12-21-04-15-12-25-02-08-15-12-0C-01-08-1C-1E-00-15-12-29-01-13-00"" />
-        <constant name=""D"" value=""0"" type=""Decimal"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
@@ -3798,7 +3596,6 @@ namespace N
         <entry offset=""0x0"" startLine=""14"" startColumn=""6"" endLine=""14"" endColumn=""26"" document=""1"" />
         <entry offset=""0x5"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <namespace name=""System"" />
       </scope>
@@ -3831,7 +3628,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -3842,7 +3638,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3869,7 +3664,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""31"" endLine=""4"" endColumn=""34"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -3880,7 +3674,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3903,7 +3696,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3926,7 +3718,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""41"" endLine=""4"" endColumn=""42"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3949,7 +3740,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""49"" endLine=""4"" endColumn=""56"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -3995,7 +3785,6 @@ public class C
         <entry offset=""0x1"" startLine=""4"" startColumn=""9"" endLine=""4"" endColumn=""31"" document=""2"" />
         <entry offset=""0x8"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -4064,9 +3853,6 @@ public class C
         <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""23"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
       </scope>
@@ -4088,9 +3874,6 @@ public class C
         <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""23"" document=""0"" />
         <entry offset=""0x8"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
       </scope>
@@ -4110,7 +3893,6 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -4127,7 +3909,6 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -4176,11 +3957,6 @@ public class C
         <entry offset=""0xeb"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""0"" />
         <entry offset=""0xf4"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xf5"" attributes=""0"" />
-        <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xf5"" attributes=""0"" />
-        <local name=""x"" il_index=""4"" il_start=""0x24"" il_end=""0xe7"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xf5"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xf5"" attributes=""0"" />
         <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xf5"" attributes=""0"" />
@@ -4213,10 +3989,6 @@ public class C
         <entry offset=""0xe1"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""0"" />
         <entry offset=""0xea"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xeb"" attributes=""0"" />
-        <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xeb"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0xeb"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xeb"" attributes=""0"" />
         <local name=""b"" il_index=""1"" il_start=""0x0"" il_end=""0xeb"" attributes=""0"" />
@@ -4253,7 +4025,6 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""1"" startColumn=""29"" endLine=""1"" endColumn=""30"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""D"" name=""F"">
       <customDebugInfo>
@@ -4262,7 +4033,6 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""1"" startColumn=""29"" endLine=""1"" endColumn=""30"" document=""1"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -63,7 +63,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System.Threading"" />
         <namespace name=""System.IO"" />
@@ -81,7 +80,6 @@ namespace X
         <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System.IO"" />
         <namespace name=""System"" />
@@ -97,7 +95,6 @@ namespace X
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
       </scope>
@@ -143,7 +140,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""R"" target=""System.Threading"" kind=""namespace"" />
         <alias name=""Q"" target=""System.IO"" kind=""namespace"" />
@@ -161,7 +157,6 @@ namespace X
         <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.IO"" kind=""namespace"" />
         <alias name=""P"" target=""System"" kind=""namespace"" />
@@ -177,7 +172,6 @@ namespace X
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System"" kind=""namespace"" />
       </scope>
@@ -223,7 +217,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""R"" target=""System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
         <alias name=""Q"" target=""System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -241,7 +234,6 @@ namespace X
         <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
         <alias name=""P"" target=""System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -257,7 +249,6 @@ namespace X
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
       </scope>
@@ -303,7 +294,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
         <alias name=""Q"" target=""System.Collections.Generic.List`1[[System.Collections.Generic.List`1[[System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -321,7 +311,6 @@ namespace X
         <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.Collections.Generic.List`1[[System.Collections.Generic.List`1[[System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
         <alias name=""P"" target=""System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -337,7 +326,6 @@ namespace X
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
       </scope>
@@ -407,7 +395,6 @@ namespace X
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
         <externinfo alias=""P"" assembly=""a, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" />
@@ -427,7 +414,6 @@ namespace X
         <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
         <extern alias=""P"" />
@@ -446,7 +432,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
         <extern alias=""Q"" />
@@ -496,7 +481,6 @@ class A { void M() {  } }
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""U.V.W"" />
         <externinfo alias=""X"" assembly=""TestExternAliases2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" />
@@ -545,7 +529,6 @@ class A { void M() {  } }
         <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""U.V.W"" />
         <externinfo alias=""X"" assembly=""TestExternAliases3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" />
@@ -648,7 +631,6 @@ class C { void M() { } }
                 <entry offset=""0x0"" startLine=""8"" startColumn=""20"" endLine=""8"" endColumn=""21"" document=""0""/>
                 <entry offset=""0x1"" startLine=""8"" startColumn=""22"" endLine=""8"" endColumn=""23"" document=""0""/>
             </sequencePoints>
-            <locals/>
             <scope startOffset=""0x0"" endOffset=""0x2"">
                 <extern alias=""A""/>
                 <extern alias=""B""/>
@@ -707,7 +689,6 @@ namespace N
         <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""12"" startColumn=""26"" endLine=""12"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
         <namespace qualifier=""P"" name=""N"" />
@@ -821,7 +802,6 @@ namespace X
         <entry offset=""0x0"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
         <namespace name=""System"" />
@@ -844,7 +824,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""25"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
         <namespace name=""System.IO"" />
@@ -869,7 +848,6 @@ namespace X
         <entry offset=""0x0"" startLine=""25"" startColumn=""28"" endLine=""25"" endColumn=""29"" document=""0"" />
         <entry offset=""0x1"" startLine=""25"" startColumn=""30"" endLine=""25"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
         <namespace name=""System.Text"" />
@@ -946,7 +924,6 @@ public class C
                 <entry offset=""0x22"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""45"" document=""0""/>
                 <entry offset=""0x2d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0""/>
             </sequencePoints>
-            <locals/>
             <scope startOffset=""0x0"" endOffset=""0x2e"">
                 <extern alias=""A""/>
                 <extern alias=""B""/>
@@ -1012,7 +989,6 @@ public class C
         <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""48"" document=""0"" />
         <entry offset=""0x22"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <extern alias=""A"" />
         <extern alias=""B"" />
@@ -1130,7 +1106,6 @@ namespace X
         <entry offset=""0x0"" startLine=""30"" startColumn=""26"" endLine=""30"" endColumn=""27"" document=""0"" />
         <entry offset=""0x1"" startLine=""30"" startColumn=""28"" endLine=""30"" endColumn=""29"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
         <namespace name=""System.Threading"" />
@@ -1157,7 +1132,6 @@ namespace X
         <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""0"" />
         <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
         <namespace name=""System.IO"" />
@@ -1181,7 +1155,6 @@ namespace X
         <entry offset=""0x0"" startLine=""31"" startColumn=""19"" endLine=""31"" endColumn=""20"" document=""0"" />
         <entry offset=""0x1"" startLine=""31"" startColumn=""21"" endLine=""31"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
         <namespace name=""System.Threading"" />
@@ -1322,7 +1295,6 @@ namespace X
         <entry offset=""0x0"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" document=""0"" />
         <entry offset=""0x1"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""S"" />
         <namespace name=""System.Threading"" />
@@ -1350,7 +1322,6 @@ namespace X
         <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""0"" />
         <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
         <namespace name=""System.IO"" />
@@ -1374,7 +1345,6 @@ namespace X
         <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""0"" />
         <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""S"" />
         <namespace name=""System.Threading"" />
@@ -1431,7 +1401,6 @@ namespace X
                 <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""0""/>
                 <entry offset=""0x7"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""19"" document=""0""/>
             </sequencePoints>
-            <locals/>
             <scope startOffset=""0x0"" endOffset=""0x16"">
                 <namespace name=""System""/>
             </scope>
@@ -1444,7 +1413,6 @@ namespace X
                 <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" document=""0""/>
                 <entry offset=""0x6"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""27"" document=""0""/>
             </sequencePoints>
-            <locals/>
         </method>
     </methods>
 </symbols>");
@@ -1481,7 +1449,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""59"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x38"">
         <namespace name=""System.Linq"" />
       </scope>
@@ -1497,7 +1464,6 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""10"" endColumn=""8"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__2_0"" parameterNames=""x"">
       <customDebugInfo>
@@ -1508,7 +1474,6 @@ class C
         <entry offset=""0x1"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""55"" document=""0"" />
         <entry offset=""0xa"" startLine=""6"" startColumn=""56"" endLine=""6"" endColumn=""57"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__3_0"" parameterNames=""x"">
       <customDebugInfo>
@@ -1519,7 +1484,6 @@ class C
         <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" document=""0"" />
         <entry offset=""0xa"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1548,13 +1512,11 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""14"" endLine=""6"" endColumn=""18"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""set_P1"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""19"" endLine=""6"" endColumn=""23"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""get_P2"">
       <customDebugInfo>
@@ -1567,7 +1529,6 @@ class C
         <entry offset=""0x1"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""29"" document=""0"" />
         <entry offset=""0x5"" startLine=""7"" startColumn=""30"" endLine=""7"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
       </scope>
@@ -1580,7 +1541,6 @@ class C
         <entry offset=""0x0"" startLine=""7"" startColumn=""36"" endLine=""7"" endColumn=""37"" document=""0"" />
         <entry offset=""0x1"" startLine=""7"" startColumn=""38"" endLine=""7"" endColumn=""39"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""add_E2"" parameterNames=""value"">
       <customDebugInfo>
@@ -1590,7 +1550,6 @@ class C
         <entry offset=""0x0"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""35"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""36"" endLine=""10"" endColumn=""37"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""remove_E2"" parameterNames=""value"">
       <customDebugInfo>
@@ -1600,7 +1559,6 @@ class C
         <entry offset=""0x0"" startLine=""10"" startColumn=""45"" endLine=""10"" endColumn=""46"" document=""0"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""47"" endLine=""10"" endColumn=""48"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""get_Item"" parameterNames=""x"">
       <customDebugInfo>
@@ -1611,7 +1569,6 @@ class C
         <entry offset=""0x1"" startLine=""8"" startColumn=""29"" endLine=""8"" endColumn=""38"" document=""0"" />
         <entry offset=""0x5"" startLine=""8"" startColumn=""39"" endLine=""8"" endColumn=""40"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""C"" name=""set_Item"" parameterNames=""x, value"">
       <customDebugInfo>
@@ -1621,7 +1578,6 @@ class C
         <entry offset=""0x0"" startLine=""8"" startColumn=""45"" endLine=""8"" endColumn=""46"" document=""0"" />
         <entry offset=""0x1"" startLine=""8"" startColumn=""47"" endLine=""8"" endColumn=""48"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1651,13 +1607,11 @@ class Derived : Base
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""28"" endLine=""6"" endColumn=""32"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Base"" name=""set_P"" parameterNames=""value"">
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""37"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
     <method containingType=""Derived"" name=""set_P"" parameterNames=""value"">
       <customDebugInfo>
@@ -1669,7 +1623,6 @@ class Derived : Base
         <entry offset=""0x0"" startLine=""11"" startColumn=""40"" endLine=""11"" endColumn=""41"" document=""0"" />
         <entry offset=""0x1"" startLine=""11"" startColumn=""42"" endLine=""11"" endColumn=""43"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
       </scope>
@@ -1716,7 +1669,6 @@ class C : I1, I2
         <entry offset=""0x1"" startLine=""18"" startColumn=""36"" endLine=""18"" endColumn=""45"" document=""0"" />
         <entry offset=""0x5"" startLine=""18"" startColumn=""46"" endLine=""18"" endColumn=""47"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System.Runtime.CompilerServices"" />
       </scope>
@@ -1729,7 +1681,6 @@ class C : I1, I2
         <entry offset=""0x0"" startLine=""18"" startColumn=""52"" endLine=""18"" endColumn=""53"" document=""0"" />
         <entry offset=""0x1"" startLine=""18"" startColumn=""54"" endLine=""18"" endColumn=""55"" document=""0"" />
       </sequencePoints>
-      <locals />
     </method>
   </methods>
 </symbols>");
@@ -1821,7 +1772,6 @@ public class Test
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""I"" target=""Outer+Inner, Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" kind=""type"" />
       </scope>
@@ -1867,7 +1817,6 @@ class Test { static void Main() { } }
       <sequencePoints>
         <entry offset=""0x0"" startLine=""20"" startColumn=""35"" endLine=""20"" endColumn=""36"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <namespace name=""namespace"" />
         <alias name=""object"" target=""namespace"" kind=""namespace"" />
@@ -1920,7 +1869,6 @@ namespace N
       <sequencePoints>
         <entry offset=""0x0"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""31"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <namespace qualifier=""Q"" name="""" />
         <alias name=""S"" qualifier=""Q"" target="""" kind=""namespace"" />
@@ -1962,7 +1910,6 @@ class D
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""26"" endLine=""6"" endColumn=""27"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <alias name=""AD"" target=""System.Action`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
       </scope>
@@ -2062,7 +2009,6 @@ public class C1
         <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""t1"" target=""Y`1[[W[], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" kind=""type"" />
         <alias name=""t2"" target=""Y`1[[W[,], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" kind=""type"" />
@@ -2138,7 +2084,6 @@ class D
                 <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""0""/>
                 <entry offset=""0x8"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0""/>
             </sequencePoints>
-            <locals/>
             <scope startOffset=""0x0"" endOffset=""0x9"">
                 <type name=""System.Math, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""/>
             </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.IO
 Imports System.Text
@@ -2573,9 +2573,6 @@ End Class
                 <entry offset="0x4" startLine="7" startColumn="9" endLine="7" endColumn="32" document="1"/>
                 <entry offset="0x10" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="ch" il_index="0" il_start="0x0" il_end="0x11" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x11">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="Microsoft.VisualBasic" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -362,7 +362,6 @@ End Class
                 <entry offset="0x25" startLine="7" startColumn="9" endLine="7" endColumn="16" document="1"/>
                 <entry offset="0x40" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x42">
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -676,7 +675,6 @@ End Class
                 <entry offset="0xa6" startLine="6" startColumn="5" endLine="6" endColumn="17" document="1"/>
                 <entry offset="0xb0" hidden="true" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xbe">
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
 Imports System.IO
@@ -1429,11 +1429,6 @@ End Class
                 <entry offset="0x21" startLine="13" startColumn="9" endLine="13" endColumn="13" document="0"/>
                 <entry offset="0x28" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="z" il_index="3" il_start="0x0" il_end="0x29" attributes="0"/>
-                <local name="y" il_index="1" il_start="0x0" il_end="0x29" attributes="0"/>
-                <local name="w" il_index="4" il_start="0x0" il_end="0x29" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x29">
                 <currentnamespace name=""/>
                 <local name="z" il_index="3" il_start="0x0" il_end="0x29" attributes="0"/>
@@ -1483,10 +1478,6 @@ End Class
                 <entry offset="0x1b" startLine="12" startColumn="9" endLine="12" endColumn="13" document="0"/>
                 <entry offset="0x22" startLine="13" startColumn="5" endLine="13" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="5" il_start="0x0" il_end="0x23" attributes="0"/>
-                <local name="z" il_index="3" il_start="0x0" il_end="0x23" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x23">
                 <currentnamespace name=""/>
                 <local name="x" il_index="5" il_start="0x0" il_end="0x23" attributes="0"/>
@@ -1543,10 +1534,6 @@ End Class
                 <entry offset="0x19" startLine="18" startColumn="9" endLine="18" endColumn="13" document="0"/>
                 <entry offset="0x25" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="c" il_index="2" il_start="0x0" il_end="0x26" attributes="0"/>
-                <local name="b" il_index="1" il_start="0x0" il_end="0x26" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x26">
                 <currentnamespace name=""/>
                 <local name="c" il_index="2" il_start="0x0" il_end="0x26" attributes="0"/>
@@ -1632,10 +1619,6 @@ End Class
                 <entry offset="0x3" startLine="4" startColumn="13" endLine="4" endColumn="29" document="0"/>
                 <entry offset="0x9" startLine="5" startColumn="5" endLine="5" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="a" il_index="2" il_start="0x0" il_end="0xa" attributes="0"/>
-                <local name="b" il_index="1" il_start="0x0" il_end="0xa" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xa">
                 <currentnamespace name=""/>
                 <local name="a" il_index="2" il_start="0x0" il_end="0xa" attributes="0"/>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
@@ -110,10 +110,6 @@ End Class
         <entry offset=""0x29"" hidden=""true"" document=""1"" />
         <entry offset=""0x35"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""12"" document=""1"" />
       </sequencePoints>
-      <locals>
-        <local name=""index"" il_index=""1"" il_start=""0x1"" il_end=""0x18"" attributes=""0"" />
-        <local name=""index"" il_index=""4"" il_start=""0x19"" il_end=""0x34"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x36"">
         <namespace name=""System"" importlevel=""file"" />
         <currentnamespace name="""" />
@@ -239,7 +235,6 @@ End Class
         <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
         <entry offset=""0x1c"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""12"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x1d"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
@@ -261,7 +256,6 @@ End Class
         <entry offset=""0x9"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
         <entry offset=""0x13"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""12"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
@@ -596,7 +590,6 @@ End Class
         <entry offset=""0xd"" startLine=""13"" startColumn=""21"" endLine=""13"" endColumn=""30"" document=""1"" />
         <entry offset=""0x1e"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""29"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0x20"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
@@ -806,7 +799,6 @@ End Class
         <entry offset=""0xb3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""16"" document=""1"" />
         <entry offset=""0xce"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""17"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xd2"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
@@ -1012,7 +1004,6 @@ End Class
         <entry offset=""0xe4"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""17"" document=""1"" />
         <entry offset=""0xee"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <locals />
       <scope startOffset=""0x0"" endOffset=""0xfc"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
@@ -204,7 +204,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="10" document="1"/>
                 <entry offset="0x1" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <currentnamespace name=""/>
             </scope>
@@ -265,7 +264,6 @@ End Class
                 <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="3"/>
                 <entry offset="0x2b" hidden="true" document="3"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2c">
                 <currentnamespace name=""/>
             </scope>
@@ -333,7 +331,6 @@ End Class
                 <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="6"/>
                 <entry offset="0x2b" hidden="true" document="6"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2c">
                 <currentnamespace name=""/>
             </scope>
@@ -387,7 +384,6 @@ End Class
                 <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="4"/>
                 <entry offset="0x1d" hidden="true" document="4"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x1e">
                 <currentnamespace name=""/>
             </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -54,7 +54,6 @@ End Module
                 <forwardIterator name="VB$StateMachine_1_F"/>
             </customDebugInfo>
             <sequencePoints/>
-            <locals/>
         </method>
     </methods>
 </symbols>)
@@ -87,7 +86,6 @@ End Module
                 <entry offset="0xa8" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
                 <entry offset="0xb2" hidden="true" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xc0">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -107,7 +105,6 @@ End Module
                 <forwardIterator name="VB$StateMachine_2_Test"/>
             </customDebugInfo>
             <sequencePoints/>
-            <locals/>
         </method>
     </methods>
 </symbols>)
@@ -162,7 +159,6 @@ End Module
                 <entry offset="0x51c" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
                 <entry offset="0x526" hidden="true" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x533">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -190,7 +186,6 @@ End Module
                 <forwardIterator name="VB$StateMachine_3_S"/>
             </customDebugInfo>
             <sequencePoints/>
-            <locals/>
         </method>
     </methods>
 </symbols>)
@@ -221,7 +216,6 @@ End Module
                 <entry offset="0xa3" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
                 <entry offset="0xad" hidden="true" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xba">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -296,10 +290,6 @@ End Class
                 <entry offset="0x126" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
                 <entry offset="0x130" hidden="true" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x12" il_end="0x100" attributes="0"/>
-                <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x12" il_end="0x100" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x13d">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
                 <scope startOffset="0x12" endOffset="0x100">
@@ -365,9 +355,6 @@ End Class
                 <entry offset="0xf9" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
                 <entry offset="0x103" hidden="true" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0xa" il_end="0xd6" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10f">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
                 <scope startOffset="0xa" endOffset="0xd6">
@@ -440,10 +427,6 @@ End Class
                 <entry offset="0xe3" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
                 <entry offset="0xed" hidden="true" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0xf" il_end="0xbd" attributes="0"/>
-                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0xf" il_end="0xbd" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xfa">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
@@ -508,10 +491,6 @@ End Class
                 <entry offset="0xcd" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
                 <entry offset="0xd7" hidden="true" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0xa" il_end="0xaa" attributes="0"/>
-                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0xa" il_end="0xaa" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xe3">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
@@ -572,7 +551,6 @@ End Class
                 <entry offset="0x2f" startLine="7" startColumn="5" endLine="7" endColumn="17" document="0"/>
                 <entry offset="0x39" hidden="true" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x47">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
     Public Class PDBCollectionInitializerTests
@@ -46,9 +46,6 @@ End Class
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="91" document="0"/>
                 <entry offset="0x2a" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x2b" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2b">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -104,9 +101,6 @@ End Class
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="73" document="0"/>
                 <entry offset="0x2a" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="aList2" il_index="0" il_start="0x0" il_end="0x2b" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2b">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -160,9 +154,6 @@ End Class
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="107" document="0"/>
                 <entry offset="0x2c" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x2d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2d">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -220,10 +211,6 @@ End Class
                 <entry offset="0x2a" startLine="10" startColumn="21" endLine="10" endColumn="27" document="0"/>
                 <entry offset="0x53" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x54" attributes="0"/>
-                <local name="aList2" il_index="1" il_start="0x0" il_end="0x54" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x54">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBConstLocalTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBConstLocalTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Roslyn.Test.Utilities
 Imports System.Xml.Linq
@@ -39,10 +39,6 @@ end class
                 <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="33" document="0"/>
                 <entry offset="0x8" startLine="7" startColumn="5" endLine="7" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <constant name="x" value="1" type="Int32"/>
-                <constant name="y" value="2" type="Int32"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x9">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -93,9 +89,6 @@ end class
                 <entry offset="0x1" startLine="5" startColumn="9" endLine="11" endColumn="11" document="0"/>
                 <entry offset="0x2c" startLine="12" startColumn="5" endLine="12" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <constant name="x" value="1" type="Int32"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2d">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -108,10 +101,6 @@ end class
                 <entry offset="0x1" startLine="9" startColumn="17" endLine="9" endColumn="45" document="0"/>
                 <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <constant name="y" value="2" type="Int32"/>
-                <constant name="z" value="3" type="Int32"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="C" methodName="M" parameterNames="a"/>
                 <constant name="y" value="2" type="Int32"/>
@@ -177,14 +166,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="12" document="0"/>
                 <entry offset="0x1" startLine="10" startColumn="5" endLine="10" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <constant name="o" value="null" type="Object"/>
-                <constant name="s" value="hello" type="String"/>
-                <constant name="f" value="-3.402823E+38" type="Single"/>
-                <constant name="d" value="1.79769313486232E+308" type="Double"/>
-                <constant name="dec" value="1.5" type="Decimal"/>
-                <constant name="dt" value="02/29/2012 00:00:00" type="DateTime"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Roslyn.Test.Utilities
 
@@ -63,9 +63,6 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0x18" hidden="true" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -81,7 +78,6 @@ End Class
                 <entry offset="0x17" hidden="true" document="2"/>
                 <entry offset="0x22" hidden="true" document="2"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x23">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
             </scope>
@@ -163,9 +159,6 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0x18" hidden="true" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -204,9 +197,6 @@ End Class
                 <entry offset="0x9d" hidden="true" document="3"/>
                 <entry offset="0xa9" hidden="true" document="3"/>
             </sequencePoints>
-            <locals>
-                <local name="i" il_index="0" il_start="0x0" il_end="0xaa" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xaa">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
                 <local name="i" il_index="0" il_start="0x0" il_end="0xaa" attributes="0"/>
@@ -273,9 +263,6 @@ End Class
                 <entry offset="0x7" startLine="11" startColumn="9" endLine="11" endColumn="42" document="1"/>
                 <entry offset="0x18" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -290,7 +277,6 @@ End Class
                 <entry offset="0xc" startLine="20" startColumn="9" endLine="20" endColumn="41" document="1"/>
                 <entry offset="0x17" startLine="21" startColumn="5" endLine="21" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x18">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
             </scope>
@@ -362,9 +348,6 @@ End Class
                 <entry offset="0x7" startLine="11" startColumn="9" endLine="11" endColumn="42" document="1"/>
                 <entry offset="0x18" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -379,7 +362,6 @@ End Class
                 <entry offset="0xc" startLine="23" startColumn="9" endLine="23" endColumn="41" document="1"/>
                 <entry offset="0x17" startLine="27" startColumn="5" endLine="27" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x18">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
             </scope>
@@ -452,9 +434,6 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0x18" hidden="true" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -469,7 +448,6 @@ End Class
                 <entry offset="0xc" hidden="true" document="1"/>
                 <entry offset="0x17" hidden="true" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x18">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
             </scope>
@@ -545,9 +523,6 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0x18" hidden="true" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x19" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x19">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -563,7 +538,6 @@ End Class
                 <entry offset="0x17" hidden="true" document="1"/>
                 <entry offset="0x22" hidden="true" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x23">
                 <importsforward declaringType="C1" methodName="FooInvisible"/>
             </scope>
@@ -657,7 +631,6 @@ End Class
                 <entry offset="0x6" startLine="46" startColumn="12" endLine="46" endColumn="30" document="2"/>
                 <entry offset="0xe" startLine="27" startColumn="36" endLine="27" endColumn="54" document="3"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x17">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -670,7 +643,6 @@ End Class
                 <entry offset="0xd" startLine="12" startColumn="9" endLine="12" endColumn="30" document="2"/>
                 <entry offset="0x19" startLine="13" startColumn="5" endLine="13" endColumn="12" document="2"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x1a">
                 <importsforward declaringType="C1" methodName=".ctor"/>
             </scope>
@@ -687,9 +659,6 @@ End Class
                 <entry offset="0x7" startLine="3" startColumn="9" endLine="3" endColumn="23" document="2"/>
                 <entry offset="0xe" startLine="4" startColumn="5" endLine="4" endColumn="12" document="2"/>
             </sequencePoints>
-            <locals>
-                <local name="c" il_index="0" il_start="0x0" il_end="0xf" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xf">
                 <importsforward declaringType="C1" methodName=".ctor"/>
                 <local name="c" il_index="0" il_start="0x0" il_end="0xf" attributes="0"/>
@@ -700,7 +669,6 @@ End Class
                 <entry offset="0x0" hidden="true" document="1"/>
                 <entry offset="0x6" hidden="true" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xf">
                 <importsforward declaringType="C1" methodName=".ctor"/>
             </scope>
@@ -885,7 +853,6 @@ End Module
                                            <entry offset="0x4e" hidden="true" document="2"/>
                                            <entry offset="0x59" hidden="true" document="2"/>
                                        </sequencePoints>
-                                       <locals/>
                                        <scope startOffset="0x0" endOffset="0x5a">
                                            <namespace name="System" importlevel="file"/>
                                            <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -933,7 +900,6 @@ End Class
                                            <entry offset="0x1" startLine="4" startColumn="2" endLine="4" endColumn="8" document="2"/>
                                            <entry offset="0x8" hidden="true" document="2"/>
                                        </sequencePoints>
-                                       <locals/>
                                        <scope startOffset="0x0" endOffset="0x9">
                                            <currentnamespace name=""/>
                                        </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBForEachTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBForEachTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -53,10 +53,6 @@ End Class
         <entry offset=""0x2f"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" document=""0"" />
         <entry offset=""0x33"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""17"" document=""0"" />
       </sequencePoints>
-      <locals>
-        <local name=""M"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""o"" il_index=""3"" il_start=""0x7"" il_end=""0x22"" attributes=""0"" />
-      </locals>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <currentnamespace name="""" />
         <local name=""M"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -125,10 +121,6 @@ Imports System
                 <entry offset="0x28" hidden="true" document="0"/>
                 <entry offset="0x34" startLine="14" startColumn="13" endLine="14" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="arr" il_index="0" il_start="0x0" il_end="0x35" attributes="0"/>
-                <local name="element" il_index="3" il_start="0x18" il_end="0x27" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x35">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -196,10 +188,6 @@ End Class
                 <entry offset="0x21" hidden="true" document="0"/>
                 <entry offset="0x30" startLine="12" startColumn="5" endLine="12" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x31" attributes="0"/>
-                <local name="element" il_index="3" il_start="0xd" il_end="0x20" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x31">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -278,9 +266,6 @@ End Structure
                 <entry offset="0x1e" hidden="true" document="0"/>
                 <entry offset="0x29" startLine="8" startColumn="5" endLine="8" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="1" il_start="0xe" il_end="0x1d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2a">
                 <currentnamespace name=""/>
                 <scope startOffset="0xe" endOffset="0x1d">
@@ -356,9 +341,6 @@ End Class
                 <entry offset="0x3a" hidden="true" document="0"/>
                 <entry offset="0x4a" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="j" il_index="1" il_start="0x1f" il_end="0x2d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x4b">
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <namespace name="System" importlevel="file"/>
@@ -431,9 +413,6 @@ End Class
                 <entry offset="0x33" hidden="true" document="0"/>
                 <entry offset="0x4d" startLine="8" startColumn="5" endLine="8" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="1" il_start="0xe" il_end="0x26" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x4e">
                 <currentnamespace name=""/>
                 <scope startOffset="0xe" endOffset="0x26">
@@ -501,10 +480,6 @@ End Module
                 <entry offset="0x13" hidden="true" document="0"/>
                 <entry offset="0x1e" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="myFArr" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
-                <local name="i" il_index="1" il_start="0x0" il_end="0x1f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1f">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -563,9 +538,6 @@ End Module
                 <entry offset="0x2f" startLine="8" startColumn="5" endLine="8" endColumn="9" document="0"/>
                 <entry offset="0x3c" startLine="9" startColumn="4" endLine="9" endColumn="11" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="i" il_index="1" il_start="0x1" il_end="0x3b" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -55,7 +55,6 @@ End Module
                 <entry offset="0x4c" startLine="9" startColumn="17" endLine="9" endColumn="24" document="0"/>
                 <entry offset="0x6c" startLine="10" startColumn="13" endLine="10" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6e">
                 <importsforward declaringType="Program" methodName="Main" parameterNames="args"/>
             </scope>
@@ -138,11 +137,6 @@ End Module
                 <entry offset="0x16d" hidden="true" document="0"/>
                 <entry offset="0x187" startLine="26" startColumn="5" endLine="26" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_arr$0" il_index="0" il_start="0x47" il_end="0x188" attributes="0"/>
-                <local name="$VB$ResumableLocal_x$3" il_index="3" il_start="0x73" il_end="0xd4" attributes="0"/>
-                <local name="$VB$ResumableLocal_x$6" il_index="6" il_start="0xfd" il_end="0x16c" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x189">
                 <importsforward declaringType="Module1" methodName="Main"/>
                 <scope startOffset="0x47" endOffset="0x188">
@@ -203,9 +197,6 @@ End Class
                 <entry offset="0x85" startLine="13" startColumn="9" endLine="13" endColumn="21" document="0"/>
                 <entry offset="0x96" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x19" il_end="0x97" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x98">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
                 <scope startOffset="0x19" endOffset="0x97">
@@ -255,9 +246,6 @@ End Class
                 <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="20" document="0"/>
                 <entry offset="0x54" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$Closure_0" il_index="1" il_start="0x19" il_end="0x55" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x56">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
                 <scope startOffset="0x19" endOffset="0x55">
@@ -309,10 +297,6 @@ End Class
                 <entry offset="0x5a" startLine="10" startColumn="9" endLine="10" endColumn="21" document="0"/>
                 <entry offset="0x66" startLine="11" startColumn="5" endLine="11" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0x19" il_end="0x67" attributes="0"/>
-                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0x19" il_end="0x67" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x68">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -365,10 +349,6 @@ End Class
                 <entry offset="0x1d" startLine="8" startColumn="9" endLine="8" endColumn="20" document="0"/>
                 <entry offset="0x3a" startLine="9" startColumn="5" endLine="9" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="1" il_start="0x19" il_end="0x3b" attributes="0"/>
-                <local name="y" il_index="2" il_start="0x19" il_end="0x3b" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3c">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -435,7 +415,6 @@ End Module
                 <entry offset="0x4c" startLine="15" startColumn="9" endLine="15" endColumn="16" document="0"/>
                 <entry offset="0x67" startLine="16" startColumn="5" endLine="16" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x69">
                 <importsforward declaringType="Module1" methodName="Main"/>
             </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -50,9 +50,6 @@ End Class
                 <entry offset="0x26" startLine="6" startColumn="9" endLine="6" endColumn="12" document="1"/>
                 <entry offset="0x2d" startLine="7" startColumn="5" endLine="7" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals>
-                <local name="d" il_index="0" il_start="0x0" il_end="0x2e" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2e">
                 <currentnamespace name=""/>
                 <local name="d" il_index="0" il_start="0x0" il_end="0x2e" attributes="0"/>
@@ -68,7 +65,6 @@ End Class
                 <entry offset="0x0" startLine="5" startColumn="22" endLine="5" endColumn="32" document="1"/>
                 <entry offset="0x1" startLine="5" startColumn="33" endLine="5" endColumn="34" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="C" methodName="Main"/>
             </scope>
@@ -146,11 +142,6 @@ End Module
                 <entry offset="0x32" startLine="26" startColumn="21" endLine="26" endColumn="33" document="0"/>
                 <entry offset="0x3f" startLine="27" startColumn="17" endLine="27" endColumn="24" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x40" attributes="0"/>
-                <local name="iii" il_index="1" il_start="0x0" il_end="0x40" attributes="0"/>
-                <local name="d2" il_index="2" il_start="0x0" il_end="0x40" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x40">
                 <importsforward declaringType="M1" methodName="Main"/>
                 <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x40" attributes="0"/>
@@ -225,9 +216,6 @@ End Module
                 <entry offset="0x4" startLine="7" startColumn="21" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x8" startLine="8" startColumn="12" endLine="8" endColumn="24" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="r" il_index="1" il_start="0x0" il_end="0xa" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Main"/>
                 <local name="r" il_index="1" il_start="0x0" il_end="0xa" attributes="0"/>
@@ -283,7 +271,6 @@ End Class
                 <entry offset="0x6" startLine="3" startColumn="12" endLine="3" endColumn="49" document="1"/>
                 <entry offset="0x30" startLine="3" startColumn="12" endLine="3" endColumn="49" document="2"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x5b">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -294,7 +281,6 @@ End Class
                 <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15" document="1"/>
                 <entry offset="0x1" startLine="6" startColumn="5" endLine="6" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -309,7 +295,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="37" endLine="3" endColumn="47" document="1"/>
                 <entry offset="0x1" startLine="3" startColumn="48" endLine="3" endColumn="49" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -324,7 +309,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="37" endLine="3" endColumn="47" document="2"/>
                 <entry offset="0x1" startLine="3" startColumn="48" endLine="3" endColumn="49" document="2"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -376,7 +360,6 @@ End Class
                 <entry offset="0x6" startLine="3" startColumn="12" endLine="3" endColumn="49" document="1"/>
                 <entry offset="0x30" startLine="10" startColumn="12" endLine="10" endColumn="49" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x5b">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -387,7 +370,6 @@ End Class
                 <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15" document="1"/>
                 <entry offset="0x1" startLine="6" startColumn="5" endLine="6" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -402,7 +384,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="37" endLine="3" endColumn="47" document="1"/>
                 <entry offset="0x1" startLine="3" startColumn="48" endLine="3" endColumn="49" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -417,7 +398,6 @@ End Class
                 <entry offset="0x0" startLine="10" startColumn="37" endLine="10" endColumn="47" document="1"/>
                 <entry offset="0x1" startLine="10" startColumn="48" endLine="10" endColumn="49" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="C" methodName=".ctor"/>
             </scope>
@@ -468,7 +448,6 @@ End Class
                 <entry offset="0x1" startLine="3" startColumn="19" endLine="3" endColumn="56" document="2"/>
                 <entry offset="0x16" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x17">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -484,7 +463,6 @@ End Class
                 <entry offset="0x0" startLine="3" startColumn="44" endLine="3" endColumn="54" document="2"/>
                 <entry offset="0x1" startLine="3" startColumn="55" endLine="3" endColumn="56" document="2"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="C2" methodName=".cctor"/>
             </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBNamespaceScopes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBNamespaceScopes.vb
@@ -112,7 +112,6 @@ End Namespace
                                 <entry offset="0x6" startLine="22" startColumn="12" endLine="22" endColumn="43" document="1"/>
                                 <entry offset="0x16" startLine="16" startColumn="12" endLine="16" endColumn="43" document="2"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0x27">
                                 <xmlnamespace prefix="file1" name="http://stuff/fromFile" importlevel="file"/>
                                 <xmlnamespace prefix="" name="http://stuff/fromFile1" importlevel="file"/>
@@ -137,7 +136,6 @@ End Namespace
                                 <entry offset="0x1" startLine="25" startColumn="9" endLine="25" endColumn="42" document="1"/>
                                 <entry offset="0xc" startLine="26" startColumn="5" endLine="26" endColumn="12" document="1"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <importsforward declaringType="Boo.C1" methodName=".ctor"/>
                             </scope>
@@ -148,7 +146,6 @@ End Namespace
                                 <entry offset="0x1" startLine="29" startColumn="9" endLine="29" endColumn="48" document="1"/>
                                 <entry offset="0xc" startLine="30" startColumn="5" endLine="30" endColumn="12" document="1"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <importsforward declaringType="Boo.C1" methodName=".ctor"/>
                             </scope>
@@ -159,7 +156,6 @@ End Namespace
                                 <entry offset="0x1" startLine="24" startColumn="9" endLine="24" endColumn="65" document="2"/>
                                 <entry offset="0xc" startLine="25" startColumn="5" endLine="25" endColumn="12" document="2"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <xmlnamespace prefix="file2" name="http://stuff/fromFile" importlevel="file"/>
                                 <xmlnamespace prefix="" name="http://stuff/fromFile2" importlevel="file"/>
@@ -290,7 +286,6 @@ End Namespace
                                 <entry offset="0x6" startLine="22" startColumn="12" endLine="22" endColumn="43" document="1"/>
                                 <entry offset="0x16" startLine="16" startColumn="12" endLine="16" endColumn="43" document="2"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0x27">
                                 <xmlnamespace prefix="file1" name="http://stuff/fromFile" importlevel="file"/>
                                 <xmlnamespace prefix="" name="http://stuff/fromFile1" importlevel="file"/>
@@ -316,7 +311,6 @@ End Namespace
                                 <entry offset="0x1" startLine="25" startColumn="9" endLine="25" endColumn="42" document="1"/>
                                 <entry offset="0xc" startLine="26" startColumn="5" endLine="26" endColumn="12" document="1"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <importsforward declaringType="DefaultNamespace.Boo.C1" methodName=".ctor"/>
                             </scope>
@@ -327,7 +321,6 @@ End Namespace
                                 <entry offset="0x1" startLine="29" startColumn="9" endLine="29" endColumn="48" document="1"/>
                                 <entry offset="0xc" startLine="30" startColumn="5" endLine="30" endColumn="12" document="1"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <importsforward declaringType="DefaultNamespace.Boo.C1" methodName=".ctor"/>
                             </scope>
@@ -338,7 +331,6 @@ End Namespace
                                 <entry offset="0x1" startLine="24" startColumn="9" endLine="24" endColumn="65" document="2"/>
                                 <entry offset="0xc" startLine="25" startColumn="5" endLine="25" endColumn="12" document="2"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0xd">
                                 <xmlnamespace prefix="file2" name="http://stuff/fromFile" importlevel="file"/>
                                 <xmlnamespace prefix="" name="http://stuff/fromFile2" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
     Public Class PDBObjectInitializerTests
@@ -51,9 +51,6 @@ End Class
                 <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="78" document="0"/>
                 <entry offset="0x19" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1a">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -114,9 +111,6 @@ End Class
                 <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="68" document="0"/>
                 <entry offset="0x19" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1a">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -177,9 +171,6 @@ End Class
                 <entry offset="0x1" startLine="14" startColumn="13" endLine="14" endColumn="90" document="0"/>
                 <entry offset="0x1d" startLine="15" startColumn="5" endLine="15" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1e" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1e">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -242,10 +233,6 @@ End Class
                 <entry offset="0x19" startLine="15" startColumn="20" endLine="15" endColumn="25" document="0"/>
                 <entry offset="0x31" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="inst1" il_index="0" il_start="0x0" il_end="0x32" attributes="0"/>
-                <local name="inst2" il_index="1" il_start="0x0" il_end="0x32" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x32">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBSyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBSyncLockTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
 
@@ -125,10 +125,6 @@ End Class
                 <entry offset="0x4a" startLine="19" startColumn="9" endLine="19" endColumn="16" document="0"/>
                 <entry offset="0x4b" startLine="20" startColumn="5" endLine="20" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="lock" il_index="0" il_start="0x2" il_end="0x3c" attributes="0"/>
-                <local name="x" il_index="3" il_start="0x21" il_end="0x29" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x4c">
                 <importsforward declaringType="C1" methodName="Something" parameterNames="x"/>
                 <scope startOffset="0x2" endOffset="0x3c">

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -36,7 +36,6 @@ End Class
                 <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="50" document="0"/>
                 <entry offset="0xc" startLine="4" startColumn="5" endLine="4" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <currentnamespace name=""/>
             </scope>
@@ -47,7 +46,6 @@ End Class
                 <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25" document="0"/>
                 <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name="My"/>
             </scope>
@@ -63,9 +61,6 @@ End Class
                 <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62" document="0"/>
                 <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Computer" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Computer" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -82,9 +77,6 @@ End Class
                 <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57" document="0"/>
                 <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Application" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Application" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -101,9 +93,6 @@ End Class
                 <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58" document="0"/>
                 <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="User" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="User" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -120,9 +109,6 @@ End Class
                 <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67" document="0"/>
                 <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="WebServices" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="WebServices" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -135,7 +121,6 @@ End Class
                 <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136" document="0"/>
                 <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x29">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -151,9 +136,6 @@ End Class
                 <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40" document="0"/>
                 <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Equals" il_index="0" il_start="0x0" il_end="0x12" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x12">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Equals" il_index="0" il_start="0x0" il_end="0x12" attributes="0"/>
@@ -170,9 +152,6 @@ End Class
                 <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42" document="0"/>
                 <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetHashCode" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetHashCode" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
@@ -189,9 +168,6 @@ End Class
                 <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46" document="0"/>
                 <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetType" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetType" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -208,9 +184,6 @@ End Class
                 <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39" document="0"/>
                 <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="ToString" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="ToString" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
@@ -231,9 +204,6 @@ End Class
                 <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36" document="0"/>
                 <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Create__Instance__" il_index="0" il_start="0x0" il_end="0x1d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1d">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Create__Instance__" il_index="0" il_start="0x0" il_end="0x1d" attributes="0"/>
@@ -245,7 +215,6 @@ End Class
                 <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35" document="0"/>
                 <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -256,7 +225,6 @@ End Class
                 <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28" document="0"/>
                 <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -275,9 +243,6 @@ End Class
                 <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47" document="0"/>
                 <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetInstance" il_index="0" il_start="0x0" il_end="0x26" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x26">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetInstance" il_index="0" il_start="0x0" il_end="0x26" attributes="0"/>
@@ -289,7 +254,6 @@ End Class
                 <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29" document="0"/>
                 <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -374,13 +338,6 @@ End Module
                 <entry offset="0x4f" startLine="24" startColumn="9" endLine="24" endColumn="29" document="0"/>
                 <entry offset="0x56" startLine="26" startColumn="5" endLine="26" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x57" attributes="0"/>
-                <local name="y" il_index="1" il_start="0x4" il_end="0x1a" attributes="0"/>
-                <local name="ex" il_index="3" il_start="0x1d" il_end="0x3b" attributes="0"/>
-                <local name="z" il_index="4" il_start="0x25" il_end="0x3b" attributes="0"/>
-                <local name="q" il_index="5" il_start="0x3f" il_end="0x4c" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x57">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -477,13 +434,6 @@ End Module
                 <entry offset="0x5d" startLine="22" startColumn="9" endLine="22" endColumn="29" document="0"/>
                 <entry offset="0x64" startLine="24" startColumn="5" endLine="24" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x65" attributes="0"/>
-                <local name="y" il_index="1" il_start="0x4" il_end="0xf" attributes="0"/>
-                <local name="ex" il_index="2" il_start="0x12" il_end="0x49" attributes="0"/>
-                <local name="z" il_index="3" il_start="0x34" il_end="0x49" attributes="0"/>
-                <local name="q" il_index="4" il_start="0x4d" il_end="0x5a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x65">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -551,10 +501,6 @@ End Module
                 <entry offset="0xc" startLine="6" startColumn="9" endLine="6" endColumn="26" document="0"/>
                 <entry offset="0x17" startLine="10" startColumn="5" endLine="10" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x18" attributes="0"/>
-                <local name="y" il_index="1" il_start="0x5" il_end="0xb" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x18">
                 <currentnamespace name=""/>
                 <local name="x" il_index="0" il_start="0x0" il_end="0x18" attributes="0"/>
@@ -591,7 +537,6 @@ End Class
                 <entry offset="0x7" startLine="3" startColumn="9" endLine="3" endColumn="50" document="0"/>
                 <entry offset="0x12" startLine="4" startColumn="5" endLine="4" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x13">
                 <currentnamespace name=""/>
             </scope>
@@ -630,7 +575,6 @@ End Class
                 <entry offset="0x9" startLine="5" startColumn="9" endLine="5" endColumn="16" document="0"/>
                 <entry offset="0xa" startLine="7" startColumn="9" endLine="7" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xc">
                 <currentnamespace name=""/>
             </scope>
@@ -735,16 +679,6 @@ End Module
                 <entry offset="0xe0" startLine="11" startColumn="9" endLine="11" endColumn="23" document="0"/>
                 <entry offset="0xe8" startLine="29" startColumn="5" endLine="29" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0xe9" attributes="0"/>
-                <local name="xx" il_index="1" il_start="0x0" il_end="0xe9" attributes="0"/>
-                <local name="s" il_index="3" il_start="0x17" il_end="0x23" attributes="0"/>
-                <local name="s" il_index="4" il_start="0x62" il_end="0x70" attributes="0"/>
-                <local name="newX" il_index="5" il_start="0x73" il_end="0xdf" attributes="0"/>
-                <local name="s2" il_index="6" il_start="0x97" il_end="0xa6" attributes="0"/>
-                <local name="s3" il_index="7" il_start="0xb4" il_end="0xc3" attributes="0"/>
-                <local name="e1" il_index="8" il_start="0xc7" il_end="0xd6" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xe9">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -850,13 +784,6 @@ End Module
                 <entry offset="0x6e" startLine="7" startColumn="9" endLine="7" endColumn="23" document="0"/>
                 <entry offset="0x76" startLine="25" startColumn="5" endLine="25" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x77" attributes="0"/>
-                <local name="newX" il_index="1" il_start="0x5" il_end="0x6d" attributes="0"/>
-                <local name="s2" il_index="3" il_start="0x29" il_end="0x36" attributes="0"/>
-                <local name="s3" il_index="4" il_start="0x44" il_end="0x53" attributes="0"/>
-                <local name="e1" il_index="5" il_start="0x57" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x77">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -957,13 +884,6 @@ End Module
                 <entry offset="0x6c" startLine="24" startColumn="9" endLine="24" endColumn="25" document="0"/>
                 <entry offset="0x75" startLine="26" startColumn="5" endLine="26" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x76" attributes="0"/>
-                <local name="newX" il_index="1" il_start="0x4" il_end="0x6c" attributes="0"/>
-                <local name="s2" il_index="3" il_start="0x28" il_end="0x35" attributes="0"/>
-                <local name="s3" il_index="4" il_start="0x43" il_end="0x52" attributes="0"/>
-                <local name="e1" il_index="5" il_start="0x56" il_end="0x65" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x76">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1029,10 +949,6 @@ End Module
                 <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="21" document="0"/>
                 <entry offset="0xa" startLine="11" startColumn="9" endLine="11" endColumn="13" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0xd" attributes="0"/>
-                <local name="newX" il_index="1" il_start="0x4" il_end="0xa" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xd">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1088,7 +1004,6 @@ End Module
                 <entry offset="0x23" startLine="10" startColumn="9" endLine="10" endColumn="15" document="0"/>
                 <entry offset="0x24" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x25">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1150,7 +1065,6 @@ End Module
                 <entry offset="0x36" startLine="16" startColumn="9" endLine="16" endColumn="31" document="0"/>
                 <entry offset="0x41" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x42">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1238,10 +1152,6 @@ End Module
                 <entry offset="0x55" startLine="21" startColumn="9" endLine="21" endColumn="16" document="0"/>
                 <entry offset="0x56" startLine="23" startColumn="5" endLine="23" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="1" il_start="0x9" il_end="0x16" attributes="0"/>
-                <local name="ex" il_index="2" il_start="0x2f" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x57">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1358,15 +1268,6 @@ End Module
                 <entry offset="0x13f" startLine="34" startColumn="9" endLine="34" endColumn="28" document="0"/>
                 <entry offset="0x15f" startLine="35" startColumn="5" endLine="35" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="y" il_index="1" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="z" il_index="2" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="a" il_index="3" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="b" il_index="4" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="c" il_index="5" il_start="0x0" il_end="0x160" attributes="0"/>
-                <local name="ct" il_index="6" il_start="0x0" il_end="0x160" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x160">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1440,12 +1341,6 @@ End Module
                 <entry offset="0x35" startLine="10" startColumn="9" endLine="10" endColumn="20" document="0"/>
                 <entry offset="0x3f" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x40" attributes="0"/>
-                <local name="i" il_index="1" il_start="0x0" il_end="0x40" attributes="0"/>
-                <local name="q" il_index="2" il_start="0x0" il_end="0x40" attributes="0"/>
-                <local name="y" il_index="3" il_start="0x0" il_end="0x40" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x40">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1510,10 +1405,6 @@ End Module
                 <entry offset="0x41" startLine="13" startColumn="9" endLine="13" endColumn="28" document="0"/>
                 <entry offset="0x48" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="del" il_index="0" il_start="0x0" il_end="0x49" attributes="0"/>
-                <local name="v" il_index="1" il_start="0x0" il_end="0x49" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x49">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1560,9 +1451,6 @@ End Module
                 <entry offset="0x4" startLine="6" startColumn="9" endLine="6" endColumn="19" document="0"/>
                 <entry offset="0x5" startLine="7" startColumn="5" endLine="7" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x6" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x6">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1619,9 +1507,6 @@ End Module
                 <entry offset="0x14" startLine="11" startColumn="9" endLine="11" endColumn="19" document="0"/>
                 <entry offset="0x15" startLine="12" startColumn="5" endLine="12" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x16" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x16">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1679,9 +1564,6 @@ End Module
                 <entry offset="0x38" startLine="10" startColumn="9" endLine="10" endColumn="19" document="0"/>
                 <entry offset="0x39" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x3a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3a">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1742,9 +1624,6 @@ End Module
                 <entry offset="0x5d" startLine="13" startColumn="9" endLine="13" endColumn="19" document="0"/>
                 <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x5f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x5f">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1809,9 +1688,6 @@ End Module
                 <entry offset="0x6c" startLine="14" startColumn="9" endLine="14" endColumn="19" document="0"/>
                 <entry offset="0x6d" startLine="15" startColumn="5" endLine="15" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x6e" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x6e">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1874,9 +1750,6 @@ End Module
                 <entry offset="0x55" startLine="13" startColumn="9" endLine="13" endColumn="19" document="0"/>
                 <entry offset="0x56" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x57" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x57">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -1941,9 +1814,6 @@ End Module
                 <entry offset="0x62" startLine="14" startColumn="9" endLine="14" endColumn="19" document="0"/>
                 <entry offset="0x63" startLine="15" startColumn="5" endLine="15" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="num" il_index="0" il_start="0x0" il_end="0x64" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x64">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2006,9 +1876,6 @@ End Module
                 <entry offset="0x162" startLine="13" startColumn="9" endLine="13" endColumn="19" document="0"/>
                 <entry offset="0x163" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x164" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x164">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2068,9 +1935,6 @@ End Module
                 <entry offset="0x56" startLine="12" startColumn="9" endLine="12" endColumn="19" document="0"/>
                 <entry offset="0x57" startLine="13" startColumn="5" endLine="13" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x58" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x58">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2131,9 +1995,6 @@ End Module
                 <entry offset="0x72" startLine="11" startColumn="9" endLine="11" endColumn="19" document="0"/>
                 <entry offset="0x73" startLine="12" startColumn="5" endLine="12" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="str" il_index="0" il_start="0x0" il_end="0x74" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x74">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2175,9 +2036,6 @@ End Class
                 <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="36" document="0"/>
                 <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="o" il_index="0" il_start="0x0" il_end="0x9" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name=""/>
                 <local name="o" il_index="0" il_start="0x0" il_end="0x9" attributes="0"/>
@@ -2216,9 +2074,6 @@ End Class
                 <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="40" document="0"/>
                 <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="o" il_index="0" il_start="0x0" il_end="0x9" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name=""/>
                 <local name="o" il_index="0" il_start="0x0" il_end="0x9" attributes="0"/>
@@ -2306,13 +2161,6 @@ End Module
                 <entry offset="0x4a" hidden="true" document="0"/>
                 <entry offset="0x58" startLine="24" startColumn="5" endLine="24" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="I" il_index="0" il_start="0x0" il_end="0x59" attributes="0"/>
-                <local name="J" il_index="1" il_start="0x0" il_end="0x59" attributes="0"/>
-                <local name="q" il_index="2" il_start="0x0" il_end="0x59" attributes="0"/>
-                <local name="count" il_index="3" il_start="0x0" il_end="0x59" attributes="0"/>
-                <local name="dims" il_index="4" il_start="0x0" il_end="0x59" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x59">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2366,7 +2214,6 @@ End Module
                 <entry offset="0x8" startLine="9" startColumn="9" endLine="9" endColumn="16" document="0"/>
                 <entry offset="0xa" startLine="10" startColumn="5" endLine="10" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xb">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2408,7 +2255,6 @@ End Module
                 <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="12" document="0"/>
                 <entry offset="0x7" startLine="5" startColumn="5" endLine="5" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x8">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2419,7 +2265,6 @@ End Module
                 <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="19" document="0"/>
                 <entry offset="0x1" startLine="11" startColumn="5" endLine="11" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="M1" methodName="Main"/>
             </scope>
@@ -2475,10 +2320,6 @@ End Module
                 <entry offset="0x4" startLine="19" startColumn="13" endLine="19" endColumn="25" document="0"/>
                 <entry offset="0xb" startLine="20" startColumn="5" endLine="20" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-                <local name="b2" il_index="1" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2492,7 +2333,6 @@ End Module
                 <entry offset="0x7" startLine="9" startColumn="13" endLine="9" endColumn="18" document="0"/>
                 <entry offset="0xe" startLine="10" startColumn="9" endLine="10" endColumn="16" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xf">
                 <importsforward declaringType="Module1" methodName="Main"/>
             </scope>
@@ -2508,7 +2348,6 @@ End Module
                 <entry offset="0x1" startLine="13" startColumn="13" endLine="13" endColumn="29" document="0"/>
                 <entry offset="0xa" startLine="14" startColumn="9" endLine="14" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="Module1" methodName="Main"/>
             </scope>
@@ -2559,7 +2398,6 @@ End Module
                 <entry offset="0x21" startLine="6" startColumn="12" endLine="6" endColumn="31" document="0"/>
                 <entry offset="0x28" startLine="10" startColumn="5" endLine="10" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x29">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2649,9 +2487,6 @@ End Class
                 <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="23" document="0"/>
                 <entry offset="0xa" startLine="6" startColumn="5" endLine="6" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="F" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <type name="Microsoft.VisualBasic.Strings" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2705,10 +2540,6 @@ End Module
                 <entry offset="0xe" startLine="8" startColumn="9" endLine="10" endColumn="21" document="0"/>
                 <entry offset="0x1d" startLine="11" startColumn="5" endLine="11" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
-                <local name="MakeIncrementer" il_index="1" il_start="0x0" il_end="0x1f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="Module1" methodName="Main"/>
                 <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
@@ -2746,7 +2577,6 @@ End Class
                 <entry offset="0x0" hidden="true" document="0"/>
                 <entry offset="0x6" startLine="2" startColumn="13" endLine="2" endColumn="39" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x17">
                 <currentnamespace name=""/>
             </scope>
@@ -2794,7 +2624,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="3" startColumn="13" endLine="7" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x16">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -2810,7 +2639,6 @@ End Module
                 <entry offset="0x0" startLine="5" startColumn="96" endLine="5" endColumn="107" document="0"/>
                 <entry offset="0x1" startLine="5" startColumn="108" endLine="5" endColumn="112" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x17">
                 <importsforward declaringType="M" methodName=".cctor"/>
             </scope>
@@ -2830,10 +2658,6 @@ End Module
                 <entry offset="0x4b" startLine="6" startColumn="13" endLine="6" endColumn="33" document="0"/>
                 <entry offset="0x5b" startLine="7" startColumn="9" endLine="7" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="f" il_index="1" il_start="0x0" il_end="0x5d" attributes="0"/>
-                <local name="g" il_index="2" il_start="0x0" il_end="0x5d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x5d">
                 <importsforward declaringType="M" methodName=".cctor"/>
                 <local name="f" il_index="1" il_start="0x0" il_end="0x5d" attributes="0"/>
@@ -2850,7 +2674,6 @@ End Module
                 <entry offset="0x0" startLine="4" startColumn="49" endLine="4" endColumn="60" document="0"/>
                 <entry offset="0x1" startLine="4" startColumn="61" endLine="4" endColumn="62" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="M" methodName=".cctor"/>
             </scope>
@@ -2867,9 +2690,6 @@ End Module
                 <entry offset="0x1" hidden="true" document="0"/>
                 <entry offset="0xe" startLine="5" startColumn="96" endLine="5" endColumn="112" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="M" methodName=".cctor"/>
                 <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
@@ -2929,9 +2749,6 @@ End Module
                 <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="25" document="0"/>
                 <entry offset="0x15" startLine="7" startColumn="5" endLine="7" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x17" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x17">
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <namespace name="System.Linq" importlevel="file"/>
@@ -2965,10 +2782,6 @@ End Module
                 <entry offset="0x100" startLine="22" startColumn="9" endLine="22" endColumn="21" document="0"/>
                 <entry offset="0x107" startLine="23" startColumn="5" endLine="23" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x108" attributes="0"/>
-                <local name="qq" il_index="1" il_start="0x0" il_end="0x108" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x108">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x108" attributes="0"/>
@@ -2979,7 +2792,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="13" startColumn="26" endLine="13" endColumn="27" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -2988,7 +2800,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="60" endLine="14" endColumn="67" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -2998,7 +2809,6 @@ End Module
                 <entry offset="0x0" startLine="14" startColumn="27" endLine="14" endColumn="33" document="0"/>
                 <entry offset="0x4" startLine="14" startColumn="39" endLine="14" endColumn="46" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xe">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3009,7 +2819,6 @@ End Module
                 <entry offset="0x1" startLine="15" startColumn="30" endLine="15" endColumn="44" document="0"/>
                 <entry offset="0x2b" startLine="15" startColumn="50" endLine="15" endColumn="64" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x5b">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3018,7 +2827,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="43" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3027,7 +2835,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="54" endLine="15" endColumn="63" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3036,7 +2843,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="19" startColumn="25" endLine="19" endColumn="32" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3045,7 +2851,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="20" startColumn="26" endLine="20" endColumn="27" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3097,9 +2902,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3125,10 +2927,6 @@ End Module
                 <entry offset="0x30" startLine="15" startColumn="9" endLine="15" endColumn="36" document="0"/>
                 <entry offset="0x3c" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -3182,9 +2980,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3213,10 +3008,6 @@ End Module
                 <entry offset="0x7d" startLine="15" startColumn="9" endLine="15" endColumn="35" document="0"/>
                 <entry offset="0x89" startLine="16" startColumn="5" endLine="16" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
@@ -3227,7 +3018,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="28" endLine="14" endColumn="35" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3236,7 +3026,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="68" endLine="14" endColumn="74" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3245,7 +3034,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="57" endLine="14" endColumn="64" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3298,9 +3086,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3326,10 +3111,6 @@ End Module
                 <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -3340,7 +3121,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="29" endLine="15" endColumn="42" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3393,9 +3173,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3422,10 +3199,6 @@ End Module
                 <entry offset="0x59" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x65" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
@@ -3436,7 +3209,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="37" endLine="15" endColumn="50" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xb">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3445,7 +3217,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="64" endLine="15" endColumn="85" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x20">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3498,9 +3269,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3526,10 +3294,6 @@ End Module
                 <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36" document="0"/>
                 <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -3540,7 +3304,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3593,9 +3356,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3621,10 +3381,6 @@ End Module
                 <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36" document="0"/>
                 <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -3635,7 +3391,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="33" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3688,9 +3443,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3716,10 +3468,6 @@ End Module
                 <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -3731,7 +3479,6 @@ End Module
                 <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45" document="0"/>
                 <entry offset="0x3" startLine="15" startColumn="59" endLine="15" endColumn="72" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x15">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3784,9 +3531,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3815,10 +3559,6 @@ End Module
                 <entry offset="0xa6" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0xb2" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0xb3" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0xb3" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xb3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0xb3" attributes="0"/>
@@ -3829,7 +3569,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="53" endLine="14" endColumn="60" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3838,7 +3577,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3847,7 +3585,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3902,9 +3639,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -3935,10 +3669,6 @@ End Module
                 <entry offset="0xf3" startLine="18" startColumn="9" endLine="18" endColumn="35" document="0"/>
                 <entry offset="0xff" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x100" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x100" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x100">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x100" attributes="0"/>
@@ -3949,7 +3679,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="63" endLine="16" endColumn="72" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3958,7 +3687,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="46" endLine="16" endColumn="55" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3968,7 +3696,6 @@ End Module
                 <entry offset="0x0" startLine="17" startColumn="41" endLine="17" endColumn="50" document="0"/>
                 <entry offset="0x1" startLine="17" startColumn="93" endLine="17" endColumn="106" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -3978,7 +3705,6 @@ End Module
                 <entry offset="0x0" startLine="17" startColumn="58" endLine="17" endColumn="67" document="0"/>
                 <entry offset="0x6" startLine="17" startColumn="72" endLine="17" endColumn="85" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x14">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4032,9 +3758,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4063,10 +3786,6 @@ End Module
                 <entry offset="0xa6" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0xb2" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0xb3" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0xb3" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xb3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0xb3" attributes="0"/>
@@ -4077,7 +3796,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4086,7 +3804,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4095,7 +3812,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4152,9 +3868,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4189,10 +3902,6 @@ End Module
                 <entry offset="0x145" startLine="20" startColumn="9" endLine="20" endColumn="35" document="0"/>
                 <entry offset="0x151" startLine="21" startColumn="5" endLine="21" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x152" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x152" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x152">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x152" attributes="0"/>
@@ -4203,7 +3912,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4212,7 +3920,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="63" endLine="15" endColumn="70" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4221,7 +3928,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="69" endLine="16" endColumn="78" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4230,7 +3936,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="52" endLine="16" endColumn="61" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4240,7 +3945,6 @@ End Module
                 <entry offset="0x0" hidden="true" document="0"/>
                 <entry offset="0x1" startLine="17" startColumn="47" endLine="17" endColumn="61" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4249,7 +3953,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="17" startColumn="51" endLine="17" endColumn="60" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4258,7 +3961,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="18" startColumn="41" endLine="18" endColumn="50" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4267,7 +3969,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="18" startColumn="58" endLine="18" endColumn="67" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4277,7 +3978,6 @@ End Module
                 <entry offset="0x0" hidden="true" document="0"/>
                 <entry offset="0x1" startLine="19" startColumn="43" endLine="19" endColumn="57" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4286,7 +3986,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="19" startColumn="47" endLine="19" endColumn="56" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4340,9 +4039,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4371,10 +4067,6 @@ End Module
                 <entry offset="0x7d" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x89" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
@@ -4386,7 +4078,6 @@ End Module
                 <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="0"/>
                 <entry offset="0x1" startLine="15" startColumn="93" endLine="15" endColumn="106" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4396,7 +4087,6 @@ End Module
                 <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="0"/>
                 <entry offset="0x1" startLine="15" startColumn="72" endLine="15" endColumn="85" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4407,7 +4097,6 @@ End Module
                 <entry offset="0x2" startLine="16" startColumn="56" endLine="16" endColumn="70" document="0"/>
                 <entry offset="0x2c" startLine="16" startColumn="72" endLine="16" endColumn="79" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x38">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4416,7 +4105,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="60" endLine="16" endColumn="69" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4469,9 +4157,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4499,10 +4184,6 @@ End Module
                 <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
@@ -4513,7 +4194,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4522,7 +4202,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="19" endLine="15" endColumn="73" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4575,9 +4254,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4605,10 +4281,6 @@ End Module
                 <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
@@ -4619,7 +4291,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4628,7 +4299,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4681,9 +4351,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4711,10 +4378,6 @@ End Module
                 <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8a" attributes="0"/>
@@ -4725,7 +4388,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4734,7 +4396,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -4787,9 +4448,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4811,10 +4469,6 @@ End Module
                 <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x1a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
@@ -4869,9 +4523,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4893,10 +4544,6 @@ End Module
                 <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35" document="0"/>
                 <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x1a" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
@@ -4952,9 +4599,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -4983,10 +4627,6 @@ End Module
                 <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0xae" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
@@ -4997,7 +4637,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5006,7 +4645,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="22" endLine="15" endColumn="31" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5060,9 +4698,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5092,10 +4727,6 @@ End Module
                 <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0xae" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
@@ -5106,7 +4737,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5115,7 +4745,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5125,7 +4754,6 @@ End Module
                 <entry offset="0x0" hidden="true" document="0"/>
                 <entry offset="0x1" startLine="16" startColumn="18" endLine="16" endColumn="32" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5134,7 +4762,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="31" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5188,9 +4815,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5220,10 +4844,6 @@ End Module
                 <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0xae" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0xae" attributes="0"/>
@@ -5234,7 +4854,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5244,7 +4863,6 @@ End Module
                 <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47" document="0"/>
                 <entry offset="0x8" startLine="15" startColumn="61" endLine="15" endColumn="74" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5255,7 +4873,6 @@ End Module
                 <entry offset="0xd" startLine="16" startColumn="31" endLine="16" endColumn="45" document="0"/>
                 <entry offset="0x37" startLine="16" startColumn="47" endLine="16" endColumn="54" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x43">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5264,7 +4881,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="35" endLine="16" endColumn="44" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5318,9 +4934,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5348,10 +4961,6 @@ End Module
                 <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -5362,7 +4971,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="36" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x5e">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5371,7 +4979,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5380,7 +4987,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="35" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5434,9 +5040,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5466,10 +5069,6 @@ End Module
                 <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x3d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x3d" attributes="0"/>
@@ -5480,7 +5079,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="50" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xab">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5489,7 +5087,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5498,7 +5095,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5507,7 +5103,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="49" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xf">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5562,9 +5157,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5593,10 +5185,6 @@ End Module
                 <entry offset="0x59" startLine="18" startColumn="9" endLine="18" endColumn="35" document="0"/>
                 <entry offset="0x65" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
@@ -5607,7 +5195,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5616,7 +5203,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="13" endLine="17" endColumn="36" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x58">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5625,7 +5211,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5634,7 +5219,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="17" startColumn="22" endLine="17" endColumn="35" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5688,9 +5272,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5718,10 +5299,6 @@ End Module
                 <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
@@ -5732,7 +5309,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="42" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5743,7 +5319,6 @@ End Module
                 <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="0"/>
                 <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5752,7 +5327,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5806,9 +5380,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5839,10 +5410,6 @@ End Module
                 <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
@@ -5853,7 +5420,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x82">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5862,7 +5428,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5871,7 +5436,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5882,7 +5446,6 @@ End Module
                 <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="0"/>
                 <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5891,7 +5454,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -5945,9 +5507,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -5979,10 +5538,6 @@ End Module
                 <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="0"/>
                 <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x66" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x66" attributes="0"/>
@@ -5993,7 +5548,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xab">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6002,7 +5556,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6011,7 +5564,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="79" endLine="15" endColumn="88" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6020,7 +5572,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="96" endLine="15" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6031,7 +5582,6 @@ End Module
                 <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="0"/>
                 <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6040,7 +5590,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6095,9 +5644,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -6126,10 +5672,6 @@ End Module
                 <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="0"/>
                 <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
@@ -6140,7 +5682,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6149,7 +5690,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="42" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6159,7 +5699,6 @@ End Module
                 <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="0"/>
                 <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6168,7 +5707,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6223,9 +5761,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -6257,10 +5792,6 @@ End Module
                 <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="0"/>
                 <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
@@ -6271,7 +5802,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6280,7 +5810,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7c">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6289,7 +5818,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6298,7 +5826,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="65" endLine="16" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6308,7 +5835,6 @@ End Module
                 <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="0"/>
                 <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6317,7 +5843,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6372,9 +5897,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -6407,10 +5929,6 @@ End Module
                 <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="0"/>
                 <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
-                <local name="x" il_index="1" il_start="0x0" il_end="0x8f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="q" il_index="0" il_start="0x0" il_end="0x8f" attributes="0"/>
@@ -6421,7 +5939,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6430,7 +5947,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa5">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6439,7 +5955,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6448,7 +5963,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="79" endLine="16" endColumn="88" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6457,7 +5971,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="16" startColumn="96" endLine="16" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6467,7 +5980,6 @@ End Module
                 <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="0"/>
                 <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6476,7 +5988,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6526,9 +6037,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -6553,9 +6061,6 @@ End Module
                 <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="36" document="0"/>
                 <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x5f" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x5f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="x" il_index="0" il_start="0x0" il_end="0x5f" attributes="0"/>
@@ -6565,7 +6070,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="12" startColumn="33" endLine="12" endColumn="40" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6574,7 +6078,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="13" startColumn="22" endLine="13" endColumn="35" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6624,9 +6127,6 @@ End Module
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="0"/>
                 <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Nums" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -6654,9 +6154,6 @@ End Module
                 <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="47" document="0"/>
                 <entry offset="0x8a" startLine="14" startColumn="5" endLine="14" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="x" il_index="0" il_start="0x0" il_end="0x8b" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x8b">
                 <importsforward declaringType="Module1" methodName="Nums"/>
                 <local name="x" il_index="0" il_start="0x0" il_end="0x8b" attributes="0"/>
@@ -6666,7 +6163,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="12" startColumn="65" endLine="12" endColumn="71" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x2f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6675,7 +6171,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="12" startColumn="54" endLine="12" endColumn="61" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6684,7 +6179,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="13" startColumn="28" endLine="13" endColumn="37" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
             </scope>
@@ -6723,7 +6217,6 @@ End Module
             <sequencePoints>
                 <entry offset="0x0" startLine="8" startColumn="25" endLine="8" endColumn="30" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Main"/>
             </scope>
@@ -6769,7 +6262,6 @@ End Class
                 <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="38" document="0"/>
                 <entry offset="0x15" startLine="4" startColumn="5" endLine="4" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x16">
                 <currentnamespace name=""/>
             </scope>
@@ -6780,7 +6272,6 @@ End Class
                 <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="17" document="0"/>
                 <entry offset="0x7" startLine="8" startColumn="5" endLine="8" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x8">
                 <importsforward declaringType="IntervalUpdate" methodName="Update"/>
             </scope>
@@ -6791,7 +6282,6 @@ End Class
                 <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25" document="0"/>
                 <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name="My"/>
             </scope>
@@ -6807,9 +6297,6 @@ End Class
                 <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62" document="0"/>
                 <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Computer" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Computer" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -6826,9 +6313,6 @@ End Class
                 <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57" document="0"/>
                 <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Application" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Application" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -6845,9 +6329,6 @@ End Class
                 <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58" document="0"/>
                 <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="User" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="User" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -6864,9 +6345,6 @@ End Class
                 <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67" document="0"/>
                 <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="WebServices" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="WebServices" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -6879,7 +6357,6 @@ End Class
                 <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136" document="0"/>
                 <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x29">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -6895,9 +6372,6 @@ End Class
                 <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40" document="0"/>
                 <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Equals" il_index="0" il_start="0x0" il_end="0x12" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x12">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Equals" il_index="0" il_start="0x0" il_end="0x12" attributes="0"/>
@@ -6914,9 +6388,6 @@ End Class
                 <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42" document="0"/>
                 <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetHashCode" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetHashCode" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
@@ -6933,9 +6404,6 @@ End Class
                 <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46" document="0"/>
                 <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetType" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetType" il_index="0" il_start="0x0" il_end="0x10" attributes="0"/>
@@ -6952,9 +6420,6 @@ End Class
                 <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39" document="0"/>
                 <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="ToString" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="ToString" il_index="0" il_start="0x0" il_end="0xc" attributes="0"/>
@@ -6975,9 +6440,6 @@ End Class
                 <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36" document="0"/>
                 <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="Create__Instance__" il_index="0" il_start="0x0" il_end="0x1d" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x1d">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="Create__Instance__" il_index="0" il_start="0x0" il_end="0x1d" attributes="0"/>
@@ -6989,7 +6451,6 @@ End Class
                 <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35" document="0"/>
                 <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -7000,7 +6461,6 @@ End Class
                 <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28" document="0"/>
                 <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -7019,9 +6479,6 @@ End Class
                 <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47" document="0"/>
                 <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="GetInstance" il_index="0" il_start="0x0" il_end="0x26" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x26">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
                 <local name="GetInstance" il_index="0" il_start="0x0" il_end="0x26" attributes="0"/>
@@ -7033,7 +6490,6 @@ End Class
                 <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29" document="0"/>
                 <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
             </scope>
@@ -7112,7 +6568,6 @@ End Class
                 <entry offset="0x12" startLine="81" startColumn="13" endLine="81" endColumn="37" document="0"/>
                 <entry offset="0x1e" startLine="82" startColumn="9" endLine="82" endColumn="16" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x1f">
                 <currentnamespace name="My"/>
             </scope>
@@ -7165,7 +6620,6 @@ End Class
                 <entry offset="0x50" startLine="11" startColumn="9" endLine="11" endColumn="19" document="0"/>
                 <entry offset="0x51" startLine="12" startColumn="5" endLine="12" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals/>
             <scope startOffset="0x0" endOffset="0x52">
                 <namespace name="System" importlevel="file"/>
                 <currentnamespace name=""/>
@@ -7243,33 +6697,6 @@ End Class
                 <entry offset="0x0" startLine="18" startColumn="5" endLine="18" endColumn="25" document="0"/>
                 <entry offset="0x1" startLine="48" startColumn="5" endLine="48" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <constant name="B" value="0" type="Boolean"/>
-                <constant name="C" value="0" type="Char"/>
-                <constant name="I1" value="0" type="SByte"/>
-                <constant name="U1" value="0" type="Byte"/>
-                <constant name="I2" value="0" type="Int16"/>
-                <constant name="U2" value="0" type="UInt16"/>
-                <constant name="I4" value="0" type="Int32"/>
-                <constant name="U4" value="0" type="UInt32"/>
-                <constant name="I8" value="0" type="Int64"/>
-                <constant name="U8" value="0" type="UInt64"/>
-                <constant name="R4" value="0" type="Single"/>
-                <constant name="R8" value="0" type="Double"/>
-                <constant name="EI1" value="0" signature="15-11-10-01-08"/>
-                <constant name="EU1" value="0" signature="15-11-14-01-08"/>
-                <constant name="EI2" value="0" signature="15-11-18-01-08"/>
-                <constant name="EU2" value="0" signature="15-11-1C-01-08"/>
-                <constant name="EI4" value="null" signature="15-11-20-01-08"/>
-                <constant name="EU4" value="0" signature="15-11-24-01-08"/>
-                <constant name="EI8" value="0" signature="15-11-28-01-08"/>
-                <constant name="EU8" value="0" signature="15-11-2C-01-08"/>
-                <constant name="EmptyStr" value="" type="String"/>
-                <constant name="NullStr" value="null" type="String"/>
-                <constant name="NullObject" value="null" type="Object"/>
-                <constant name="D" value="0" type="Decimal"/>
-                <constant name="DT" value="01/01/2015 00:00:00" type="DateTime"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x2">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 
@@ -70,11 +70,6 @@ End Class
                 <entry offset="0x43" startLine="20" startColumn="9" endLine="20" endColumn="18" document="0"/>
                 <entry offset="0x54" startLine="21" startColumn="5" endLine="21" endColumn="12" document="0"/>
             </sequencePoints>
-            <locals>
-                <local name="foo1" il_index="0" il_start="0x2" il_end="0x53" attributes="0"/>
-                <local name="foo2" il_index="1" il_start="0x2" il_end="0x53" attributes="0"/>
-                <local name="foo3" il_index="2" il_start="0x2" il_end="0x53" attributes="0"/>
-            </locals>
             <scope startOffset="0x0" endOffset="0x55">
                 <importsforward declaringType="MyDisposable" methodName="Dispose"/>
                 <scope startOffset="0x2" endOffset="0x53">
@@ -343,9 +338,6 @@ End Namespace
                                 <entry offset="0x1" startLine="5" startColumn="17" endLine="5" endColumn="33" document="0"/>
                                 <entry offset="0x3" startLine="6" startColumn="9" endLine="6" endColumn="16" document="0"/>
                             </sequencePoints>
-                            <locals>
-                                <local name="o" il_index="0" il_start="0x0" il_end="0x4" attributes="0"/>
-                            </locals>
                             <scope startOffset="0x0" endOffset="0x4">
                                 <defunct name="&amp;PIA"/>
                                 <currentnamespace name="N1"/>
@@ -357,7 +349,6 @@ End Namespace
                                 <entry offset="0x0" startLine="12" startColumn="9" endLine="12" endColumn="23" document="0"/>
                                 <entry offset="0x1" startLine="13" startColumn="9" endLine="13" endColumn="16" document="0"/>
                             </sequencePoints>
-                            <locals/>
                             <scope startOffset="0x0" endOffset="0x2">
                                 <defunct name="&amp;PIA"/>
                                 <currentnamespace name="N2"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBVariableInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBVariableInitializerTests.vb
@@ -68,7 +68,6 @@ End Class
                     <entry offset="0x24" startLine="8" startColumn="16" endLine="8" endColumn="18" document="1"/>
                     <entry offset="0x2f" startLine="11" startColumn="36" endLine="11" endColumn="54" document="2"/>
                 </sequencePoints>
-                <locals/>
                 <scope startOffset="0x0" endOffset="0x38">
                     <namespace name="System" importlevel="file"/>
                     <currentnamespace name=""/>

--- a/src/Test/PdbUtilities/Pdb/PdbToXml.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbToXml.cs
@@ -214,34 +214,20 @@ namespace Roslyn.Test.PdbUtilities
             {
                 WriteSequencePoints(method);
 
-                // TODO (tomat): Ideally this would be done in a separate test helper, not in PdbToXml.
-                // verify ISymUnmanagedMethod APIs:
-                var expectedSlotNames = new Dictionary<int, ImmutableArray<string>>();
-                WriteLocals(method, expectedSlotNames);
+                var rootScope = method.GetRootScope();
 
-                var actualSlotNames = method.GetLocalVariableSlots();
-
-                Debug.Assert(actualSlotNames.Length == (expectedSlotNames.Count == 0 ? 0 : expectedSlotNames.Keys.Max() + 1));
-
-                int i = 0;
-                foreach (var slotName in actualSlotNames)
+                // C# and VB compilers leave the root scope empty and put outermost lexical scope in it.
+                // Don't display such empty root scope.
+                if (rootScope.GetNamespaces().IsEmpty && rootScope.GetLocals().IsEmpty && rootScope.GetConstants().IsEmpty)
                 {
-                    if (slotName == null)
+                    foreach (ISymUnmanagedScope child in rootScope.GetScopes())
                     {
-                        Debug.Assert(!expectedSlotNames.ContainsKey(i));
+                        WriteScope(child, isRoot: false);
                     }
-                    else
-                    {
-                        Debug.Assert(expectedSlotNames[i].Contains(slotName));
-                    }
-
-                    i++;
                 }
-
-                ImmutableArray<ISymUnmanagedScope> children = method.GetRootScope().GetScopes();
-                if (children.Length != 0)
+                else
                 {
-                    WriteScopes(children[0]);
+                    WriteScope(rootScope, isRoot: true);
                 }
 
                 WriteAsyncInfo(method);
@@ -655,26 +641,25 @@ namespace Roslyn.Test.PdbUtilities
             }
         }
 
-        private void WriteScopes(ISymUnmanagedScope scope)
+        private void WriteScope(ISymUnmanagedScope scope, bool isRoot)
         {
-            _writer.WriteStartElement("scope");
-            {
-                _writer.WriteAttributeString("startOffset", AsILOffset(scope.GetStartOffset()));
-                _writer.WriteAttributeString("endOffset", AsILOffset(scope.GetEndOffset()));
-                {
-                    foreach (ISymUnmanagedNamespace @namespace in scope.GetNamespaces())
-                    {
-                        WriteNamespace(@namespace);
-                    }
+            _writer.WriteStartElement(isRoot ? "rootScope" : "scope");
+            _writer.WriteAttributeString("startOffset", AsILOffset(scope.GetStartOffset()));
+            _writer.WriteAttributeString("endOffset", AsILOffset(scope.GetEndOffset()));
 
-                    WriteLocalsHelper(scope, slotNames: null, includeChildScopes: false);
-                }
-                foreach (ISymUnmanagedScope child in scope.GetScopes())
-                {
-                    WriteScopes(child);
-                }
+            foreach (ISymUnmanagedNamespace @namespace in scope.GetNamespaces())
+            {
+                WriteNamespace(@namespace);
             }
-            _writer.WriteEndElement(); // </scope>
+
+            WriteLocals(scope);
+
+            foreach (ISymUnmanagedScope child in scope.GetScopes())
+            {
+                WriteScope(child, isRoot: false);
+            }
+
+            _writer.WriteEndElement(); 
         }
 
         private void WriteNamespace(ISymUnmanagedNamespace @namespace)
@@ -902,67 +887,22 @@ namespace Roslyn.Test.PdbUtilities
             _writer.WriteEndElement();
         }
 
-        // Write all the locals in the given method out to an XML file.
-        // Since the symbol store represents the locals in a recursive scope structure, we need to walk a tree.
-        // Although the locals are technically a hierarchy (based off nested scopes), it's easiest for clients
-        // if we present them as a linear list. We will provide the range for each local's scope so that somebody
-        // could reconstruct an approximation of the scope tree. The reconstruction may not be exact.
-        // (Note this would still break down if you had an empty scope nested in another scope.
-        private void WriteLocals(ISymUnmanagedMethod method, Dictionary<int, ImmutableArray<string>> slotNames)
-        {
-            _writer.WriteStartElement("locals");
-            // If there are no locals, then this element will just be empty.
-            WriteLocalsHelper(method.GetRootScope(), slotNames, includeChildScopes: true);
-            _writer.WriteEndElement();
-        }
-
-        private void WriteLocalsHelper(ISymUnmanagedScope scope, Dictionary<int, ImmutableArray<string>> slotNames, bool includeChildScopes)
+        private void WriteLocals(ISymUnmanagedScope scope)
         {
             foreach (ISymUnmanagedVariable l in scope.GetLocals())
             {
                 _writer.WriteStartElement("local");
-                {
-                    _writer.WriteAttributeString("name", l.GetName());
+                _writer.WriteAttributeString("name", l.GetName());
 
-                    // Each local maps to a "IL Index" or "slot" number. 
-                    // The index is not necessarily unique. Several locals may refer to the same slot. 
-                    // It just means that the same local is known under different names inside the same or different scopes.
-                    // This index is what you pass to ICorDebugILFrame::GetLocalVariable() to get
-                    // a specific local variable. 
-                    // NOTE: VB emits "fake" locals for resumable locals which are actually backed by fields.
-                    //       These locals always map to the slot #0 which is just a valid number that is 
-                    //       not used. Only scoping information is used by EE in this case.
-                    int slot = l.GetSlot();
-                    _writer.WriteAttributeString("il_index", CultureInvariantToString(slot));
+                // NOTE: VB emits "fake" locals for resumable locals which are actually backed by fields.
+                //       These locals always map to the slot #0 which is just a valid number that is 
+                //       not used. Only scoping information is used by EE in this case.
+                _writer.WriteAttributeString("il_index", CultureInvariantToString(l.GetSlot()));
 
-                    bool reusingSlot = false;
-
-                    // collect slot names so that we can verify ISymUnmanagedReader APIs
-                    if (slotNames != null)
-                    {
-                        ImmutableArray<string> existingNames;
-                        if (slotNames.TryGetValue(slot, out existingNames))
-                        {
-                            slotNames[slot] = existingNames.Add(l.GetName());
-                            reusingSlot = true;
-                        }
-                        else
-                        {
-                            slotNames.Add(slot, ImmutableArray.Create(l.GetName()));
-                        }
-                    }
-
-                    // Provide scope range
-                    _writer.WriteAttributeString("il_start", AsILOffset(scope.GetStartOffset()));
-                    _writer.WriteAttributeString("il_end", AsILOffset(scope.GetEndOffset()));
-                    _writer.WriteAttributeString("attributes", CultureInvariantToString(l.GetAttributes()));
-
-                    if (reusingSlot)
-                    {
-                        _writer.WriteAttributeString("reusingslot", reusingSlot.ToString(CultureInfo.InvariantCulture));
-                    }
-                }
-                _writer.WriteEndElement(); // </local>
+                _writer.WriteAttributeString("il_start", AsILOffset(scope.GetStartOffset()));
+                _writer.WriteAttributeString("il_end", AsILOffset(scope.GetEndOffset()));
+                _writer.WriteAttributeString("attributes", CultureInvariantToString(l.GetAttributes()));
+                _writer.WriteEndElement();
             }
 
             foreach (ISymUnmanagedConstant constant in scope.GetConstants())
@@ -1055,14 +995,6 @@ namespace Roslyn.Test.PdbUtilities
                 }
 
                 _writer.WriteEndElement();
-            }
-
-            if (includeChildScopes)
-            {
-                foreach (ISymUnmanagedScope childScope in scope.GetScopes())
-                {
-                    WriteLocalsHelper(childScope, slotNames, includeChildScopes);
-                }
             }
         }
 


### PR DESCRIPTION
Remove duplicate local information produced by PdbToXml. All locals are already included in their respective scopes.