### PR TITLE
Add simplifier annotation as part of Add Using fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -1927,6 +1927,49 @@ namespace ConsoleApplication1
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; using A ; class Program { public B B { get { return B . Instance ; } } } namespace A { public class B { public static readonly B Instance ; } } ");
         }
 
+        [WorkItem(1893, "https://github.com/dotnet/roslyn/issues/1893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNameSimplification()
+        {
+            // Generated using directive must be simplified from "using A.B;" to "using B;" below.
+            Test(
+@"
+namespace A.B
+{
+    class T1 { }
+}
+namespace A.C
+{
+    using System;
+    class T2
+    {
+        void Test()
+        {
+            Console.WriteLine();
+            [|T1|] t1;
+        }
+    }
+}",
+@"
+namespace A.B
+{
+    class T1 { }
+}
+namespace A.C
+{
+    using System;
+    using B;
+    class T2
+    {
+        void Test()
+        {
+            Console.WriteLine();
+            T1 t1;
+        }
+    }
+}");
+        }
+
         public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -10,12 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.AddImport;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
-using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -491,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                 {
                     if (TryGetNamespaceString(namespaceSymbol, root, false, externAliasString, out namespaceString))
                     {
-                        return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceString));
+                        return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceString).WithAdditionalAnnotations(Simplifier.Annotation));
                     }
 
                     return null;
@@ -499,7 +496,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
                 if (TryGetNamespaceString(namespaceSymbol, root, fullyQualify, null, out namespaceString))
                 {
-                    return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceString));
+                    return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceString).WithAdditionalAnnotations(Simplifier.Annotation));
                 }
             }
 
@@ -509,10 +506,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                 if (TryGetStaticNamespaceString(namespaceSymbol, root, fullyQualify, null, out staticNamespaceString))
                 {
                     return SyntaxFactory.UsingDirective(
-                        SyntaxFactory.Token(SyntaxKind.UsingKeyword), 
-                        SyntaxFactory.Token(SyntaxKind.StaticKeyword), 
-                        null, 
-                        SyntaxFactory.ParseName(staticNamespaceString), 
+                        SyntaxFactory.Token(SyntaxKind.UsingKeyword),
+                        SyntaxFactory.Token(SyntaxKind.StaticKeyword),
+                        null,
+                        SyntaxFactory.ParseName(staticNamespaceString).WithAdditionalAnnotations(Simplifier.Annotation),
                         SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                 }
             }

--- a/src/Features/VisualBasic/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.AddImport
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
@@ -282,7 +283,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                 placeSystemNamespaceFirst As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
             Dim memberImportsClause =
-                SyntaxFactory.SimpleImportsClause(name:=DirectCast(symbol.GenerateTypeSyntax(addGlobal:=False), NameSyntax))
+                SyntaxFactory.SimpleImportsClause(name:=DirectCast(symbol.GenerateTypeSyntax(addGlobal:=False), NameSyntax).WithAdditionalAnnotations(Simplifier.Annotation))
             Dim newImport = SyntaxFactory.ImportsStatement(
                 importsClauses:=SyntaxFactory.SingletonSeparatedList(Of ImportsClauseSyntax)(memberImportsClause))
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/UsingDirectivesAdder.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/UsingDirectivesAdder.Rewriter.cs
@@ -3,15 +3,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 {
@@ -41,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var usingDirectives =
                     from n in namespaces
                     let displayString = n.ToDisplayString(SymbolDisplayFormats.NameFormat)
-                    let name = SyntaxFactory.ParseName(displayString)
+                    let name = SyntaxFactory.ParseName(displayString).WithAdditionalAnnotations(Simplifier.Annotation)
                     select SyntaxFactory.UsingDirective(name);
 
                 return usingDirectives.ToList();

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/ImportsStatementsAdder.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/ImportsStatementsAdder.vb
@@ -1,20 +1,13 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Generic
-Imports System.Linq
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CaseCorrection
 Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.Formatting
-Imports Microsoft.CodeAnalysis.Shared.Extensions
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
     Friend Class ImportsStatementsAdder
@@ -45,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Private Overloads Function GetExistingNamespaces(semanticModel As SemanticModel, namespaceDeclaration As NamespaceBlockSyntax, cancellationToken As CancellationToken) As IList(Of INamespaceSymbol)
 
             Dim namespaceSymbol = TryCast(semanticModel.GetDeclaredSymbol(namespaceDeclaration, cancellationToken), INamespaceSymbol)
-            Dim namespaceImports = GetContainingNamespacesAndThis(NamespaceSymbol).ToList()
+            Dim namespaceImports = GetContainingNamespacesAndThis(namespaceSymbol).ToList()
 
             Dim outerNamespaces = Me.GetExistingNamespaces(semanticModel, namespaceDeclaration.Parent, cancellationToken)
 
@@ -91,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
             Dim usingDirectives =
                 From n In importsContainerToMissingNamespaces.Values.Flatten
-                Let name = DirectCast(n.GenerateTypeSyntax(addGlobal:=False), NameSyntax)
+                Let name = DirectCast(n.GenerateTypeSyntax(addGlobal:=False), NameSyntax).WithAdditionalAnnotations(Simplifier.Annotation)
                 Select SyntaxFactory.ImportsStatement(
                     importsClauses:=SyntaxFactory.SingletonSeparatedList(Of ImportsClauseSyntax)(SyntaxFactory.SimpleImportsClause(name)))
 


### PR DESCRIPTION
Add simplifier annotation on using directives generated via the Add Using fix so that generated directives are already simplified (in the case where using is generated inside a namespace declaration) without the user having to simplify manually in a subsequent step.

Note: I also added the annotation inthe corresponding VB fix for parity. However, this should be a no-op for VB since VB only supports file-level namespace imports.

Fixes #1893