### PR TITLE
Explicitly pass SDK path to compilers

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly string _responseFile;
         private CommandLineDiagnosticFormatter _diagnosticFormatter;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string baseDirectory, string additionalReferencePaths)
-            : base(parser, responseFile, args, baseDirectory, additionalReferencePaths)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
+            : base(parser, responseFile, args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         {
             Debug.Assert(responseFile == null || Path.IsPathRooted(responseFile));
             _responseFile = responseFile;

--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -33,6 +33,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
+        /// <summary>
+        /// Parses a command line.
+        /// </summary>
+        /// <param name="args">A collection of strings representing the command line arguments.</param>
+        /// <param name="baseDirectory">The base directory used for qualifying file locations.</param>
+        /// <param name="sdkDirectory">The directory to search for mscorlib.</param>
+        /// <param name="additionalReferenceDirectories">A string representing additional reference paths.</param>
+        /// <returns>a commandlinearguments object representing the parsed command line.</returns>
         public new CSharpCommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories = null)
         {
             List<Diagnostic> diagnostics = new List<Diagnostic>();

--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -28,12 +28,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override string RegularFileExtension { get { return ".cs"; } }
         protected override string ScriptFileExtension { get { return ".csx"; } }
 
-        internal sealed override CommandLineArguments CommonParse(IEnumerable<string> args, string baseDirectory, string additionalReferencePaths)
+        internal sealed override CommandLineArguments CommonParse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
         {
-            return Parse(args, baseDirectory, additionalReferencePaths);
+            return Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
-        public new CSharpCommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string additionalReferencePaths = null)
+        public new CSharpCommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories = null)
         {
             List<Diagnostic> diagnostics = new List<Diagnostic>();
             List<string> flattenedArgs = new List<string>();
@@ -981,12 +981,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // add additional reference paths if specified
-            if (!string.IsNullOrWhiteSpace(additionalReferencePaths))
+            if (!string.IsNullOrWhiteSpace(additionalReferenceDirectories))
             {
-                ParseAndResolveReferencePaths(null, additionalReferencePaths, baseDirectory, libPaths, MessageID.IDS_LIB_ENV, diagnostics);
+                ParseAndResolveReferencePaths(null, additionalReferenceDirectories, baseDirectory, libPaths, MessageID.IDS_LIB_ENV, diagnostics);
             }
 
-            ImmutableArray<string> referencePaths = BuildSearchPaths(libPaths);
+            ImmutableArray<string> referencePaths = BuildSearchPaths(sdkDirectory, libPaths);
 
             ValidateWin32Settings(win32ResourceFile, win32IconFile, win32ManifestFile, outputKind, diagnostics);
 
@@ -1218,7 +1218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static ImmutableArray<string> BuildSearchPaths(List<string> libPaths)
+        private static ImmutableArray<string> BuildSearchPaths(string sdkDirectory, List<string> libPaths)
         {
             var builder = ArrayBuilder<string>.GetInstance();
 
@@ -1228,7 +1228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // current folder first -- base directory is searched by default
 
             // SDK path is specified or current runtime directory
-            builder.Add(RuntimeEnvironment.GetRuntimeDirectory());
+            builder.Add(sdkDirectory);
 
             // libpath
             builder.AddRange(libPaths);

--- a/src/Compilers/CSharp/Desktop/PublicAPI.txt
+++ b/src/Compilers/CSharp/Desktop/PublicAPI.txt
@@ -2,7 +2,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments
 Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments.CompilationOptions.get -> Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions
 Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments.ParseOptions.get -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
 Microsoft.CodeAnalysis.CSharp.CSharpCommandLineParser
-Microsoft.CodeAnalysis.CSharp.CSharpCommandLineParser.Parse(System.Collections.Generic.IEnumerable<string> args, string baseDirectory, string additionalReferencePaths = null) -> Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments
+Microsoft.CodeAnalysis.CSharp.CSharpCommandLineParser.Parse(System.Collections.Generic.IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories = null) -> Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments
 Microsoft.CodeAnalysis.CSharp.CSharpFileSystemExtensions
 override Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments.CompilationOptionsCore.get -> Microsoft.CodeAnalysis.CompilationOptions
 override Microsoft.CodeAnalysis.CSharp.CSharpCommandLineArguments.ParseOptionsCore.get -> Microsoft.CodeAnalysis.ParseOptions

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     public class CommandLineTests : CSharpTestBase
     {
         private static readonly string s_CSharpCompilerExecutable = typeof(Microsoft.CodeAnalysis.CSharp.CommandLine.Csc).Assembly.Location;
+        private static readonly string s_defaultSdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
 
         private readonly string _baseDirectory = TempRoot.Root;
 
@@ -70,6 +71,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             {
                 return new StringReader(_responseFiles[fullPath]);
             }
+        }
+
+        private static CSharpCommandLineArguments DefaultParse(IEnumerable<string> args, string baseDirectory, string sdkDirectory = null, string additionalReferenceDirectories = null)
+        {
+            sdkDirectory = sdkDirectory ?? s_defaultSdkDirectory;
+            return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
         [Fact]
@@ -182,7 +189,7 @@ d.cs
                 }
             }, isInteractive: true);
 
-            var args = parser.Parse(new[] { "first.cs", "second.cs", "@a.rsp", "last.cs" }, basePath);
+            var args = parser.Parse(new[] { "first.cs", "second.cs", "@a.rsp", "last.cs" }, basePath, s_defaultSdkDirectory);
             args.Errors.Verify();
             Assert.True(args.IsInteractive);
 
@@ -209,7 +216,7 @@ d.cs
                     { @"C:\temp\a\|*.cs", new[] { @"a\x.cs", @"a\b\b.cs", @"a\c.cs" } },
                 });
 
-            var args = parser.Parse(new[] { @"*.cs", @"/recurse:a\*.cs" }, @"C:\temp");
+            var args = parser.Parse(new[] { @"*.cs", @"/recurse:a\*.cs" }, @"C:\temp", s_defaultSdkDirectory);
             args.Errors.Verify();
 
             string[] resolvedSourceFiles = args.SourceFiles.Select(f => f.Path).ToArray();
@@ -228,32 +235,32 @@ d.cs
             var folder = Temp.CreateDirectory();
             CreateFile(folder, "a.cs");
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/main:Test", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/main:Test", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.MainTypeName);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/main:\"Test\"", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/main:\"Test\"", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.MainTypeName);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/main:\"Test.Class1\"", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/main:\"Test.Class1\"", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test.Class1", args.CompilationOptions.MainTypeName);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/m:Test", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/m:Test", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.MainTypeName);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/m:\"Test\"", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/m:\"Test\"", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.MainTypeName);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/m:\"Test.Class1\"", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/m:\"Test.Class1\"", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("Test.Class1", args.CompilationOptions.MainTypeName);
 
             // Use of Cyrillic namespace
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/m:\"решения.Class1\"", "a.cs" }, folder.Path);
+            args = DefaultParse(new[] { "/m:\"решения.Class1\"", "a.cs" }, folder.Path);
             args.Errors.Verify();
             Assert.Equal("решения.Class1", args.CompilationOptions.MainTypeName);
         }
@@ -301,17 +308,17 @@ d.cs
             CSharpCommandLineArguments args;
             string[] resolvedSourceFiles;
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { @"/recurse:*.cp*", @"/recurse:a\*.c*", @"/out:a.dll" }, folder.Path);
+            args = DefaultParse(new[] { @"/recurse:*.cp*", @"/recurse:a\*.c*", @"/out:a.dll" }, folder.Path);
             args.Errors.Verify();
             resolvedSourceFiles = args.SourceFiles.Select(f => f.Path).ToArray();
             AssertEx.Equal(new[] { folder.Path + @"\c.cpp", folder.Path + @"\B\B_c.cpx", folder.Path + @"\a\A_a.cs", folder.Path + @"\a\A_b.cs", }, resolvedSourceFiles);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { @"/recurse:.\\\\\\*.cs", @"/out:a.dll" }, folder.Path);
+            args = DefaultParse(new[] { @"/recurse:.\\\\\\*.cs", @"/out:a.dll" }, folder.Path);
             args.Errors.Verify();
             resolvedSourceFiles = args.SourceFiles.Select(f => f.Path).ToArray();
             Assert.Equal(4, resolvedSourceFiles.Length);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { @"/recurse:.////*.cs", @"/out:a.dll" }, folder.Path);
+            args = DefaultParse(new[] { @"/recurse:.////*.cs", @"/out:a.dll" }, folder.Path);
             args.Errors.Verify();
             resolvedSourceFiles = args.SourceFiles.Select(f => f.Path).ToArray();
             Assert.Equal(4, resolvedSourceFiles.Length);
@@ -331,7 +338,7 @@ d.cs
                 @"/win32manifest:..\here\there\everywhere\nonexistent"
             };
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            var parsedArgs = DefaultParse(args, _baseDirectory);
             var compilation = CreateCompilationWithMscorlib(new SyntaxTree[0]);
             IEnumerable<DiagnosticInfo> errors;
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
@@ -344,7 +351,7 @@ d.cs
                 @"/Win32icon:\bogus"
             };
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            parsedArgs = DefaultParse(args, _baseDirectory);
 
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
             Assert.Equal(1, errors.Count());
@@ -356,7 +363,7 @@ d.cs
                 @"/Win32Res:\bogus"
             };
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            parsedArgs = DefaultParse(args, _baseDirectory);
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
             Assert.Equal(1, errors.Count());
             Assert.Equal((int)ErrorCode.ERR_CantOpenWin32Res, errors.First().Code);
@@ -367,7 +374,7 @@ d.cs
                 @"/Win32Res:foo.win32data:bar.win32data2"
             };
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            parsedArgs = DefaultParse(args, _baseDirectory);
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
             Assert.Equal(1, errors.Count());
             Assert.Equal((int)ErrorCode.ERR_CantOpenWin32Res, errors.First().Code);
@@ -378,7 +385,7 @@ d.cs
                 @"/Win32icon:foo.win32data:bar.win32data2"
             };
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            parsedArgs = DefaultParse(args, _baseDirectory);
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
             Assert.Equal(1, errors.Count());
             Assert.Equal((int)ErrorCode.ERR_CantOpenIcon, errors.First().Code);
@@ -389,7 +396,7 @@ d.cs
                 @"/Win32manifest:foo.win32data:bar.win32data2"
             };
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(args, _baseDirectory);
+            parsedArgs = DefaultParse(args, _baseDirectory);
             CSharpCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, out errors);
             Assert.Equal(1, errors.Count());
             Assert.Equal((int)ErrorCode.ERR_CantOpenWin32Manifest, errors.First().Code);
@@ -399,30 +406,30 @@ d.cs
         [Fact]
         public void Win32ResConflicts()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32res:foo", "/win32icon:foob", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/win32res:foo", "/win32icon:foob", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_CantHaveWin32ResAndIcon, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32res:foo", "/win32manifest:foob", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32res:foo", "/win32manifest:foob", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_CantHaveWin32ResAndManifest, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32res:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32res:", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_NoFileSpec, parsedArgs.Errors.First().Code);
             Assert.Equal(1, parsedArgs.Errors.First().Arguments.Count);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32Icon: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32Icon: ", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_NoFileSpec, parsedArgs.Errors.First().Code);
             Assert.Equal(1, parsedArgs.Errors.First().Arguments.Count);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32Manifest:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32Manifest:", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_NoFileSpec, parsedArgs.Errors.First().Code);
             Assert.Equal(1, parsedArgs.Errors.First().Arguments.Count);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32Manifest:foo", "/noWin32Manifest", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32Manifest:foo", "/noWin32Manifest", "a.cs" }, _baseDirectory);
             Assert.Equal(0, parsedArgs.Errors.Length);
             Assert.True(parsedArgs.NoWin32Manifest);
             Assert.Equal(null, parsedArgs.Win32Manifest);
@@ -431,22 +438,22 @@ d.cs
         [Fact]
         public void Win32ResInvalid()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32res", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/win32res", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/win32res"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32res+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32res+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/win32res+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32icon", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32icon", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/win32icon"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32icon+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32icon+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/win32icon+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32manifest", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32manifest", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/win32manifest"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32manifest+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/win32manifest+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/win32manifest+"));
         }
 
@@ -455,7 +462,7 @@ d.cs
         {
             string tmpFileName = Temp.CreateFile().WriteAllBytes(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).Path;
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/win32icon:" + tmpFileName, "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/win32icon:" + tmpFileName, "a.cs" }, _baseDirectory);
             var compilation = CreateCompilationWithMscorlib(new SyntaxTree[0]);
             IEnumerable<DiagnosticInfo> errors;
 
@@ -474,21 +481,21 @@ d.cs
                 @" /win32res:d:\\""abc def""\a""b c""d\a.res",
             };
 
-            CSharpCommandLineArguments args = CSharpCommandLineParser.Default.Parse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.res", args.Win32ResourceFile);
 
             responseFile = new string[] {
                 @" /win32icon:d:\\""abc def""\a""b c""d\a.ico",
             };
 
-            args = CSharpCommandLineParser.Default.Parse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.ico", args.Win32Icon);
 
             responseFile = new string[] {
                 @" /win32manifest:d:\\""abc def""\a""b c""d\a.manifest",
             };
 
-            args = CSharpCommandLineParser.Default.Parse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.manifest", args.Win32Manifest);
         }
 
@@ -707,28 +714,28 @@ d.cs
             CSharpCommandLineArguments parsedArgs;
             ResourceDescription resourceDescription;
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/resource:a", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/resource:a", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             resourceDescription = parsedArgs.ManifestResources.Single();
             Assert.Null(resourceDescription.FileName); // since embedded
             Assert.Equal("a", resourceDescription.ResourceName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/res:b", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/res:b", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             resourceDescription = parsedArgs.ManifestResources.Single();
             Assert.Null(resourceDescription.FileName); // since embedded
             Assert.Equal("b", resourceDescription.ResourceName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkresource:c", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkresource:c", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             resourceDescription = parsedArgs.ManifestResources.Single();
             Assert.Equal("c", resourceDescription.FileName);
             Assert.Equal("c", resourceDescription.ResourceName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkres:d", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkres:d", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             resourceDescription = parsedArgs.ManifestResources.Single();
@@ -739,64 +746,64 @@ d.cs
         [Fact]
         public void ManagedResourceOptions_SimpleErrors()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/resource:", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/resource:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/resource:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/resource: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/resource: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/resource:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/res", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/res", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/res"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/RES+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/RES+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/RES+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/res-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/res-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/res-:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkresource:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkresource:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/linkresource:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkresource: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkresource: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/linkresource:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkres", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkres", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/linkres"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkRES+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkRES+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/linkRES+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/linkres-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/linkres-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/linkres-:"));
         }
 
         [Fact]
         public void Link_SimpleTests()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/link:a", "/link:b,,,,c", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/link:a", "/link:b,,,,c", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "a", "b", "c" },
                        parsedArgs.MetadataReferences.
                                   Where((res) => res.Properties.EmbedInteropTypes).
                                   Select((res) => res.Reference));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/Link: ,,, b ,,", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/Link: ,,, b ,,", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { " b " },
                            parsedArgs.MetadataReferences.
                                       Where((res) => res.Properties.EmbedInteropTypes).
                                       Select((res) => res.Reference));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/l:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/l:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/l:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/L", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/L", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/L"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/l+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/l+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/l+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/link-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/link-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/link-:"));
         }
 
@@ -816,29 +823,29 @@ d.cs
             file4.WriteAllText("");
             file5.WriteAllText("");
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/recurse:" + dir.ToString() + "\\*.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/recurse:" + dir.ToString() + "\\*.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "{DIR}\\a.cs", "{DIR}\\b.cs", "{DIR}\\d2\\e.cs" },
                            parsedArgs.SourceFiles.Select((file) => file.Path.Replace(dir.ToString(), "{DIR}")));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "*.cs" }, dir.ToString());
+            parsedArgs = DefaultParse(new[] { "*.cs" }, dir.ToString());
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "{DIR}\\a.cs", "{DIR}\\b.cs" },
                            parsedArgs.SourceFiles.Select((file) => file.Path.Replace(dir.ToString(), "{DIR}")));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/reCURSE:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/reCURSE:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/reCURSE:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/RECURSE: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/RECURSE: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/RECURSE:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/recurse", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/recurse", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/recurse"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/recurse+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/recurse+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/recurse+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/recurse-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/recurse-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/recurse-:"));
 
             CleanupAllGeneratedFiles(file1.Path);
@@ -851,95 +858,95 @@ d.cs
         [Fact]
         public void Reference_SimpleTests()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/nostdlib", "/r:a", "/REFERENCE:b,,,,c", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/nostdlib", "/r:a", "/REFERENCE:b,,,,c", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "a", "b", "c" },
                            parsedArgs.MetadataReferences.
                                       Where((res) => !res.Properties.EmbedInteropTypes).
                                       Select((res) => res.Reference));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/Reference: ,,, b ,,", "/nostdlib", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/Reference: ,,, b ,,", "/nostdlib", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { " b " },
                            parsedArgs.MetadataReferences.
                                       Where((res) => !res.Properties.EmbedInteropTypes).
                                       Select((res) => res.Reference));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/Reference:a=b,,,", "/nostdlib", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/Reference:a=b,,,", "/nostdlib", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("a", parsedArgs.MetadataReferences.Single().Properties.Aliases.Single());
             Assert.Equal("b", parsedArgs.MetadataReferences.Single().Reference);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/r:a=b,,,c", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/r:a=b,,,c", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_OneAliasPerReference).WithArguments("b,,,c"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/r:1=b", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/r:1=b", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadExternIdentifier).WithArguments("1"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/r:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/r:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/r:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/R", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/R", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/R"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/reference+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/reference+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/reference+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/reference-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/reference-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/reference-:"));
         }
 
         [Fact]
         public void Target_SimpleTests()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:exe", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/target:exe", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.ConsoleApplication, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/t:module", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/t:module", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.NetModule, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:library", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:library", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.DynamicallyLinkedLibrary, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/TARGET:winexe", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/TARGET:winexe", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.WindowsApplication, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:appcontainerexe", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:appcontainerexe", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.WindowsRuntimeApplication, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:winmdobj", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:winmdobj", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.WindowsRuntimeMetadata, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:winexe", "/T:exe", "/target:module", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:winexe", "/T:exe", "/target:module", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OutputKind.NetModule, parsedArgs.CompilationOptions.OutputKind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/t", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/t", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/t"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_InvalidTarget));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/target:xyz", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/target:xyz", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_InvalidTarget));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/T+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/T+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/T+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/TARGET-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/TARGET-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/TARGET-:"));
         }
 
         [Fact]
         public void ModuleManifest()
         {
-            CSharpCommandLineArguments args = CSharpCommandLineParser.Default.Parse(new[] { "/win32manifest:blah", "/target:module", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments args = DefaultParse(new[] { "/win32manifest:blah", "/target:module", "a.cs" }, _baseDirectory);
             args.Errors.Verify(
                 // warning CS1927: Ignoring /win32manifest for module because it only applies to assemblies
                 Diagnostic(ErrorCode.WRN_CantHaveManifestForModule));
@@ -951,32 +958,32 @@ d.cs
         [Fact]
         public void ArgumentParsing()
         {
-            var parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "a + b" }, _baseDirectory);
+            var parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "a + b" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "a + b; c" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "a + b; c" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/help" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/help" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(true, parsedArgs.DisplayHelp);
             Assert.Equal(false, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/?" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/?" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(true, parsedArgs.DisplayHelp);
             Assert.Equal(false, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx  /langversion:6" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx  /langversion:6" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx", "/langversion:-1" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx", "/langversion:-1" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/langversion:-1'
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/langversion:-1"));
@@ -984,12 +991,12 @@ d.cs
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(1, parsedArgs.SourceFiles.Length);
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx  /r:s=d /r:d.dll" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx  /r:s=d /r:d.dll" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "@roslyn_test_non_existing_file" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "@roslyn_test_non_existing_file" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2011: Error opening response file 'D:\R0\Main\Binaries\Debug\dd'
                 Diagnostic(ErrorCode.ERR_OpenResponseFile).WithArguments(Path.Combine(_baseDirectory, @"roslyn_test_non_existing_file")));
@@ -997,27 +1004,27 @@ d.cs
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(false, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c /define:DEBUG" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c /define:DEBUG" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "\\" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "\\" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx", "/r:d.dll", "/define:DEGUG" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "c.csx", "/r:d.dll", "/define:DEGUG" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "\"/r d.dll\"" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "\"/r d.dll\"" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/r: d.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/r: d.dll", "a.cs" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.DisplayHelp);
             Assert.Equal(true, parsedArgs.SourceFiles.Any());
@@ -1028,101 +1035,101 @@ d.cs
         {
             const LanguageVersion DefaultVersion = LanguageVersion.CSharp6;
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:1", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/langversion:1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp1, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:2", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:2", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp2, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:3", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:3", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp3, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:4", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:4", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp4, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:5", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:5", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp5, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:6", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:6", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp6, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:default", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:default", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:iso-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:iso-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp1, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:iso-2", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:iso-2", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp2, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:default", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:default", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
             // default value
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
             // override value with iso-1
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:6", "/langversion:iso-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:6", "/langversion:iso-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp1, parsedArgs.ParseOptions.LanguageVersion);
 
             // override value with iso-2
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:6", "/langversion:iso-2", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:6", "/langversion:iso-2", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp2, parsedArgs.ParseOptions.LanguageVersion);
 
             // override value with default
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:6", "/langversion:default", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:6", "/langversion:default", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
             // override value with numeric
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:iso-2", "/langversion:6", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:iso-2", "/langversion:6", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(LanguageVersion.CSharp6, parsedArgs.ParseOptions.LanguageVersion);
 
             //  errors
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:iso-3", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:iso-3", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("iso-3"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:iso1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:iso1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("iso1"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:0", "/langversion:7", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:0", "/langversion:7", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("0"),
                 Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("7"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion:0", "/langversion:1000", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion:0", "/langversion:1000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("0"),
                 Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("1000"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/langversion:"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/LANGversion:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/LANGversion:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/langversion:"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/langversion: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/langversion: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/langversion:"));
             Assert.Equal(DefaultVersion, parsedArgs.ParseOptions.LanguageVersion);
         }
@@ -1131,23 +1138,23 @@ d.cs
         [WorkItem(546961, "DevDiv")]
         public void Define()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             Assert.Equal(0, parsedArgs.ParseOptions.PreprocessorSymbolNames.Count());
             Assert.Equal(false, parsedArgs.Errors.Any());
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/d:FOO", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/d:FOO", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.ParseOptions.PreprocessorSymbolNames.Count());
             Assert.Contains("FOO", parsedArgs.ParseOptions.PreprocessorSymbolNames);
             Assert.Equal(false, parsedArgs.Errors.Any());
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/d:FOO;BAR,ZIP", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/d:FOO;BAR,ZIP", "a.cs" }, _baseDirectory);
             Assert.Equal(3, parsedArgs.ParseOptions.PreprocessorSymbolNames.Count());
             Assert.Contains("FOO", parsedArgs.ParseOptions.PreprocessorSymbolNames);
             Assert.Contains("BAR", parsedArgs.ParseOptions.PreprocessorSymbolNames);
             Assert.Contains("ZIP", parsedArgs.ParseOptions.PreprocessorSymbolNames);
             Assert.Equal(false, parsedArgs.Errors.Any());
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/d:FOO;4X", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/d:FOO;4X", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.ParseOptions.PreprocessorSymbolNames.Count());
             Assert.Contains("FOO", parsedArgs.ParseOptions.PreprocessorSymbolNames);
             Assert.Equal(1, parsedArgs.Errors.Length);
@@ -1184,167 +1191,167 @@ d.cs
             Assert.Equal(new[] { "def1", "def2" }, parsed);
 
             // Bug 17360
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/d:public1;public2;", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/d:public1;public2;", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
         }
 
         [Fact]
         public void Debug()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug+", "/debug-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug+", "/debug-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:full", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:full", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:FULL", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:FULL", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:pdbonly", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:pdbonly", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:PDBONLY", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:PDBONLY", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:full", "/debug:pdbonly", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:full", "/debug:pdbonly", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:pdbonly", "/debug:full", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:pdbonly", "/debug:full", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:pdbonly", "/debug-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:pdbonly", "/debug-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:pdbonly", "/debug-", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:pdbonly", "/debug-", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:pdbonly", "/debug-", "/debug+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:pdbonly", "/debug-", "/debug+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "debug"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadDebugType).WithArguments("+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug:invalid", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug:invalid", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadDebugType).WithArguments("invalid"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/debug-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/debug-:"));
         }
 
         [Fact]
         public void Pdb()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:something", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/pdb:something", "a.cs" }, _baseDirectory);
 
             // No pdb
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Null(parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/pdb"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/pdb:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:something", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:something", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
             // temp: path changed
-            //parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/debug", "/pdb:.x", "a.cs" }, baseDirectory);
+            //parsedArgs = DefaultParse(new[] { "/debug", "/pdb:.x", "a.cs" }, baseDirectory);
             //parsedArgs.Errors.Verify(
             //    // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
             //    Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".x"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:""""", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:""""", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(""));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:C:\\", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:C:\\", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("C:\\"));
 
             // Should preserve fully qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:C:\MyFolder\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:C:\MyFolder\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\MyFolder\MyPdb.pdb", parsedArgs.PdbPath);
 
             // Should preserve fully qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:c:\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:c:\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"c:\MyPdb.pdb", parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:\MyFolder\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:\MyFolder\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Path.Combine(Path.GetPathRoot(_baseDirectory), @"MyFolder\MyPdb.pdb"), parsedArgs.PdbPath);
 
             // Should handle quotes
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:C:\""My Folder""\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:C:\""My Folder""\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyPdb.pdb", parsedArgs.PdbPath);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(FileUtilities.ResolveRelativePath("MyPdb.pdb", _baseDirectory), parsedArgs.PdbPath);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:..\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:..\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             // Temp: Path info changed
             // Assert.Equal(FileUtilities.ResolveRelativePath("MyPdb.pdb", "..\\", baseDirectory), parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:\\b", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:\\b", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"\\b"));
             Assert.Null(parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:\\b\OkFileName.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:\\b\OkFileName.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"\\b\OkFileName.pdb"));
             Assert.Null(parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:\\server\share\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:\\server\share\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"\\server\share\MyPdb.pdb", parsedArgs.PdbPath);
 
             // invalid name:
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:a.b\0b", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:a.b\0b", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a.b\0b"));
             Assert.Null(parsedArgs.PdbPath);
 
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:a\uD800b.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:a\uD800b.pdb", "/debug", "a.cs" }, _baseDirectory);
             //parsedArgs.Errors.Verify(
             //    Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a\uD800b.pdb"));
             Assert.Null(parsedArgs.PdbPath);
 
             // Dev11 reports CS0016: Could not write to output file 'd:\Temp\q\a<>.z'
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/pdb:""a<>.pdb""", "a.vb" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:""a<>.pdb""", "a.vb" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'a<>.pdb' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a<>.pdb"));
             Assert.Null(parsedArgs.PdbPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/pdb:.x", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/pdb:.x", "/debug", "a.cs" }, _baseDirectory);
             //parsedArgs.Errors.Verify(
             //    // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
             //    Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".x"));
