### PR TITLE
Updates Concord APIs in Roslyn to add new field "CustomTypeInfo"

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.NetFX20.il
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.NetFX20.il
@@ -3579,6 +3579,7 @@
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_LOAD_VSDEBUGENG_IMPORTS_FAILED' = int32(0x80040C11)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_LOGON_FAILURE_ON_CALLBACK' = int32(0x80040756)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_MANAGED_FEATURE_NOTSUPPORTED' = int32(0x80040BAD)
+		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_MANAGED_HEAP_ENUMERATION_PARTIAL' = int32(0x92330065)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_MANAGED_HEAP_ENUMERATION_TARGET_NOT_STOPPED' = int32(0x92330061)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_MANAGED_HEAP_NOT_ENUMERABLE' = int32(0x92330056)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger'.'DkmExceptionCode' 'E_MARSHALLING_SIZE_TOO_LARGE' = int32(0x9233005F)
@@ -4989,6 +4990,7 @@
 		.method public final virtual hidebysig newslot 
 			instance void 'GetObjectData'(class ['mscorlib']'System.Runtime.Serialization'.'SerializationInfo' 'info', valuetype ['mscorlib']'System.Runtime.Serialization'.'StreamingContext' 'context')
 		{
+			.permissionset linkcheck = (2E 01 80 84 53 79 73 74 65 6D 2E 53 65 63 75 72 69 74 79 2E 50 65 72 6D 69 73 73 69 6F 6E 73 2E 53 65 63 75 72 69 74 79 50 65 72 6D 69 73 73 69 6F 6E 41 74 74 72 69 62 75 74 65 2C 20 6D 73 63 6F 72 6C 69 62 2C 20 56 65 72 73 69 6F 6E 3D 32 2E 30 2E 30 2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D 62 37 37 61 35 63 35 36 31 39 33 34 65 30 38 39 80 8D 01 54 55 7F 53 79 73 74 65 6D 2E 53 65 63 75 72 69 74 79 2E 50 65 72 6D 69 73 73 69 6F 6E 73 2E 53 65 63 75 72 69 74 79 50 65 72 6D 69 73 73 69 6F 6E 46 6C 61 67 2C 20 6D 73 63 6F 72 6C 69 62 2C 20 56 65 72 73 69 6F 6E 3D 32 2E 30 2E 30 2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D 62 37 37 61 35 63 35 36 31 39 33 34 65 30 38 39 05 46 6C 61 67 73 80 00 00 00)
 			ret
 		}
 		.property instance native int 'ItemsPtr'()
@@ -11716,7 +11718,7 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
-			instance string 'GetTypeName'(class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'inspectionContext', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'clrType', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'formatSpecifiers')
+			instance string 'GetTypeName'(class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'inspectionContext', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'clrType', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'formatSpecifiers', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'customTypeInfo')
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -11823,7 +11825,7 @@
 	.class public interface abstract 'IDkmClrResultProvider'
 	{
 		.method public virtual hidebysig newslot abstract 
-			instance void 'GetResult'(class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrValue' 'clrValue', class 'Microsoft.VisualStudio.Debugger'.'DkmWorkList' 'workList', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'declaredType', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'inspectionContext', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'formatSpecifiers', string 'resultName', string 'resultFullName', class 'Microsoft.VisualStudio.Debugger'.'DkmCompletionRoutine`1'<valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmEvaluationAsyncResult'> 'completionRoutine')
+			instance void 'GetResult'(class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrValue' 'clrValue', class 'Microsoft.VisualStudio.Debugger'.'DkmWorkList' 'workList', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'declaredType', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'inspectionContext', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'formatSpecifiers', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'customTypeInfo', string 'resultName', string 'resultFullName', class 'Microsoft.VisualStudio.Debugger'.'DkmCompletionRoutine`1'<valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmEvaluationAsyncResult'> 'completionRoutine')
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -17244,7 +17246,7 @@
 			ret
 		}
 		.method public hidebysig 
