### PR TITLE
Improved code generation for ?. in some scenarios (in particular async)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6437,7 +6437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 receiverType = receiverType.GetNullableUnderlyingType();
             }
 
-            receiver = new BoundConditionalReceiver(receiver.Syntax, receiverType) { WasCompilerGenerated = true };
+            receiver = new BoundConditionalReceiver(receiver.Syntax, 0, receiverType) { WasCompilerGenerated = true };
             return receiver;
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -332,6 +332,36 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get { return this.IsBaseConversion; }
         }
+
+        /// <summary>
+        /// Returns true when conversion itself (not the operand) may have sideeffects
+        /// A typical sideeffect of a conversion is an exception when conversion is unsuccessful.
+        /// </summary>
+        /// <returns></returns>
+        internal bool ConversionHasSideEffects()
+        {
+            // only some intrinsic conversions are side effect free 
+            // the only side effect of an intrinsic conversion is a throw when we fail to convert.
+            // and some intrinsic conversion always succeed
+            switch (this.ConversionKind)
+            {
+                case ConversionKind.Identity:
+                // NOTE: even explicit float/double identity conversion does not have side
+                // effects since it does not throw
+                case ConversionKind.ImplicitNumeric:
+                case ConversionKind.ImplicitEnumeration:
+                // implicit ref cast does not throw ...
+                case ConversionKind.ImplicitReference:
+                case ConversionKind.Boxing:
+                    return false;
+
+                // unchecked numeric conversion does not throw 
+                case ConversionKind.ExplicitNumeric:
+                    return this.Checked;
+            }
+
+            return true;
+        }
     }
 
     internal partial class BoundObjectCreationExpression

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -973,11 +973,22 @@
     <Field Name="Receiver" Type="BoundExpression"/>
     <Field Name="WhenNotNull" Type="BoundExpression"/>
     <Field Name="WhenNullOpt" Type="BoundExpression" Null="allow"/>
+    <!-- 
+    Async rewriter needs to replace receivers with their spilled values
+    and for that it needs to match receivers and the containing conditional 
+    expressions.
+    To be able to do that, during lowering, we will assign 
+    BoundLoweredConditionalAccess and corresponding BoundConditionalReceiver 
+    matching ID that are integers unique for the containing method body.
+    -->
+    <Field Name="ID" Type="int"/>
   </Node>
   
   <!-- represents the receiver of a conditional access expression -->
   <Node Name="BoundConditionalReceiver" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <!-- See the comment in BoundLoweredConditionalAccess -->
+    <Field Name="ID" Type="int"/>
   </Node>
 
   <!--  This node represents a complex receiver for a conditional access.  

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -968,6 +968,13 @@
     <Field Name="AccessExpression" Type="BoundExpression"/> 
   </Node>
 
+  <Node Name="BoundLoweredConditionalAccess" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Receiver" Type="BoundExpression"/>
+    <Field Name="WhenNotNull" Type="BoundExpression"/>
+    <Field Name="WhenNullOpt" Type="BoundExpression" Null="allow"/>
+  </Node>
+  
   <!-- represents the receiver of a conditional access expression -->
   <Node Name="BoundConditionalReceiver" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -979,7 +979,18 @@
   <Node Name="BoundConditionalReceiver" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
   </Node>
-    
+
+  <!--  This node represents a complex receiver for a conditional access.  
+        At runtime, when its type is a value type, ValueTypeReceiver should be used as a receiver. 
+        Otherwise, ReferenceTypeReceiver should be used.  
+        This kind of receiver is created only by Async rewriter. 
+  -->
+  <Node Name="BoundComplexConditionalReceiver" Base="BoundExpression" HasValidate="true">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="ValueTypeReceiver" Type="BoundExpression" Null="disallow"/>
+    <Field Name="ReferenceTypeReceiver" Type="BoundExpression" Null="disallow"/>
+  </Node>
+
   <Node Name="BoundMethodGroup" Base="BoundMethodOrPropertyGroup">
     <!-- SPEC: A method group is a set of overloaded methods resulting from a member lookup. 
          SPEC: A method group may have an associated instance expression and 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -979,16 +979,16 @@
     expressions.
     To be able to do that, during lowering, we will assign 
     BoundLoweredConditionalAccess and corresponding BoundConditionalReceiver 
-    matching ID that are integers unique for the containing method body.
+    matching Id that are integers unique for the containing method body.
     -->
-    <Field Name="ID" Type="int"/>
+    <Field Name="Id" Type="int"/>
   </Node>
   
   <!-- represents the receiver of a conditional access expression -->
   <Node Name="BoundConditionalReceiver" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <!-- See the comment in BoundLoweredConditionalAccess -->
-    <Field Name="ID" Type="int"/>
+    <Field Name="Id" Type="int"/>
   </Node>
 
   <!--  This node represents a complex receiver for a conditional access.  

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
@@ -45,6 +46,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // do nothing receiver ref must be already pushed
                     Debug.Assert(!expression.Type.IsReferenceType);
                     Debug.Assert(!expression.Type.IsValueType);
+                    break;
+
+                case BoundKind.ComplexConditionalReceiver:
+                    EmitComplexConditionalReceiver((BoundComplexConditionalReceiver)expression);
                     break;
 
                 case BoundKind.Parameter:
@@ -93,6 +98,31 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             return null;
+        }
+
+        private void EmitComplexConditionalReceiver(BoundComplexConditionalReceiver expression)
+        {
+            Debug.Assert(!expression.Type.IsReferenceType);
+            Debug.Assert(!expression.Type.IsValueType);
+
+            var receiverType = expression.Type;
+
+            var whenValueTypeLabel = new Object();
+            var doneLabel = new Object();
+
+            EmitInitObj(receiverType, true, expression.Syntax);
+            EmitBox(receiverType, expression.Syntax);
+            _builder.EmitBranch(ILOpCode.Brtrue, whenValueTypeLabel);
+
+            var receiverTemp = EmitAddress(expression.ReferenceTypeReceiver, addressKind: AddressKind.ReadOnly);
+            Debug.Assert(receiverTemp == null);
+            _builder.EmitBranch(ILOpCode.Br, doneLabel);
+            _builder.AdjustStack(-1);
+
+            _builder.MarkLabel(whenValueTypeLabel);
+            EmitReceiverRef(expression.ValueTypeReceiver, isAccessConstrained: true);
+
+            _builder.MarkLabel(doneLabel);
         }
 
         private void EmitLocalAddress(BoundLocal localAccess)