@@ -1355,65 +1362,65 @@ d.cs
         [Fact]
         public void Optimize()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(new CSharpCompilationOptions(OutputKind.ConsoleApplication).OptimizationLevel, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize+", "/optimize-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize+", "/optimize-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize:+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize:+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/optimize:+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/optimize:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/optimize-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/optimize-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/optimize-:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/o-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/o-", "a.cs" }, _baseDirectory);
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o", "a.cs" }, _baseDirectory);
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o+", "a.cs" }, _baseDirectory);
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o+", "/optimize-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o+", "/optimize-", "a.cs" }, _baseDirectory);
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o:+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o:+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/o:+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/o:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/o-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/o-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/o-:"));
         }
 
         [Fact]
         public void ParseReferences()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/r:foo.dll", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { "/r:foo.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(2, parsedArgs.MetadataReferences.Length);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/r:foo.dll;", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/r:foo.dll;", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(2, parsedArgs.MetadataReferences.Length);
 
@@ -1424,7 +1431,7 @@ d.cs
             Assert.Equal(MetadataReferenceProperties.Assembly, parsedArgs.MetadataReferences[1].Properties);
 
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/l:foo.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/l:foo.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(2, parsedArgs.MetadataReferences.Length);
 
@@ -1435,7 +1442,7 @@ d.cs
             Assert.Equal(MetadataReferenceProperties.Assembly.WithEmbedInteropTypes(true), parsedArgs.MetadataReferences[1].Properties);
 
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/addmodule:foo.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/addmodule:foo.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(2, parsedArgs.MetadataReferences.Length);
 
@@ -1446,7 +1453,7 @@ d.cs
             Assert.Equal(MetadataReferenceProperties.Module, parsedArgs.MetadataReferences[1].Properties);
 
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/r:a=foo.dll", "/l:b=bar.dll", "/addmodule:c=mod.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/r:a=foo.dll", "/l:b=bar.dll", "/addmodule:c=mod.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(4, parsedArgs.MetadataReferences.Length);
 
@@ -1468,32 +1475,32 @@ d.cs
         [Fact]
         public void ParseAnalyzers()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/a:foo.dll", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { @"/a:foo.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences[0].FilePath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/analyzer:foo.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/analyzer:foo.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences[0].FilePath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/analyzer:\"foo.dll\"", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/analyzer:\"foo.dll\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences[0].FilePath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/a:foo.dll;bar.dll", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/a:foo.dll;bar.dll", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(2, parsedArgs.AnalyzerReferences.Length);
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences[0].FilePath);
             Assert.Equal("bar.dll", parsedArgs.AnalyzerReferences[1].FilePath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/a:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/a:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/a:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/a", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/a", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/a"));
         }
@@ -1565,7 +1572,7 @@ class C
 </RuleSet>
 ";
             var file = CreateRuleSetFile(source);
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:" + file.Path, "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { @"/ruleset:" + file.Path, "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.SpecificDiagnosticOptions.ContainsKey("CA1012"));
             Assert.True(parsedArgs.CompilationOptions.SpecificDiagnosticOptions["CA1012"] == ReportDiagnostic.Error);
@@ -1590,31 +1597,31 @@ class C
 </RuleSet>
 ";
             var file = CreateRuleSetFile(source);
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:" + "\"" + file.Path + "\"", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { @"/ruleset:" + "\"" + file.Path + "\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
         }
 
         [Fact]
         public void RuleSetSwitchParseErrors()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { @"/ruleset", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                  Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "ruleset"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/ruleset:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "ruleset"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:blah", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/ruleset:blah", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_CantReadRulesetFile).WithArguments(Path.Combine(TempRoot.Root, "blah"), "File not found."));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:blah;blah.ruleset", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/ruleset:blah;blah.ruleset", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_CantReadRulesetFile).WithArguments(Path.Combine(TempRoot.Root, "blah;blah.ruleset"), "File not found."));
 
             var file = CreateRuleSetFile("Random text");
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/ruleset:" + file.Path, "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/ruleset:" + file.Path, "a.cs" }, _baseDirectory);
             //parsedArgs.Errors.Verify(
             //    Diagnostic(ErrorCode.ERR_CantReadRulesetFile).WithArguments(file.Path, "Data at the root level is invalid. Line 1, position 1."));
             var err = parsedArgs.Errors.Single();
@@ -1752,7 +1759,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1784,7 +1791,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1817,7 +1824,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1850,7 +1857,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1883,7 +1890,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1917,7 +1924,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1951,7 +1958,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -1986,7 +1993,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -2020,7 +2027,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -2055,7 +2062,7 @@ class C
 ";
             var ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource);
 
-            var arguments = CSharpCommandLineParser.Default.Parse(
+            var arguments = DefaultParse(
                 new[]
                 {
                     "/nologo",
@@ -2229,28 +2236,28 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             const string baseDirectory = @"C:\abc\def\baz";
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:""""", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/out:""""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '' contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(""));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2005: Missing file specification for '/out:' option
                 Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/out:"));
 
             // Dev11 reports CS2007: Unrecognized option: '/out'
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2005: Missing file specification for '/out' option
                 Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/out"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out+", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out+", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/out+"));
 
             // Should preserve fully qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:C:\MyFolder\MyBinary.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:C:\MyFolder\MyBinary.dll", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("MyBinary", parsedArgs.CompilationName);
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName);
@@ -2258,7 +2265,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(@"C:\MyFolder", parsedArgs.OutputDirectory);
 
             // Should handle quotes
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:C:\""My Folder""\MyBinary.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:C:\""My Folder""\MyBinary.dll", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"MyBinary", parsedArgs.CompilationName);
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName);
@@ -2266,7 +2273,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(@"C:\My Folder", parsedArgs.OutputDirectory);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:MyBinary.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:MyBinary.dll", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("MyBinary", parsedArgs.CompilationName);
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName);
@@ -2274,7 +2281,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:..\MyBinary.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:..\MyBinary.dll", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("MyBinary", parsedArgs.CompilationName);
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName);
@@ -2282,7 +2289,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(@"C:\abc\def", parsedArgs.OutputDirectory);
 
             // not specified: exe
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.OutputFileName);
@@ -2290,7 +2297,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // not specified: dll
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:library", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:library", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("a", parsedArgs.CompilationName);
             Assert.Equal("a.dll", parsedArgs.OutputFileName);
@@ -2298,14 +2305,14 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // not specified: module
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:module", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:module", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Null(parsedArgs.CompilationName);
             Assert.Equal("a.netmodule", parsedArgs.CompilationOptions.ModuleName);
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // not specified: appcontainerexe
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:appcontainerexe", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:appcontainerexe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.OutputFileName);
@@ -2313,7 +2320,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // not specified: winmdobj
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:winmdobj", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:winmdobj", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("a", parsedArgs.CompilationName);
             Assert.Equal("a.winmdobj", parsedArgs.OutputFileName);
@@ -2322,7 +2329,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
 
             // drive-relative path:
             char currentDrive = Directory.GetCurrentDirectory()[0];
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { currentDrive + @":a.cs", "b.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { currentDrive + @":a.cs", "b.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'D:a.cs' is contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(currentDrive + ":a.cs"));
@@ -2333,7 +2340,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory);
 
             // UNC
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:\\b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:\\b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"\\b"));
@@ -2342,7 +2349,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:\\server\share\file.exe", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:\\server\share\file.exe", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"\\server\share", parsedArgs.OutputDirectory);
@@ -2351,7 +2358,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal("file.exe", parsedArgs.CompilationOptions.ModuleName);
 
             // invalid name:
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/out:a.b\0b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/out:a.b\0b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a.b\0b"));
@@ -2361,13 +2368,13 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
             // Temporary skip following scenarios because of the error message changed (path)
-            //parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/out:a\uD800b.dll", "a.cs" }, baseDirectory);
+            //parsedArgs = DefaultParse(new[] { "/out:a\uD800b.dll", "a.cs" }, baseDirectory);
             //parsedArgs.Errors.Verify(
             //    // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
             //    Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a\uD800b.dll"));
 
             // Dev11 reports CS0016: Could not write to output file 'd:\Temp\q\a<>.z'
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:""a<>.dll""", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:""a<>.dll""", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'a<>.dll' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a<>.dll"));
@@ -2376,7 +2383,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/out:.exe", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".exe")
@@ -2386,7 +2393,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:exe", @"/out:.exe", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:exe", @"/out:.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.exe' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".exe")
@@ -2396,7 +2403,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:library", @"/out:.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:library", @"/out:.dll", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.dll' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".dll")
@@ -2406,7 +2413,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:module", @"/out:.netmodule", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:module", @"/out:.netmodule", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.netmodule' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".netmodule")
@@ -2416,21 +2423,21 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { ".cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { ".cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Null(parsedArgs.OutputFileName);
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:exe", ".cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:exe", ".cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Null(parsedArgs.OutputFileName);
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:library", ".cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:library", ".cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.dll' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".dll")
@@ -2440,7 +2447,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/t:module", ".cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/t:module", ".cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(".netmodule", parsedArgs.OutputFileName);
@@ -2453,7 +2460,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ParseOut2()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/out:.x", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/out:.x", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".x"));
@@ -2462,7 +2469,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.CompilationName);
             Assert.Null(parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/out:.x", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/out:.x", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name '.x' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(".x"));
@@ -2477,57 +2484,57 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             const string baseDirectory = @"C:\abc\def\baz";
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:""""", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/doc:""""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for '/doc:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/doc:"));
             Assert.Null(parsedArgs.DocumentationPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for '/doc:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/doc:"));
             Assert.Null(parsedArgs.DocumentationPath);
 
             // NOTE: no colon in error message '/doc'
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for '/doc' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/doc"));
             Assert.Null(parsedArgs.DocumentationPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc+", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc+", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/doc+"));
             Assert.Null(parsedArgs.DocumentationPath);
 
             // Should preserve fully qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:C:\MyFolder\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:C:\MyFolder\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\MyFolder\MyBinary.xml", parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // Should handle quotes
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyBinary.xml", parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Path.Combine(baseDirectory, "MyBinary.xml"), parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:..\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:..\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\abc\def\MyBinary.xml", parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // drive-relative path:
             char currentDrive = Directory.GetCurrentDirectory()[0];
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/doc:" + currentDrive + @":a.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/doc:" + currentDrive + @":a.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'D:a.xml' is contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(currentDrive + ":a.xml"));
@@ -2536,21 +2543,21 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode); //Even though the format was incorrect
 
             // UNC
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:\\b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:\\b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"\\b"));
 
             Assert.Null(parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode); //Even though the format was incorrect
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:\\server\share\file.xml", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:\\server\share\file.xml", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"\\server\share\file.xml", parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // invalid name:
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/doc:a.b\0b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/doc:a.b\0b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a.b\0b"));
 
@@ -2558,14 +2565,14 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode); //Even though the format was incorrect
 
             // Temp
-            // parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/doc:a\uD800b.xml", "a.cs" }, baseDirectory);
+            // parsedArgs = DefaultParse(new[] { "/doc:a\uD800b.xml", "a.cs" }, baseDirectory);
             // parsedArgs.Errors.Verify(
             //    Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a\uD800b.xml"));
 
             // Assert.Null(parsedArgs.DocumentationPath);
             // Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode); //Even though the format was incorrect
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:""a<>.xml""", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:""a<>.xml""", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'a<>.xml' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a<>.xml"));
@@ -2579,47 +2586,47 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             const string baseDirectory = @"C:\abc\def\baz";
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:""""", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/errorlog:""""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<file>' for '/errorlog:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<file>", "/errorlog:"));
             Assert.Null(parsedArgs.ErrorLogPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<file>' for '/errorlog:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<file>", "/errorlog:"));
             Assert.Null(parsedArgs.ErrorLogPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<file>' for '/errorlog' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<file>", "/errorlog"));
             Assert.Null(parsedArgs.ErrorLogPath);
 
             // Should preserve fully qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:C:\MyFolder\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:C:\MyFolder\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\MyFolder\MyBinary.xml", parsedArgs.ErrorLogPath);
 
             // Should handle quotes
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyBinary.xml", parsedArgs.ErrorLogPath);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Path.Combine(baseDirectory, "MyBinary.xml"), parsedArgs.ErrorLogPath);
 
             // Should expand partially qualified paths
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:..\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:..\MyBinary.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\abc\def\MyBinary.xml", parsedArgs.ErrorLogPath);
 
             // drive-relative path:
             char currentDrive = Directory.GetCurrentDirectory()[0];
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/errorlog:" + currentDrive + @":a.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/errorlog:" + currentDrive + @":a.xml", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'D:a.xml' is contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(currentDrive + ":a.xml"));
@@ -2627,25 +2634,25 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Null(parsedArgs.ErrorLogPath);
 
             // UNC
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:\\b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:\\b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"\\b"));
 
             Assert.Null(parsedArgs.ErrorLogPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:\\server\share\file.xml", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:\\server\share\file.xml", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"\\server\share\file.xml", parsedArgs.ErrorLogPath);
 
             // invalid name:
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/errorlog:a.b\0b", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/errorlog:a.b\0b", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a.b\0b"));
 
             Assert.Null(parsedArgs.ErrorLogPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:""a<>.xml""", "a.vb" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:""a<>.xml""", "a.vb" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2021: File name 'a<>.xml' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long
                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments("a<>.xml"));
@@ -2658,25 +2665,25 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             const string baseDirectory = @"C:\abc\def\baz";
 
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/appconfig:""""", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/appconfig:""""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<text>' for '/appconfig:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<text>", "/appconfig:"));
             Assert.Null(parsedArgs.AppConfigPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/appconfig:", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/appconfig:", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<text>' for '/appconfig:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<text>", "/appconfig:"));
             Assert.Null(parsedArgs.AppConfigPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/appconfig", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/appconfig", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing ':<text>' for '/appconfig' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments(":<text>", "/appconfig"));
             Assert.Null(parsedArgs.AppConfigPath);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/appconfig:a.exe.config", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/appconfig:a.exe.config", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\abc\def\baz\a.exe.config", parsedArgs.AppConfigPath);
 
@@ -2739,7 +2746,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             const string baseDirectory = @"C:\abc\def\baz";
 
             // Can specify separate directories for binary and XML output.
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:a\b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/doc:a\b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"C:\abc\def\baz\a\b.xml", parsedArgs.DocumentationPath);
@@ -2748,7 +2755,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal("d.exe", parsedArgs.OutputFileName);
 
             // XML does not fall back on output directory.
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/doc:b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"C:\abc\def\baz\b.xml", parsedArgs.DocumentationPath);
@@ -2763,7 +2770,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             const string baseDirectory = @"C:\abc\def\baz";
 
             // Can specify separate directories for binary and error log output.
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:a\b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/errorlog:a\b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"C:\abc\def\baz\a\b.xml", parsedArgs.ErrorLogPath);
@@ -2772,7 +2779,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal("d.exe", parsedArgs.OutputFileName);
 
             // XML does not fall back on output directory.
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/errorlog:b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/errorlog:b.xml", @"/out:c\d.exe", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
 
             Assert.Equal(@"C:\abc\def\baz\b.xml", parsedArgs.ErrorLogPath);
@@ -2784,22 +2791,22 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ModuleAssemblyName()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:module", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/target:module", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("foo", parsedArgs.CompilationName);
             Assert.Equal("a.netmodule", parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:library", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:library", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS0734: The /moduleassemblyname option may only be specified when building a target type of 'module'
                 Diagnostic(ErrorCode.ERR_AssemblyNameOnNonModule));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:exe", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:exe", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS0734: The /moduleassemblyname option may only be specified when building a target type of 'module'
                 Diagnostic(ErrorCode.ERR_AssemblyNameOnNonModule));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:winexe", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:winexe", "/moduleassemblyname:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS0734: The /moduleassemblyname option may only be specified when building a target type of 'module'
                 Diagnostic(ErrorCode.ERR_AssemblyNameOnNonModule));