-			instance string 'GetTypeName'(class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'ClrType', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers')
+			instance string 'GetTypeName'(class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'ClrType', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo')
 		{
 			ret
 		}
@@ -18333,6 +18335,34 @@
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'PotentialSideEffect' = int32(0x00000001)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'ReadOnlyResult' = int32(0x00000002)
 	}
+	.class public 'DkmClrCustomTypeInfo'
+		extends ['mscorlib']'System'.'Object'
+	{
+		.custom instance void ['mscorlib']'System.Runtime.InteropServices'.'GuidAttribute'::.ctor(string) = (01 00 24 32 34 61 63 36 66 36 32 2D 66 33 66 38 2D 31 66 32 66 2D 35 32 64 62 2D 39 38 36 65 33 65 39 36 66 33 38 65 00 00)
+		.method public hidebysig specialname 
+			instance valuetype ['mscorlib']'System'.'Guid' 'get_PayloadTypeId'()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
+			instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'get_Payload'()
+		{
+			ret
+		}
+		.method public static hidebysig 
+			class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'Create'(valuetype ['mscorlib']'System'.'Guid' 'PayloadTypeId', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Payload')
+		{
+			ret
+		}
+		.property instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Payload'()
+		{
+			.get instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo'::'get_Payload'()
+		}
+		.property instance valuetype ['mscorlib']'System'.'Guid' 'PayloadTypeId'()
+		{
+			.get instance valuetype ['mscorlib']'System'.'Guid' 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo'::'get_PayloadTypeId'()
+		}
+	}
 	.class public 'DkmClrDebuggerBrowsableAttribute'
 		extends 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrEvalAttribute'
 	{
@@ -18837,7 +18867,7 @@
 			ret
 		}
 		.method public hidebysig 
-			instance void 'GetResult'(class 'Microsoft.VisualStudio.Debugger'.'DkmWorkList' 'WorkList', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'DeclaredType', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'InspectionContext', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers', string 'ResultName', string 'ResultFullName', class 'Microsoft.VisualStudio.Debugger'.'DkmCompletionRoutine`1'<valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmEvaluationAsyncResult'> 'CompletionRoutine')
+			instance void 'GetResult'(class 'Microsoft.VisualStudio.Debugger'.'DkmWorkList' 'WorkList', class 'Microsoft.VisualStudio.Debugger.Clr'.'DkmClrType' 'DeclaredType', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmInspectionContext' 'InspectionContext', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo', string 'ResultName', string 'ResultFullName', class 'Microsoft.VisualStudio.Debugger'.'DkmCompletionRoutine`1'<valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmEvaluationAsyncResult'> 'CompletionRoutine')
 		{
 			ret
 		}
@@ -19004,12 +19034,17 @@
 			ret
 		}
 		.method public hidebysig specialname 
+			instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'get_CustomTypeInfo'()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
 			instance valuetype ['mscorlib']'System'.'Guid' 'get_UniqueId'()
 		{
 			ret
 		}
 		.method public static hidebysig 
-			class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrInspectionQuery' 'Create'(class 'Microsoft.VisualStudio.Debugger'.'DkmRuntimeInstance' 'RuntimeInstance', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCustomDataContainer' 'DataContainer', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCompilerId' 'LanguageId', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Binary', string 'TypeName', string 'MethodName', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'CompilationFlags', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultCategory' 'ResultCategory', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultAccessType' 'Access', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultStorageType' 'StorageType', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultTypeModifierFlags' 'TypeModifierFlags')
+			class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrInspectionQuery' 'Create'(class 'Microsoft.VisualStudio.Debugger'.'DkmRuntimeInstance' 'RuntimeInstance', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCustomDataContainer' 'DataContainer', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCompilerId' 'LanguageId', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Binary', string 'TypeName', string 'MethodName', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'CompilationFlags', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultCategory' 'ResultCategory', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultAccessType' 'Access', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultStorageType' 'StorageType', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmEvaluationResultTypeModifierFlags' 'TypeModifierFlags', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo')
 		{
 			ret
 		}
@@ -19029,6 +19064,10 @@
 		.property instance valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'CompilationFlags'()
 		{
 			.get instance valuetype 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCompilationResultFlags' 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrInspectionQuery'::'get_CompilationFlags'()
+		}
+		.property instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo'()
+		{
+			.get instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrInspectionQuery'::'get_CustomTypeInfo'()
 		}
 		.property instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<string> 'FormatSpecifiers'()
 		{
@@ -19079,12 +19118,17 @@
 			ret
 		}
 		.method public hidebysig specialname 
+			instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'get_CustomTypeInfo'()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
 			instance valuetype ['mscorlib']'System'.'Guid' 'get_UniqueId'()
 		{
 			ret
 		}
 		.method public static hidebysig 
-			class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrLocalsQuery' 'Create'(class 'Microsoft.VisualStudio.Debugger'.'DkmRuntimeInstance' 'RuntimeInstance', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCustomDataContainer' 'DataContainer', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCompilerId' 'LanguageId', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Binary', string 'TypeName', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrLocalVariableInfo'> 'LocalInfo')
+			class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrLocalsQuery' 'Create'(class 'Microsoft.VisualStudio.Debugger'.'DkmRuntimeInstance' 'RuntimeInstance', class 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCustomDataContainer' 'DataContainer', valuetype 'Microsoft.VisualStudio.Debugger.Evaluation'.'DkmCompilerId' 'LanguageId', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Binary', string 'TypeName', class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrLocalVariableInfo'> 'LocalInfo', class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo')
 		{
 			ret
 		}