@@ -259,6 +289,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BoundKind.Sequence:
                     return HasHome(((BoundSequence)expression).Value);
+
+                case BoundKind.ComplexConditionalReceiver:
+                    Debug.Assert(HasHome(((BoundComplexConditionalReceiver)expression).ValueTypeReceiver));
+                    Debug.Assert(HasHome(((BoundComplexConditionalReceiver)expression).ReferenceTypeReceiver));
+                    goto case BoundKind.ConditionalReceiver;
+
+                case BoundKind.ConditionalReceiver:
+                    return true;
 
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     break;
 
                 case BoundKind.ComplexConditionalReceiver:
-                    EmitComplexConditionalReceiver((BoundComplexConditionalReceiver)expression);
+                    EmitComplexConditionalReceiverAddress((BoundComplexConditionalReceiver)expression);
                     break;
 
                 case BoundKind.Parameter:
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return null;
         }
 
-        private void EmitComplexConditionalReceiver(BoundComplexConditionalReceiver expression)
+        private void EmitComplexConditionalReceiverAddress(BoundComplexConditionalReceiver expression)
         {
             Debug.Assert(!expression.Type.IsReferenceType);
             Debug.Assert(!expression.Type.IsValueType);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return;
             }
 
-            if (!used && !ConversionHasSideEffects(conversion))
+            if (!used && !LocalRewriter.ConversionHasSideEffects(conversion))
             {
                 EmitExpression(conversion.Operand, false); // just do expr side effects
                 return;
@@ -113,30 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 default:
                     throw ExceptionUtilities.UnexpectedValue(conversion.ConversionKind);
             }
-        }
-
-        private static bool ConversionHasSideEffects(BoundConversion conversion)
-        {
-            // only some intrinsic conversions are side effect free the only side effect of an
-            // intrinsic conversion is a throw when we fail to convert.
-            switch (conversion.ConversionKind)
-            {
-                case ConversionKind.Identity:
-                // NOTE: even explicit float/double identity conversion does not have side
-                // effects since it does not throw
-                case ConversionKind.ImplicitNumeric:
-                case ConversionKind.ImplicitEnumeration:
-                // implicit ref cast does not throw ...
-                case ConversionKind.ImplicitReference:
-                case ConversionKind.Boxing:
-                    return false;
-
-                // unchecked numeric conversion does not throw 
-                case ConversionKind.ExplicitNumeric:
-                    return conversion.Checked;
-            }
-
-            return true;
         }
 
         private void EmitIdentityConversion(BoundConversion conversion)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return;
             }
 
-            if (!used && !LocalRewriter.ConversionHasSideEffects(conversion))
+            if (!used && !conversion.ConversionHasSideEffects())
             {
                 EmitExpression(conversion.Operand, false); // just do expr side effects
                 return;

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // we need a copy if we deal with nonlocal value (to capture the value)
             // or if we have a ref-constrained T (to do box just once)
             // or if we deal with stack local (reads are destructive)
-            var nullCheckOnCopy = LocalRewriter.IntroducingReadCanBeObservable(receiver, localsMayBeAssignedOrCaptured: false) ||
+            var nullCheckOnCopy = LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                    (receiverType.IsReferenceType && receiverType.TypeKind == TypeKind.TypeParameter) ||
                                    (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol));
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         // we need a copy if we deal with nonlocal value (to capture the value)
                         // or if we deal with stack local (reads are destructive)
                         var complexCase = !receiverType.IsReferenceType ||
-                                          LocalRewriter.IntroducingReadCanBeObservable(receiver, localsMayBeAssignedOrCaptured: false) ||
+                                          LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                           (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol)) ||
                                           (ca.WhenNullOpt?.IsDefaultValue() == false) ;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1231,8 +1231,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 whenNull = (BoundExpression)this.Visit(whenNull);
                 EnsureStackState(cookie);   // implicit label here
             }
+            else
+            {
+                _counter += 1;
+            }
 
-            return node.Update(receiver, whenNotNull, whenNull, node.ID, node.Type);
+            return node.Update(receiver, whenNotNull, whenNull, node.Id, node.Type);
         }
 
         public override BoundNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)
@@ -1251,7 +1255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EnsureStackState(cookie); // implicit label here 
 
             this._evalStack = origStack; // alternative is evaluated with original stack 
-             var referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
+            var referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
 
             EnsureStackState(cookie); // implicit label here 
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 EnsureStackState(cookie);   // implicit label here
             }
 
