### PR TITLE
Change how we do UTF8 output

### DIFF
--- a/src/Compilers/CSharp/csc/Csc.cs
+++ b/src/Compilers/CSharp/csc/Csc.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             var responseFile = Path.Combine(clientDir, CSharpCompiler.ResponseFileName);
             Csc compiler = new Csc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
-            return ConsoleUtil.RunWithUtf8Output(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
+            return ConsoleUtil.RunWithOutput(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
         }
 
         public override Assembly LoadAssembly(string fullPath)

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\..\Core\VBCSCompiler\CompilerServerLogger.cs">
       <Link>CompilerServerLogger.cs</Link>
     </Compile>
+    <Compile Include="..\..\Helpers\ConsoleUtil.cs">
+      <Link>ConsoleUtil.cs</Link>
+    </Compile>
     <Compile Include="Csc.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/BuildClient.cs
+++ b/src/Compilers/Core/MSBuildTask/BuildClient.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             if (response.Type == BuildResponse.ResponseType.Completed)
             {
                 var completedResponse = (CompletedBuildResponse)response;
-                return ConsoleUtil.RunWithUtf8Output(
+                return ConsoleUtil.RunWithOutput(
                     completedResponse.Utf8Output,
                     (outWriter, errorWriter) =>
                     {

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\VBCSCompiler\CompilerServerLogger.cs">
       <Link>CompilerServerLogger.cs</Link>
     </Compile>
+    <Compile Include="..\..\Helpers\ConsoleUtil.cs">
+      <Link>ConsoleUtil.cs</Link>
+    </Compile>
     <Compile Include="BuildClient.cs" />
     <Compile Include="CanonicalError.cs" />
     <Compile Include="CommandLineBuilderExtension.cs" />

--- a/src/Compilers/Helpers/ConsoleUtil.cs
+++ b/src/Compilers/Helpers/ConsoleUtil.cs
@@ -13,11 +13,11 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// When <paramref name="utf8Encoding"/> is true then <paramref name="func"/> will be run
-        /// ent while both <see cref="Console.Out"/> and <see cref="Console.Error"/> are set 
+        /// while both <see cref="Console.Out"/> and <see cref="Console.Error"/> are set 
         /// to set to UTF8 encoding.  Otherwise it will be run with the <see cref="Console"/> in
         /// its current state.
         /// </summary>
-        internal static T RunWithUtf8Output<T>(bool utf8Encoding, Func<TextWriter, TextWriter, T> func)
+        internal static T RunWithOutput<T>(bool utf8Encoding, Func<TextWriter, TextWriter, T> func)
         {
             return utf8Encoding
                 ? RunWithEncoding(s_utf8Encoding, func)
@@ -46,15 +46,16 @@ namespace Roslyn.Utilities
             {
                 try
                 {
-                    if (savedOut != null)
-                    {
-                        Console.SetOut(savedOut);
-                    }
+                    Console.SetOut(savedOut);
+                }
+                catch
+                {
+                    // Nothing to do if we can't reset the console. 
+                }
 
-                    if (savedError != null)
-                    {
-                        Console.SetError(savedError);
-                    }
+                try
+                {
+                    Console.SetError(savedOut);
                 }
                 catch
                 {

--- a/src/Compilers/Helpers/ConsoleUtil.cs
+++ b/src/Compilers/Helpers/ConsoleUtil.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Roslyn.Utilities
+{
+    internal static class ConsoleUtil
+    {
+        private static readonly Encoding s_utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
+        /// When <paramref name="utf8Encoding"/> is true then <paramref name="func"/> will be run
+        /// ent while both <see cref="Console.Out"/> and <see cref="Console.Error"/> are set 
+        /// to set to UTF8 encoding.  Otherwise it will be run with the <see cref="Console"/> in
+        /// its current state.
+        /// </summary>
+        internal static T RunWithUtf8Output<T>(bool utf8Encoding, Func<TextWriter, TextWriter, T> func)
+        {
+            return utf8Encoding
+                ? RunWithEncoding(s_utf8Encoding, func)
+                : func(Console.Out, Console.Error);
+        }
+
+        /// <summary>
+        /// Run the <paramref name="func"/> argument while both <see cref="Console.Out"/> and 
+        /// <see cref="Console.Error"/> are set to set to <paramref name="encoding"/>
+        /// </summary>
+        internal static T RunWithEncoding<T>(Encoding encoding, Func<TextWriter, TextWriter, T> func)
+        {
+            TextWriter savedOut = Console.Out;
+            TextWriter savedError = Console.Error;
+            try
+            {
+                using (var streamWriterOut = new StreamWriter(Console.OpenStandardOutput(), encoding))
+                using (var streamWriterError = new StreamWriter(Console.OpenStandardError(), encoding))
+                {
+                    Console.SetOut(streamWriterOut);
+                    Console.SetError(streamWriterError);
+                    return func(streamWriterOut, streamWriterError);
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (savedOut != null)
+                    {
+                        Console.SetOut(savedOut);
+                    }
+
+                    if (savedError != null)
+                    {
+                        Console.SetError(savedError);
+                    }
+                }
+                catch
+                {
+                    // Nothing to do if we can't reset the console. 
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/vbc/Vbc.cs
+++ b/src/Compilers/VisualBasic/vbc/Vbc.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             var responseFile = Path.Combine(clientDir, VisualBasicCompiler.ResponseFileName);
             Vbc compiler = new Vbc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
-            return ConsoleUtil.RunWithUtf8Output(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
+            return ConsoleUtil.RunWithOutput(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
         }
 
         public override Assembly LoadAssembly(string fullPath)

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\..\Core\VBCSCompiler\CompilerServerLogger.cs">
       <Link>CompilerServerLogger.cs</Link>
     </Compile>
+    <Compile Include="..\..\Helpers\ConsoleUtil.cs">
+      <Link>ConsoleUtil.cs</Link>
+    </Compile>
     <Compile Include="Vbc.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>


### PR DESCRIPTION
Both compilers support the /utf8output flag to change the output
encoding to UTF8.  The implementation was using Console.OutputEncoding
which is not supported in CoreFx.  Changed the implementation to use the
supported API pairs of OpenStandard* and Set*.

Note: The compiler was also using IsOutputRedirected which isn't
supported on CoreFx and has no portable replacement.  After discussion
with the compiler team we decided to omit this check.  It a check that
is more aimed at preventing the user from making a mistake by not
redirecting the output vs. enforcing an actual constraint.