@@ -19096,6 +19140,10 @@
 		.property instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Binary'()
 		{
 			.get instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<uint8> 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrLocalsQuery'::'get_Binary'()
+		}
+		.property instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'CustomTypeInfo'()
+		{
+			.get instance class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrCustomTypeInfo' 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmCompiledClrLocalsQuery'::'get_CustomTypeInfo'()
 		}
 		.property instance class ['mscorlib']'System.Collections.ObjectModel'.'ReadOnlyCollection`1'<class 'Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation'.'DkmClrLocalVariableInfo'> 'LocalInfo'()
 		{

--- a/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.Portable.il
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.Portable.il
@@ -3674,6 +3674,7 @@
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_LOAD_VSDEBUGENG_IMPORTS_FAILED' = int32(0x80040C11)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_LOGON_FAILURE_ON_CALLBACK' = int32(0x80040756)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_MANAGED_FEATURE_NOTSUPPORTED' = int32(0x80040BAD)
+		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_MANAGED_HEAP_ENUMERATION_PARTIAL' = int32(0x92330065)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_MANAGED_HEAP_ENUMERATION_TARGET_NOT_STOPPED' = int32(0x92330061)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_MANAGED_HEAP_NOT_ENUMERABLE' = int32(0x92330056)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.DkmExceptionCode 'E_MARSHALLING_SIZE_TOO_LARGE' = int32(0x9233005F)
@@ -12319,7 +12320,7 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
-			instance string GetTypeName(class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext inspectionContext, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType clrType, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> formatSpecifiers)
+			instance string GetTypeName(class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext inspectionContext, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType clrType, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> formatSpecifiers, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo customTypeInfo)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -12426,7 +12427,7 @@
 	.class public interface abstract IDkmClrResultProvider
 	{
 		.method public virtual hidebysig newslot abstract 
-			instance void GetResult(class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue clrValue, class Microsoft.VisualStudio.Debugger.DkmWorkList workList, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType declaredType, class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext inspectionContext, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> formatSpecifiers, string resultName, string resultFullName, class 'Microsoft.VisualStudio.Debugger.DkmCompletionRoutine`1'<valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult> completionRoutine)
+			instance void GetResult(class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue clrValue, class Microsoft.VisualStudio.Debugger.DkmWorkList workList, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType declaredType, class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext inspectionContext, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> formatSpecifiers, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo customTypeInfo, string resultName, string resultFullName, class 'Microsoft.VisualStudio.Debugger.DkmCompletionRoutine`1'<valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult> completionRoutine)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -17997,7 +17998,7 @@
 			ret
 		}
 		.method public hidebysig 
-			instance string GetTypeName(class Microsoft.VisualStudio.Debugger.Clr.DkmClrType ClrType, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers)
+			instance string GetTypeName(class Microsoft.VisualStudio.Debugger.Clr.DkmClrType ClrType, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo)
 		{
 			.custom instance void [System.Runtime]System.Security.SecuritySafeCriticalAttribute::.ctor() = { }
 			ret
@@ -19178,6 +19179,35 @@
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags PotentialSideEffect = int32(0x00000001)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags ReadOnlyResult = int32(0x00000002)
 	}
+	.class public DkmClrCustomTypeInfo
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime.InteropServices]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = { string('24ac6f62-f3f8-1f2f-52db-986e3e96f38e') }
+		.method public hidebysig specialname 
+			instance valuetype [System.Runtime]System.Guid get_PayloadTypeId()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
+			instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> get_Payload()
+		{
+			ret
+		}
+		.method public static hidebysig 
+			class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo Create(valuetype [System.Runtime]System.Guid PayloadTypeId, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Payload)
+		{
+			.custom instance void [System.Runtime]System.Security.SecuritySafeCriticalAttribute::.ctor() = { }
+			ret
+		}
+		.property instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Payload()
+		{
+			.get instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo::get_Payload()
+		}
+		.property instance valuetype [System.Runtime]System.Guid PayloadTypeId()
+		{
+			.get instance valuetype [System.Runtime]System.Guid Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo::get_PayloadTypeId()
+		}
+	}
 	.class public DkmClrDebuggerBrowsableAttribute
 		extends Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrEvalAttribute
 	{
@@ -19717,7 +19747,7 @@
 			ret
 		}
 		.method public hidebysig 
-			instance void GetResult(class Microsoft.VisualStudio.Debugger.DkmWorkList WorkList, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType DeclaredType, class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext InspectionContext, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers, string ResultName, string ResultFullName, class 'Microsoft.VisualStudio.Debugger.DkmCompletionRoutine`1'<valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult> CompletionRoutine)
+			instance void GetResult(class Microsoft.VisualStudio.Debugger.DkmWorkList WorkList, class Microsoft.VisualStudio.Debugger.Clr.DkmClrType DeclaredType, class Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext InspectionContext, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo, string ResultName, string ResultFullName, class 'Microsoft.VisualStudio.Debugger.DkmCompletionRoutine`1'<valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult> CompletionRoutine)
 		{
 			.custom instance void [System.Runtime]System.Security.SecuritySafeCriticalAttribute::.ctor() = { }
 			ret
@@ -19893,12 +19923,17 @@
 			ret
 		}
 		.method public hidebysig specialname 
+			instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo get_CustomTypeInfo()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
 			instance valuetype [System.Runtime]System.Guid get_UniqueId()
 		{
 			ret
 		}
 		.method public static hidebysig 