@@ -2808,23 +2815,23 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ModuleName()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:module", "/modulename:foo", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/target:module", "/modulename:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("foo", parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:library", "/modulename:bar", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:library", "/modulename:bar", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("bar", parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:exe", "/modulename:CommonLanguageRuntimeLibrary", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:exe", "/modulename:CommonLanguageRuntimeLibrary", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("CommonLanguageRuntimeLibrary", parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:winexe", "/modulename:foo", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:winexe", "/modulename:foo", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("foo", parsedArgs.CompilationOptions.ModuleName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/target:exe", "/modulename:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/target:exe", "/modulename:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for 'modulename' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "modulename").WithLocation(1, 1)
@@ -2878,42 +2885,42 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ParsePlatform()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x64", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/platform:x64", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.Equal(Platform.X64, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:X86", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:X86", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.Equal(Platform.X86, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:itanum", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:itanum", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadPlatformType, parsedArgs.Errors.First().Code);
             Assert.Equal(Platform.AnyCpu, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform:itanium", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform:itanium", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Platform.Itanium, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform:anycpu", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform:anycpu", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Platform.AnyCpu, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform:anycpu32bitpreferred", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform:anycpu32bitpreferred", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Platform.AnyCpu32BitPreferred, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform:arm", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform:arm", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(Platform.Arm, parsedArgs.CompilationOptions.Platform);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<string>' for 'platform' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<string>", "/platform"));
             Assert.Equal(Platform.AnyCpu, parsedArgs.CompilationOptions.Platform);  //anycpu is default
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/platform:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/platform:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<string>' for 'platform' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<string>", "/platform:"));
@@ -2927,99 +2934,99 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ParseBaseAddress()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/baseaddress:x64", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/baseaddress:x64", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadBaseNumber, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x64", @"/baseaddress:0x8000000000011111", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:x64", @"/baseaddress:0x8000000000011111", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.Equal(0x8000000000011111ul, parsedArgs.EmitOptions.BaseAddress);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x86", @"/baseaddress:0x8000000000011111", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:x86", @"/baseaddress:0x8000000000011111", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadBaseNumber, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/baseaddress:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/baseaddress:", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_SwitchNeedsNumber, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/baseaddress:-23", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/baseaddress:-23", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadBaseNumber, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x64", @"/baseaddress:01777777777777777777777", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:x64", @"/baseaddress:01777777777777777777777", "a.cs" }, _baseDirectory);
             Assert.Equal(ulong.MaxValue, parsedArgs.EmitOptions.BaseAddress);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x64", @"/baseaddress:0x0000000100000000", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:x64", @"/baseaddress:0x0000000100000000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/platform:x64", @"/baseaddress:0xffff8000", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/platform:x64", @"/baseaddress:0xffff8000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "test.cs", "/platform:x86", "/baseaddress:0xffffffff" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "test.cs", "/platform:x86", "/baseaddress:0xffffffff" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0xFFFFFFFF"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "test.cs", "/platform:x86", "/baseaddress:0xffff8000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "test.cs", "/platform:x86", "/baseaddress:0xffff8000" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0xFFFF8000"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "test.cs", "/baseaddress:0xffff8000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "test.cs", "/baseaddress:0xffff8000" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0xFFFF8000"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "C:\\test.cs", "/platform:x86", "/baseaddress:0xffff7fff" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "C:\\test.cs", "/platform:x86", "/baseaddress:0xffff7fff" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0xffff8000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0xffff8000" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0x100000000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0x100000000" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "test.cs", "/baseaddress:0xFFFF0000FFFF0000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "test.cs", "/baseaddress:0xFFFF0000FFFF0000" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0xFFFF0000FFFF0000"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0x10000000000000000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "C:\\test.cs", "/platform:x64", "/baseaddress:0x10000000000000000" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0x10000000000000000"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "C:\\test.cs", "/baseaddress:0xFFFF0000FFFF0000" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "C:\\test.cs", "/baseaddress:0xFFFF0000FFFF0000" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadBaseNumber).WithArguments("0xFFFF0000FFFF0000"));
         }
 
         [Fact]
         public void ParseFileAlignment()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:x64", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/filealign:x64", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2024: Invalid file section alignment number 'x64'
                 Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("x64"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:0x200", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:0x200", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(0x200, parsedArgs.EmitOptions.FileAlignment);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:512", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:512", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(512, parsedArgs.EmitOptions.FileAlignment);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for 'filealign' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("filealign"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:-23", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:-23", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2024: Invalid file section alignment number '-23'
                 Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("-23"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:020000", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:020000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(8192, parsedArgs.EmitOptions.FileAlignment);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2024: Invalid file section alignment number '0'
                 Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/filealign:123", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/filealign:123", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2024: Invalid file section alignment number '123'
                 Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("123"));
@@ -3028,28 +3035,28 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void SdkPathAndLibEnvVariable()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib:c:lib2", @"/lib:o:\sdk1", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/lib:c:lib2", @"/lib:o:\sdk1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // warning CS1668: Invalid search path 'c:lib2' specified in '/LIB option' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"c:lib2", "/LIB option", "path is too long or invalid"),
                 // warning CS1668: Invalid search path 'o:\sdk1' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"o:\sdk1", "/LIB option", "directory does not exist"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib:c:\Windows,o:\Windows;e:;", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib:c:\Windows,o:\Windows;e:;", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // warning CS1668: Invalid search path 'o:\Windows' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"o:\Windows", "/LIB option", "directory does not exist"),
                 // warning CS1668: Invalid search path 'e:' specified in '/LIB option' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"e:", "/LIB option", "path is too long or invalid"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib:c:\Windows,.\Windows;e;", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib:c:\Windows,.\Windows;e;", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // warning CS1668: Invalid search path '.\Windows' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@".\Windows", "/LIB option", "directory does not exist"),
                 // warning CS1668: Invalid search path 'e' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"e", "/LIB option", "directory does not exist"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib:c:\Windows,o:\Windows;e:; ; ; ; ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib:c:\Windows,o:\Windows;e:; ; ; ; ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // warning CS1668: Invalid search path 'o:\Windows' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(@"o:\Windows", "/LIB option", "directory does not exist"),
@@ -3062,16 +3069,16 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
                 // warning CS1668: Invalid search path ' ' specified in '/LIB option' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments(" ", "/LIB option", "path is too long or invalid"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<path list>", "lib"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<path list>", "lib"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/lib+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/lib: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/lib: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<path list>", "lib"));
         }
 
@@ -3121,25 +3128,25 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void ParseHighEntropyVA()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highentropyva", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/highentropyva", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.True(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highentropyva+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/highentropyva+", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.True(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highentropyva-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/highentropyva-", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highentropyva:-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/highentropyva:-", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal(EmitOptions.Default.HighEntropyVirtualAddressSpace, parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highentropyva:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/highentropyva:", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal(EmitOptions.Default.HighEntropyVirtualAddressSpace, parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
 
             //last one wins
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/highenTROPyva+", @"/HIGHentropyva-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/highenTROPyva+", @"/HIGHentropyva-", "a.cs" }, _baseDirectory);
             Assert.False(parsedArgs.Errors.Any());
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace);
         }
@@ -3147,23 +3154,23 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void Checked()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/checked+", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { @"/checked+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.CheckOverflow);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/checked-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/checked-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.False(parsedArgs.CompilationOptions.CheckOverflow);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/checked", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/checked", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.CheckOverflow);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/checked-", @"/checked", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/checked-", @"/checked", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.CheckOverflow);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/checked:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/checked:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/checked:"));
         }
 
@@ -3172,19 +3179,19 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             CSharpCommandLineArguments parsedArgs;
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo.Bar" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo.Bar" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "Foo.Bar" }, parsedArgs.CompilationOptions.Usings.AsEnumerable());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo.Bar;Baz", "/using:System.Core;System" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo.Bar;Baz", "/using:System.Core;System" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "Foo.Bar", "Baz", "System.Core", "System" }, parsedArgs.CompilationOptions.Usings.AsEnumerable());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo;;Bar" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:Foo;;Bar" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
             AssertEx.Equal(new[] { "Foo", "Bar" }, parsedArgs.CompilationOptions.Usings.AsEnumerable());
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new string[] { "/u:" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<namespace>' for '/u:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<namespace>", "/u:"));
@@ -3193,12 +3200,12 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void WarningsErrors()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { "/nowarn", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for 'nowarn' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("nowarn"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for 'nowarn' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("nowarn"));
@@ -3206,67 +3213,67 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             // Previous versions of the compiler used to report a warning (CS1691)
             // whenever an unrecognized warning code was supplied via /nowarn or /warnaserror.
             // We no longer generate a warning in such cases.
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:abc", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:abc", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for 'warnaserror' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("warnaserror"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:70000", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:70000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:abc", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:abc", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror+:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror+:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for '/warnaserror+:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("warnaserror+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for '/warnaserror-:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("warnaserror-"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/w", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/w", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for '/w' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("w"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/w:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/w:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for '/w:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("w"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warn:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warn:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2035: Command-line syntax error: Missing ':<number>' for '/warn:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsNumber).WithArguments("warn"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/w:-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/w:-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS1900: Warning level must be in the range 0-4
                 Diagnostic(ErrorCode.ERR_BadWarningLevel).WithArguments("w"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/w:5", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/w:5", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS1900: Warning level must be in the range 0-4
                 Diagnostic(ErrorCode.ERR_BadWarningLevel).WithArguments("w"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warn:-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warn:-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS1900: Warning level must be in the range 0-4
                 Diagnostic(ErrorCode.ERR_BadWarningLevel).WithArguments("warn"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warn:5", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warn:5", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS1900: Warning level must be in the range 0-4
                 Diagnostic(ErrorCode.ERR_BadWarningLevel).WithArguments("warn"));
@@ -3274,13 +3281,13 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             // Previous versions of the compiler used to report a warning (CS1691)
             // whenever an unrecognized warning code was supplied via /nowarn or /warnaserror.
             // We no longer generate a warning in such cases.
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:1,2,3", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:1,2,3", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:1,2,3", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:1,2,3", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:1;2;;3", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:1;2;;3", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
         }
 
@@ -3298,49 +3305,49 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void WarningsParse()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror", "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new string[] { "/warnaserror", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Error, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             Assert.Equal(0, parsedArgs.CompilationOptions.SpecificDiagnosticOptions.Count);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:1062,1066,1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:1062,1066,1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:+1062,+1066,+1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:+1062,+1066,+1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Error, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new int[0], new ReportDiagnostic[0], parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror+:1062,1066,1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror+:1062,1066,1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new int[0], new ReportDiagnostic[0], parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror-:1062,1066,1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror-:1062,1066,1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Default, ReportDiagnostic.Default, ReportDiagnostic.Default }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror+:1062,1066,1734", "/warnaserror-:1762,1974", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror+:1062,1066,1734", "/warnaserror-:1762,1974", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
@@ -3349,56 +3356,56 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
                 new[] { ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Default, ReportDiagnostic.Default },
                 parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror+:1062,1066,1734", "/warnaserror-:1062,1974", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror+:1062,1066,1734", "/warnaserror-:1062,1974", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             Assert.Equal(4, parsedArgs.CompilationOptions.SpecificDiagnosticOptions.Count);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734, 1974 }, new[] { ReportDiagnostic.Default, ReportDiagnostic.Error, ReportDiagnostic.Error, ReportDiagnostic.Default }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror-:1062,1066,1734", "/warnaserror+:1062,1974", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror-:1062,1066,1734", "/warnaserror+:1062,1974", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734, 1974 }, new[] { ReportDiagnostic.Error, ReportDiagnostic.Default, ReportDiagnostic.Default, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/w:1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/w:1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(1, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new int[0], new ReportDiagnostic[0], parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warn:1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warn:1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(1, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new int[0], new ReportDiagnostic[0], parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warn:1", "/warnaserror+:1062,1974", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warn:1", "/warnaserror+:1062,1974", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(1, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1974 }, new[] { ReportDiagnostic.Error, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:1062,1066,1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:1062,1066,1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Suppress, ReportDiagnostic.Suppress, ReportDiagnostic.Suppress }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { @"/nowarn:""1062 1066 1734""", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { @"/nowarn:""1062 1066 1734""", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734 }, new[] { ReportDiagnostic.Suppress, ReportDiagnostic.Suppress, ReportDiagnostic.Suppress }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/nowarn:1062,1066,1734", "/warnaserror:1066,1762", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/nowarn:1062,1066,1734", "/warnaserror:1066,1762", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
             AssertSpecificDiagnostics(new[] { 1062, 1066, 1734, 1762 }, new[] { ReportDiagnostic.Suppress, ReportDiagnostic.Suppress, ReportDiagnostic.Suppress, ReportDiagnostic.Error }, parsedArgs);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new string[] { "/warnaserror:1066,1762", "/nowarn:1062,1066,1734", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new string[] { "/warnaserror:1066,1762", "/nowarn:1062,1066,1734", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(4, parsedArgs.CompilationOptions.WarningLevel);
@@ -3408,33 +3415,33 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void AllowUnsafe()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/unsafe", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.AllowUnsafe);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/unsafe+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.AllowUnsafe);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/UNSAFE-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/UNSAFE-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.False(parsedArgs.CompilationOptions.AllowUnsafe);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe-", "/unsafe+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/unsafe-", "/unsafe+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True(parsedArgs.CompilationOptions.AllowUnsafe);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory); // default
+            parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory); // default
             parsedArgs.Errors.Verify();
             Assert.False(parsedArgs.CompilationOptions.AllowUnsafe);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/unsafe:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/unsafe:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe:+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/unsafe:+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/unsafe:+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/unsafe-:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/unsafe-:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/unsafe-:"));
         }
 
@@ -3443,22 +3450,22 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         {
             CSharpCommandLineArguments parsedArgs;
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/delaysign", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/delaysign", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign);
             Assert.True((bool)parsedArgs.CompilationOptions.DelaySign);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/delaysign+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/delaysign+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign);
             Assert.True((bool)parsedArgs.CompilationOptions.DelaySign);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/DELAYsign-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/DELAYsign-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign);
             Assert.False((bool)parsedArgs.CompilationOptions.DelaySign);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/delaysign:-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/delaysign:-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/delaysign:-'
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/delaysign:-"));
@@ -3470,68 +3477,68 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void SubsystemVersionTests()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4.0", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/subsystemversion:4.0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(SubsystemVersion.Create(4, 0), parsedArgs.EmitOptions.SubsystemVersion);
 
             // wrongly supported subsystem version. CompilationOptions data will be faithful to the user input.
             // It is normalized at the time of emit.
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:0.0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:0.0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(); // no error in Dev11
             Assert.Equal(SubsystemVersion.Create(0, 0), parsedArgs.EmitOptions.SubsystemVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(); // no error in Dev11
             Assert.Equal(SubsystemVersion.Create(0, 0), parsedArgs.EmitOptions.SubsystemVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:3.99", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:3.99", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(); // no error in Dev11
             Assert.Equal(SubsystemVersion.Create(3, 99), parsedArgs.EmitOptions.SubsystemVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4.0", "/SUBsystemversion:5.333", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4.0", "/SUBsystemversion:5.333", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(SubsystemVersion.Create(5, 333), parsedArgs.EmitOptions.SubsystemVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "subsystemversion"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "subsystemversion"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/subsystemversion-"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "subsystemversion"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion: 4.1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion: 4.1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments(" 4.1"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4 .0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4 .0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("4 .0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4. 0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4. 0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("4. 0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:.", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:.", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("."));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4.", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4.", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("4."));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:.0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:.0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments(".0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4.2 ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4.2 ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:4.65536", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:4.65536", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("4.65536"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:65536.0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:65536.0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("65536.0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/subsystemversion:-4.0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/subsystemversion:-4.0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("-4.0"));
 
             // TODO: incompatibilities: versions lower than '6.2' and 'arm', 'winmdobj', 'appcontainer'
@@ -3540,119 +3547,119 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
         [Fact]
         public void MainType()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/m:A.B.C", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/m:A.B.C", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("A.B.C", parsedArgs.CompilationOptions.MainTypeName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/m: ", "a.cs" }, _baseDirectory); // Mimicking Dev11
+            parsedArgs = DefaultParse(new[] { "/m: ", "a.cs" }, _baseDirectory); // Mimicking Dev11
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "m"));
             Assert.Null(parsedArgs.CompilationOptions.MainTypeName);
 
             //  overriding the value
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/m:A.B.C", "/MAIN:X.Y.Z", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/m:A.B.C", "/MAIN:X.Y.Z", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("X.Y.Z", parsedArgs.CompilationOptions.MainTypeName);
 
             //  error
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/maiN:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/maiN:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "main"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/MAIN+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/MAIN+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/MAIN+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/M", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/M", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "m"));
 
             //  incompatible values /main && /target
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/main:a", "/t:library", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/main:a", "/t:library", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoMainOnDLL));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/main:a", "/t:module", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/main:a", "/t:module", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoMainOnDLL));
         }
 
         [Fact]
         public void Codepage()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/CodePage:1200", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/CodePage:1200", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("Unicode", parsedArgs.Encoding.EncodingName);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/CodePage:1200", "/codePAGE:65001", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/CodePage:1200", "/codePAGE:65001", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("Unicode (UTF-8)", parsedArgs.Encoding.EncodingName);
 
             //  error
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage:0", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage:0", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadCodepage).WithArguments("0"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage:abc", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage:abc", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadCodepage).WithArguments("abc"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage:-5", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage:-5", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadCodepage).WithArguments("-5"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadCodepage).WithArguments(""));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadCodepage).WithArguments(""));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "codepage"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/codepage+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/codepage+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/codepage+"));
         }
 
         [Fact]
         public void ChecksumAlgorithm()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:sHa1", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:sHa1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(SourceHashAlgorithm.Sha1, parsedArgs.ChecksumAlgorithm);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:sha256", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:sha256", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(SourceHashAlgorithm.Sha256, parsedArgs.ChecksumAlgorithm);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(SourceHashAlgorithm.Sha1, parsedArgs.ChecksumAlgorithm);
 
             //  error
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:256", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:256", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadChecksumAlgorithm).WithArguments("256"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:sha-1", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:sha-1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadChecksumAlgorithm).WithArguments("sha-1"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:sha", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:sha", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.FTL_BadChecksumAlgorithm).WithArguments("sha"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "checksumalgorithm"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "checksumalgorithm"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "checksumalgorithm"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/checksumAlgorithm+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/checksumAlgorithm+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/checksumAlgorithm+"));
         }
 
         [Fact]
         public void AddModule()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/noconfig", "/nostdlib", "/addmodule:abc.netmodule", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/noconfig", "/nostdlib", "/addmodule:abc.netmodule", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(1, parsedArgs.MetadataReferences.Length);
             Assert.Equal("abc.netmodule", parsedArgs.MetadataReferences[0].Reference);
             Assert.Equal(MetadataImageKind.Module, parsedArgs.MetadataReferences[0].Properties.Kind);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/noconfig", "/nostdlib", "/aDDmodule:c:\\abc;c:\\abc;d:\\xyz", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/noconfig", "/nostdlib", "/aDDmodule:c:\\abc;c:\\abc;d:\\xyz", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(3, parsedArgs.MetadataReferences.Length);
             Assert.Equal("c:\\abc", parsedArgs.MetadataReferences[0].Reference);
@@ -3663,13 +3670,13 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(MetadataImageKind.Module, parsedArgs.MetadataReferences[2].Properties.Kind);
 
             //  error
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/ADDMODULE", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/ADDMODULE", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/addmodule:"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/ADDMODULE+", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/ADDMODULE+", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/ADDMODULE+"));
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/ADDMODULE:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/ADDMODULE:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("/ADDMODULE:"));
         }
 
@@ -3699,7 +3706,7 @@ class Test { static void Main() {} }").Path;
 
             var modfile = source1.Substring(0, source1.Length - 2) + "netmodule";
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/nologo", "/addmodule:" + modfile, source }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "/nologo", "/addmodule:" + modfile, source }, _baseDirectory);
             parsedArgs.Errors.Verify();
             exitCode = new MockCSharpCompiler(null, baseDir, new[] { "/nologo", "/addmodule:" + modfile, source }).Run(outWriter);
             Assert.Empty(outWriter.ToString());
@@ -3711,7 +3718,7 @@ class Test { static void Main() {} }").Path;
 
             modfile = source2.Substring(0, source2.Length - 2) + "netmodule";
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/nologo", "/addmodule:" + modfile, source }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/nologo", "/addmodule:" + modfile, source }, _baseDirectory);
             parsedArgs.Errors.Verify();
             exitCode = new MockCSharpCompiler(null, baseDir, new[] { "/nologo", "/preferreduilang:en", "/addmodule:" + modfile, source }).Run(outWriter);
             Assert.Equal(1, exitCode);
@@ -3768,15 +3775,15 @@ class Test { static void Main() {} }").Path;
         [Fact]
         public void Utf8Output()
         {
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/utf8output", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/utf8output", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True((bool)parsedArgs.Utf8Output);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/utf8output", "/utf8output", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/utf8output", "/utf8output", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.True((bool)parsedArgs.Utf8Output);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/utf8output:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/utf8output:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/utf8output:"));
         }
 
@@ -3862,67 +3869,67 @@ class Test { static void Main() {} }").Path;
         public void KeyContainerAndKeyFile()
         {
             // KEYCONTAINER
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keycontainer:RIPAdamYauch", "a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/keycontainer:RIPAdamYauch", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("RIPAdamYauch", parsedArgs.CompilationOptions.CryptoKeyContainer);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keycontainer", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keycontainer", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for 'keycontainer' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "keycontainer"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keycontainer-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keycontainer-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/keycontainer-'
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/keycontainer-"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keycontainer:", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keycontainer:", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<text>' for 'keycontainer' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "keycontainer"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keycontainer: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keycontainer: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "keycontainer"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer);
 
             // KEYFILE
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { @"/keyfile:\somepath\s""ome Fil""e.foo.bar", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/keyfile:\somepath\s""ome Fil""e.foo.bar", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             //EDMAURER let's not set the option in the event that there was an error.
             //Assert.Equal(@"\somepath\some File.foo.bar", parsedArgs.CompilationOptions.CryptoKeyFile);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keyFile", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keyFile", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2005: Missing file specification for 'keyfile' option
                 Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("keyfile"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keyFile: ", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keyFile: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments("keyfile"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keyfile-", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keyfile-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/keyfile-'
                 Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("/keyfile-"));
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile);
 
             // DEFAULTS
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile);
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer);
 
             // KEYFILE | KEYCONTAINER conflicts
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keyFile:a", "/keyContainer:b", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keyFile:a", "/keyContainer:b", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("a", parsedArgs.CompilationOptions.CryptoKeyFile);
             Assert.Equal("b", parsedArgs.CompilationOptions.CryptoKeyContainer);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/keyContainer:b", "/keyFile:a", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/keyContainer:b", "/keyFile:a", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal("a", parsedArgs.CompilationOptions.CryptoKeyFile);
             Assert.Equal("b", parsedArgs.CompilationOptions.CryptoKeyContainer);
@@ -3957,13 +3964,13 @@ public class CS1698_a {}
             var snkFile = Temp.CreateFile().WriteAllBytes(TestResources.SymbolsTests.General.snKey);
             var kfile = "/keyfile:" + snkFile.Path;
 
-            CSharpCommandLineArguments parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/t:library", kfile, "CS1698a.cs" }, _baseDirectory);
+            CSharpCommandLineArguments parsedArgs = DefaultParse(new[] { "/t:library", kfile, "CS1698a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/t:library", kfile, "/r:" + cs1698a.Path, "CS1698b.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/t:library", kfile, "/r:" + cs1698a.Path, "CS1698b.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "/t:library", kfile, "/r:" + cs1698b.Path, "/out:" + cs1698a.Path, "CS1698.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "/t:library", kfile, "/r:" + cs1698b.Path, "/out:" + cs1698a.Path, "CS1698.cs" }, _baseDirectory);
 
             // Roslyn no longer generates a warning for this...since this was only a warning, we're not really
             // saving anyone...does not provide high value to implement...
