### PR TITLE
Ensure that IOFailure_OpenOutputFile unit-test passes in presence of localized resources.

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6167,7 +6167,7 @@ class Program2
         {
             string sourcePath = MakeTrivialExe();
             string exePath = Path.Combine(Path.GetDirectoryName(sourcePath), "test.exe");
-            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", $"/out:{exePath}", sourcePath });
+            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", $"/out:{exePath}", sourcePath });
             csc.FileOpen = (file, mode, access, share) =>
             {
                 if (file == exePath)


### PR DESCRIPTION
Fixes #1394.