-			class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery Create(class Microsoft.VisualStudio.Debugger.DkmRuntimeInstance RuntimeInstance, class Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer DataContainer, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId LanguageId, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Binary, string TypeName, string MethodName, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers, valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags CompilationFlags, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultCategory ResultCategory, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultAccessType Access, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultStorageType StorageType, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultTypeModifierFlags TypeModifierFlags)
+			class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery Create(class Microsoft.VisualStudio.Debugger.DkmRuntimeInstance RuntimeInstance, class Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer DataContainer, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId LanguageId, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Binary, string TypeName, string MethodName, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers, valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags CompilationFlags, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultCategory ResultCategory, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultAccessType Access, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultStorageType StorageType, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultTypeModifierFlags TypeModifierFlags, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo)
 		{
 			.custom instance void [System.Runtime]System.Security.SecuritySafeCriticalAttribute::.ctor() = { }
 			ret
@@ -19920,6 +19955,10 @@
 		.property instance valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags CompilationFlags()
 		{
 			.get instance valuetype Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery::get_CompilationFlags()
+		}
+		.property instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo()
+		{
+			.get instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery::get_CustomTypeInfo()
 		}
 		.property instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<string> FormatSpecifiers()
 		{
@@ -19970,12 +20009,17 @@
 			ret
 		}
 		.method public hidebysig specialname 
+			instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo get_CustomTypeInfo()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
 			instance valuetype [System.Runtime]System.Guid get_UniqueId()
 		{
 			ret
 		}
 		.method public static hidebysig 
-			class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery Create(class Microsoft.VisualStudio.Debugger.DkmRuntimeInstance RuntimeInstance, class Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer DataContainer, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId LanguageId, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Binary, string TypeName, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo> LocalInfo)
+			class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery Create(class Microsoft.VisualStudio.Debugger.DkmRuntimeInstance RuntimeInstance, class Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer DataContainer, valuetype Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId LanguageId, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Binary, string TypeName, class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo> LocalInfo, class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo)
 		{
 			.custom instance void [System.Runtime]System.Security.SecuritySafeCriticalAttribute::.ctor() = { }
 			ret
@@ -19989,6 +20033,10 @@
 		.property instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Binary()
 		{
 			.get instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<uint8> Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery::get_Binary()
+		}
+		.property instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo CustomTypeInfo()
+		{
+			.get instance class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery::get_CustomTypeInfo()
 		}
 		.property instance class [System.Runtime]'System.Collections.ObjectModel.ReadOnlyCollection`1'<class Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo> LocalInfo()
 		{

--- a/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.XML
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Engine.XML
@@ -6956,7 +6956,7 @@
              [Out] The local variables query.
              </returns>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext.GetTypeName(Microsoft.VisualStudio.Debugger.Clr.DkmClrType,System.Collections.ObjectModel.ReadOnlyCollection{System.String})">
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext.GetTypeName(Microsoft.VisualStudio.Debugger.Clr.DkmClrType,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo)">
              <summary>
              Gets the type name string to display in the UI for the given DkmClrType.
             
@@ -6971,6 +6971,10 @@
              <param name="FormatSpecifiers">
              [In,Optional] The optional format specifier(s) to use when formatting this
              result.
+             </param>
+             <param name="CustomTypeInfo">
+             [In,Optional] The optional information provided by the expression compiler for
+             identifying compiler intrinsic type information.
              </param>
              <returns>
              [Out] The type name string.
@@ -7496,7 +7500,7 @@
              <summary>
              Compile the given DebuggerDisplayAttribute string.  The resulting IL should
              return a string. For debugger display, there is no code context.  Instead the
-             complier must do its binding based on a type token.
+             compiler must do its binding based on a type token.
             
              Location constraint: API must be called from an IDE component (component level
              &gt; 100,000).
@@ -8851,6 +8855,74 @@
             Indicates that the return type of compiled expression is boolean.
             </summary>
         </member>
+        <member name="T:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo">
+             <summary>
+             A custom type info is an object passed between an IDkmClrExpressionCompiler and an
+             IDkmClrResultProvider, this can be used by the result provider to decode a
+             compiler-specific type that does not have an underlying CLR type. A result provider
+             should always check the PayloadTypeId for a compiler it recognizes before attempting
+             to decode the included payload.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+        </member>
+        <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.PayloadTypeId">
+             <summary>
+             This Guid is used to identify the type of the payload. This allows result
+             providers to ignore ClrCustomTypeInfos from different compilers.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+        </member>
+        <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.Payload">
+             <summary>
+             Data payload that contains compiler-specific custom information to be used by a
+             result provider to decode the given type.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+        </member>
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.Create(System.Guid,System.Collections.ObjectModel.ReadOnlyCollection{System.Byte})">
+             <summary>
+             Create a new DkmClrCustomTypeInfo object instance.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+             <param name="PayloadTypeId">
+             [In] This Guid is used to identify the type of the payload. This allows result
+             providers to ignore ClrCustomTypeInfos from different compilers.
+             </param>
+             <param name="Payload">
+             [In] Data payload that contains compiler-specific custom information to be used
+             by a result provider to decode the given type.
+             </param>
+             <returns>
+             [Out] Result of this method call.
+             </returns>
+        </member>
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.ManagedToNativeImpl(XapiOutgoingCall)">
+            <summary>
+            Obtain a pointer to the native object used to call into native. This method
+            is invoked from IXapiMarshalableElement&lt;IntPtr&gt;.ManagedToNative or from
+            a derived classes's implementation of this function.
+            </summary>
+            <param name="outerCall">Outgoing managed-&gt;native call</param>
+            <returns>Native object</returns>
+        </member>
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.NativeToManaged(XapiOutgoingCall,System.IntPtr)">
+            <summary>
+            Convert a native dispatcher object to managed
+            </summary>
+            <param name="pvNativeObject">[Optional] Pointer to native object.</param>
+            <returns>[Optional] Managed object. Null if input object is null.</returns>
+        </member>
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo.TryCreateNewManagedObject(NativeXapiDispatcherObjectBase*)">
+            <summary>
+            Create a new managed object for the passed in native object. This function is called from 'NativeToManaged'
+            </summary>
+            <param name="pNativeObject">Native object</param>
+            <returns>[Optional] Managed object. Returns null if the native object is not of this type.</returns>
+        </member>
         <member name="T:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrDebuggerBrowsableAttribute">
              <summary>
              Represents a DebuggerBrowsable attribute on a field or property and determines if and
@@ -9506,7 +9578,7 @@
         </member>
         <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo.CompilationFlags">
              <summary>
-             [Optional] Flags, provided by the complier, describing the local variable.
+             [Optional] Flags, provided by the compiler, describing the local variable.
             
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
@@ -9532,7 +9604,7 @@
              [In] The name of the method to execute to get the value of this variable.
              </param>
              <param name="CompilationFlags">
-             [In,Optional] Flags, provided by the complier, describing the local variable.
+             [In,Optional] Flags, provided by the compiler, describing the local variable.
              </param>
              <param name="ResultCategory">
              [In,Optional] What category this variable belongs to, this controls the glyph
@@ -9860,7 +9932,7 @@
              [Out] The underlying string representation.
              </returns>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue.GetResult(Microsoft.VisualStudio.Debugger.DkmWorkList,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,System.Collections.ObjectModel.ReadOnlyCollection{System.String},System.String,System.String,Microsoft.VisualStudio.Debugger.DkmCompletionRoutine{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult})">
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue.GetResult(Microsoft.VisualStudio.Debugger.DkmWorkList,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo,System.String,System.String,Microsoft.VisualStudio.Debugger.DkmCompletionRoutine{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult})">
              <summary>
              Format a DkmClrValue and return a DkmEvaluationResult.
             
@@ -9886,6 +9958,10 @@
              <param name="FormatSpecifiers">
              [In,Optional] The optional format specifier(s) to use when formatting this
              result.
+             </param>
+             <param name="CustomTypeInfo">
+             [In,Optional] The optional information provided by the expression compiler for
+             identifying compiler intrinsic type information.
              </param>
              <param name="ResultName">
              [In] The name of this result.  This value is typically the expression being
@@ -10152,7 +10228,7 @@
         </member>
         <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery.CompilationFlags">
              <summary>
-             [Optional] Flags, provided by the complier, describing the inspection query.
+             [Optional] Flags, provided by the compiler, describing the inspection query.
             
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
@@ -10187,6 +10263,14 @@
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
         </member>
+        <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery.CustomTypeInfo">
+             <summary>
+             [Optional] The optional information provided to the result formatter for
+             identifying compiler intrinsic type information.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+        </member>
         <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery.UniqueId">
              <summary>
              Guid which uniquely identifies this query.
@@ -10194,7 +10278,7 @@
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery.Create(Microsoft.VisualStudio.Debugger.DkmRuntimeInstance,Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer,Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId,System.Collections.ObjectModel.ReadOnlyCollection{System.Byte},System.String,System.String,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultCategory,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultAccessType,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultStorageType,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultTypeModifierFlags)">
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrInspectionQuery.Create(Microsoft.VisualStudio.Debugger.DkmRuntimeInstance,Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer,Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId,System.Collections.ObjectModel.ReadOnlyCollection{System.Byte},System.String,System.String,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCompilationResultFlags,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultCategory,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultAccessType,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultStorageType,Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultTypeModifierFlags,Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo)">
              <summary>
              Create a new DkmCompiledClrInspectionQuery object instance.
             
@@ -10225,7 +10309,7 @@
              query.
              </param>
              <param name="CompilationFlags">
-             [In,Optional] Flags, provided by the complier, describing the inspection query.
+             [In,Optional] Flags, provided by the compiler, describing the inspection query.
              </param>
              <param name="ResultCategory">
              [In,Optional] What category this variable belongs to, this controls the glyph
@@ -10240,6 +10324,10 @@
              </param>
              <param name="TypeModifierFlags">
              [In,Optional] Type modifier flags (ex: const) of the evaluation result.
+             </param>
+             <param name="CustomTypeInfo">
+             [In,Optional] The optional information provided to the result formatter for
+             identifying compiler intrinsic type information.
              </param>
              <returns>
              [Out] Result of this method call.
@@ -10327,6 +10415,14 @@
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
         </member>
+        <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery.CustomTypeInfo">
+             <summary>
+             [Optional] The optional information provided to the result formatter for
+             identifying compiler intrinsic type information.
+            
+             This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
+             </summary>
+        </member>
         <member name="P:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery.UniqueId">
              <summary>
              Guid which uniquely identifies this query.
@@ -10334,7 +10430,7 @@
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery.Create(Microsoft.VisualStudio.Debugger.DkmRuntimeInstance,Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer,Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId,System.Collections.ObjectModel.ReadOnlyCollection{System.Byte},System.String,System.Collections.ObjectModel.ReadOnlyCollection{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo})">
+        <member name="M:Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmCompiledClrLocalsQuery.Create(Microsoft.VisualStudio.Debugger.DkmRuntimeInstance,Microsoft.VisualStudio.Debugger.Evaluation.DkmCustomDataContainer,Microsoft.VisualStudio.Debugger.Evaluation.DkmCompilerId,System.Collections.ObjectModel.ReadOnlyCollection{System.Byte},System.String,System.Collections.ObjectModel.ReadOnlyCollection{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrLocalVariableInfo},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo)">
              <summary>
              Create a new DkmCompiledClrLocalsQuery object instance.
             
@@ -10360,6 +10456,10 @@
              <param name="LocalInfo">
              [In] The collection of local variable names and method names on the query type to
              get the values.
+             </param>
+             <param name="CustomTypeInfo">
+             [In,Optional] The optional information provided to the result formatter for
+             identifying compiler intrinsic type information.
              </param>
              <returns>
              [Out] Result of this method call.
@@ -24776,7 +24876,7 @@
             [Out] The value string.
             </returns>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrFormatter.GetTypeName(Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,System.Collections.ObjectModel.ReadOnlyCollection{System.String})">
+        <member name="M:Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrFormatter.GetTypeName(Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo)">
             <summary>
             Gets the type name string to display in the UI for the given DkmClrType.
             </summary>
@@ -24789,6 +24889,10 @@
             <param name="formatSpecifiers">
             [In,Optional] The optional format specifier(s) to use when formatting this
             result.
+            </param>
+            <param name="customTypeInfo">
+            [In,Optional] The optional information provided by the expression compiler for
+            identifying compiler intrinsic type information.
             </param>
             <returns>
             [Out] The type name string.
@@ -24838,7 +24942,7 @@
              This API was introduced in Visual Studio 14 RTM (DkmApiVersion.VS14RTM).
              </summary>
         </member>
-        <member name="M:Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrResultProvider.GetResult(Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue,Microsoft.VisualStudio.Debugger.DkmWorkList,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,System.Collections.ObjectModel.ReadOnlyCollection{System.String},System.String,System.String,Microsoft.VisualStudio.Debugger.DkmCompletionRoutine{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult})">
+        <member name="M:Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrResultProvider.GetResult(Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrValue,Microsoft.VisualStudio.Debugger.DkmWorkList,Microsoft.VisualStudio.Debugger.Clr.DkmClrType,Microsoft.VisualStudio.Debugger.Evaluation.DkmInspectionContext,System.Collections.ObjectModel.ReadOnlyCollection{System.String},Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmClrCustomTypeInfo,System.String,System.String,Microsoft.VisualStudio.Debugger.DkmCompletionRoutine{Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation.DkmEvaluationAsyncResult})">
             <summary>
             Format a DkmClrValue and return a DkmEvaluationResult.
             </summary>
@@ -24860,6 +24964,10 @@
             <param name="formatSpecifiers">
             [In,Optional] The optional format specifier(s) to use when formatting this
             result.
+            </param>
+            <param name="customTypeInfo">
+            [In,Optional] The optional information provided by the expression compiler for
+            identifying compiler intrinsic type information.
             </param>
             <param name="resultName">
             [In] The name of this result.  This value is typically the expression being
@@ -25071,7 +25179,7 @@
             <summary>
             Compile the given DebuggerDisplayAttribute string.  The resulting IL should
             return a string. For debugger display, there is no code context.  Instead the
-            complier must do its binding based on a type token.
+            compiler must do its binding based on a type token.
             </summary>
             <param name="expression">
             [In] DkmLanguageExpression represents an expression to be parsed and evaluated by
@@ -58931,6 +59039,11 @@
         <member name="F:Microsoft.VisualStudio.Debugger.DkmExceptionCode.E_DETACH_FAILED_ON_ENC">
             <summary>
             Detach is not allowed after changes have been applied through Edit and Continue.
+            </summary>
+        </member>
+        <member name="F:Microsoft.VisualStudio.Debugger.DkmExceptionCode.E_MANAGED_HEAP_ENUMERATION_PARTIAL">
+            <summary>
+            Managed heap enumeration ran into an issue reading objects from the heap, not all objects were captured
             </summary>
         </member>
         <member name="F:Microsoft.VisualStudio.Debugger.DkmExceptionCode.E_XAPI_COMPONENT_LOAD_FAILURE">

--- a/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Metadata.NetFX20.il
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Metadata.NetFX20.il
@@ -1,3 +1,8 @@
+.assembly extern System.Core
+{
+	.publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+	.ver 3:5:0:0
+}
 .assembly extern mscorlib
 {
 	.publickeytoken = (B7 7A 5C 56 19 34 E0 89)
@@ -5,6 +10,7 @@
 }
 .assembly Microsoft.VisualStudio.Debugger.Metadata
 {
+	.custom instance void [System.Core]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = { }
 	.custom instance void [mscorlib]System.CLSCompliantAttribute::.ctor(bool) = { bool(false) }
 	.custom instance void [mscorlib]System.Runtime.CompilerServices.InternalsVisibleToAttribute::.ctor(string) = { string('vsdebugeng.manimpl, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293') }
 	.custom instance void [mscorlib]System.Runtime.CompilerServices.InternalsVisibleToAttribute::.ctor(string) = { string('Microsoft.VisualStudio.VIL, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293') }
@@ -4164,6 +4170,17 @@
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.Metadata.TypeCode UInt16 = int32(0x00000008)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.Metadata.TypeCode UInt32 = int32(0x0000000A)
 		.field static public literal valuetype Microsoft.VisualStudio.Debugger.Metadata.TypeCode UInt64 = int32(0x0000000C)
+	}
+	.class public abstract sealed TypeExtensions
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [System.Core]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = { }
+		.method public static hidebysig 
+			class [mscorlib]System.Type GetTypeInfo(class [mscorlib]System.Type 'type')
+		{
+			.custom instance void [System.Core]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = { }
+			ret
+		}
 	}
 	.class public sealed TypeFilter
 		extends [mscorlib]System.MulticastDelegate

--- a/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Metadata.Portable.il
+++ b/src/ExpressionEvaluator/Core/Source/Concord/Microsoft.VisualStudio.Debugger.Metadata.Portable.il
@@ -3828,6 +3828,15 @@
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger.Metadata'.'TypeCode' 'UInt32' = int32(0x0000000A)
 		.field static public literal valuetype 'Microsoft.VisualStudio.Debugger.Metadata'.'TypeCode' 'UInt64' = int32(0x0000000C)
 	}
+	.class public abstract sealed 'TypeExtensions'
+		extends ['System.Runtime']'System'.'Object'
+	{
+		.method public static hidebysig 
+			class ['System.Reflection']'System.Reflection'.'TypeInfo' 'GetTypeInfo'(class ['System.Runtime']'System'.'Type' 'type')
+		{
+			ret
+		}
+	}
 	.class public sealed 'TypeFilter'
 		extends ['System.Runtime']'System'.'MulticastDelegate'
 	{

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -154,7 +154,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 ResultCategory: resultProperties.Category,
                 Access: resultProperties.AccessType,
                 StorageType: resultProperties.StorageType,
-                TypeModifierFlags: resultProperties.ModifierFlags);
+                TypeModifierFlags: resultProperties.ModifierFlags,
+                CustomTypeInfo: null);
         }
 
         internal static ResultProperties GetResultProperties<TSymbol>(this TSymbol symbol, DkmClrCompilationResultFlags flags, bool isConstant)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         return new GetLocalsResult(typeName, locals, assembly);
                     },
                     out error);
