### PR TITLE
Codemodel should return only Namespace when asked for CodeNamespace

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeType.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeType.cs
@@ -39,6 +39,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
                 .FirstOrDefault();
         }
 
+        private SyntaxNode GetNamespaceNode()
+        {
+            return LookupNode().Ancestors()
+                .Where(n => CodeModelService.IsNamespace(n))
+                .FirstOrDefault();
+        }
+
         internal INamedTypeSymbol LookupTypeSymbol()
         {
             return (INamedTypeSymbol)LookupSymbol();
@@ -123,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                var namespaceNode = GetNamespaceOrTypeNode();
+                var namespaceNode = GetNamespaceNode();
 
                 return namespaceNode != null
                     ? FileCodeModel.CreateCodeElement<EnvDTE.CodeNamespace>(namespaceNode)

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeClassTests.vb
@@ -108,6 +108,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return Sub(name) codeElement.Name = name
         End Function
 
+        Protected Overrides Function GetNamespace(codeElement As EnvDTE80.CodeClass2) As EnvDTE.CodeNamespace
+            Return codeElement.Namespace
+        End Function
+
         Protected Overrides Function GetParent(codeElement As EnvDTE80.CodeClass2) As Object
             Return codeElement.Parent
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -151,6 +151,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         Protected MustOverride Function GetName(codeElement As TCodeElement) As String
         Protected MustOverride Function GetNameSetter(codeElement As TCodeElement) As Action(Of String)
 
+        Protected Overridable Function GetNamespace(codeElement As TCodeElement) As EnvDTE.CodeNamespace
+            Throw New NotSupportedException
+        End Function
+
         Protected Overridable Function GetAccess(codeElement As TCodeElement) As EnvDTE.vsCMAccess
             Throw New NotSupportedException
         End Function
@@ -1061,6 +1065,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
 
                 Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
+            End Using
+        End Sub
+
+        Protected Sub TestNamespaceName(Code As XElement, name As String)
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(Code))
+                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
+                Assert.NotNull(codeElement)
+
+                Dim codeNamespaceElement = GetNamespace(codeElement)
+                Assert.NotNull(codeNamespaceElement)
+
+                Assert.Equal(name, codeNamespaceElement.Name)
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -2812,6 +2812,38 @@ End Class
         End Sub
 #End Region
 
+#Region "NameSpace Tests"
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetNamespaceNameFromInnerClass()
+            Dim code =
+    <Code>
+Namespace NS1
+    Class C1
+        Class $$C2
+        End Class
+    End Class
+End NameSpace
+</Code>
+
+            TestNamespaceName(code, "NS1")
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetNamespaceNameFromOuterClass()
+            Dim code =
+    <Code>
+Namespace NS1
+    Class $$C1
+        Class C2
+        End Class
+    End Class
+End NameSpace
+</Code>
+
+            TestNamespaceName(code, "NS1")
+        End Sub
+#End Region
+
 #Region "GenericExtender"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>


### PR DESCRIPTION
Fix #1923 AbstractCodeType should return only a namespace when asked for
a CodeNamespace but not a Type