-            return node.Update(receiver, whenNotNull, whenNull, node.Type);
+            return node.Update(receiver, whenNotNull, whenNull, node.ID, node.Type);
         }
 
         public override BoundNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -272,9 +272,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         // build argument
                         arguments[i] = F.Convert(manager.System_Object,
-                                                 new BoundConditionalAccess(F.Syntax,
+                                                 new BoundLoweredConditionalAccess(F.Syntax,
                                                                             F.Field(F.This(), property.BackingField),
                                                                             F.Call(new BoundConditionalReceiver(F.Syntax, property.BackingField.Type), manager.System_Object__ToString),
+                                                                            null,
                                                                             manager.System_String),
                                                  ConversionKind.ImplicitReference);
                     }

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -274,9 +274,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         arguments[i] = F.Convert(manager.System_Object,
                                                  new BoundLoweredConditionalAccess(F.Syntax,
                                                                             F.Field(F.This(), property.BackingField),
-                                                                            F.Call(new BoundConditionalReceiver(F.Syntax, property.BackingField.Type), manager.System_Object__ToString),
+                                                                            F.Call(new BoundConditionalReceiver(
+                                                                                F.Syntax, 
+                                                                                iD: i, 
+                                                                                type: property.BackingField.Type), manager.System_Object__ToString),
                                                                             null,
-                                                                            manager.System_String),
+                                                                            iD: i,
+                                                                            type: manager.System_String),
                                                  ConversionKind.ImplicitReference);
                     }
                     formatString.Builder.Append(" }}");

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -276,10 +276,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                                             F.Field(F.This(), property.BackingField),
                                                                             F.Call(new BoundConditionalReceiver(
                                                                                 F.Syntax, 
-                                                                                iD: i, 
+                                                                                id: i, 
                                                                                 type: property.BackingField.Type), manager.System_Object__ToString),
                                                                             null,
-                                                                            iD: i,
+                                                                            id: i,
                                                                             type: manager.System_String),
                                                  ConversionKind.ImplicitReference);
                     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2004,6 +2004,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)
+        {
+            var savedState = this.State.Clone();
+
+            VisitRvalue(node.ValueTypeReceiver);
+            IntersectWith(ref this.State, ref savedState);
+
+            savedState = this.State.Clone();
+            VisitRvalue(node.ReferenceTypeReceiver);
+            IntersectWith(ref this.State, ref savedState);
+
+            return null;
+        }
+
         public override BoundNode VisitSequence(BoundSequence node)
         {
             var sideEffects = node.SideEffects;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1980,6 +1980,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
+        {
+            VisitRvalue(node.Receiver);
+
+            var savedState = this.State.Clone();
+
+            VisitRvalue(node.WhenNotNull);
+            IntersectWith(ref this.State, ref savedState);
+
+            if (node.WhenNullOpt != null)
+            {
+                savedState = this.State.Clone();
+                VisitRvalue(node.WhenNullOpt);
+                IntersectWith(ref this.State, ref savedState);
+            }
+
+            return null;
+        }
+
         public override BoundNode VisitConditionalReceiver(BoundConditionalReceiver node)
         {
             return null;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -392,6 +392,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.TypeExpression:
                         return expression;
 
+                    case BoundKind.ConditionalReceiver:
+                        // we will rewrite this as a part of rewriting whole LoweredConditionalAccess
+                        // later, if needed
+                        return expression;
+
                     default:
                         if (expression.Type.SpecialType == SpecialType.System_Void || sideEffectsOnly)
                         {
@@ -880,6 +885,127 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return UpdateExpression(builder, node.Update(left, right, node.LeftConversion, node.Type));
         }
+
+        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
+        {
+            var receiverRefKind = ReceiverSpillRefKind(node.Receiver);
+            
+            BoundSpillSequenceBuilder receiverBuilder = null;
+            var receiver = VisitExpression(ref receiverBuilder, node.Receiver);
+
+            BoundSpillSequenceBuilder whenNotNullBuilder = null;
+            var whenNotNull = VisitExpression(ref whenNotNullBuilder, node.WhenNotNull);
+
+            BoundSpillSequenceBuilder whenNullBuilder = null;
+            var whenNull = VisitExpression(ref whenNullBuilder, node.WhenNullOpt);
+
+            if (whenNotNullBuilder == null && whenNullBuilder == null)
+            {
+                return UpdateExpression(receiverBuilder, node.Update(receiver, whenNotNull, whenNull, node.Type));
+            }
+
+            if (receiverBuilder == null) receiverBuilder = new BoundSpillSequenceBuilder();
+            if (whenNotNullBuilder == null) whenNotNullBuilder = new BoundSpillSequenceBuilder();
+            if (whenNullBuilder == null) whenNullBuilder = new BoundSpillSequenceBuilder();
+            
+
+            BoundExpression condition;
+            if (receiver.Type.IsReferenceType || receiverRefKind == RefKind.None)
+            {
+                // spill to a clone
+                receiver = Spill(receiverBuilder, receiver, RefKind.None);
+                condition = _F.ObjectNotEqual(
+                    _F.Convert(_F.SpecialType(SpecialType.System_Object), receiver),
+                    _F.Null(_F.SpecialType(SpecialType.System_Object)));
+            }
+            else
+            {
+                receiver = Spill(receiverBuilder, receiver, RefKind.Ref);
+
+                var clone = _F.SynthesizedLocal(receiver.Type, _F.Syntax, refKind: RefKind.None, kind: SynthesizedLocalKind.AwaitSpill);
+                receiverBuilder.AddLocal(clone, _F.Diagnostics);
+
+                //  (object)default(T) != null
+                var isNotClass = _F.ObjectNotEqual(
+                                _F.Convert(_F.SpecialType(SpecialType.System_Object), _F.Default(receiver.Type)),
+                                _F.Null(_F.SpecialType(SpecialType.System_Object)));
+                
+                // isNotCalss || {clone = receiver; (object)clone != null}
+                condition = _F.LogicalOr(
+                                    isNotClass,
+                                    _F.Sequence(
+                                        _F.AssignmentExpression(_F.Local(clone), receiver),
+                                        _F.ObjectNotEqual(
+                                            _F.Convert(_F.SpecialType(SpecialType.System_Object), _F.Local(clone)),
+                                            _F.Null(_F.SpecialType(SpecialType.System_Object))))
+                                    );
+
+                receiver = _F.ComplexConditionalReceiver(receiver, _F.Local(clone));
+            }
+
+            if (node.Type.SpecialType == SpecialType.System_Void)
+            {
+                var wnenNotNullStatement = UpdateStatement(whenNotNullBuilder, _F.ExpressionStatement(whenNotNull), substituteTemps: false);
+                wnenNotNullStatement = ConditionalReceiverReplacer.Replace(wnenNotNullStatement, receiver);
+
+                receiverBuilder.AddStatement(
+                    _F.If(condition,
+                        wnenNotNullStatement,
+                        UpdateStatement(whenNullBuilder, _F.ExpressionStatement(whenNull), substituteTemps: false)));
+
+                return receiverBuilder.Update(_F.Default(node.Type));
+            }
+            else
+            {
+                Debug.Assert(_F.Syntax.IsKind(SyntaxKind.AwaitExpression));
+                var tmp = _F.SynthesizedLocal(node.Type, kind: SynthesizedLocalKind.AwaitSpill, syntax: _F.Syntax);
+                var wnenNotNullStatement = UpdateStatement(whenNotNullBuilder, _F.Assignment(_F.Local(tmp), whenNotNull), substituteTemps: false);
+                wnenNotNullStatement = ConditionalReceiverReplacer.Replace(wnenNotNullStatement, receiver);
+
+                receiverBuilder.AddLocal(tmp, _F.Diagnostics);
+                receiverBuilder.AddStatement(
+                    _F.If(condition,
+                        wnenNotNullStatement,
+                        UpdateStatement(whenNullBuilder, _F.Assignment(_F.Local(tmp), whenNull), substituteTemps: false)));
+
+                return receiverBuilder.Update(_F.Local(tmp));
+            }
+        }
+
+        private class ConditionalReceiverReplacer: BoundTreeRewriter
+        {
+            private readonly BoundExpression _receiver;
+
+#if DEBUG
+            // we must replace exatly one node
+            private int _replaced;
+#endif
+                       
+            private ConditionalReceiverReplacer(BoundExpression receiver)
+            {
+                this._receiver = receiver;
+            }
+
+            public static BoundStatement Replace(BoundNode node, BoundExpression receiver)
+            {
+                var replacer = new ConditionalReceiverReplacer(receiver);
+                var result = (BoundStatement)replacer.Visit(node);
+#if DEBUG
+                Debug.Assert(replacer._replaced == 1, "should have replaced exactly one node");
+#endif
+
+                return result;
+            }
+
+            public override BoundNode VisitConditionalReceiver(BoundConditionalReceiver node)
+            {
+#if DEBUG
+                _replaced++;
+#endif
+                return _receiver;
+            }
+        }
+
 
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (constantValue != null)
             {
                 TypeSymbol type = node.Type;
-                if (((object)type == null || !type.IsNullableType()))
+                if (type?.IsNullableType() != true)
                 {
                     return MakeLiteral(node.Syntax, constantValue, type);
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -510,6 +510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conditionalLeft.Receiver,
                     whenNotNull: result,
                     whenNullOpt: whenNullOpt,
+                    iD: conditionalLeft.ID,
                     type: result.Type
                 );
             }
@@ -1749,7 +1750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var whenNull = kind == BinaryOperatorKind.NullableNullEqual ? MakeBooleanConstant(syntax, true) : null;
 
-                return conditionalAccess.Update(conditionalAccess.Receiver, whenNotNull, whenNull, whenNotNull.Type);
+                return conditionalAccess.Update(conditionalAccess.Receiver, whenNotNull, whenNull, conditionalAccess.ID, whenNotNull.Type);
             }
 
             MethodSymbol get_HasValue = GetNullableMethod(syntax, nullable.Type, SpecialMember.System_Nullable_T_get_HasValue);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // reading rightAlwaysHasValue should not have sideeffects here
                     // otherwise we would need to read it even when we knew that LHS is null
-                    if (rightAlwaysHasValue != null && !IntroducingReadCanBeObservable(rightAlwaysHasValue))
+                    if (rightAlwaysHasValue != null && !ReadIsSideeffecting(rightAlwaysHasValue))
                     {
                         BoundExpression accessExpression = conditionalAccess.AccessExpression;
                         accessExpression = node.Update(unliftedOperatorKind, accessExpression, rightAlwaysHasValue, null, node.MethodOpt, node.ResultKind, node.Type);
@@ -250,37 +250,35 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return RewriteDelegateOperation(syntax, operatorKind, loweredLeft, loweredRight, type, SpecialMember.System_Delegate__op_Inequality);
                 }
             }