-                return DkmCompiledClrLocalsQuery.Create(runtimeInstance, null, this.CompilerId, r.Assembly, r.TypeName, r.Locals);
+                return DkmCompiledClrLocalsQuery.Create(runtimeInstance, null, this.CompilerId, r.Assembly, r.TypeName, r.Locals, CustomTypeInfo: null);
             }
             catch (Exception e) when (ExpressionEvaluatorFatalError.CrashIfFailFastEnabled(e))
             {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/TypeVariablesExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/TypeVariablesExpansion.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 declaredType: typeArgument,
                 parent: parent,
                 value: value,
-                displayValue: inspectionContext.GetTypeName(DkmClrType.Create(value.Type.AppDomain, typeArgument), formatSpecifiers),
+                displayValue: inspectionContext.GetTypeName(DkmClrType.Create(value.Type.AppDomain, typeArgument), formatSpecifiers, CustomTypeInfo: null),
                 expansion: null,
                 childShouldParenthesize: false,
                 fullName: null,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // (Tools > Options setting) and call "value.ToString()" if appropriate.
             return IncludeObjectId(
                 value,
-                string.Format(_defaultFormat, value.EvaluateToString(inspectionContext) ?? inspectionContext.GetTypeName(value.Type, Formatter.NoFormatSpecifiers)),
+                string.Format(_defaultFormat, value.EvaluateToString(inspectionContext) ?? inspectionContext.GetTypeName(value.Type, Formatter.NoFormatSpecifiers, CustomTypeInfo: null)),
                 flags);
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return GetValueString(value, inspectionContext, options, GetValueFlags.IncludeObjectId);
         }
 
