### PR TITLE
Add Visible=false metadata to one of the instances of Errors.vb

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -971,7 +971,9 @@
     <Compile Include="Compilation\ModuleCompilationState.vb" />
     <PublicAPI Include="PublicAPI.txt" />
     <Content Include="Symbols\SymbolsAndNoPia.docx" />
-    <ErrorCode Include="Errors\Errors.vb" />
+    <ErrorCode Include="Errors\Errors.vb">
+      <Visible>false</Visible>
+    </ErrorCode>
     <SyntaxDefinition Include="Syntax\Syntax.xml">
       <SubType>Designer</SubType>
     </SyntaxDefinition>


### PR DESCRIPTION
This prevents it from being listed twice in Solution Explorer.

Fixes #1876.