-            else if (operatorKind.IsDynamic())
-            {
-                Debug.Assert(!isPointerElementAccess);
-
-                if (operatorKind.IsLogical())
-                {
-                    return MakeDynamicLogicalBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, method, type, isCompoundAssignment, applyParentUnaryOperator);
-                }
-                else
-                {
-                    Debug.Assert((object)method == null);
-                    return _dynamicFactory.MakeDynamicBinaryOperator(operatorKind, loweredLeft, loweredRight, isCompoundAssignment, type).ToExpression();
-                }
-            }
-            else if (operatorKind.IsUserDefined())
-            {
-                return LowerUserDefinedBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, type, method);
-            }
-            else if (operatorKind.IsLifted())
-            {
-                if (operatorKind.IsComparison())
-                {
-                    return LowerLiftedBuiltInComparisonOperator(syntax, operatorKind, loweredLeft, loweredRight);
-                }
-                else
-                {
-                    return LowerLiftedBinaryArithmeticOperator(syntax, operatorKind, loweredLeft, loweredRight, type, method);
-                }
-            }
             else
+            // try to lower the expression.
             {
+
+                if (operatorKind.IsDynamic())
+                {
+                    Debug.Assert(!isPointerElementAccess);
+
+                    if (operatorKind.IsLogical())
+                    {
+                        return MakeDynamicLogicalBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, method, type, isCompoundAssignment, applyParentUnaryOperator);
+                    }
+                    else
+                    {
+                        Debug.Assert((object)method == null);
+                        return _dynamicFactory.MakeDynamicBinaryOperator(operatorKind, loweredLeft, loweredRight, isCompoundAssignment, type).ToExpression();
+                    }
+                }
+
+                if (operatorKind.IsLifted())
+                {
+                    return RewriteLiftedBinaryOperator(syntax, operatorKind, ref loweredLeft, loweredRight, type, method);
+                }
+
+                if (operatorKind.IsUserDefined())
+                {
+                    return LowerUserDefinedBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, type, method);
+                }
+                
                 switch (operatorKind.OperatorWithLogical() | operatorKind.OperandTypes())
                 {
                     case BinaryOperatorKind.NullableNullEqual:
@@ -477,6 +475,49 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new BoundBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, null, null, LookupResultKind.Viable, type);
         }
 