@@ -3989,7 +3996,7 @@ public class CS1698_a {}
 
             CSharpCommandLineArguments parsedArgs;
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/rp:a;b", "/referencePath:c" }, baseDir.Path);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/rp:a;b", "/referencePath:c" }, baseDir.Path, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify();
 
             AssertEx.Equal(new[]
@@ -4002,7 +4009,7 @@ public class CS1698_a {}
                 parsedArgs.ReferencePaths,
                 StringComparer.Ordinal);
 
-            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/referencePath:" }, _baseDirectory);
+            parsedArgs = CSharpCommandLineParser.Interactive.Parse(new[] { "/referencePath:" }, _baseDirectory, s_defaultSdkDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2006: Command-line syntax error: Missing '<path list>' for 'referencepath' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<path list>", "referencepath"));
@@ -4283,7 +4290,7 @@ class myClass
                 @"d:\\""abc def""\baz.cs ab""c d""e.cs",
             };
 
-            CSharpCommandLineArguments args = CSharpCommandLineParser.Default.Parse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             AssertEx.Equal(new[] { @"d:\abc def\baz.cs", @"c:\abc de.cs" }, args.SourceFiles.Select(file => file.Path));
         }
 
@@ -5809,25 +5816,25 @@ class C {}
         [Fact]
         public void ParseFullpaths()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "a.cs" }, _baseDirectory);
             Assert.Equal(false, parsedArgs.PrintFullPaths);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/fullpaths" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/fullpaths" }, _baseDirectory);
             Assert.Equal(true, parsedArgs.PrintFullPaths);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/fullpaths:" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/fullpaths:" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadSwitch, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/fullpaths: " }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/fullpaths: " }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadSwitch, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/fullpaths+" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/fullpaths+" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadSwitch, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/fullpaths+:" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/fullpaths+:" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_BadSwitch, parsedArgs.Errors.First().Code);
         }
@@ -6458,7 +6465,7 @@ public class C { }
             var allCommandLineArgs = new[] { "/nologo", "/preferreduilang:en", "/t:library" }.Concat(commandLineArgs).ToArray();
 
             // Verify command line parser diagnostics.
-            CSharpCommandLineParser.Default.Parse(allCommandLineArgs, baseDirectory).Errors.Verify(parseDiagnostics);
+            DefaultParse(allCommandLineArgs, baseDirectory).Errors.Verify(parseDiagnostics);
 
             // Verify compile.
             int exitCode = new MockCSharpCompiler(null, baseDirectory, allCommandLineArgs).Run(outWriter);
@@ -6605,23 +6612,23 @@ using System.Diagnostics; // Unused.
         [Fact]
         public void RuntimeMetadataVersion()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/runtimemetadataversion" }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "a.cs", "/runtimemetadataversion" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_SwitchNeedsString, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/runtimemetadataversion:" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/runtimemetadataversion:" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_SwitchNeedsString, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/runtimemetadataversion:  " }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/runtimemetadataversion:  " }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_SwitchNeedsString, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/runtimemetadataversion:v4.0.30319" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/runtimemetadataversion:v4.0.30319" }, _baseDirectory);
             Assert.Equal(0, parsedArgs.Errors.Length);
             Assert.Equal("v4.0.30319", parsedArgs.EmitOptions.RuntimeMetadataVersion);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/runtimemetadataversion:-_+@%#*^" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/runtimemetadataversion:-_+@%#*^" }, _baseDirectory);
             Assert.Equal(0, parsedArgs.Errors.Length);
             Assert.Equal("-_+@%#*^", parsedArgs.EmitOptions.RuntimeMetadataVersion);
 
@@ -6643,26 +6650,26 @@ using System.Diagnostics; // Unused.
             var nonExistentPath = "DoesNotExist";
 
             // lib switch
