### PR TITLE
Avoid a hang in CompileWithRetry...

### DIFF
--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -98,6 +98,22 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal static CompileResult CompileExpressionWithRetry(
             ImmutableArray<MetadataBlock> metadataBlocks,
+            EvaluationContextBase context,
+            ExpressionCompiler.CompileDelegate<CompileResult> compile,
+            DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,
+            out string errorMessage)
+        {
+            return ExpressionCompiler.CompileWithRetry(
+                metadataBlocks,
+                DiagnosticFormatter.Instance,
+                (blocks, useReferencedModulesOnly) => context,
+                compile,
+                getMetaDataBytesPtr,
+                out errorMessage);
+        }
+
+        internal static CompileResult CompileExpressionWithRetry(
+            ImmutableArray<MetadataBlock> metadataBlocks,
             string expr,
             ExpressionCompiler.CreateContextDelegate createContext,
             out string errorMessage,


### PR DESCRIPTION
If we've already asked the debugger to load an assembly with a particular identity, bail out if we ever try to load the same assembly again.  We expect that compilation should succeed (or generate a different error) after the first attempt to load the missing assembly.  If it doesn't, then something else is wrong, but we don't want to loop infinitely.