+        private BoundExpression RewriteLiftedBinaryOperator(CSharpSyntaxNode syntax, BinaryOperatorKind operatorKind, ref BoundExpression loweredLeft, BoundExpression loweredRight, TypeSymbol type, MethodSymbol method)
+        {
+            var conditionalLeft = loweredLeft as BoundLoweredConditionalAccess;
+
+            // NOTE: we could in theory handle sideeffecting loweredRight here too
+            //       by including it as a part of whenNull, but there is a concern 
+            //       that it can lead to code duplication
+            var optimize = conditionalLeft != null &&
+                !ReadIsSideeffecting(loweredRight) &&
+                (conditionalLeft.WhenNullOpt == null || conditionalLeft.WhenNullOpt.IsDefaultValue());
+
+            if (optimize)
+            {
+                loweredLeft = conditionalLeft.WhenNotNull;
+            }
+
+            var result = operatorKind.IsComparison() ?
+                            operatorKind.IsUserDefined() ?
+                                LowerLiftedUserDefinedComparisonOperator(syntax, operatorKind, loweredLeft, loweredRight, method) :
+                                LowerLiftedBuiltInComparisonOperator(syntax, operatorKind, loweredLeft, loweredRight) :
+                            LowerLiftedBinaryArithmeticOperator(syntax, operatorKind, loweredLeft, loweredRight, type, method);
+
+            if (optimize)
+            {
+                BoundExpression whenNullOpt = null;
+
+                if (operatorKind.Operator() == BinaryOperatorKind.NotEqual)
+                {
+                    whenNullOpt = MakeBooleanConstant(syntax, true);
+                }
+
+                result = conditionalLeft.Update(
+                    conditionalLeft.Receiver,
+                    whenNotNull: result,
+                    whenNullOpt: whenNullOpt,
+                    type: result.Type
+                );
+            }
+
+            return result;
+        }
+
+
         //array length produces native uint, so the node typically implies a conversion to int32/int64.  
         //Sometimes the conversion is not necessary - i.e. when we just check for 0
         //This helper removes unnecessary implied conversion from ArrayLength node.
@@ -662,14 +703,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (operatorKind.IsLifted())
             {
-                if (operatorKind.IsComparison())
-                {
-                    return LowerLiftedUserDefinedComparisonOperator(syntax, operatorKind, loweredLeft, loweredRight, method);
-                }
-                else
-                {
-                    return LowerLiftedBinaryArithmeticOperator(syntax, operatorKind, loweredLeft, loweredRight, type, method);
-                }
+                return RewriteLiftedBinaryOperator(syntax, operatorKind, ref loweredLeft, loweredRight, type, method);
             }
 
             // Otherwise, nothing special here.
@@ -1699,6 +1733,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     sideEffects: ImmutableArray.Create<BoundExpression>(nonNullValue),
                     value: MakeBooleanConstant(syntax, kind == BinaryOperatorKind.NullableNullNotEqual),
                     type: returnType);
+            }
+
+            // arr?.Leghth == null   
+            var conditionalAccess = nullable as BoundLoweredConditionalAccess;
+            if (conditionalAccess != null && 
+                (conditionalAccess.WhenNullOpt == null || conditionalAccess.WhenNullOpt.IsDefaultValue()))
+            {
+                BoundExpression whenNotNull = RewriteNullableNullEquality(
+                    syntax,
+                    kind,
+                    conditionalAccess.WhenNotNull,
+                    _factory.Null(conditionalAccess.WhenNotNull.Type),
+                    returnType);
+
+                var whenNull = kind == BinaryOperatorKind.NullableNullEqual ? MakeBooleanConstant(syntax, true) : null;
+
+                return conditionalAccess.Update(conditionalAccess.Receiver, whenNotNull, whenNull, whenNotNull.Type);
             }
 
             MethodSymbol get_HasValue = GetNullableMethod(syntax, nullable.Type, SpecialMember.System_Nullable_T_get_HasValue);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -620,7 +620,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // a simple check for common nonsideeffecting expressions
-        private static bool ReadIsSideeffecting(
+        internal static bool ReadIsSideeffecting(
             BoundExpression expression)
         {
             if (expression.ConstantValue != null)
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.Conversion:
                     var conv = (BoundConversion)expression;
-                    return ConversionHasSideEffects(conv) || 
+                    return conv.ConversionHasSideEffects() || 
                         ReadIsSideeffecting(conv.Operand);
 
                 case BoundKind.ObjectCreationExpression:
@@ -662,30 +662,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     return true;
             }
-        }
-
-        internal static bool ConversionHasSideEffects(BoundConversion conversion)
-        {
-            // only some intrinsic conversions are side effect free the only side effect of an
-            // intrinsic conversion is a throw when we fail to convert.
-            switch (conversion.ConversionKind)
-            {
-                case ConversionKind.Identity:
-                // NOTE: even explicit float/double identity conversion does not have side
-                // effects since it does not throw
-                case ConversionKind.ImplicitNumeric:
-                case ConversionKind.ImplicitEnumeration:
-                // implicit ref cast does not throw ...
-                case ConversionKind.ImplicitReference:
-                case ConversionKind.Boxing:
-                    return false;
-
-                // unchecked numeric conversion does not throw 
-                case ConversionKind.ExplicitNumeric:
-                    return conversion.Checked;
-            }
-
-            return true;
         }
 
         // nontrivial literals do not change between reads

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (binaryOperator == BinaryOperatorKind.Addition || binaryOperator == BinaryOperatorKind.Subtraction);
 
             // save RHS to a temp, we need to use it twice:
