### PR TITLE
changed preview warning tagger name from "Warning" to "Preview Warning" ...

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -729,8 +729,8 @@
     <Compile Include="Shared\Tagging\Tags\AbstractNavigatableReferenceHighlightingTag.cs" />
     <Compile Include="Shared\Tagging\Tags\ConflictTag.cs" />
     <Compile Include="Shared\Tagging\Tags\ConflictTagDefinition.cs" />
-    <Compile Include="Shared\Tagging\Tags\WarningTag.cs" />
-    <Compile Include="Shared\Tagging\Tags\WarningTagDefinition.cs" />
+    <Compile Include="Shared\Tagging\Tags\PreviewWarningTag.cs" />
+    <Compile Include="Shared\Tagging\Tags\PreviewWarningTagDefinition.cs" />
     <Compile Include="Shared\Tagging\TagSources\BufferTagSource.cs" />
     <Compile Include="Implementation\ReferenceHighlighting\ReferenceHighlightingTagSource.cs" />
     <Compile Include="Shared\Tagging\TagSources\SemanticBufferTagSource.cs" />

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1844,7 +1844,7 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning.
+        ///   Looks up a localized string similar to Preview Warning.
         /// </summary>
         internal static string Warning {
             get {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -364,7 +364,7 @@
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="Warning" xml:space="preserve">
-    <value>Warning</value>
+    <value>Preview Warning</value>
   </data>
   <data name="FromMetadata" xml:space="preserve">
     <value>from metadata</value>

--- a/src/EditorFeatures/Core/Implementation/Preview/PreviewWarningViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Preview/PreviewWarningViewTaggerProvider.cs
@@ -10,15 +10,15 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
 {
     [Export(typeof(ITaggerProvider))]
-    [TagType(typeof(WarningTag))]
+    [TagType(typeof(PreviewWarningTag))]
     [ContentType(ContentTypeNames.RoslynContentType)]
     [TextViewRole(TextViewRoles.PreviewRole)]
     internal class PreviewWarningTaggerProvider
-        : AbstractPreviewTaggerProvider<WarningTag>
+        : AbstractPreviewTaggerProvider<PreviewWarningTag>
     {
         [ImportingConstructor]
         public PreviewWarningTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.WarningSpansKey, WarningTag.Instance)
+            base(PredefinedPreviewTaggerKeys.WarningSpansKey, PreviewWarningTag.Instance)
         {
         }
     }

--- a/src/EditorFeatures/Core/Shared/Tagging/Tags/PreviewWarningTag.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Tags/PreviewWarningTag.cs
@@ -4,13 +4,13 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 {
-    internal class WarningTag : TextMarkerTag
+    internal class PreviewWarningTag : TextMarkerTag
     {
-        public const string TagId = "RoslynWarningTag";
+        public const string TagId = "RoslynPreviewWarningTag";
 
-        public static readonly WarningTag Instance = new WarningTag();
+        public static readonly PreviewWarningTag Instance = new PreviewWarningTag();
 
-        private WarningTag()
+        private PreviewWarningTag()
             : base(TagId)
         {
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/Tags/PreviewWarningTagDefinition.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Tags/PreviewWarningTagDefinition.cs
@@ -9,12 +9,12 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging.Tags
 {
     [Export(typeof(EditorFormatDefinition))]
-    [Name(WarningTag.TagId)]
+    [Name(PreviewWarningTag.TagId)]
     [UserVisible(true)]
     [ExcludeFromCodeCoverage]
-    internal class WarningTagDefinition : MarkerFormatDefinition
+    internal class PreviewWarningTagDefinition : MarkerFormatDefinition
     {
-        public WarningTagDefinition()
+        public PreviewWarningTagDefinition()
         {
             // this.Border = new Pen(Brushes.Yellow, thickness: 1.5);
             this.BackgroundColor = Colors.Yellow;


### PR DESCRIPTION
...to reduce confusion between compiler warning tag.