### PR TITLE
Don't recommend #Const after #Const

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/ConstDirectiveKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/ConstDirectiveKeywordRecommenderTests.vb
@@ -44,5 +44,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Pr
         Public Sub HashConstAfterPartialConstWithoutHash()
             VerifyRecommendationsContain(<File>Con|</File>, "#Const")
         End Sub
+
+        <Fact>
+        <WorkItem(722, "https://github.com/dotnet/roslyn/issues/722")>
+        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub NotAfterHashConst()
+            VerifyRecommendationsMissing(<File>#Const |</File>, "#Const")
+        End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Completion/KeywordRecommenders/PreprocessorDirectives/ElseDirectiveKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Completion/KeywordRecommenders/PreprocessorDirectives/ElseDirectiveKeywordRecommender.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Prep
         Inherits AbstractKeywordRecommender
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As IEnumerable(Of RecommendedKeyword)
-            If context.IsPreprocessorStartContext Then
+            If context.IsPreprocessorStartContext OrElse context.IsWithinPreprocessorContext Then
                 Dim innermostKind = context.SyntaxTree.GetInnermostIfPreprocessorKind(context.Position, cancellationToken)
 
                 If innermostKind.HasValue AndAlso innermostKind.Value <> SyntaxKind.ElseDirectiveTrivia Then

--- a/src/Features/VisualBasic/Completion/KeywordRecommenders/PreprocessorDirectives/ElseIfDirectiveKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Completion/KeywordRecommenders/PreprocessorDirectives/ElseIfDirectiveKeywordRecommender.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Prep
         Inherits AbstractKeywordRecommender
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As IEnumerable(Of RecommendedKeyword)
-            If context.IsPreprocessorStartContext Then
+            If context.IsPreprocessorStartContext OrElse context.IsWithinPreprocessorContext Then
                 Dim innermostKind = context.SyntaxTree.GetInnermostIfPreprocessorKind(context.Position, cancellationToken)
 
                 If innermostKind.HasValue AndAlso innermostKind.Value <> SyntaxKind.ElseDirectiveTrivia Then

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -48,6 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         Public ReadOnly WithinAsyncMethod As Boolean
 
         Public ReadOnly IsPreprocessorEndDirectiveKeywordContext As Boolean
+        Public ReadOnly IsWithinPreprocessorContext As Boolean
 
         Private Sub New(
             workspace As Workspace,
@@ -105,6 +106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
             Me.TouchingToken = syntaxTree.GetTouchingToken(position, cancellationToken)
             Me.IsInLambda = isInLambda
             Me.IsPreprocessorStartContext = ComputeIsPreprocessorStartContext(position, targetToken)
+            Me.IsWithinPreprocessorContext = ComputeIsWithinPreprocessorContext(position, targetToken)
             Me.IsQueryOperatorContext = syntaxTree.IsFollowingCompleteExpression(Of QueryExpressionSyntax)(position, targetToken, Function(query) query, cancellationToken)
 
             Me.EnclosingNamedType = CancellableLazy.Create(AddressOf ComputeEnclosingNamedType)
@@ -160,10 +162,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
             Return container
         End Function
 
-        Private Shared Function ComputeIsPreprocessorStartContext(position As Integer, targetToken As SyntaxToken) As Boolean
+        Private Shared Function ComputeIsWithinPreprocessorContext(position As Integer, targetToken As SyntaxToken) As Boolean
             ' If we're touching it, then we can just look past it
             If targetToken.IsKind(SyntaxKind.HashToken) AndAlso targetToken.Span.End = position Then
                 targetToken = targetToken.GetPreviousToken()
+            End If
+
+            Return targetToken.Kind = SyntaxKind.None OrElse
+                targetToken.Kind = SyntaxKind.EndOfFileToken OrElse
+                (targetToken.HasNonContinuableEndOfLineBeforePosition(position) AndAlso Not targetToken.FollowsBadEndDirective(position))
+        End Function
+
+        Private Shared Function ComputeIsPreprocessorStartContext(position As Integer, targetToken As SyntaxToken) As Boolean
+            ' The triggering hash token must be part of a directive (not trivia within it)
+            If targetToken.Kind = SyntaxKind.HashToken Then
+                Return TypeOf targetToken.Parent Is DirectiveTriviaSyntax
             End If
 
             Return targetToken.Kind = SyntaxKind.None OrElse


### PR DESCRIPTION
Allow directive keyword recommenders to differentiate between the start
and middle of a preprocessor directive.

Fixes #722.

Potential reviewers: @balajikris @basoundr @dpoeschl @jasonmalinowski @Pilchie 