-        string IDkmClrFormatter.GetTypeName(DkmInspectionContext inspectionContext, DkmClrType type, ReadOnlyCollection<string> formatSpecifiers)
+        string IDkmClrFormatter.GetTypeName(DkmInspectionContext inspectionContext, DkmClrType type, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo CustomTypeInfo)
         {
             return GetTypeName(type.GetLmrType());
         }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             this.Formatter = formatter;
         }
 
-        void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)
+        void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo customTypeInfo, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)
         {
             // TODO: Use full name
             var wl = new WorkList(workList, e => completionRoutine(DkmEvaluationAsyncResult.CreateErrorResult(e)));
@@ -284,9 +284,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 !declaredLmrType.IsPointer &&
                 (kind != ExpansionKind.PointerDereference) &&
                 (!declaredLmrType.IsNullable() || value.EvalFlags.Includes(DkmEvaluationResultFlags.ExceptionThrown));
-            var declaredTypeName = inspectionContext.GetTypeName(declaredType, Formatter.NoFormatSpecifiers);
+            var declaredTypeName = inspectionContext.GetTypeName(declaredType, Formatter.NoFormatSpecifiers, CustomTypeInfo: null);
             return includeRuntimeTypeName ?
-                string.Format("{0} {{{1}}}", declaredTypeName, inspectionContext.GetTypeName(runtimeType, Formatter.NoFormatSpecifiers)) :
+                string.Format("{0} {{{1}}}", declaredTypeName, inspectionContext.GetTypeName(runtimeType, Formatter.NoFormatSpecifiers, CustomTypeInfo: null)) :
                 declaredTypeName;
         }
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrCustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrCustomTypeInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+using System;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
+{
+    public class DkmClrCustomTypeInfo
+    {
+        public readonly Guid PayloadTypeId;
+        public readonly ReadOnlyCollection<byte> Payload;
+
+        public DkmClrCustomTypeInfo(Guid payloadTypeId, ReadOnlyCollection<byte> payload)
+        {
+            PayloadTypeId = payloadTypeId;
+            Payload = payload;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 
 namespace Microsoft.VisualStudio.Debugger.Evaluation
 {
@@ -37,10 +38,10 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         //     '16' and '10'.
         public readonly uint Radix;
 
-        public string GetTypeName(DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers)
+        public string GetTypeName(DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo CustomTypeInfo)
         {
             // The real version does some sort of dynamic dispatch that ultimately calls this method.
-            return _formatter.GetTypeName(this, clrType, formatSpecifiers);
+            return _formatter.GetTypeName(this, clrType, formatSpecifiers, customTypeInfo: null);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFormatter.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFormatter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
 {
     public interface IDkmClrFormatter
     {
-        string GetTypeName(DkmInspectionContext inspectionContext, DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers);
+        string GetTypeName(DkmInspectionContext inspectionContext, DkmClrType clrType, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo customTypeInfo);
         string GetUnderlyingString(DkmClrValue clrValue, DkmInspectionContext inspectionContext);
         string GetValueString(DkmClrValue clrValue, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers);
         bool HasUnderlyingString(DkmClrValue clrValue, DkmInspectionContext inspectionContext);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrResultProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
 {
     public interface IDkmClrResultProvider
     {
-        void GetResult(DkmClrValue clrValue, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine);
+        void GetResult(DkmClrValue clrValue, DkmWorkList workList, DkmClrType declaredType, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, DkmClrCustomTypeInfo customTypeInfo, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine);
         void GetChildren(DkmEvaluationResult evaluationResult, DkmWorkList workList, int initialRequestSize, DkmInspectionContext inspectionContext, DkmCompletionRoutine<DkmGetChildrenAsyncResult> completionRoutine);
         void GetItems(DkmEvaluationResultEnumContext enumContext, DkmWorkList workList, int startIndex, int count, DkmCompletionRoutine<DkmEvaluationEnumAsyncResult> completionRoutine);
         string GetUnderlyingString(DkmEvaluationResult result);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -162,6 +162,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 declaredType: declaredType ?? value.Type,
                 inspectionContext: inspectionContext ?? DefaultInspectionContext,
                 formatSpecifiers: Formatter.NoFormatSpecifiers,
+                customTypeInfo: null,
                 resultName: name,
                 resultFullName: null,
                 completionRoutine: asyncResult => evaluationResult = asyncResult.Result);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
@@ -85,6 +85,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Debugger\Engine\DkmClrCustomTypeInfo.cs" />
     <Compile Include="Debugger\Engine\DkmCompilerId.cs" />
     <Compile Include="Debugger\Engine\DkmContinueCorruptingException.cs" />
     <Compile Include="Debugger\Engine\DkmEngineSettings.cs" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                        staticMembersString:=Resources.SharedMembers)
         End Sub
 
-        Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, formatSpecifiers As ReadOnlyCollection(Of String)) As String Implements IDkmClrFormatter.GetTypeName
+        Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, formatSpecifiers As ReadOnlyCollection(Of String), customTypeInfo As DkmClrCustomTypeInfo) As String Implements IDkmClrFormatter.GetTypeName
             Return GetTypeName(clrType.GetLmrType())
         End Function
 


### PR DESCRIPTION
 CustomTypeInfo is passed between an managed expression complier and a result provider.

This new field is a new value type "DkmClrCustomTypeInfo", which is used to convey complier specific type information that is not represented by .NET data types (such as C#'s 'dynamic' type).
In Roslyn, this commit also updates the ResultProvider's mock implementation of the Concord API and fixes all affected callsites.