-            CSharpCommandLineParser.Default.Parse(new[] { "/lib:" + invalidPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
+            DefaultParse(new[] { "/lib:" + invalidPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
                 // warning CS1668: Invalid search path '::' specified in '/LIB option' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("::", "/LIB option", "path is too long or invalid"));
-            CSharpCommandLineParser.Default.Parse(new[] { "/lib:" + nonExistentPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
+            DefaultParse(new[] { "/lib:" + nonExistentPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
                 // warning CS1668: Invalid search path 'DoesNotExist' specified in '/LIB option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("DoesNotExist", "/LIB option", "directory does not exist"));
 
             // referencepath switch
-            CSharpCommandLineParser.Interactive.Parse(new[] { "/referencepath:" + invalidPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
+            CSharpCommandLineParser.Interactive.Parse(new[] { "/referencepath:" + invalidPath, sourceFile.Path }, _baseDirectory, s_defaultSdkDirectory).Errors.Verify(
                 // warning CS1668: Invalid search path '::' specified in '/REFERENCEPATH option' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("::", "/REFERENCEPATH option", "path is too long or invalid"));
-            CSharpCommandLineParser.Interactive.Parse(new[] { "/referencepath:" + nonExistentPath, sourceFile.Path }, _baseDirectory).Errors.Verify(
+            CSharpCommandLineParser.Interactive.Parse(new[] { "/referencepath:" + nonExistentPath, sourceFile.Path }, _baseDirectory, s_defaultSdkDirectory).Errors.Verify(
                 // warning CS1668: Invalid search path 'DoesNotExist' specified in '/REFERENCEPATH option' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("DoesNotExist", "/REFERENCEPATH option", "directory does not exist"));
 
             // LIB environment variable
-            CSharpCommandLineParser.Default.Parse(new[] { sourceFile.Path }, _baseDirectory, invalidPath).Errors.Verify(
+            DefaultParse(new[] { sourceFile.Path }, _baseDirectory, additionalReferenceDirectories: invalidPath).Errors.Verify(
                 // warning CS1668: Invalid search path '::' specified in 'LIB environment variable' -- 'path is too long or invalid'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("::", "LIB environment variable", "path is too long or invalid"));
-            CSharpCommandLineParser.Default.Parse(new[] { sourceFile.Path }, _baseDirectory, nonExistentPath).Errors.Verify(
+            DefaultParse(new[] { sourceFile.Path }, _baseDirectory, additionalReferenceDirectories: nonExistentPath).Errors.Verify(
                 // warning CS1668: Invalid search path 'DoesNotExist' specified in 'LIB environment variable' -- 'directory does not exist'
                 Diagnostic(ErrorCode.WRN_InvalidSearchPathDir).WithArguments("DoesNotExist", "LIB environment variable", "directory does not exist"));
 
@@ -6672,27 +6679,27 @@ using System.Diagnostics; // Unused.
         [Fact, WorkItem(650083, "DevDiv")]
         public void ReservedDeviceNameAsFileName()
         {
-            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "com9.cs", "/t:library " }, _baseDirectory);
+            var parsedArgs = DefaultParse(new[] { "com9.cs", "/t:library " }, _baseDirectory);
             Assert.Equal(0, parsedArgs.Errors.Length);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/t:library ", "/appconfig:.\\aux.config" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/t:library ", "/appconfig:.\\aux.config" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.FTL_InputFileNameTooLong, parsedArgs.Errors.First().Code);
 
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/out:com1.dll " }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/out:com1.dll " }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.FTL_InputFileNameTooLong, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/doc:..\\lpt2.xml:  " }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/doc:..\\lpt2.xml:  " }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.FTL_InputFileNameTooLong, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "/debug+", "/pdb:.\\prn.pdb" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "/debug+", "/pdb:.\\prn.pdb" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.FTL_InputFileNameTooLong, parsedArgs.Errors.First().Code);
 
-            parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { "a.cs", "@con.rsp" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { "a.cs", "@con.rsp" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Length);
             Assert.Equal((int)ErrorCode.ERR_OpenResponseFile, parsedArgs.Errors.First().Code);
         }
@@ -6726,31 +6733,31 @@ using System.Diagnostics; // Unused.
         [Fact]
         public void ParseFeatures()
         {
-            var args = CSharpCommandLineParser.Default.Parse(new[] { "/features:Test", "a.vb" }, _baseDirectory);
+            var args = DefaultParse(new[] { "/features:Test", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.Features.Single());
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/features:Test", "a.vb", "/Features:Experiment" }, _baseDirectory);
+            args = DefaultParse(new[] { "/features:Test", "a.vb", "/Features:Experiment" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.CompilationOptions.Features.Length);
             Assert.Equal("Test", args.CompilationOptions.Features[0]);
             Assert.Equal("Experiment", args.CompilationOptions.Features[1]);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/features:Test:false,Key:value", "a.vb" }, _baseDirectory);
+            args = DefaultParse(new[] { "/features:Test:false,Key:value", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal("Test:false,Key:value", args.CompilationOptions.Features.Single());
 
             // We don't do any rigorous validation of /features arguments...
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/features", "a.vb" }, _baseDirectory);
+            args = DefaultParse(new[] { "/features", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Empty(args.CompilationOptions.Features);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/features:,", "a.vb" }, _baseDirectory);
+            args = DefaultParse(new[] { "/features:,", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(",", args.CompilationOptions.Features.Single());
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/features:Test,", "a.vb" }, _baseDirectory);
+            args = DefaultParse(new[] { "/features:Test,", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal("Test,", args.CompilationOptions.Features.Single());
         }
@@ -6758,23 +6765,23 @@ using System.Diagnostics; // Unused.
         [Fact]
         public void ParseAdditionalFile()
         {
-            var args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config", "a.cs" }, _baseDirectory);
+            var args = DefaultParse(new[] { "/additionalfile:web.config", "a.cs" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles.Single().Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config", "a.cs", "/additionalfile:app.manifest" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:web.config", "a.cs", "/additionalfile:app.manifest" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles[0].Path);
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles[1].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config", "a.cs", "/additionalfile:web.config" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:web.config", "a.cs", "/additionalfile:web.config" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles[0].Path);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles[1].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:..\\web.config", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:..\\web.config", "a.cs" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(Path.Combine(_baseDirectory, "..\\web.config"), args.AdditionalFiles.Single().Path);
 
@@ -6783,35 +6790,35 @@ using System.Diagnostics; // Unused.
             baseDir.CreateFile("web2.config");
             baseDir.CreateFile("web3.config");
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web*.config", "a.cs" }, baseDir.Path);
+            args = DefaultParse(new[] { "/additionalfile:web*.config", "a.cs" }, baseDir.Path);
             args.Errors.Verify();
             Assert.Equal(3, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(baseDir.Path, "web1.config"), args.AdditionalFiles[0].Path);
             Assert.Equal(Path.Combine(baseDir.Path, "web2.config"), args.AdditionalFiles[1].Path);
             Assert.Equal(Path.Combine(baseDir.Path, "web3.config"), args.AdditionalFiles[2].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config;app.manifest", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:web.config;app.manifest", "a.cs" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles[0].Path);
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles[1].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config,app.manifest", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:web.config,app.manifest", "a.cs" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles[0].Path);
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles[1].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:web.config:app.manifest", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:web.config:app.manifest", "a.cs" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(1, args.AdditionalFiles.Length);
             Assert.Equal(Path.Combine(_baseDirectory, "web.config:app.manifest"), args.AdditionalFiles[0].Path);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile", "a.cs" }, _baseDirectory);
             args.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<file list>", "additionalfile"));
             Assert.Equal(0, args.AdditionalFiles.Length);
 
-            args = CSharpCommandLineParser.Default.Parse(new[] { "/additionalfile:", "a.cs" }, _baseDirectory);
+            args = DefaultParse(new[] { "/additionalfile:", "a.cs" }, _baseDirectory);
             args.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<file list>", "additionalfile"));
             Assert.Equal(0, args.AdditionalFiles.Length);
         }
@@ -7495,7 +7502,7 @@ class C
         [Fact]
         public void WarnAsError_LastOneWins1()
         {
-            var arguments = CSharpCommandLineParser.Default.Parse(new[] { "/warnaserror-:3001", "/warnaserror" }, null);
+            var arguments = DefaultParse(new[] { "/warnaserror-:3001", "/warnaserror" }, null);
             var options = arguments.CompilationOptions;
 
             var comp = CreateCompilationWithMscorlib(@"[assembly: System.CLSCompliant(true)]
@@ -7520,7 +7527,7 @@ public class C
         [Fact]
         public void WarnAsError_LastOneWins2()
         {
-            var arguments = CSharpCommandLineParser.Default.Parse(new[] { "/warnaserror", "/warnaserror-:3001" }, null);
+            var arguments = DefaultParse(new[] { "/warnaserror", "/warnaserror-:3001" }, null);
             var options = arguments.CompilationOptions;
 
             var comp = CreateCompilationWithMscorlib(@"[assembly: System.CLSCompliant(true)]

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CompilerServer;
 using ProprietaryTestResources = Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -215,6 +216,7 @@ public class C { }").Path;
                 var cmd = new CSharpCompilerServer(null,
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
                     _baseDirectory,
+                    RuntimeEnvironment.GetRuntimeDirectory(),
                     s_libDirectory);
 
                 List<string> expectedReads;

--- a/src/Compilers/CSharp/csc/Csc.cs
+++ b/src/Compilers/CSharp/csc/Csc.cs
@@ -11,17 +11,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 {
     internal sealed class Csc : CSharpCompiler
     {
-        internal Csc(string responseFile, string baseDirectory, string[] args)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, Environment.GetEnvironmentVariable("LIB"))
+        internal Csc(string responseFile, string baseDirectory, string sdkDirectory, string[] args)
+            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
         {
         }
 
-        internal static int Run(string clientDir, string[] args)
+        internal static int Run(string clientDir, string sdkDirectory, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
             var responseFile = Path.Combine(clientDir, CSharpCompiler.ResponseFileName);
-            Csc compiler = new Csc(responseFile, Directory.GetCurrentDirectory(), args);
+            Csc compiler = new Csc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
             // We store original encoding and restore it later to revert 
             // the changes that might be done by /utf8output options

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
@@ -13,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
                 args,
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Environment.CurrentDirectory,
+                sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
                 language: RequestLanguage.CSharpCompile,
                 fallbackCompiler: Csc.Run);
     }

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
@@ -60,6 +60,14 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract CommandLineArguments CommonParse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories);
 
+        /// <summary>
+        /// Parses a command line.
+        /// </summary>
+        /// <param name="args">A collection of strings representing the command line arguments.</param>
+        /// <param name="baseDirectory">The base directory used for qualifying file locations.</param>
+        /// <param name="sdkDirectory">The directory to search for mscorlib.</param>
+        /// <param name="additionalReferenceDirectories">A string representing additional reference paths.</param>
+        /// <returns>a commandlinearguments object representing the parsed command line.</returns>
         public CommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
         {
             return CommonParse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineParser.cs
@@ -58,11 +58,11 @@ namespace Microsoft.CodeAnalysis
             return Directory.EnumerateFiles(directory, fileNamePattern, searchOption);
         }
 
-        internal abstract CommandLineArguments CommonParse(IEnumerable<string> args, string baseDirectory, string additionalReferencePaths);
+        internal abstract CommandLineArguments CommonParse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories);
 
-        public CommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string additionalReferencePaths)
+        public CommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
         {
-            return CommonParse(args, baseDirectory, additionalReferencePaths);
+            return CommonParse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
         internal static bool TryParseOption(string arg, out string name, out string value)

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
         protected abstract void CompilerSpecificSqm(IVsSqmMulti sqm, uint sqmSession);
         protected abstract ImmutableArray<DiagnosticAnalyzer> ResolveAnalyzersFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger touchedFiles);
 
-        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, string baseDirectory, string additionalReferencePaths)
+        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
         {
             IEnumerable<string> allArgs = args;
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
                 allArgs = new[] { "@" + responseFile }.Concat(allArgs);
             }
 
-            this.Arguments = parser.Parse(allArgs, baseDirectory, additionalReferencePaths);
+            this.Arguments = parser.Parse(allArgs, baseDirectory, sdkDirectory, additionalReferenceDirectories);
             this.MessageProvider = parser.MessageProvider;
         }
 

--- a/src/Compilers/Core/Desktop/PublicAPI.txt
+++ b/src/Compilers/Core/Desktop/PublicAPI.txt
@@ -40,7 +40,7 @@ Microsoft.CodeAnalysis.CommandLineArguments.Win32Manifest.get -> string
 Microsoft.CodeAnalysis.CommandLineArguments.Win32ResourceFile.get -> string
 Microsoft.CodeAnalysis.CommandLineParser
 Microsoft.CodeAnalysis.CommandLineParser.IsInteractive.get -> bool
-Microsoft.CodeAnalysis.CommandLineParser.Parse(System.Collections.Generic.IEnumerable<string> args, string baseDirectory, string additionalReferencePaths) -> Microsoft.CodeAnalysis.CommandLineArguments
+Microsoft.CodeAnalysis.CommandLineParser.Parse(System.Collections.Generic.IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories) -> Microsoft.CodeAnalysis.CommandLineArguments
 Microsoft.CodeAnalysis.CommandLineReference
 Microsoft.CodeAnalysis.CommandLineReference.Equals(Microsoft.CodeAnalysis.CommandLineReference other) -> bool
 Microsoft.CodeAnalysis.CommandLineReference.Properties.get -> Microsoft.CodeAnalysis.MetadataReferenceProperties

--- a/src/Compilers/Core/MSBuildTask/BuildClient.cs
+++ b/src/Compilers/Core/MSBuildTask/BuildClient.cs
@@ -39,8 +39,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             string[] args,
             string clientDir,
             string workingDir,
+            string sdkDir,
             RequestLanguage language,
-            Func<string, string[], int> fallbackCompiler)
+            Func<string, string, string[], int> fallbackCompiler)
         {
             args = args.Select(arg => arg.Trim()).ToArray();
 
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
-            return fallbackCompiler(clientDir, parsedArgs.ToArray());
+            return fallbackCompiler(clientDir, sdkDir, parsedArgs.ToArray());
         }
 
         private static int HandleResponse(BuildResponse response)

--- a/src/Compilers/Core/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Core/VBCSCompiler/CSharpCompilerServer.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class CSharpCompilerServer : CSharpCompiler
     {
-        internal CSharpCompilerServer(string responseFile, string[] args, string baseDirectory, string libDirectory)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, libDirectory)
+        internal CSharpCompilerServer(string responseFile, string[] args, string baseDirectory, string sdkDirectory, string libDirectory)
+            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, libDirectory)
         {
         }
 
@@ -22,13 +22,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             string responseFileDirectory,
             string[] args,
             string baseDirectory,
+            string sdkDirectory,
             string libDirectory,
             TextWriter output,
             CancellationToken cancellationToken,
             out bool utf8output)
         {
             var responseFile = Path.Combine(responseFileDirectory, CSharpCompiler.ResponseFileName);
-            var compiler = new CSharpCompilerServer(responseFile, args, baseDirectory, libDirectory);
+            var compiler = new CSharpCompilerServer(responseFile, args, baseDirectory, sdkDirectory, libDirectory);
             utf8output = compiler.Arguments.Utf8Output;
             return compiler.Run(output, cancellationToken);
         }

--- a/src/Compilers/Core/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Core/VBCSCompiler/CompilerRequestHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
@@ -158,6 +159,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 responseFileDirectory,
                 commandLineArguments,
                 currentDirectory,
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 libDirectory,
                 output,
                 cancellationToken,
@@ -220,6 +222,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 responseFileDirectory,
                 commandLineArguments,
                 currentDirectory,
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 libDirectory,
                 output,
                 cancellationToken,

--- a/src/Compilers/Core/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Core/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class VisualBasicCompilerServer : VisualBasicCompiler
     {
-        internal VisualBasicCompilerServer(string responseFile, string[] args, string baseDirectory, string libDirectory)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, libDirectory)
+        internal VisualBasicCompilerServer(string responseFile, string[] args, string baseDirectory, string sdkDirectory, string libDirectory)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, libDirectory)
         {
         }
 
@@ -24,13 +24,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             string responseFileDirectory,
             string[] args,
             string baseDirectory,
+            string sdkDirectory,
             string libDirectory,
             TextWriter output,
             CancellationToken cancellationToken,
             out bool utf8output)
         {
             var responseFile = Path.Combine(responseFileDirectory, VisualBasicCompiler.ResponseFileName);
-            var compiler = new VisualBasicCompilerServer(responseFile, args, baseDirectory, libDirectory);
+            var compiler = new VisualBasicCompilerServer(responseFile, args, baseDirectory, sdkDirectory, libDirectory);
             utf8output = compiler.Arguments.Utf8Output;
             return compiler.Run(output, cancellationToken);
         }

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         }
 
         public MockCSharpCompiler(string responseFile, string baseDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, Environment.GetEnvironmentVariable("LIB"))
+            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
         {
             _analyzers = analyzers;
         }

--- a/src/Compilers/Test/Utilities/CSharp/MockCsi.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCsi.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
     internal class MockCsi : CSharpCompiler
     {
         public MockCsi(string responseFIle, string baseDirectory, string[] args)
-            : base(CSharpCommandLineParser.Interactive, responseFIle, args, baseDirectory, null)
+            : base(CSharpCommandLineParser.Interactive, responseFIle, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null)
         {
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Reflection
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.Shell.Interop
 
@@ -8,7 +9,7 @@ Friend Class MockVbi
     Inherits VisualBasicCompiler
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, Nothing)
+        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing)
 
     End Sub
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -3,6 +3,7 @@
 Imports System.Collections.Immutable
 Imports System.IO
 Imports System.Reflection
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.Shell.Interop
 
@@ -21,7 +22,7 @@ Friend Class MockVisualBasicCompiler
     End Sub
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, Environment.GetEnvironmentVariable("LIB"))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
 
         _analyzers = analyzers
     End Sub

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -68,6 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="args">A collection of strings representing the command line arguments.</param>
         ''' <param name="baseDirectory">The base directory used for qualifying file locations.</param>
+        ''' <param name="sdkDirectory">The directory to search for mscorlib.</param>
         ''' <param name="additionalReferenceDirectories">A string representing additional reference paths.</param>
         ''' <returns>A CommandLineArguments object representing the parsed command line.</returns>
         Public Shadows Function Parse(args As IEnumerable(Of String), baseDirectory As String, sdkDirectory As String, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -95,9 +95,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim documentationPath As String = Nothing
             Dim errorLogPath As String = Nothing
             Dim parseDocumentationComments As Boolean = False ' Don't just null check documentationFileName because we want to do this even if the file name is invalid.
-            Dim outputKind As outputKind = outputKind.ConsoleApplication
+            Dim outputKind As OutputKind = OutputKind.ConsoleApplication
             Dim ssVersion As SubsystemVersion = SubsystemVersion.None
-            Dim languageVersion As languageVersion = languageVersion.VisualBasic14
+            Dim languageVersion As LanguageVersion = LanguageVersion.VisualBasic14
             Dim mainTypeName As String = Nothing
             Dim win32ManifestFile As String = Nothing
             Dim win32ResourceFile As String = Nothing
@@ -117,12 +117,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim keyFileSearchPaths = New List(Of String)()
             Dim globalImports = New List(Of GlobalImport)
             Dim rootNamespace As String = ""
-            Dim optionStrict As optionStrict = optionStrict.Off
+            Dim optionStrict As OptionStrict = OptionStrict.Off
             Dim optionInfer As Boolean = False ' MSDN says: ...The compiler default for this option is /optioninfer-.
             Dim optionExplicit As Boolean = True
             Dim optionCompareText As Boolean = False
             Dim embedVbCoreRuntime As Boolean = False
-            Dim platform As platform = platform.AnyCpu
+            Dim platform As Platform = Platform.AnyCpu
             Dim preferredUILang As CultureInfo = Nothing
             Dim fileAlignment As Integer = 0
             Dim baseAddress As ULong = 0
@@ -702,15 +702,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Else
                                 Select Case value.ToLowerInvariant()
                                     Case "9", "9.0"
-                                        languageVersion = languageVersion.VisualBasic9
+                                        languageVersion = LanguageVersion.VisualBasic9
                                     Case "10", "10.0"
-                                        languageVersion = languageVersion.VisualBasic10
+                                        languageVersion = LanguageVersion.VisualBasic10
                                     Case "11", "11.0"
-                                        languageVersion = languageVersion.VisualBasic11
+                                        languageVersion = LanguageVersion.VisualBasic11
                                     Case "12", "12.0"
-                                        languageVersion = languageVersion.VisualBasic12
+                                        languageVersion = LanguageVersion.VisualBasic12
                                     Case "14", "14.0"
-                                        languageVersion = languageVersion.VisualBasic12
+                                        languageVersion = LanguageVersion.VisualBasic12
                                     Case Else
                                         AddDiagnostic(diagnostics, ERRID.ERR_InvalidSwitchValue, "langversion", value)
                                 End Select
@@ -1150,7 +1150,7 @@ lVbRuntimePlus:
                         optimizationLevel:=If(optimize, OptimizationLevel.Release, OptimizationLevel.Debug),
                         parseOptions:=parseOptions).WithFeatures(features.AsImmutable())
 
-            Dim emitOptions = New emitOptions(
+            Dim emitOptions = New EmitOptions(
                     metadataOnly:=False,
                     debugInformationFormat:=DebugInformationFormat.Pdb,
                     pdbFilePath:=Nothing, ' to be determined later

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/CommandLineParser.vb
@@ -59,8 +59,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend NotOverridable Overrides Function CommonParse(args As IEnumerable(Of String), baseDirectory As String, additionalReferencePaths As String) As CommandLineArguments
-            Return Parse(args, baseDirectory, additionalReferencePaths)
+        Friend NotOverridable Overrides Function CommonParse(args As IEnumerable(Of String), baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String) As CommandLineArguments
+            Return Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         End Function
 
         ''' <summary>
@@ -68,9 +68,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="args">A collection of strings representing the command line arguments.</param>
         ''' <param name="baseDirectory">The base directory used for qualifying file locations.</param>
-        ''' <param name="additionalReferencePaths">A string representing additional reference paths.</param>
+        ''' <param name="additionalReferenceDirectories">A string representing additional reference paths.</param>
         ''' <returns>A CommandLineArguments object representing the parsed command line.</returns>
-        Public Shadows Function Parse(args As IEnumerable(Of String), baseDirectory As String, Optional additionalReferencePaths As String = Nothing) As VisualBasicCommandLineArguments
+        Public Shadows Function Parse(args As IEnumerable(Of String), baseDirectory As String, sdkDirectory As String, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             Const GenerateFileNameForDocComment As String = "USE-OUTPUT-NAME"
 
             Dim diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
@@ -95,9 +95,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim documentationPath As String = Nothing
             Dim errorLogPath As String = Nothing
             Dim parseDocumentationComments As Boolean = False ' Don't just null check documentationFileName because we want to do this even if the file name is invalid.
-            Dim outputKind As OutputKind = OutputKind.ConsoleApplication
+            Dim outputKind As outputKind = outputKind.ConsoleApplication
             Dim ssVersion As SubsystemVersion = SubsystemVersion.None
-            Dim languageVersion As LanguageVersion = LanguageVersion.VisualBasic14
+            Dim languageVersion As languageVersion = languageVersion.VisualBasic14
             Dim mainTypeName As String = Nothing
             Dim win32ManifestFile As String = Nothing
             Dim win32ResourceFile As String = Nothing
@@ -117,12 +117,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim keyFileSearchPaths = New List(Of String)()
             Dim globalImports = New List(Of GlobalImport)
             Dim rootNamespace As String = ""
-            Dim optionStrict As OptionStrict = OptionStrict.Off
+            Dim optionStrict As optionStrict = optionStrict.Off
             Dim optionInfer As Boolean = False ' MSDN says: ...The compiler default for this option is /optioninfer-.
             Dim optionExplicit As Boolean = True
             Dim optionCompareText As Boolean = False
             Dim embedVbCoreRuntime As Boolean = False
-            Dim platform As Platform = Platform.AnyCpu
+            Dim platform As platform = platform.AnyCpu
             Dim preferredUILang As CultureInfo = Nothing
             Dim fileAlignment As Integer = 0
             Dim baseAddress As ULong = 0
@@ -702,15 +702,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Else
                                 Select Case value.ToLowerInvariant()
                                     Case "9", "9.0"
-                                        languageVersion = LanguageVersion.VisualBasic9
+                                        languageVersion = languageVersion.VisualBasic9
                                     Case "10", "10.0"
-                                        languageVersion = LanguageVersion.VisualBasic10
+                                        languageVersion = languageVersion.VisualBasic10
                                     Case "11", "11.0"
-                                        languageVersion = LanguageVersion.VisualBasic11
+                                        languageVersion = languageVersion.VisualBasic11
                                     Case "12", "12.0"
-                                        languageVersion = LanguageVersion.VisualBasic12
+                                        languageVersion = languageVersion.VisualBasic12
                                     Case "14", "14.0"
-                                        languageVersion = LanguageVersion.VisualBasic12
+                                        languageVersion = languageVersion.VisualBasic12
                                     Case Else
                                         AddDiagnostic(diagnostics, ERRID.ERR_InvalidSwitchValue, "langversion", value)
                                 End Select
@@ -1046,7 +1046,7 @@ lVbRuntimePlus:
 
             ' Prepare SDK PATH
             If sdkPaths.Count = 0 Then
-                sdkPaths.Add(RuntimeEnvironment.GetRuntimeDirectory)
+                sdkPaths.Add(sdkDirectory)
             End If
 
             ' Locate default 'mscorlib.dll' or 'System.Runtime.dll', if any.
@@ -1081,8 +1081,8 @@ lVbRuntimePlus:
             End If
 
             ' add additional reference paths if specified
-            If Not String.IsNullOrWhiteSpace(additionalReferencePaths) Then
-                libPaths.AddRange(ParseSeparatedPaths(additionalReferencePaths))
+            If Not String.IsNullOrWhiteSpace(additionalReferenceDirectories) Then
+                libPaths.AddRange(ParseSeparatedPaths(additionalReferenceDirectories))
             End If
 
             ' Build search path
@@ -1150,7 +1150,7 @@ lVbRuntimePlus:
                         optimizationLevel:=If(optimize, OptimizationLevel.Release, OptimizationLevel.Debug),
                         parseOptions:=parseOptions).WithFeatures(features.AsImmutable())
 
-            Dim emitOptions = New EmitOptions(
+            Dim emitOptions = New emitOptions(
                     metadataOnly:=False,
                     debugInformationFormat:=DebugInformationFormat.Pdb,
                     pdbFilePath:=Nothing, ' to be determined later

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _responseFile As String
         Private ReadOnly _diagnosticFormatter As CommandLineDiagnosticFormatter
 
-        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), baseDirectory As String, additionalReferencePaths As String)
-            MyBase.New(parser, responseFile, args, baseDirectory, additionalReferencePaths)
+        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String)
+            MyBase.New(parser, responseFile, args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
             Debug.Assert(responseFile Is Nothing OrElse Path.IsPathRooted(responseFile))
             _responseFile = responseFile
             _diagnosticFormatter = New CommandLineDiagnosticFormatter(baseDirectory)

--- a/src/Compilers/VisualBasic/Desktop/PublicAPI.txt
+++ b/src/Compilers/VisualBasic/Desktop/PublicAPI.txt
@@ -1,7 +1,7 @@
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser.New(isInteractive As Boolean = False) -> Void
-Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser.Parse(args As System.Collections.Generic.IEnumerable(Of String), baseDirectory As String, additionalReferencePaths As String = Nothing) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments
+Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser.Parse(args As System.Collections.Generic.IEnumerable(Of String), baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String = Nothing) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments.CompilationOptionsCore() -> Microsoft.CodeAnalysis.CompilationOptions
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments.ParseOptionsCore() -> Microsoft.CodeAnalysis.ParseOptions
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser.RegularFileExtension() -> String

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -27,6 +27,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
 
         Private ReadOnly _baseDirectory As String = TempRoot.Root
         Private Shared ReadOnly s_basicCompilerExecutable As String = GetType(Vbc).Assembly.Location
+        Private Shared ReadOnly s_defaultSdkDirectory As String = RuntimeEnvironment.GetRuntimeDirectory()
+
+        Private Shared Function DefaultParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
+            sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
+            Return VisualBasicCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
+        End Function
+
+        Private Shared Function InteractiveParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
+            sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
+            Return InteractiveParse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
+        End Function
 
         <Fact>
         <WorkItem(946954)>
@@ -87,29 +98,29 @@ End Module
         Public Sub ParseQuotedMainTypeAndRootnamespace()
             'These options are always unquoted when parsed in VisualBasicCommandLineParser.Parse.
 
-            Dim args = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:Test", "a.vb"}, _baseDirectory)
+            Dim args = DefaultParse({"/rootnamespace:Test", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test", args.CompilationOptions.RootNamespace)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/main:Test", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/main:Test", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test", args.CompilationOptions.MainTypeName)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/main:""Test""", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/main:""Test""", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test", args.CompilationOptions.MainTypeName)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:""Test""", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/rootnamespace:""Test""", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test", args.CompilationOptions.RootNamespace)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:""test""", "/main:""test.Module1""", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/rootnamespace:""test""", "/main:""test.Module1""", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("test.Module1", args.CompilationOptions.MainTypeName)
             Assert.Equal("test", args.CompilationOptions.RootNamespace)
 
             ' Use of Cyrillic namespace
-            args = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:""решения""", "/main:""решения.Module1""", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/rootnamespace:""решения""", "/main:""решения.Module1""", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("решения.Module1", args.CompilationOptions.MainTypeName)
             Assert.Equal("решения", args.CompilationOptions.RootNamespace)
@@ -334,28 +345,28 @@ a.vb
 
         <Fact>
         Public Sub ParseGlobalImports()
-            Dim args = VisualBasicCommandLineParser.Default.Parse({"/imports: System ,System.Xml ,System.Linq", "a.vb"}, _baseDirectory)
+            Dim args = DefaultParse({"/imports: System ,System.Xml ,System.Linq", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             AssertEx.Equal({"System", "System.Xml", "System.Linq"}, args.CompilationOptions.GlobalImports.Select(Function(import) import.Clause.ToString()))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/impORt: System,,,,,", "/IMPORTs:,,,Microsoft.VisualBasic,,System.IO", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/impORt: System,,,,,", "/IMPORTs:,,,Microsoft.VisualBasic,,System.IO", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             AssertEx.Equal({"System", "Microsoft.VisualBasic", "System.IO"}, args.CompilationOptions.GlobalImports.Select(Function(import) import.Clause.ToString()))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/impORt: System, ,, ,,", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/impORt: System, ,, ,,", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ExpectedIdentifier),
                                Diagnostic(ERRID.ERR_ExpectedIdentifier))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/impORt:", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/impORt:", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("import", ":<str>"))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/impORts:", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/impORts:", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("imports", ":<import_list>"))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/imports", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/imports", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("imports", ":<import_list>"))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/imports+", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/imports+", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/imports+")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
@@ -391,7 +402,7 @@ a.vb
         <Fact, WorkItem(546028, "DevDiv")>
         Public Sub Win32ResourceArguments()
             Dim args As String() = {"/win32manifest:..\here\there\everywhere\nonexistent"}
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            Dim parsedArgs = DefaultParse(args, _baseDirectory)
             Dim compilation = CreateCompilationWithMscorlib(New VisualBasicSyntaxTree() {})
             Dim errors As IEnumerable(Of DiagnosticInfo) = Nothing
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
@@ -399,32 +410,32 @@ a.vb
             Assert.Equal(DirectCast(ERRID.ERR_UnableToReadUacManifest2, Integer), errors.First().Code)
             Assert.Equal(2, errors.First().Arguments.Count())
             args = {"/Win32icon:\bogus"}
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            parsedArgs = DefaultParse(args, _baseDirectory)
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
             Assert.Equal(1, errors.Count())
             Assert.Equal(DirectCast(ERRID.ERR_UnableToOpenResourceFile1, Integer), errors.First().Code)
             Assert.Equal(2, errors.First().Arguments.Count())
             args = {"/Win32Resource:\bogus"}
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            parsedArgs = DefaultParse(args, _baseDirectory)
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
             Assert.Equal(1, errors.Count())
             Assert.Equal(DirectCast(ERRID.ERR_UnableToOpenResourceFile1, Integer), errors.First().Code)
             Assert.Equal(2, errors.First().Arguments.Count())
 
             args = {"/win32manifest:foo.win32data:bar.win32data2"}
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            parsedArgs = DefaultParse(args, _baseDirectory)
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
             Assert.Equal(1, errors.Count())
             Assert.Equal(DirectCast(ERRID.ERR_UnableToReadUacManifest2, Integer), errors.First().Code)
             Assert.Equal(2, errors.First().Arguments.Count())
             args = {"/Win32icon:foo.win32data:bar.win32data2"}
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            parsedArgs = DefaultParse(args, _baseDirectory)
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
             Assert.Equal(1, errors.Count())
             Assert.Equal(DirectCast(ERRID.ERR_UnableToOpenResourceFile1, Integer), errors.First().Code)
             Assert.Equal(2, errors.First().Arguments.Count())
             args = {"/Win32Resource:foo.win32data:bar.win32data2"}
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            parsedArgs = DefaultParse(args, _baseDirectory)
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
             Assert.Equal(1, errors.Count())
             Assert.Equal(DirectCast(ERRID.ERR_UnableToOpenResourceFile1, Integer), errors.First().Code)
@@ -434,7 +445,7 @@ a.vb
         <Fact>
         Public Sub Win32IconContainsGarbage()
             Dim tmpFileName As String = Temp.CreateFile().WriteAllBytes(New Byte() {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}).Path
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32icon:" + tmpFileName}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/win32icon:" + tmpFileName}, _baseDirectory)
             Dim compilation = CreateCompilationWithMscorlib(New VisualBasicSyntaxTree() {})
             Dim errors As IEnumerable(Of DiagnosticInfo) = Nothing
             CommonCompiler.GetWin32ResourcesInternal(MessageProvider.Instance, parsedArgs, compilation, errors)
@@ -538,37 +549,37 @@ a.vb
         <Fact>
         Public Sub Win32ResourceOptions_SimplyInvalid()
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32resource", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/win32resource", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("win32resource", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32resource+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32resource+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32resource+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32resource-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32resource-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32resource-")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32icon", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32icon", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("win32icon", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32icon+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32icon+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32icon+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32icon-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32icon-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32icon-")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32manifest", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32manifest", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("win32manifest", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32manifest+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32manifest+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32manifest+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32manifest-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/win32manifest-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/win32manifest-")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
         End Sub
 
         Private Sub CheckWin32ResourceOptions(args As String(), expectedResourceFile As String, expectedIcon As String, expectedManifest As String, expectedNoManifest As Boolean, ParamArray diags As DiagnosticDescription())
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(args.Concat({"Test.vb"}), _baseDirectory)
+            Dim parsedArgs = DefaultParse(args.Concat({"Test.vb"}), _baseDirectory)
             parsedArgs.Errors.Verify(diags)
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(expectedResourceFile, parsedArgs.Win32ResourceFile)
@@ -753,28 +764,28 @@ a.vb
             Dim parsedArgs As VisualBasicCommandLineArguments
             Dim resourceDescription As resourceDescription
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource:a", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/resource:a", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.DisplayHelp)
             resourceDescription = parsedArgs.ManifestResources.Single()
             Assert.Null(resourceDescription.FileName) ' since embedded
             Assert.Equal("a", resourceDescription.ResourceName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/res:b", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/res:b", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.DisplayHelp)
             resourceDescription = parsedArgs.ManifestResources.Single()
             Assert.Null(resourceDescription.FileName) ' since embedded
             Assert.Equal("b", resourceDescription.ResourceName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkresource:c", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkresource:c", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.DisplayHelp)
             resourceDescription = parsedArgs.ManifestResources.Single()
             Assert.Equal("c", resourceDescription.FileName)
             Assert.Equal("c", resourceDescription.ResourceName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkres:d", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkres:d", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.DisplayHelp)
             resourceDescription = parsedArgs.ManifestResources.Single()
@@ -784,40 +795,40 @@ a.vb
 
         <Fact>
         Public Sub ManagedResourceOptions_SimpleErrors()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource:", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/resource:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("resource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/resource: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("resource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/resource", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("resource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/RES+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/RES+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/RES+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/res-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/res-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/res-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkresource:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkresource:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("linkresource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkresource: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkresource: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("linkresource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkresource", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkresource", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("linkresource", ":<resinfo>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkRES+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkRES+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/linkRES+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/linkres-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/linkres-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/linkres-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
         <Fact>
         Public Sub ModuleManifest()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/win32manifest:blah", "/target:module", "a.cs"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/win32manifest:blah", "/target:module", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_IgnoreModuleManifest))
 
@@ -827,57 +838,57 @@ a.vb
 
         <Fact>
         Public Sub ArgumentParsing()
-            Dim parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"a + b"}, _baseDirectory)
+            Dim parsedArgs = InteractiveParse({"a + b"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"a + b; c"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"a + b; c"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/help"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/help"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(True, parsedArgs.DisplayHelp)
             Assert.Equal(False, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/?"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/?"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(True, parsedArgs.DisplayHelp)
             Assert.Equal(False, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"c.vbx  /langversion:10"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"c.vbx  /langversion:10"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"c.vbx", "/langversion:-1"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"c.vbx", "/langversion:-1"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(1, parsedArgs.SourceFiles.Length)
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"c.vbx  /r:d /r:d.dll"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"c.vbx  /r:d /r:d.dll"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"@dd"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"@dd"}, _baseDirectory)
             Assert.Equal(True, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(False, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"c /define:DEBUG"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"c /define:DEBUG"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"\\"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"\\"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"c.vbx", "/r:d.dll", "/define:DEGUG"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"c.vbx", "/r:d.dll", "/define:DEGUG"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"""/r d.dll"""}, _baseDirectory)
+            parsedArgs = InteractiveParse({"""/r d.dll"""}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(True, parsedArgs.SourceFiles.Any())
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/r: d.dll"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/r: d.dll"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             Assert.Equal(False, parsedArgs.DisplayHelp)
             Assert.Equal(False, parsedArgs.SourceFiles.Any())
@@ -885,91 +896,91 @@ a.vb
 
         <Fact>
         Public Sub LangVersion()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langversion:9", "a.VB"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/langversion:9", "a.VB"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic9, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:9.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:9.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic9, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:10", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:10", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic10, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:10.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:10.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic10, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:11", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:11", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic11, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:11.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:11.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic11, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:12", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:12", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic12, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:12.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:12.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic12, parsedArgs.ParseOptions.LanguageVersion)
 
             ' default: "current version"
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
 
             ' overriding
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:10", "/langVERSION:9.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:10", "/langVERSION:9.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic9, parsedArgs.ParseOptions.LanguageVersion)
 
             ' errors
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("langversion", ":<number>"))
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/langVERSION+")) ' TODO: Dev11 reports ERR_ArgumentRequired
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("langversion", ":<number>"))
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:8", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:8", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("langversion", "8"))
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/langVERSION:" & (LanguageVersion.VisualBasic12 + 1), "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/langVERSION:" & (LanguageVersion.VisualBasic12 + 1), "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("langversion", CStr(LanguageVersion.VisualBasic12 + 1)))
             Assert.Equal(LanguageVersion.VisualBasic14, parsedArgs.ParseOptions.LanguageVersion)
         End Sub
 
         <Fact>
         Public Sub DelaySign()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/delaysign", "a.cs"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/delaysign", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign)
             Assert.Equal(True, parsedArgs.CompilationOptions.DelaySign)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/delaysign+", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/delaysign+", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign)
             Assert.Equal(True, parsedArgs.CompilationOptions.DelaySign)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/DELAYsign-", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/DELAYsign-", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.NotNull(parsedArgs.CompilationOptions.DelaySign)
             Assert.Equal(False, parsedArgs.CompilationOptions.DelaySign)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/delaysign:-", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/delaysign:-", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("delaysign"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             parsedArgs.Errors.Verify()
             Assert.Null(parsedArgs.CompilationOptions.DelaySign)
         End Sub
@@ -977,39 +988,39 @@ a.vb
         <WorkItem(546113, "DevDiv")>
         <Fact>
         Public Sub OutputVerbose()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/verbose", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Verbose, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Verbose, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/VERBOSE:-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/VERBOSE:-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/VERBOSE:-"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("verbose"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose+:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("verbose"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbOSE:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbOSE:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/verbOSE:"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet", "/verbose", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet", "/verbose", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Verbose, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet", "/verbose-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet", "/verbose-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
         End Sub
@@ -1017,197 +1028,197 @@ a.vb
         <WorkItem(546113, "DevDiv")>
         <Fact>
         Public Sub OutputQuiet()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/quiet", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Quiet, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Quiet, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/QUIET:-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/QUIET:-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/QUIET:-"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("quiet"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiet+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiet+:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("quiet"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/quiET:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/quiET:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/quiET:"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose", "/quiet", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose", "/quiet", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Quiet, parsedArgs.OutputLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/verbose", "/quiet-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/verbose", "/quiet-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputLevel.Normal, parsedArgs.OutputLevel)
         End Sub
 
         <Fact>
         Public Sub Optimize()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optimize", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/optimize", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel) ' default
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OPTIMIZE+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/OPTIMIZE+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optimize-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optimize-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OptimizationLevel.Debug, parsedArgs.CompilationOptions.OptimizationLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optimize-", "/optimize+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optimize-", "/optimize+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OptimizationLevel.Release, parsedArgs.CompilationOptions.OptimizationLevel)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OPTIMIZE:", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/OPTIMIZE:", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optimize"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OPTIMIZE+:", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/OPTIMIZE+:", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optimize"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optimize-:", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optimize-:", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optimize"))
         End Sub
 
         <WorkItem(546301, "DevDiv")>
         <Fact>
         Public Sub Parallel()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/parallel", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/parallel", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/p", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/p", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild) ' default
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/PARALLEL+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/PARALLEL+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/PARALLEL-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/PARALLEL-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/PArallel-", "/PArallel+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/PArallel-", "/PArallel+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/parallel:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/parallel:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("parallel"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/parallel+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/parallel+:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("parallel"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/parallel-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/parallel-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("parallel"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/P+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/P+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/P-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/P-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/P-", "/P+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/P-", "/P+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.ConcurrentBuild)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/p:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/p:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("p"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/p+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/p+:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("p"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/p-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/p-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("p"))
         End Sub
 
         <Fact>
         Public Sub SubsystemVersionTests()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4.0", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/subsystemversion:4.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(SubsystemVersion.Create(4, 0), parsedArgs.EmitOptions.SubsystemVersion)
 
             ' wrongly supported subsystem version. CompilationOptions data will be faithful to the user input.
             ' It is normalized at the time of emit.
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:0.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:0.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify() ' no error in Dev11
             Assert.Equal(SubsystemVersion.Create(0, 0), parsedArgs.EmitOptions.SubsystemVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify() ' no error in Dev11
             Assert.Equal(SubsystemVersion.Create(0, 0), parsedArgs.EmitOptions.SubsystemVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:3.99", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:3.99", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify() ' no warning in Dev11
             Assert.Equal(SubsystemVersion.Create(3, 99), parsedArgs.EmitOptions.SubsystemVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4.0", "/subsystemversion:5.333", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4.0", "/subsystemversion:5.333", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(SubsystemVersion.Create(5, 333), parsedArgs.EmitOptions.SubsystemVersion)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("subsystemversion", ":<version>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("subsystemversion", ":<version>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/subsystemversion-")) ' TODO: Dev11 reports ERRID.ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("subsystemversion", ":<version>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion: 4.1", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion: 4.1", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments(" 4.1"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4 .0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4 .0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("4 .0"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4. 0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4. 0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("4. 0"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:.", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:.", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("."))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4.", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4.", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("4."))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments(".0"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4.2 ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4.2 ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:4.65536", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:4.65536", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("4.65536"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:65536.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:65536.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("65536.0"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/subsystemversion:-4.0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/subsystemversion:-4.0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSubsystemVersion).WithArguments("-4.0"))
 
             ' TODO: incompatibilities: versions lower than '6.2' and 'arm', 'winmdobj', 'appcontainer'
@@ -1215,34 +1226,34 @@ a.vb
 
         <Fact>
         Public Sub Codepage()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/CodePage:1200", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/CodePage:1200", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("Unicode", parsedArgs.Encoding.EncodingName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/CodePage:1200", "/CodePage:65001", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/CodePage:1200", "/CodePage:65001", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("Unicode (UTF-8)", parsedArgs.Encoding.EncodingName)
 
             ' errors 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage:0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage:0", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadCodepage).WithArguments("0"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage:abc", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage:abc", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadCodepage).WithArguments("abc"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage:-5", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage:-5", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadCodepage).WithArguments("-5"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("codepage", ":<number>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("codepage", ":<number>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/codepage+")) ' Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/codepage", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/codepage", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("codepage", ":<number>"))
         End Sub
 
@@ -1250,146 +1261,146 @@ a.vb
         Public Sub ChecksumAlgorithm()
             Dim parsedArgs As VisualBasicCommandLineArguments
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:sHa1", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:sHa1", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(SourceHashAlgorithm.Sha1, parsedArgs.ChecksumAlgorithm)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:sha256", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:sha256", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(SourceHashAlgorithm.Sha256, parsedArgs.ChecksumAlgorithm)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(SourceHashAlgorithm.Sha1, parsedArgs.ChecksumAlgorithm)
 
             ' error
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:256", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:256", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadChecksumAlgorithm).WithArguments("256"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:sha-1", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:sha-1", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadChecksumAlgorithm).WithArguments("sha-1"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:sha", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:sha", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadChecksumAlgorithm).WithArguments("sha"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm: ", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm: ", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("checksumalgorithm", ":<algorithm>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm:", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm:", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("checksumalgorithm", ":<algorithm>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("checksumalgorithm", ":<algorithm>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/checksumAlgorithm+", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/checksumAlgorithm+", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/checksumAlgorithm+"))
         End Sub
 
         <Fact>
         Public Sub MainTypeName()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/main:A.B.C", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/main:A.B.C", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("A.B.C", parsedArgs.CompilationOptions.MainTypeName)
 
             ' overriding the value
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/Main:A.B.C", "/M:X.Y.Z", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/Main:A.B.C", "/M:X.Y.Z", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("X.Y.Z", parsedArgs.CompilationOptions.MainTypeName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/MAIN: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/MAIN: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("main", ":<class>"))
             Assert.Null(parsedArgs.CompilationOptions.MainTypeName) ' EDMAURER Dev11 accepts and MainTypeName is " "
 
             ' errors 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/maiN:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/maiN:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("main", ":<class>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/m", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/m", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("m", ":<class>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/m+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/m+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/m+")) ' Dev11 reports ERR_ArgumentRequired
 
             ' incompatibilities ignored by Dev11
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/MAIN:XYZ", "/t:library", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/MAIN:XYZ", "/t:library", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("XYZ", parsedArgs.CompilationOptions.MainTypeName)
             Assert.Equal(OutputKind.DynamicallyLinkedLibrary, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/MAIN:XYZ", "/t:module", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/MAIN:XYZ", "/t:module", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.NetModule, parsedArgs.CompilationOptions.OutputKind)
         End Sub
 
         <Fact>
         Public Sub OptionCompare()
-            Dim parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optioncompare"}, _baseDirectory)
+            Dim parsedArgs = InteractiveParse({"/optioncompare"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("optioncompare", ":binary|text"))
             Assert.Equal(False, parsedArgs.CompilationOptions.OptionCompareText)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optioncompare:text", "/optioncompare"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optioncompare:text", "/optioncompare"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("optioncompare", ":binary|text"))
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionCompareText)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/opTioncompare:Text", "/optioncomparE:bINARY"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/opTioncompare:Text", "/optioncomparE:bINARY"}, _baseDirectory)
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(False, parsedArgs.CompilationOptions.OptionCompareText)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(False, parsedArgs.CompilationOptions.OptionCompareText)
         End Sub
 
         <Fact>
         Public Sub OptionExplicit()
-            Dim parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optiONexplicit"}, _baseDirectory)
+            Dim parsedArgs = InteractiveParse({"/optiONexplicit"}, _baseDirectory)
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionExplicit)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optiONexplicit:+"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optiONexplicit:+"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optionexplicit"))
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionExplicit)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optiONexplicit-:"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optiONexplicit-:"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optionexplicit"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optionexplicit+", "/optiONexplicit-:"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optionexplicit+", "/optiONexplicit-:"}, _baseDirectory)
             Assert.Equal(1, parsedArgs.Errors.Length)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optionexplicit"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optionexplicit+", "/optiONexplicit-", "/optiONexpliCIT+"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optionexplicit+", "/optiONexplicit-", "/optiONexpliCIT+"}, _baseDirectory)
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionExplicit)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionExplicit)
         End Sub
 
         <Fact>
         Public Sub OptionInfer()
-            Dim parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optiONinfer"}, _baseDirectory)
+            Dim parsedArgs = InteractiveParse({"/optiONinfer"}, _baseDirectory)
             Assert.Equal(0, parsedArgs.Errors.Length)
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionInfer)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/OptionInfer:+"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/OptionInfer:+"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optioninfer"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/OPTIONinfer-:"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/OPTIONinfer-:"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optioninfer"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optioninfer+", "/optioninFER-:"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optioninfer+", "/optioninFER-:"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("optioninfer"))
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/optioninfer+", "/optioninfeR-", "/OptionInfer+"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/optioninfer+", "/optioninfeR-", "/OptionInfer+"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.CompilationOptions.OptionInfer)
 
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/d:a=1"}, _baseDirectory) ' test default value
+            parsedArgs = InteractiveParse({"/d:a=1"}, _baseDirectory) ' test default value
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.CompilationOptions.OptionInfer)
         End Sub
@@ -1427,7 +1438,7 @@ a.vb
         End Sub
 
         Private Sub TestDefines(args As IEnumerable(Of String), ParamArray symbols As Object()())
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(args, _baseDirectory)
+            Dim parsedArgs = DefaultParse(args, _baseDirectory)
             Assert.False(parsedArgs.Errors.Any)
             Assert.Equal(symbols.Length, parsedArgs.ParseOptions.PreprocessorSymbols.Length)
             Dim sortedDefines = parsedArgs.ParseOptions.
@@ -1442,34 +1453,34 @@ a.vb
 
         <Fact>
         Public Sub OptionStrict()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionStrict", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/optionStrict", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.On, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionStrict+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optionStrict+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.On, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionStrict-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optionStrict-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.Off, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.Custom, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OptionStrict:cusTom", "/optionstrict-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/OptionStrict:cusTom", "/optionstrict-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.Off, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionstrict-", "/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optionstrict-", "/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(VisualBasic.OptionStrict.Custom, parsedArgs.CompilationOptions.OptionStrict)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionstrict:", "/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optionstrict:", "/OptionStrict:cusTom", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("optionstrict", ":custom"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/optionstrict:xxx", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/optionstrict:xxx", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("optionstrict", ":custom"))
         End Sub
 
@@ -1478,112 +1489,112 @@ a.vb
         <WorkItem(685392, "DevDiv")>
         <Fact>
         Public Sub RootNamespace()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:One.Two.Three", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/rootnamespace:One.Two.Three", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("One.Two.Three", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:One Two Three", "/rootnamespace:One.Two.Three", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:One Two Three", "/rootnamespace:One.Two.Three", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("One.Two.Three", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:""One.Two.Three""", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:""One.Two.Three""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("One.Two.Three", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("rootnamespace", ":<string>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("rootnamespace", ":<string>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/rootnamespace+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/rootnamespace-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("+"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("rootnamespace", ":<string>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace: A.B.C", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace: A.B.C", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments(" A.B.C"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[abcdef", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[abcdef", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("[abcdef"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:abcdef]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:abcdef]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("abcdef]"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[[abcdef]]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[[abcdef]]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("[[abcdef]]"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[global]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[global]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("[global]", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:foo.[global].bar", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:foo.[global].bar", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("foo.[global].bar", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:foo.[bar]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:foo.[bar]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("foo.[bar]", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:foo$", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:foo$", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("foo$"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:I(", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:I(", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("I("))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:_", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:_", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("_"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[_]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[_]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("[_]"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:__.___", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:__.___", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("__.___", parsedArgs.CompilationOptions.RootNamespace)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("["))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("]"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/rootnamespace:[]", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/rootnamespace:[]", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_BadNamespaceName1).WithArguments("[]"))
         End Sub
 
         <Fact>
         Public Sub Link_SimpleTests()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/link:a", "/link:b,,,,c", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/link:a", "/link:b,,,,c", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertEx.Equal({"a", "b", "c"},
                            parsedArgs.MetadataReferences.
                                       Where(Function(res) res.Properties.EmbedInteropTypes).
                                       Select(Function(res) res.Reference))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/Link: ,,, b ,,", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/Link: ,,, b ,,", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertEx.Equal({" ", " b "},
                            parsedArgs.MetadataReferences.
                                       Where(Function(res) res.Properties.EmbedInteropTypes).
                                       Select(Function(res) res.Reference))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/l:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/l:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("l", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/L", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/L", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("l", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/l+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/l+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/l+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/link-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/link-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/link-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
@@ -1602,27 +1613,27 @@ a.vb
             file4.WriteAllText("")
             file5.WriteAllText("")
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/recurse:" & dir.ToString() & "\*.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/recurse:" & dir.ToString() & "\*.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertEx.Equal({"{DIR}\a.vb", "{DIR}\b.vb", "{DIR}\d2\e.vb"}, parsedArgs.SourceFiles.Select(Function(file) file.Path.Replace(dir.ToString(), "{DIR}")))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"*.vb"}, dir.ToString())
+            parsedArgs = DefaultParse({"*.vb"}, dir.ToString())
             parsedArgs.Errors.Verify()
             AssertEx.Equal({"{DIR}\a.vb", "{DIR}\b.vb"}, parsedArgs.SourceFiles.Select(Function(file) file.Path.Replace(dir.ToString(), "{DIR}")))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/reCURSE:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/reCURSE:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("recurse", ":<wildcard>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/RECURSE: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/RECURSE: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("recurse", ":<wildcard>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/recurse", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/recurse", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("recurse", ":<wildcard>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/recurse+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/recurse+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/recurse+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/recurse-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/recurse-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/recurse-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
             CleanupAllGeneratedFiles(file1.Path)
@@ -1674,17 +1685,17 @@ a.vb
             Dim args As VisualBasicCommandLineArguments
             Dim resolvedSourceFiles As String()
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/recurse:*.cp*", "/recurse:b\*.v*", "/out:a.dll"}, folder.Path)
+            args = DefaultParse({"/recurse:*.cp*", "/recurse:b\*.v*", "/out:a.dll"}, folder.Path)
             args.Errors.Verify()
             resolvedSourceFiles = args.SourceFiles.Select(Function(f) f.Path).ToArray()
             AssertEx.Equal({folder.Path + "\c.cpp", folder.Path + "\b\B_e.vb"}, resolvedSourceFiles)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/recurse:.\\\\\\*.vb", "/out:a.dll"}, folder.Path)
+            args = DefaultParse({"/recurse:.\\\\\\*.vb", "/out:a.dll"}, folder.Path)
             args.Errors.Verify()
             resolvedSourceFiles = args.SourceFiles.Select(Function(f) f.Path).ToArray()
             Assert.Equal(2, resolvedSourceFiles.Length)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/recurse:.////*.vb", "/out:a.dll"}, folder.Path)
+            args = DefaultParse({"/recurse:.////*.vb", "/out:a.dll"}, folder.Path)
             args.Errors.Verify()
             resolvedSourceFiles = args.SourceFiles.Select(Function(f) f.Path).ToArray()
             Assert.Equal(2, resolvedSourceFiles.Length)
@@ -1709,60 +1720,60 @@ a.vb
 
         <Fact>
         Public Sub Reference_SimpleTests()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nostdlib", "/vbruntime-", "/r:a", "/REFERENCE:b,,,,c", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/nostdlib", "/vbruntime-", "/r:a", "/REFERENCE:b,,,,c", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertEx.Equal({"a", "b", "c"},
                            parsedArgs.MetadataReferences.
                                       Where(Function(res) Not res.Properties.EmbedInteropTypes AndAlso Not res.Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal)).
                                       Select(Function(res) res.Reference))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/Reference: ,,, b ,,", "/nostdlib", "/vbruntime-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/Reference: ,,, b ,,", "/nostdlib", "/vbruntime-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertEx.Equal({" ", " b "},
                            parsedArgs.MetadataReferences.
                                       Where(Function(res) Not res.Properties.EmbedInteropTypes AndAlso Not res.Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal)).
                                       Select(Function(res) res.Reference))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/r:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/r:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("r", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/R", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/R", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("r", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/reference+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/reference+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/reference+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/reference-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/reference-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/reference-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
         <Fact>
         Public Sub ParseAnalyzers()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/a:foo.dll", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/a:foo.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences(0).FilePath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzer:foo.dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/analyzer:foo.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences(0).FilePath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/analyzer:""foo.dll""", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/analyzer:""foo.dll""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(1, parsedArgs.AnalyzerReferences.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences(0).FilePath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/a:foo.dll,bar.dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/a:foo.dll,bar.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(2, parsedArgs.AnalyzerReferences.Length)
             Assert.Equal("foo.dll", parsedArgs.AnalyzerReferences(0).FilePath)
             Assert.Equal("bar.dll", parsedArgs.AnalyzerReferences(1).FilePath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/a:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/a:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("a", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/a", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/a", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("a", ":<file_list>"))
         End Sub
 
@@ -2010,7 +2021,7 @@ a.vb
                          </RuleSet>
 
             Dim file = CreateRuleSetFile(source)
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset:" + file.Path, "a.cs"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse(New String() {"/ruleset:" + file.Path, "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.True(parsedArgs.CompilationOptions.SpecificDiagnosticOptions.ContainsKey("CA1012"))
             Assert.True(parsedArgs.CompilationOptions.SpecificDiagnosticOptions("CA1012") = ReportDiagnostic.Error)
@@ -2034,30 +2045,30 @@ a.vb
                          </RuleSet>
 
             Dim file = CreateRuleSetFile(source)
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset:" + """" + file.Path + """", "a.cs"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse(New String() {"/ruleset:" + """" + file.Path + """", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
         End Sub
 
         <Fact>
         Public Sub RulesetSwitchParseErrors()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset", "a.cs"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse(New String() {"/ruleset", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(
             Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("ruleset", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse(New String() {"/ruleset", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(
             Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("ruleset", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset:blah", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse(New String() {"/ruleset:blah", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(
             Diagnostic(ERRID.ERR_CantReadRulesetFile).WithArguments(Path.Combine(TempRoot.Root, "blah"), "File not found."))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset:blah;blah.ruleset", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse(New String() {"/ruleset:blah;blah.ruleset", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(
             Diagnostic(ERRID.ERR_CantReadRulesetFile).WithArguments(Path.Combine(TempRoot.Root, "blah;blah.ruleset"), "File not found."))
 
             Dim file = CreateRuleSetFile(New XDocument())
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse(New String() {"/ruleset:" + file.Path, "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse(New String() {"/ruleset:" + file.Path, "a.cs"}, _baseDirectory)
             'parsedArgs.Errors.Verify(
             '   Diagnostic(ERRID.ERR_CantReadRulesetFile).WithArguments(file.Path, "Root element is missing."))
             Dim err = parsedArgs.Errors.Single()
@@ -2073,137 +2084,137 @@ a.vb
 
         <Fact>
         Public Sub Target_SimpleTests()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:exe", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/target:exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.ConsoleApplication, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:module", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:module", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.NetModule, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:library", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:library", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.DynamicallyLinkedLibrary, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/TARGET:winexe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/TARGET:winexe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.WindowsApplication, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:winmdobj", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:winmdobj", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.WindowsRuntimeMetadata, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:appcontainerexe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:appcontainerexe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.WindowsRuntimeApplication, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:winexe", "/T:exe", "/target:module", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:winexe", "/T:exe", "/target:module", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(OutputKind.NetModule, parsedArgs.CompilationOptions.OutputKind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("t", ":exe|winexe|library|module|appcontainerexe|winmdobj"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("target", ":exe|winexe|library|module|appcontainerexe|winmdobj"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:xyz", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:xyz", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("target", "xyz"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/T+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/T+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/T+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/TARGET-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/TARGET-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/TARGET-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
         <Fact>
         Public Sub Utf8Output()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/utf8output", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/utf8output", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.Utf8Output)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/utf8output+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/utf8output+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(True, parsedArgs.Utf8Output)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/utf8output-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/utf8output-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.Utf8Output)
 
             ' default
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nologo", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nologo", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.Utf8Output)
 
             ' overriding
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/utf8output+", "/utf8output-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/utf8output+", "/utf8output-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(False, parsedArgs.Utf8Output)
 
             ' errors
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/utf8output:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/utf8output:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("utf8output"))
 
         End Sub
 
         <Fact>
         Public Sub Debug()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug+", "/debug-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug+", "/debug-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:full", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:full", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:FULL", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:FULL", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:pdbonly", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:pdbonly", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:PDBONLY", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:PDBONLY", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:full", "/debug:pdbonly", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:full", "/debug:pdbonly", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:pdbonly", "/debug:full", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:pdbonly", "/debug:full", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:pdbonly", "/debug-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:pdbonly", "/debug-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:pdbonly", "/debug-", "/debug", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:pdbonly", "/debug-", "/debug", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:pdbonly", "/debug-", "/debug+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:pdbonly", "/debug-", "/debug+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("debug", ":pdbonly|full"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("debug", "+"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug:invalid", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug:invalid", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("debug", "invalid"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug-:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("debug"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/pdb:something", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/pdb:something", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/pdb:something"))
         End Sub
 
@@ -2213,35 +2224,35 @@ a.vb
             Const baseDirectory As String = "C:\abc\def\baz"
 
             ' Should preserve fully qualified paths
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:C:\MyFolder\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/out:C:\MyFolder\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal("C:\MyFolder", parsedArgs.OutputDirectory)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:C:\""My Folder""\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out:C:\""My Folder""\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal("C:\My Folder", parsedArgs.OutputDirectory)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out:MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:Ignored.dll", "/out:MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out:Ignored.dll", "/out:MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:..\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out:..\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
@@ -2249,7 +2260,7 @@ a.vb
             Assert.Equal("C:\abc\def", parsedArgs.OutputDirectory)
 
             ' not specified: exe
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("a", parsedArgs.CompilationName)
             Assert.Equal("a.exe", parsedArgs.OutputFileName)
@@ -2257,7 +2268,7 @@ a.vb
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
             ' not specified: dll
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/target:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("a", parsedArgs.CompilationName)
             Assert.Equal("a.dll", parsedArgs.OutputFileName)
@@ -2265,7 +2276,7 @@ a.vb
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
             ' not specified: module
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:module", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/target:module", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Null(parsedArgs.CompilationName)
             Assert.Equal("a.netmodule", parsedArgs.OutputFileName)
@@ -2273,7 +2284,7 @@ a.vb
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
             ' not specified: appcontainerexe
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:appcontainerexe", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/target:appcontainerexe", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("a", parsedArgs.CompilationName)
             Assert.Equal("a.exe", parsedArgs.OutputFileName)
@@ -2281,7 +2292,7 @@ a.vb
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
             ' not specified: winmdobj
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:winmdobj", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/target:winmdobj", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("a", parsedArgs.CompilationName)
             Assert.Equal("a.winmdobj", parsedArgs.OutputFileName)
@@ -2290,7 +2301,7 @@ a.vb
 
             ' drive-relative path:
             Dim currentDrive As Char = Directory.GetCurrentDirectory()(0)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({currentDrive + ":a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({currentDrive + ":a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(currentDrive + ":a.vb"))
 
@@ -2300,7 +2311,7 @@ a.vb
             Assert.Equal(baseDirectory, parsedArgs.OutputDirectory)
 
             ' UNC
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:\\b", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:\\b", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("\\b"))
 
@@ -2308,7 +2319,7 @@ a.vb
             Assert.Equal("a", parsedArgs.CompilationName)
             Assert.Equal("a.exe", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:\\server\share\file.exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:\\server\share\file.exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("\\server\share", parsedArgs.OutputDirectory)
@@ -2317,7 +2328,7 @@ a.vb
             Assert.Equal("file.exe", parsedArgs.CompilationOptions.ModuleName)
 
             ' invalid name
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:a.b" & vbNullChar & "b", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:a.b" & vbNullChar & "b", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("a.b" & vbNullChar & "b"))
 
@@ -2326,7 +2337,7 @@ a.vb
             Assert.Equal("a.exe", parsedArgs.CompilationOptions.ModuleName)
 
             ' Temp Skip: Unicode?
-            ' parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:a" & ChrW(&HD800) & "b.dll", "a.vb"}, _baseDirectory)
+            ' parsedArgs = DefaultParse({"/out:a" & ChrW(&HD800) & "b.dll", "a.vb"}, _baseDirectory)
             ' parsedArgs.Errors.Verify(
             '    Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("a" & ChrW(&HD800) & "b.dll"))
 
@@ -2335,7 +2346,7 @@ a.vb
             ' Assert.Equal("a.exe", parsedArgs.CompilationOptions.ModuleName)
 
             ' Temp Skip: error message changed (path)
-            'parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:"" a.dll""", "a.vb"}, _baseDirectory)
+            'parsedArgs = DefaultParse({"/out:"" a.dll""", "a.vb"}, _baseDirectory)
             'parsedArgs.Errors.Verify(
             '    Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(" a.dll"))
 
@@ -2344,7 +2355,7 @@ a.vb
             'Assert.Equal("a.exe", parsedArgs.CompilationOptions.ModuleName)
 
             ' Dev11 reports BC2012: can't open 'a<>.z' for writing
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:""a<>.dll""", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:""a<>.dll""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("a<>.dll"))
 
@@ -2353,19 +2364,19 @@ a.vb
             Assert.Equal("a.exe", parsedArgs.CompilationOptions.ModuleName)
 
             ' bad value
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("out", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/OUT:", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/OUT:", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("out", ":<file>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out+", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out+", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/out+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out-:", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out-:", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/out-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:.exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:.exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
@@ -2373,7 +2384,7 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:exe", "/out:.exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:exe", "/out:.exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
@@ -2381,7 +2392,7 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:library", "/out:.dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:library", "/out:.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".dll"))
 
@@ -2389,14 +2400,14 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:module", "/out:.netmodule", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:module", "/out:.netmodule", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".netmodule", parsedArgs.OutputFileName)
             Assert.Null(parsedArgs.CompilationName)
             Assert.Equal(".netmodule", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({".vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({".vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
@@ -2404,7 +2415,7 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:exe", ".vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:exe", ".vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
@@ -2412,7 +2423,7 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:library", ".vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:library", ".vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".dll"))
 
@@ -2420,7 +2431,7 @@ a.vb
             Assert.Null(parsedArgs.CompilationName)
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:module", ".vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/t:module", ".vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".netmodule", parsedArgs.OutputFileName)
@@ -2431,21 +2442,21 @@ a.vb
         <Fact>
         Public Sub ParseOut2()
             ' exe
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:.x", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/out:.x", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".x", parsedArgs.CompilationName)
             Assert.Equal(".x.exe", parsedArgs.OutputFileName)
             Assert.Equal(".x.exe", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:winexe", "/out:.x.eXe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:winexe", "/out:.x.eXe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".x", parsedArgs.CompilationName)
             Assert.Equal(".x.eXe", parsedArgs.OutputFileName)
             Assert.Equal(".x.eXe", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:winexe", "/out:.exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:winexe", "/out:.exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".exe"))
 
             Assert.Null(parsedArgs.CompilationName)
@@ -2453,21 +2464,21 @@ a.vb
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
             ' dll
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:library", "/out:.x", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:library", "/out:.x", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".x", parsedArgs.CompilationName)
             Assert.Equal(".x.dll", parsedArgs.OutputFileName)
             Assert.Equal(".x.dll", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:library", "/out:.X.Dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:library", "/out:.X.Dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal(".X", parsedArgs.CompilationName)
             Assert.Equal(".X.Dll", parsedArgs.OutputFileName)
             Assert.Equal(".X.Dll", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:library", "/out:.dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:library", "/out:.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(".dll"))
 
             Assert.Null(parsedArgs.CompilationName)
@@ -2475,28 +2486,28 @@ a.vb
             Assert.Null(parsedArgs.CompilationOptions.ModuleName)
 
             ' module
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:module", "/out:.x", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:module", "/out:.x", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Null(parsedArgs.CompilationName)
             Assert.Equal(".x", parsedArgs.OutputFileName)
             Assert.Equal(".x", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:module", "/out:x.dll", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:module", "/out:x.dll", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Null(parsedArgs.CompilationName)
             Assert.Equal("x.dll", parsedArgs.OutputFileName)
             Assert.Equal("x.dll", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:module", "/out:.x.netmodule", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:module", "/out:.x.netmodule", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Null(parsedArgs.CompilationName)
             Assert.Equal(".x.netmodule", parsedArgs.OutputFileName)
             Assert.Equal(".x.netmodule", parsedArgs.CompilationOptions.ModuleName)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/target:module", "/out:x", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/target:module", "/out:x", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Null(parsedArgs.CompilationName)
@@ -2509,7 +2520,7 @@ a.vb
             Const baseDirectory As String = "C:\abc\def\baz"
 
             ' In dev11, this appears to be equivalent to /doc- (i.e. don't parse and don't output).
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:""""", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/doc:""""", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("doc", ":<file>"))
             Assert.Null(parsedArgs.DocumentationPath)
@@ -2796,20 +2807,20 @@ End Class
             ' are parsed but writing the XML file fails with (warning!) BC42311.
             Const baseDirectory As String = "C:\abc\def\baz"
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:"" """, "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/doc:"" """, "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments(" ", "The system cannot find the path specified"))
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:"" \ """, "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:"" \ """, "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments(" \ ", "The system cannot find the path specified"))
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' UNC
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:\\b", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:\\b", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("\\b", "The system cannot find the path specified"))
 
@@ -2817,21 +2828,21 @@ End Class
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode) ' Even though the format was incorrect
 
             ' invalid name:
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:a.b" + ChrW(0) + "b", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:a.b" + ChrW(0) + "b", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("a.b" + ChrW(0) + "b", "The system cannot find the path specified"))
 
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode) ' Even though the format was incorrect
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:a" + ChrW(55296) + "b.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:a" + ChrW(55296) + "b.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("a" + ChrW(55296) + "b.xml", "The system cannot find the path specified"))
 
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode) ' Even though the format was incorrect
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:""a<>.xml""", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:""a<>.xml""", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("a<>.xml", "The system cannot find the path specified"))
 
@@ -2843,65 +2854,65 @@ End Class
         Public Sub ParseDoc()
             Const baseDirectory As String = "C:\abc\def\baz"
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/doc:", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("doc", ":<file>"))
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc+", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc+", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc-", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc-", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.None, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc+:abc.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc+:abc.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("doc"))
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc-:a.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc-:a.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("doc"))
             Assert.Null(parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.None, parsedArgs.ParseOptions.DocumentationMode)
 
             ' Should preserve fully qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:C:\MyFolder\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:C:\MyFolder\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\MyFolder\MyBinary.xml", parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' Should handle quotes
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\My Folder\MyBinary.xml", parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' Should expand partially qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Path.Combine(baseDirectory, "MyBinary.xml"), parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' Should expand partially qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:..\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:..\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\abc\def\MyBinary.xml", parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' drive-relative path:
             Dim currentDrive As Char = Directory.GetCurrentDirectory()(0)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:" + currentDrive + ":a.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:" + currentDrive + ":a.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments(currentDrive + ":a.xml", "The system cannot find the path specified"))
 
@@ -2909,7 +2920,7 @@ End Class
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode) ' Even though the format was incorrect
 
             ' UNC
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:\\server\share\file.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:\\server\share\file.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("\\server\share\file.xml", parsedArgs.DocumentationPath)
@@ -2921,7 +2932,7 @@ End Class
             Const baseDirectory As String = "C:\abc\def\baz"
 
             ' Can specify separate directories for binary and XML output.
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:a\b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/doc:a\b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("C:\abc\def\baz\a\b.xml", parsedArgs.DocumentationPath)
@@ -2930,7 +2941,7 @@ End Class
             Assert.Equal("d.exe", parsedArgs.OutputFileName)
 
             ' XML does not fall back on output directory.
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("C:\abc\def\baz\b.xml", parsedArgs.DocumentationPath)
@@ -2943,32 +2954,32 @@ End Class
         Public Sub ParseDocMultiple()
             Const baseDirectory As String = "C:\abc\def\baz"
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc+", "/doc-", "/doc+", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/doc+", "/doc-", "/doc+", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc-", "/doc+", "/doc-", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc-", "/doc+", "/doc-", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.None, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Null(parsedArgs.DocumentationPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:a.xml", "/doc-", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:a.xml", "/doc-", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.None, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Null(parsedArgs.DocumentationPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:abc.xml", "/doc+", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:abc.xml", "/doc+", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc-", "/doc:a.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc-", "/doc:a.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc+", "/doc:a.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc+", "/doc:a.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
             Assert.Equal(Path.Combine(baseDirectory, "a.xml"), parsedArgs.DocumentationPath)
@@ -2978,47 +2989,47 @@ End Class
         Public Sub ParseErrorLog()
             Const baseDirectory As String = "C:\abc\def\baz"
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/errorlog:", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("errorlog", ":<file>"))
             Assert.Null(parsedArgs.ErrorLogPath)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("errorlog", ":<file>"))
             Assert.Null(parsedArgs.ErrorLogPath)
 
             ' Should preserve fully qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:C:\MyFolder\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:C:\MyFolder\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\MyFolder\MyBinary.xml", parsedArgs.ErrorLogPath)
 
             ' Should handle quotes
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\My Folder\MyBinary.xml", parsedArgs.ErrorLogPath)
 
             ' Should expand partially qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Path.Combine(baseDirectory, "MyBinary.xml"), parsedArgs.ErrorLogPath)
 
             ' Should expand partially qualified paths
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:..\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:..\MyBinary.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\abc\def\MyBinary.xml", parsedArgs.ErrorLogPath)
 
             ' drive-relative path:
             Dim currentDrive As Char = Directory.GetCurrentDirectory()(0)
             Dim filePath = currentDrive + ":a.xml"
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:" + filePath, "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:" + filePath, "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments(filePath))
 
             Assert.Null(parsedArgs.ErrorLogPath)
 
             ' UNC
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:\\server\share\file.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:\\server\share\file.xml", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("\\server\share\file.xml", parsedArgs.ErrorLogPath)
@@ -3029,7 +3040,7 @@ End Class
             Const baseDirectory As String = "C:\abc\def\baz"
 
             ' Can specify separate directories for binary and error log output.
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:a\b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
+            Dim parsedArgs = DefaultParse({"/errorlog:a\b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("C:\abc\def\baz\a\b.xml", parsedArgs.ErrorLogPath)
@@ -3038,7 +3049,7 @@ End Class
             Assert.Equal("d.exe", parsedArgs.OutputFileName)
 
             ' error log does not fall back on output directory.
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/errorlog:b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:b.xml", "/out:c\d.exe", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
 
             Assert.Equal("C:\abc\def\baz\b.xml", parsedArgs.ErrorLogPath)
@@ -3050,57 +3061,57 @@ End Class
         <Fact>
         Public Sub KeyContainerAndKeyFile()
             ' KEYCONTAINER
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/KeyContainer:key-cont-name", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/KeyContainer:key-cont-name", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("key-cont-name", parsedArgs.CompilationOptions.CryptoKeyContainer)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/KEYcontainer", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/KEYcontainer", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("keycontainer", ":<string>"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keycontainer-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keycontainer-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/keycontainer-"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keycontainer:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keycontainer:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("keycontainer", ":<string>"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keycontainer: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keycontainer: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("keycontainer", ":<string>"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyContainer)
 
             ' KEYFILE
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keyfile:\somepath\s""ome Fil""e.foo.bar", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keyfile:\somepath\s""ome Fil""e.foo.bar", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("\somepath\some File.foo.bar", parsedArgs.CompilationOptions.CryptoKeyFile)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keyFile", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keyFile", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("keyfile", ":<file>"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keyfile-", "a.cs"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keyfile-", "a.cs"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/keyfile-"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keyfile: ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keyfile: ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("keyfile", ":<file>"))
             Assert.Null(parsedArgs.CompilationOptions.CryptoKeyFile)
 
             ' default value
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Nothing, parsedArgs.CompilationOptions.CryptoKeyContainer)
             Assert.Equal(Nothing, parsedArgs.CompilationOptions.CryptoKeyFile)
 
             ' keyfile/keycontainer conflicts 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keycontainer:a", "/keyfile:b", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keycontainer:a", "/keyfile:b", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(Nothing, parsedArgs.CompilationOptions.CryptoKeyContainer)
             Assert.Equal("b", parsedArgs.CompilationOptions.CryptoKeyFile)
 
             ' keyfile/keycontainer conflicts 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/keyfile:b", "/keycontainer:a", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/keyfile:b", "/keycontainer:a", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("a", parsedArgs.CompilationOptions.CryptoKeyContainer)
             Assert.Equal(Nothing, parsedArgs.CompilationOptions.CryptoKeyFile)
@@ -3110,7 +3121,7 @@ End Class
         <Fact>
         Public Sub ReferencePaths()
             Dim parsedArgs As VisualBasicCommandLineArguments
-            parsedArgs = VisualBasicCommandLineParser.Interactive.Parse({"/rp:a;b", "/referencePath:c", "a.vb"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/rp:a;b", "/referencePath:c", "a.vb"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             AssertEx.Equal({RuntimeEnvironment.GetRuntimeDirectory(),
                             Path.Combine(_baseDirectory, "a"),
@@ -3123,148 +3134,148 @@ End Class
         <Fact, WorkItem(530088, "DevDiv")>
         Public Sub Platform()
             ' test recognizing all options
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:X86", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/platform:X86", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.X86, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:x64", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:x64", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.X64, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:itanium", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:itanium", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.Itanium, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.AnyCpu, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu32bitpreferred", "/t:exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu32bitpreferred", "/t:exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.AnyCpu32BitPreferred, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu32bitpreferred", "/t:appcontainerexe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu32bitpreferred", "/t:appcontainerexe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.AnyCpu32BitPreferred, parsedArgs.CompilationOptions.Platform)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:arm", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:arm", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.Arm, parsedArgs.CompilationOptions.Platform)
 
             ' test default (AnyCPU)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/debug-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/debug-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.AnyCpu, parsedArgs.CompilationOptions.Platform)
 
             ' test missing 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("platform", ":<string>"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("platform", ":<string>"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform+", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/platform+")) ' TODO: Dev11 reports ERR_ArgumentRequired
 
             ' test illegal input
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:abcdef", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:abcdef", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("platform", "abcdef"))
 
             ' test overriding
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu32bitpreferred", "/platform:anycpu", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu32bitpreferred", "/platform:anycpu", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(CodeAnalysis.Platform.AnyCpu, parsedArgs.CompilationOptions.Platform)
 
             ' test illegal
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu32bitpreferred", "/t:library", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu32bitpreferred", "/t:library", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_LibAnycpu32bitPreferredConflict).WithArguments("Platform", "AnyCpu32BitPreferred").WithLocation(1, 1))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:anycpu", "/platform:anycpu32bitpreferred", "/target:winmdobj", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:anycpu", "/platform:anycpu32bitpreferred", "/target:winmdobj", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_LibAnycpu32bitPreferredConflict).WithArguments("Platform", "AnyCpu32BitPreferred").WithLocation(1, 1))
         End Sub
 
         <Fact()>
         Public Sub FileAlignment()
             ' test recognizing all options
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:512", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/filealign:512", "a.vb"}, _baseDirectory)
             Assert.Equal(512, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:1024", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:1024", "a.vb"}, _baseDirectory)
             Assert.Equal(1024, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:2048", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:2048", "a.vb"}, _baseDirectory)
             Assert.Equal(2048, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:4096", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:4096", "a.vb"}, _baseDirectory)
             Assert.Equal(4096, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:8192", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:8192", "a.vb"}, _baseDirectory)
             Assert.Equal(8192, parsedArgs.EmitOptions.FileAlignment)
 
             ' test oct values
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:01000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:01000", "a.vb"}, _baseDirectory)
             Assert.Equal(512, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:02000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:02000", "a.vb"}, _baseDirectory)
             Assert.Equal(1024, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:04000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:04000", "a.vb"}, _baseDirectory)
             Assert.Equal(2048, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:010000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:010000", "a.vb"}, _baseDirectory)
             Assert.Equal(4096, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:020000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:020000", "a.vb"}, _baseDirectory)
             Assert.Equal(8192, parsedArgs.EmitOptions.FileAlignment)
 
             ' test hex values
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x200", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x200", "a.vb"}, _baseDirectory)
             Assert.Equal(512, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x400", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x400", "a.vb"}, _baseDirectory)
             Assert.Equal(1024, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x800", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x800", "a.vb"}, _baseDirectory)
             Assert.Equal(2048, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x1000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x1000", "a.vb"}, _baseDirectory)
             Assert.Equal(4096, parsedArgs.EmitOptions.FileAlignment)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x2000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x2000", "a.vb"}, _baseDirectory)
             Assert.Equal(8192, parsedArgs.EmitOptions.FileAlignment)
 
             ' test default (no value)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:x86", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:x86", "a.vb"}, _baseDirectory)
             Assert.Equal(0, parsedArgs.EmitOptions.FileAlignment)
 
             ' test missing 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("filealign", ":<number>"))
 
             ' test illegal
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("filealign", "0"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("filealign", "0x"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:0x0", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:0x0", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("filealign", "0x0"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:-1", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:-1", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("filealign", "-1"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/filealign:-0x100", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/filealign:-0x100", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("filealign", "-0x100"))
         End Sub
 
         <Fact()>
         Public Sub RemoveIntChecks()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintcheckS", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/removeintcheckS", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.False(parsedArgs.CompilationOptions.CheckOverflow)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintcheckS+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintcheckS+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.False(parsedArgs.CompilationOptions.CheckOverflow)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintcheckS-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintcheckS-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.True(parsedArgs.CompilationOptions.CheckOverflow)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintchecks+", "/removeintchecks-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintchecks+", "/removeintchecks-", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.True(parsedArgs.CompilationOptions.CheckOverflow)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintchecks:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintchecks:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("removeintchecks"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintchecks:+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintchecks:+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("removeintchecks"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/removeintchecks+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/removeintchecks+:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SwitchNeedsBool).WithArguments("removeintchecks"))
         End Sub
 
@@ -3274,57 +3285,57 @@ End Class
             ' as a valid base address later on (e.g. values >0x8000).
 
             ' test decimal values being treated as hex
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/baseaddress:0", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(0, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:1024", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:1024", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H1024, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:2048", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:2048", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H2048, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:4096", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:4096", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H4096, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:8192", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:8192", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H8192, ULong), parsedArgs.EmitOptions.BaseAddress)
 
             ' test hex values being treated as hex
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0x200", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0x200", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H200, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0x400", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0x400", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H400, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0x800", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0x800", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H800, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0x1000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0x1000", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H1000, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0xFFFFFFFFFFFFFFFF", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0xFFFFFFFFFFFFFFFF", "a.vb"}, _baseDirectory)
             Assert.Equal(ULong.MaxValue, parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:FFFFFFFFFFFFFFFF", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:FFFFFFFFFFFFFFFF", "a.vb"}, _baseDirectory)
             Assert.Equal(ULong.MaxValue, parsedArgs.EmitOptions.BaseAddress)
 
             ' test octal values being treated as hex
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:00", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:00", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(0, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:01024", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:01024", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H1024, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:02048", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:02048", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H2048, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:04096", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:04096", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H4096, ULong), parsedArgs.EmitOptions.BaseAddress)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:08192", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:08192", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(&H8192, ULong), parsedArgs.EmitOptions.BaseAddress)
 
             ' test default (no value)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/platform:x86", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/platform:x86", "a.vb"}, _baseDirectory)
             Assert.Equal(CType(0, ULong), parsedArgs.EmitOptions.BaseAddress)
 
             ' test missing 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("baseaddress", ":<number>"))
 
             ' test illegal
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/baseaddress:0x10000000000000000", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/baseaddress:0x10000000000000000", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("baseaddress", "0x10000000000000000"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/BASEADDRESS:-1", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/BASEADDRESS:-1", "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("baseaddress", "-1"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/BASEADDRESS:" + ULong.MaxValue.ToString, "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/BASEADDRESS:" + ULong.MaxValue.ToString, "a.vb"}, _baseDirectory)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("baseaddress", ULong.MaxValue.ToString))
         End Sub
 
@@ -3341,7 +3352,7 @@ End Class
 
         <Fact()>
         Public Sub AddModule()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nostdlib", "/vbruntime-", "/addMODULE:c:\;d:\x\y\z,abc;;", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/nostdlib", "/vbruntime-", "/addMODULE:c:\;d:\x\y\z,abc;;", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(3, parsedArgs.MetadataReferences.Length)
             Assert.Equal("c:\", parsedArgs.MetadataReferences(0).Reference)
@@ -3356,33 +3367,33 @@ End Class
             Assert.True(parsedArgs.DefaultCoreLibraryReference.Value.Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
             Assert.Equal(MetadataImageKind.Assembly, parsedArgs.DefaultCoreLibraryReference.Value.Properties.Kind)
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/ADDMODULE", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/ADDMODULE", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("addmodule", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/addmodule:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/addmodule:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("addmodule", ":<file_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/addmodule+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/addmodule+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/addmodule+")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
         <Fact()>
         Public Sub LibPathsAndLibEnvVariable()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:c:\;d:\x\y\z;abc;;", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:\;d:\x\y\z;abc;;", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, "c:\", "d:\x\y\z", Path.Combine(_baseDirectory, "abc"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:c:\Windows", "/libpath:abc\def; ; ; ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/libpath:c:\Windows", "/libpath:abc\def; ; ; ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, "c:\Windows", Path.Combine(_baseDirectory, "abc\def"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/libpath", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("libpath", ":<path_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/libpath:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("libpath", ":<path_list>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/libpath+", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/libpath+")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
@@ -3429,29 +3440,29 @@ End Class
 
         <Fact()>
         Public Sub SdkPathAndLibEnvVariable()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:c:lib2", "/sdkpath:<>;d:\sdk1", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:lib2", "/sdkpath:<>;d:\sdk1", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
 
             ' invalid paths are ignored
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "d:\sdk1")
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/sdkpath:c:\Windows", "/sdkpath:d:\Windows", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/sdkpath:c:\Windows", "/sdkpath:d:\Windows", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "d:\Windows")
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/sdkpath:""c:\Windows;d:\blah""", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
+            parsedArgs = DefaultParse({"/sdkpath:""c:\Windows;d:\blah""", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "c:\Windows", "d:\blah")
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:""c:\Windows;d:\blah""", "/sdkpath:c:\lib2", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
+            parsedArgs = DefaultParse({"/libpath:""c:\Windows;d:\blah""", "/sdkpath:c:\lib2", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "c:\lib2", "c:\Windows", "d:\blah")
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/sdkpath", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/sdkpath", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("sdkpath", ":<path>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/sdkpath:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/sdkpath:", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("sdkpath", ":<path>"))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/sdkpath+", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/sdkpath+", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/sdkpath+")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
@@ -3731,7 +3742,7 @@ Class C
             Dim file = Temp.CreateDirectory().CreateFile("vb.rsp")
             file.WriteAllText("")
 
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/libpath:c:\lib2;", "@" & file.ToString(), "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:\lib2;", "@" & file.ToString(), "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()) + "\", "c:\lib2")
 
@@ -3748,19 +3759,19 @@ Class C
 
         <Fact()>
         Public Sub HighEntropyVirtualAddressSpace()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/highentropyva", "a.vb"}, _baseDirectory)
             Assert.True(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/highentropyva+", "a.vb"}, _baseDirectory)
             Assert.True(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/highentropyva-", "a.vb"}, _baseDirectory)
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva:+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/highentropyva:+", "a.vb"}, _baseDirectory)
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/highentropyva:+"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/highentropyva:", "a.vb"}, _baseDirectory)
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
             Verify(parsedArgs.Errors, Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/highentropyva:"))
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/highentropyva+ /highentropyva-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/highentropyva+ /highentropyva-", "a.vb"}, _baseDirectory)
             Assert.False(parsedArgs.EmitOptions.HighEntropyVirtualAddressSpace)
         End Sub
 
@@ -3770,29 +3781,29 @@ Class C
                 " /win32resource:d:\\""abc def""\a""b c""d\a.res"
             }
 
-            Dim args = VisualBasicCommandLineParser.Default.Parse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
+            Dim args = DefaultParse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
             Assert.Equal("d:\abc def\ab cd\a.res", args.Win32ResourceFile)
 
             responseFile = {
                 " /win32icon:d:\\""abc def""\a""b c""d\a.ico"
             }
 
-            args = VisualBasicCommandLineParser.Default.Parse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
+            args = DefaultParse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
             Assert.Equal("d:\abc def\ab cd\a.ico", args.Win32Icon)
 
             responseFile = {
                 " /win32manifest:d:\\""abc def""\a""b c""d\a.manifest"
             }
 
-            args = VisualBasicCommandLineParser.Default.Parse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
+            args = DefaultParse(VisualBasicCommandLineParser.ParseResponseLines(responseFile), "c:\")
             Assert.Equal("d:\abc def\ab cd\a.manifest", args.Win32Manifest)
         End Sub
 
         <Fact>
         Public Sub ResourceOnlyCompile()
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource:foo.vb,ed", "/out:e.dll"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/resource:foo.vb,ed", "/out:e.dll"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/resource:foo.vb,ed"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/resource:foo.vb,ed"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_NoSourcesOut))
         End Sub
 
@@ -4156,58 +4167,58 @@ End Class
         <Fact>
         Public Sub WarningsOptions()
             ' Baseline
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Error, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors+
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror+", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror+", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Error, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors:
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror:", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors:42024,42025
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror:42024,42025", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror:42024,42025", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
             AssertSpecificDiagnostics({42024, 42025}, {ReportDiagnostic.Error, ReportDiagnostic.Error}, parsedArgs)
 
             ' Test for /warnaserrors+:
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror+:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror+:", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors+:42024,42025
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror+:42024,42025", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror+:42024,42025", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
             AssertSpecificDiagnostics({42024, 42025}, {ReportDiagnostic.Error, ReportDiagnostic.Error}, parsedArgs)
 
             ' Test for /warnaserrors-
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror-", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror-", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors-:
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror-:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror-:", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /warnaserrors-:42024,42025
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror-:42024,42025", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror-:42024,42025", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
             AssertSpecificDiagnostics({42024, 42025}, {ReportDiagnostic.Default, ReportDiagnostic.Default}, parsedArgs)
 
             ' Test for /nowarn
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nowarn", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nowarn", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Suppress, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /nowarn:
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nowarn:", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nowarn:", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
 
             ' Test for /nowarn:42024,42025
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nowarn:42024,42025", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nowarn:42024,42025", "a.vb"}, _baseDirectory)
             Assert.Equal(ReportDiagnostic.Default, parsedArgs.CompilationOptions.GeneralDiagnosticOption)
             AssertSpecificDiagnostics({42024, 42025}, {ReportDiagnostic.Suppress, ReportDiagnostic.Suppress}, parsedArgs)
         End Sub
@@ -4219,19 +4230,19 @@ End Class
             ' We no longer generate a warning in such cases.
 
             ' Test for /warnaserrors:1
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror:1", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/warnaserror:1", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             ' Test for /warnaserrors:abc
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/warnaserror:abc", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/warnaserror:abc", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             ' Test for /nowarn:1
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nowarn:1", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nowarn:1", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
             ' Test for /nowarn:abc
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/nowarn:abc", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/nowarn:abc", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
         End Sub
 
@@ -5793,16 +5804,16 @@ End Module
         <Fact, WorkItem(650083, "DevDiv")>
         Public Sub ReservedDeviceNameAsFileName()
             ' Source file name
-            Dim parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/t:library", "con.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/t:library", "con.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/out:com1.exe", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/out:com1.exe", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("\\.\com1").WithLocation(1, 1))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/doc:..\lpt2.xml", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/doc:..\lpt2.xml", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("..\lpt2.xml", "The system cannot find the path specified").WithLocation(1, 1))
 
-            parsedArgs = VisualBasicCommandLineParser.Default.Parse({"/SdkPath:..\aux", "com.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/SdkPath:..\aux", "com.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_CannotFindStandardLibrary1).WithArguments("System.dll").WithLocation(1, 1),
                                      Diagnostic(ERRID.ERR_LibNotFound).WithArguments("Microsoft.VisualBasic.dll").WithLocation(1, 1))
 
@@ -6013,54 +6024,54 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
 
         <Fact>
         Public Sub ParseFeatures()
-            Dim args = VisualBasicCommandLineParser.Default.Parse({"/features:Test", "a.vb"}, _baseDirectory)
+            Dim args = DefaultParse({"/features:Test", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test", args.CompilationOptions.Features.Single())
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/features:Test", "a.vb", "/Features:Experiment"}, _baseDirectory)
+            args = DefaultParse({"/features:Test", "a.vb", "/Features:Experiment"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(2, args.CompilationOptions.Features.Length)
             Assert.Equal("Test", args.CompilationOptions.Features(0))
             Assert.Equal("Experiment", args.CompilationOptions.Features(1))
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/features:Test:false,Key:value", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/features:Test:false,Key:value", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test:false,Key:value", args.CompilationOptions.Features.Single())
 
             ' We don't do any rigorous validation of /features arguments...
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/features", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/features", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Empty(args.CompilationOptions.Features)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/features:,", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/features:,", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(",", args.CompilationOptions.Features.Single())
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/features:Test,", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/features:Test,", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal("Test,", args.CompilationOptions.Features.Single())
         End Sub
 
         <Fact>
         Public Sub ParseAdditionalFile()
-            Dim args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config", "a.vb"}, _baseDirectory)
+            Dim args = DefaultParse({"/additionalfile:web.config", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles.Single().Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config", "a.vb", "/additionalfile:app.manifest"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:web.config", "a.vb", "/additionalfile:app.manifest"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(2, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles(0).Path)
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles(1).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config", "a.vb", "/additionalfile:web.config"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:web.config", "a.vb", "/additionalfile:web.config"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(2, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles(0).Path)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles(1).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:..\web.config", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:..\web.config", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(Path.Combine(_baseDirectory, "..\web.config"), args.AdditionalFiles.Single().Path)
 
@@ -6069,35 +6080,35 @@ C:\*.vb(100) : error BC30451: 'Foo' is not declared. It may be inaccessible due 
             baseDir.CreateFile("web2.config")
             baseDir.CreateFile("web3.config")
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web*.config", "a.vb"}, baseDir.Path)
+            args = DefaultParse({"/additionalfile:web*.config", "a.vb"}, baseDir.Path)
             args.Errors.Verify()
             Assert.Equal(3, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(baseDir.Path, "web1.config"), args.AdditionalFiles(0).Path)
             Assert.Equal(Path.Combine(baseDir.Path, "web2.config"), args.AdditionalFiles(1).Path)
             Assert.Equal(Path.Combine(baseDir.Path, "web3.config"), args.AdditionalFiles(2).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config;app.manifest", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:web.config;app.manifest", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(2, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles(0).Path)
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles(1).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config,app.manifest", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:web.config,app.manifest", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(2, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config"), args.AdditionalFiles(0).Path)
             Assert.Equal(Path.Combine(_baseDirectory, "app.manifest"), args.AdditionalFiles(1).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:web.config:app.manifest", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:web.config:app.manifest", "a.vb"}, _baseDirectory)
             args.Errors.Verify()
             Assert.Equal(1, args.AdditionalFiles.Length)
             Assert.Equal(Path.Combine(_baseDirectory, "web.config:app.manifest"), args.AdditionalFiles(0).Path)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("additionalfile", ":<file_list>"))
             Assert.Equal(0, args.AdditionalFiles.Length)
 
-            args = VisualBasicCommandLineParser.Default.Parse({"/additionalfile:", "a.vb"}, _baseDirectory)
+            args = DefaultParse({"/additionalfile:", "a.vb"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("additionalfile", ":<file_list>"))
             Assert.Equal(0, args.AdditionalFiles.Length)
         End Sub
@@ -6877,7 +6888,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -6897,7 +6908,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -6918,7 +6929,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -6939,7 +6950,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test001", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test001", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -6960,7 +6971,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -6981,7 +6992,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -7002,7 +7013,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test002", "/WarnAsError-:Test002", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+:Test002", "/WarnAsError-:Test002", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Default, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -7024,7 +7035,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn", "/WarnAsError+", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/NoWarn", "/WarnAsError+", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -7045,7 +7056,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/NoWarn", "/WarnAsError-", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/WarnAsError+", "/NoWarn", "/WarnAsError-", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -7068,7 +7079,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/NoWarn", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)
@@ -7091,7 +7102,7 @@ out
 "
             Dim ruleSetFile = dir.CreateFile("Rules.ruleset").WriteAllText(ruleSetSource)
 
-            Dim arguments = VisualBasicCommandLineParser.Default.Parse({"/ruleset:Rules.RuleSet", "/NoWarn:Test001", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
+            Dim arguments = DefaultParse({"/ruleset:Rules.RuleSet", "/NoWarn:Test001", "/WarnAsError+", "/WarnAsError-:Test001", "A.vb"}, dir.Path)
 
             Assert.Empty(arguments.Errors)
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=arguments.CompilationOptions.GeneralDiagnosticOption)

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
 
         Private Shared Function InteractiveParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
-            Return InteractiveParse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
+            Return VisualBasicCommandLineParser.Interactive.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         End Function
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -173,6 +173,7 @@ End Class
                      source1},
                     RuntimeEnvironment.GetRuntimeDirectory(),
                     _baseDirectory,
+                    RuntimeEnvironment.GetRuntimeDirectory(),
                     s_libDirectory)
                 Dim expectedReads As List(Of String) = Nothing
                 Dim expectedWrites As List(Of String) = Nothing

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -171,7 +171,6 @@ End Class
                     {"/nologo",
                      "/touchedfiles:" + touchedBase,
                      source1},
-                    RuntimeEnvironment.GetRuntimeDirectory(),
                     _baseDirectory,
                     RuntimeEnvironment.GetRuntimeDirectory(),
                     s_libDirectory)

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -171,6 +171,7 @@ End Class
                     {"/nologo",
                      "/touchedfiles:" + touchedBase,
                      source1},
+                    RuntimeEnvironment.GetRuntimeDirectory(),
                     _baseDirectory,
                     s_libDirectory)
                 Dim expectedReads As List(Of String) = Nothing

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.BuildTasks;
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
@@ -13,6 +14,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
                 args,
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Environment.CurrentDirectory,
+                sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
                 language: RequestLanguage.VisualBasicCompile,
                 fallbackCompiler: Vbc.Run);
     }

--- a/src/Compilers/VisualBasic/vbc/Vbc.cs
+++ b/src/Compilers/VisualBasic/vbc/Vbc.cs
@@ -12,17 +12,17 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 {
     internal sealed class Vbc : VisualBasicCompiler
     {
-        internal Vbc(string responseFile, string baseDirectory, string[] args)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, Environment.GetEnvironmentVariable("LIB"))
+        internal Vbc(string responseFile, string baseDirectory, string sdkDirectory, string[] args)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
         {
         }
 
-        internal static int Run(string clientDir, string[] args)
+        internal static int Run(string clientDir, string sdkDirectory, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
             var responseFile = Path.Combine(clientDir, VisualBasicCompiler.ResponseFileName);
-            Vbc compiler = new Vbc(responseFile, Directory.GetCurrentDirectory(), args);
+            Vbc compiler = new Vbc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
             // We store original encoding and restore it later to revert 
             // the changes that might be done by /utf8output options

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -2,13 +2,13 @@
 
 extern alias WORKSPACES;
 
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             {
                 // The base directory for relative paths is the directory that contains the .rsp file.
                 // Note that .rsp files included by this .rsp file will share the base directory (Dev10 behavior of csc/vbc).
-                var rspArguments = this.CommandLineParser.Parse(new[] { "@" + _responseFilePath }, Path.GetDirectoryName(_responseFilePath), null /* TODO: pass a valid value*/);
+                var rspArguments = this.CommandLineParser.Parse(new[] { "@" + _responseFilePath }, Path.GetDirectoryName(_responseFilePath), RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: pass a valid value*/);
                 referencePaths = rspArguments.ReferencePaths;
 
                 // the base directory for references specified in the .rsp file is the .rsp file directory:

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -466,7 +466,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                     // The base directory for relative paths is the directory that contains the .rsp file.
                     // Note that .rsp files included by this .rsp file will share the base directory (Dev10 behavior of csc/vbc).
-                    var args = parser.Parse(new[] { "@" + initializationFileOpt }, Path.GetDirectoryName(initializationFileOpt), null /* TODO: pass a valid value*/);
+                    var args = parser.Parse(new[] { "@" + initializationFileOpt }, Path.GetDirectoryName(initializationFileOpt), RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: pass a valid value*/);
 
                     foreach (var error in args.Errors)
                     {

--- a/src/Interactive/csi/Csi.cs
+++ b/src/Interactive/csi/Csi.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
@@ -19,7 +20,7 @@ namespace CSharpInteractive
         private const string InteractiveResponseFileName = "csi.rsp";
 
         internal Csi(string responseFile, string baseDirectory, string[] args)
-            : base(CSharpCommandLineParser.Interactive, responseFile, args, baseDirectory, null /* TODO: what to pass as additionalReferencePaths? */)
+            : base(CSharpCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: what to pass as additionalReferencePaths? */)
         {
         }
 

--- a/src/Interactive/vbi/Vbi.vb
+++ b/src/Interactive/vbi/Vbi.vb
@@ -3,6 +3,7 @@
 Imports System.Globalization
 Imports System.IO
 Imports System.Reflection
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -17,7 +18,7 @@ Friend NotInheritable Class Vbi
     Friend Const InteractiveResponseFileName As String = "vbi.rsp"
 
     Friend Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, Nothing) ' TODO: what to pass as additionalReferencePaths?
+        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing) ' TODO: what to pass as additionalReferencePaths?
     End Sub
 
     Public Shared Function Main(args As String()) As Integer

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1526,7 +1526,8 @@ System.Console.Write(x + y);
         {
             var commandLineArguments = CSharpCommandLineParser.Interactive.Parse(
                 new[] { "/r:" + typeof(Script).Assembly.Location }, //get corlib by default
-                Directory.GetDirectoryRoot(".")); //NOTE: any absolute path will do - we're not going to use this.
+                Directory.GetDirectoryRoot("."), //NOTE: any absolute path will do - we're not going to use this.
+                RuntimeEnvironment.GetRuntimeDirectory());
             var references = commandLineArguments.ResolveMetadataReferences(new AssemblyReferenceResolver(MetadataFileReferenceResolver.Default, metadataReferenceProvider));
             return references;
         }

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/TempPECompilerService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/TempPECompilerService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -83,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 }
             }
 
-            return CSharpCommandLineParser.Default.Parse(arguments, baseDirectory);
+            return CSharpCommandLineParser.Default.Parse(arguments, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory());
         }
     }
 }

--- a/src/Workspaces/CSharp/Desktop/LanguageServices/CSharpCommandLineArgumentsFactoryService.cs
+++ b/src/Workspaces/CSharp/Desktop/LanguageServices/CSharpCommandLineArgumentsFactoryService.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Composition;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public CommandLineArguments CreateCommandLineArguments(IEnumerable<string> arguments, string baseDirectory, bool isInteractive)
         {
             var parser = isInteractive ? CSharpCommandLineParser.Interactive : CSharpCommandLineParser.Default;
-            return parser.Parse(arguments, baseDirectory);
+            return parser.Parse(arguments, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory());
         }
     }
 }

--- a/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Execution;
@@ -178,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var commandLineParser = CSharpCommandLineParser.Default;
-                var commandLineArgs = commandLineParser.Parse(args, executedProject.Directory);
+                var commandLineArgs = commandLineParser.Parse(args, executedProject.Directory, RuntimeEnvironment.GetRuntimeDirectory());
 
                 var resolver = new MetadataFileReferenceResolver(commandLineArgs.ReferencePaths, commandLineArgs.BaseDirectory);
                 metadataReferences = commandLineArgs.ResolveMetadataReferences(new AssemblyReferenceResolver(resolver, _metadataService.GetProvider()));

--- a/src/Workspaces/VisualBasic/Desktop/LanguageServices/VisualBasicCommandLineArgumentsFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Desktop/LanguageServices/VisualBasicCommandLineArgumentsFactoryService.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Composition
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
@@ -12,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function CreateCommandLineArguments(arguments As IEnumerable(Of String), baseDirectory As String, isInteractive As Boolean) As CommandLineArguments Implements ICommandLineArgumentsFactoryService.CreateCommandLineArguments
             Dim parser = If(isInteractive, VisualBasicCommandLineParser.Interactive, VisualBasicCommandLineParser.Default)
-            Return parser.Parse(arguments, baseDirectory)
+            Return parser.Parse(arguments, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory())
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
+++ b/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Immutable
 Imports System.IO
+Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Host
@@ -139,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim commandLineParser = VisualBasicCommandLineParser.Default
-                Dim commandLineArgs = commandLineParser.Parse(args, executedProject.Directory)
+                Dim commandLineArgs = commandLineParser.Parse(args, executedProject.Directory, RuntimeEnvironment.GetRuntimeDirectory())
                 Dim resolver = New MetadataFileReferenceResolver(commandLineArgs.ReferencePaths, commandLineArgs.BaseDirectory)
                 metadataReferences = commandLineArgs.ResolveMetadataReferences(New AssemblyReferenceResolver(resolver, Me._metadataService.GetProvider()))
                 analyzerReferences = commandLineArgs.ResolveAnalyzerReferences(AddressOf _analyzerService.GetAnalyzer)


### PR DESCRIPTION
This changes the compiler APIs to no longer use
RuntimeVersion.GetRuntimeDirectory to find the path to mscorlib and
System.dll for the following reasons:

- This API is not available in CoreFx and hence blocks our transition.
- This behavior of implicitly referencing mscorlib doesn't have a
logical equivalent in coreclr where there may be no reachable mscorlib
on the machine (think Linux).

The compiler now takes the SDK search directory as a paramater.  The
consmer will be responsible for feeding down the correct value to the
compiler.

This is the first step in resolving issue #1939