-            if (isPossibleEventHandlerOperation && IntroducingReadCanBeObservable(loweredRight))
+            if (isPossibleEventHandlerOperation && CanChangeValueBetweenReads(loweredRight))
             {
                 BoundAssignmentOperator assignmentToTemp;
                 var temp = _factory.StoreToTemp(loweredRight, out assignmentToTemp);
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var prop = (BoundPropertyAccess)originalLHS;
 
                         // If the property is static or if the receiver is of kind "Base" or "this", then we can just generate prop = prop + value
-                        if (prop.ReceiverOpt == null || prop.PropertySymbol.IsStatic || !IntroducingReadCanBeObservable(prop.ReceiverOpt))
+                        if (prop.ReceiverOpt == null || prop.PropertySymbol.IsStatic || !CanChangeValueBetweenReads(prop.ReceiverOpt))
                         {
                             return prop;
                         }
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.DynamicMemberAccess:
                     {
                         var memberAccess = (BoundDynamicMemberAccess)originalLHS;
-                        if (!IntroducingReadCanBeObservable(memberAccess.Receiver))
+                        if (!CanChangeValueBetweenReads(memberAccess.Receiver))
                         {
                             return memberAccess;
                         }
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(receiverOpt != null);
 
                         BoundExpression transformedReceiver;
-                        if (IntroducingReadCanBeObservable(receiverOpt))
+                        if (CanChangeValueBetweenReads(receiverOpt))
                         {
                             BoundExpression rewrittenReceiver = VisitExpression(receiverOpt);
 
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         BoundExpression receiverOpt = fieldAccess.ReceiverOpt;
 
                         //If the receiver is static or is the receiver is of kind "Base" or "this", then we can just generate field = field + value
-                        if (fieldAccess.FieldSymbol.IsStatic || !IntroducingReadCanBeObservable(receiverOpt))
+                        if (fieldAccess.FieldSymbol.IsStatic || !CanChangeValueBetweenReads(receiverOpt))
                         {
                             return fieldAccess;
                         }
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var indexerAccess = (BoundDynamicIndexerAccess)originalLHS;
 
                         BoundExpression loweredReceiver;
-                        if (IntroducingReadCanBeObservable(indexerAccess.ReceiverOpt))
+                        if (CanChangeValueBetweenReads(indexerAccess.ReceiverOpt))
                         {
                             BoundAssignmentOperator assignmentToTemp;
                             var temp = _factory.StoreToTemp(VisitExpression(indexerAccess.ReceiverOpt), out assignmentToTemp);
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         for (int i = 0; i < arguments.Length; i++)
                         {
-                            if (IntroducingReadCanBeObservable(arguments[i]))
+                            if (CanChangeValueBetweenReads(arguments[i]))
                             {
                                 BoundAssignmentOperator assignmentToTemp;
                                 var temp = _factory.StoreToTemp(VisitExpression(arguments[i]), out assignmentToTemp, refKind: indexerAccess.ArgumentRefKindsOpt.RefKinds(i));
@@ -555,7 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundTempIndices = new BoundExpression[loweredIndices.Length];
             for (int i = 0; i < boundTempIndices.Length; i++)
             {
-                if (IntroducingReadCanBeObservable(loweredIndices[i]))
+                if (CanChangeValueBetweenReads(loweredIndices[i]))
                 {
                     BoundAssignmentOperator assignmentToTemp;
                     var temp = _factory.StoreToTemp(loweredIndices[i], out assignmentToTemp);
@@ -583,8 +583,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// even though l is a local, we must access it via a temp since "foo(ref l)" may change it
         /// on between accesses. 
         /// </summary>
-        internal static bool IntroducingReadCanBeObservable(BoundExpression expression, bool localsMayBeAssignedOrCaptured = true)
+        internal static bool CanChangeValueBetweenReads(
+            BoundExpression expression, 
+            bool localsMayBeAssignedOrCaptured = true)
         {
+            if (expression.IsDefaultValue())
+            {
+                return false;
+            }
+
+            if (expression.ConstantValue != null)
+            {
+                var type = expression.Type;
+                return !ConstantValueIsTrivial(type);
+            }
+
             switch (expression.Kind)
             {
                 case BoundKind.ThisReference:
@@ -592,12 +605,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
 
                 case BoundKind.Literal:
-                    // don't allocate a temp for simple primitive types:
                     var type = expression.Type;
-                    return (object)type != null &&
-                        !type.SpecialType.IsClrInteger() &&
-                        !type.IsReferenceType &&
-                        !type.IsEnumType();
+                    return !ConstantValueIsTrivial(type);
 
                 case BoundKind.Parameter:
                     return localsMayBeAssignedOrCaptured || ((BoundParameter)expression).ParameterSymbol.RefKind != RefKind.None;
@@ -608,6 +617,57 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     return true;
             }
+        }
+
+        // a simple check for common nonsideeffecting expressions
+        private static bool ReadIsSideeffecting(
+            BoundExpression expression)
+        {
+            if (expression.ConstantValue != null)
+            {
+                return false;
+            }
+
+            if (expression.IsDefaultValue())
+            {
+                return false;
+            }
+
+            switch (expression.Kind)
+            {
+                case BoundKind.ThisReference:
+                case BoundKind.BaseReference:
+                case BoundKind.Literal:
+                case BoundKind.Parameter:
+                case BoundKind.Local:
+                case BoundKind.Lambda:
+                    return false;
+
+                case BoundKind.ObjectCreationExpression:
+                    // common production of lowered conversions to nullable
+                    // new S?(arg)
+                    if (expression.Type.IsNullableType())
+                    {
+                        var objCreation = (BoundObjectCreationExpression)expression;
+                        return objCreation.Arguments.Length == 1 && ReadIsSideeffecting(objCreation.Arguments[0]);
+                    }
+
+                    return false;
+
+                default:
+                    return true;
+            }
+        }
+
+        // nontrivial literals do not change between reads
+        // but may require re-constructing, so it is better 
+        // to treat them as potentially changing.
+        private static bool ConstantValueIsTrivial(TypeSymbol type)
+        {
+            return (object)type == null ||
+                type.SpecialType.IsClrInteger() ||
+                type.IsReferenceType ||
+                type.IsEnumType();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -39,6 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverType = loweredReceiver.Type;
 
             ConditionalAccessLoweringKind loweringKind;
+            // nullable and dynamic receivers are not directly supported in codegen and need to be lowered
+            // in particular nullable receiver implies that the condition of the 
+            // conditional and the access receiver are actually different expressions 
+            // (HasValue and GetValueOrDefault respectively)
             var lowerToTernary = receiverType.IsNullableType() || node.AccessExpression.Type.IsDynamic();
 
             if (!lowerToTernary)
@@ -127,8 +131,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression result;
             var objectType = _compilation.GetSpecialType(SpecialType.System_Object);
 
-            rewrittenWhenNull = rewrittenWhenNull ?? _factory.Default(nodeType);
-
             switch (loweringKind)
             {
                 case ConditionalAccessLoweringKind.LoweredConditionalAccess:
@@ -165,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         result = RewriteConditionalOperator(node.Syntax,
                             condition,
                             consequence,
-                            rewrittenWhenNull,
+                            rewrittenWhenNull ?? _factory.Default(nodeType),
                             null,
                             nodeType);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             //       Nullable is special since we are not going to read any part of it twice
             //       we will read "HasValue" and then, conditionally will read "ValueOrDefault"
-            else if (IntroducingReadCanBeObservable(loweredReceiver, !receiverType.IsNullableType()))
+            else if (CanChangeValueBetweenReads(loweredReceiver, !receiverType.IsNullableType()))
             {
                 // NOTE: dynamic operations historically do not propagate mutations
                 // to the receiver if that hapens to be a value type

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundAssignmentOperator tempAssignment = null;
             BoundLocal boundTemp = null;
-            if (!eventSymbol.IsStatic && IntroducingReadCanBeObservable(rewrittenReceiverOpt))
+            if (!eventSymbol.IsStatic && CanChangeValueBetweenReads(rewrittenReceiverOpt))
             {
                 boundTemp = _factory.StoreToTemp(rewrittenReceiverOpt, out tempAssignment);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             conditionalAccess.Receiver,
                             whenNotNull: notNullAccess,
                             whenNullOpt: whenNullOpt,
+                            iD: conditionalAccess.ID,
                             type: rewrittenResultType
                         );
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             conditionalAccess.Receiver,
                             whenNotNull: notNullAccess,
                             whenNullOpt: whenNullOpt,
-                            iD: conditionalAccess.ID,
+                            id: conditionalAccess.Id,
                             type: rewrittenResultType
                         );
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var pointerAccess = (BoundPointerElementAccess)assignment.Left;
                         var rewrittenIndex = VisitExpression(pointerAccess.Index);
 
-                        if (IntroducingReadCanBeObservable(rewrittenIndex))
+                        if (CanChangeValueBetweenReads(rewrittenIndex))
                         {
                             BoundAssignmentOperator store;
                             var temp = _factory.StoreToTemp(rewrittenIndex, out store);
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var arg = args[i];
 
-                if (IntroducingReadCanBeObservable(arg))
+                if (CanChangeValueBetweenReads(arg))
                 {
                     if (newArgs == null)
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -486,6 +486,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Binary(BinaryOperatorKind.LogicalBoolAnd, SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Boolean), left, right);
         }
 
+        public BoundBinaryOperator LogicalOr(BoundExpression left, BoundExpression right)
+        {
+            return Binary(BinaryOperatorKind.LogicalBoolOr, SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Boolean), left, right);
+        }
+
         public BoundBinaryOperator IntEqual(BoundExpression left, BoundExpression right)
         {
             return Binary(BinaryOperatorKind.IntEqual, SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Boolean), left, right);
@@ -592,6 +597,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression Conditional(BoundExpression condition, BoundExpression consequence, BoundExpression alternative, TypeSymbol type)
         {
             return new BoundConditionalOperator(Syntax, condition, consequence, alternative, default(ConstantValue), type) { WasCompilerGenerated = true };
+        }
+
+        public BoundExpression ComplexConditionalReceiver(BoundExpression valueTypeReceiver, BoundExpression referenceTypeReceiver)
+        {
+            Debug.Assert(valueTypeReceiver.Type == referenceTypeReceiver.Type);
+            return new BoundComplexConditionalReceiver(Syntax, valueTypeReceiver, referenceTypeReceiver, valueTypeReceiver.Type) { WasCompilerGenerated = true };
         }
 
         public BoundExpression Coalesce(BoundExpression left, BoundExpression right)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -3328,18 +3328,15 @@ class Program
 42");
             comp.VerifyIL("Program.Test1(Program.C1)", @"
 {
-  // Code size       15 (0xf)
+  // Code size       13 (0xd)
   .maxstack  1
-  .locals init (Program.C1 V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_0008
-  IL_0005:  ldc.i4.s   42
-  IL_0007:  ret
-  IL_0008:  ldloc.0
-  IL_0009:  callvirt   ""int Program.C1.x.get""
-  IL_000e:  ret
+  IL_0001:  brtrue.s   IL_0006
+  IL_0003:  ldc.i4.s   42
+  IL_0005:  ret
+  IL_0006:  ldarg.0
+  IL_0007:  call       ""int Program.C1.x.get""
+  IL_000c:  ret
 }
 ").VerifyIL("Program.Test2(Program.C1)", @"
 {
@@ -3409,19 +3406,17 @@ class Program
 42");
             comp.VerifyIL("Program.Test1(ref Program.C1)", @"
 {
-  // Code size       16 (0x10)
-  .maxstack  1
-  .locals init (Program.C1 V_0)
+  // Code size       15 (0xf)
+  .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldind.ref
-  IL_0002:  stloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  brtrue.s   IL_0009
+  IL_0002:  dup
+  IL_0003:  brtrue.s   IL_0009
+  IL_0005:  pop
   IL_0006:  ldc.i4.s   42
   IL_0008:  ret
-  IL_0009:  ldloc.0
-  IL_000a:  callvirt   ""int Program.C1.x.get""
-  IL_000f:  ret
+  IL_0009:  call       ""int Program.C1.x.get""
+  IL_000e:  ret
 }
 ").VerifyIL("Program.Test2(ref Program.C1)", @"
 {
@@ -3682,20 +3677,17 @@ False
 False");
             comp.VerifyIL("Program.Test1(Program.C1)", @"
 {
-  // Code size       16 (0x10)
+  // Code size       14 (0xe)
   .maxstack  1
-  .locals init (Program.C1 V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_0007
-  IL_0005:  ldc.i4.1
-  IL_0006:  ret
-  IL_0007:  ldloc.0
-  IL_0008:  callvirt   ""int Program.C1.x.get""
-  IL_000d:  pop
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
+  IL_0001:  brtrue.s   IL_0005
+  IL_0003:  ldc.i4.1
+  IL_0004:  ret
+  IL_0005:  ldarg.0
+  IL_0006:  call       ""int Program.C1.x.get""
+  IL_000b:  pop
+  IL_000c:  ldc.i4.0
+  IL_000d:  ret
 }
 ").VerifyIL("Program.Test2(Program.C1)", @"
 {
@@ -3795,22 +3787,19 @@ False");
 }
 ").VerifyIL("Program.Test2(Program.C1)", @"
 {
-  // Code size       20 (0x14)
+  // Code size       18 (0x12)
   .maxstack  2
-  .locals init (Program.C1 V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_0007
-  IL_0005:  ldc.i4.1
-  IL_0006:  ret
-  IL_0007:  ldloc.0
-  IL_0008:  callvirt   ""N Program.C1.x.get""
-  IL_000d:  ldc.i4.1
-  IL_000e:  ceq
-  IL_0010:  ldc.i4.0
-  IL_0011:  ceq
-  IL_0013:  ret
+  IL_0001:  brtrue.s   IL_0005
+  IL_0003:  ldc.i4.1
+  IL_0004:  ret
+  IL_0005:  ldarg.0
+  IL_0006:  call       ""N Program.C1.x.get""
+  IL_000b:  ldc.i4.1
+  IL_000c:  ceq
+  IL_000e:  ldc.i4.0
+  IL_000f:  ceq
+  IL_0011:  ret
 }
 ").VerifyIL("Program.Test3(Program.C1)", @"
 {
@@ -4461,24 +4450,22 @@ class Program
 }
 ").VerifyIL("Program.Test2<T>(T[])", @"
 {
-  // Code size       27 (0x1b)
+  // Code size       26 (0x1a)
   .maxstack  2
-  .locals init (T[] V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_0008
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_0008
+  IL_0004:  pop
   IL_0005:  ldc.i4.1
-  IL_0006:  br.s       IL_000d
-  IL_0008:  ldloc.0
-  IL_0009:  ldlen
-  IL_000a:  ldc.i4.0
-  IL_000b:  cgt.un
-  IL_000d:  brtrue.s   IL_0015
-  IL_000f:  ldstr      ""empty""
-  IL_0014:  ret
-  IL_0015:  ldstr      ""not empty""
-  IL_001a:  ret
+  IL_0006:  br.s       IL_000c
+  IL_0008:  ldlen
+  IL_0009:  ldc.i4.0
+  IL_000a:  cgt.un
+  IL_000c:  brtrue.s   IL_0014
+  IL_000e:  ldstr      ""empty""
+  IL_0013:  ret
+  IL_0014:  ldstr      ""not empty""
+  IL_0019:  ret
 }
 ");
         }
@@ -4729,18 +4716,15 @@ public class MyType
 
             verifier.VerifyIL("C.MyMethod", @"
 {
-  // Code size       18 (0x12)
+  // Code size       16 (0x10)
   .maxstack  1
-  .locals init (MyType V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_000b
-  IL_0005:  ldsfld     ""decimal decimal.Zero""
-  IL_000a:  ret
-  IL_000b:  ldloc.0
-  IL_000c:  ldfld      ""decimal MyType.MyField""
-  IL_0011:  ret
+  IL_0001:  brtrue.s   IL_0009
+  IL_0003:  ldsfld     ""decimal decimal.Zero""
+  IL_0008:  ret
+  IL_0009:  ldarg.0
+  IL_000a:  ldfld      ""decimal MyType.MyField""
+  IL_000f:  ret
 }");
         }
 
@@ -4773,18 +4757,15 @@ public class MyType
 
             verifier.VerifyIL("C.MyMethod", @"
 {
-  // Code size       18 (0x12)
+  // Code size       16 (0x10)
   .maxstack  1
-  .locals init (MyType V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  brtrue.s   IL_000b
-  IL_0005:  ldsfld     ""decimal decimal.Zero""
-  IL_000a:  ret
-  IL_000b:  ldloc.0
-  IL_000c:  ldfld      ""decimal MyType.MyField""
-  IL_0011:  ret
+  IL_0001:  brtrue.s   IL_0009
+  IL_0003:  ldsfld     ""decimal decimal.Zero""
+  IL_0008:  ret
+  IL_0009:  ldarg.0
+  IL_000a:  ldfld      ""decimal MyType.MyField""
+  IL_000f:  ret
 }");
         }
 


### PR DESCRIPTION
The duplicated code emit in the case of async is now gone. Some existing tests now emit 5x times smaller method bodies.
Binary operators with ?. operand can now be fused (and thus avoid intermediate nullables) in more scenarios.

Fixes #825
