### PR TITLE
More CoreFx changes

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
@@ -19,14 +19,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal const string ResponseFileName = "csc.rsp";
 
-        private readonly string _responseFile;
         private CommandLineDiagnosticFormatter _diagnosticFormatter;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
-            : base(parser, responseFile, args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories)
+            : base(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         {
-            Debug.Assert(responseFile == null || Path.IsPathRooted(responseFile));
-            _responseFile = responseFile;
             _diagnosticFormatter = new CommandLineDiagnosticFormatter(baseDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
         }
 
@@ -258,16 +255,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override string GetToolName()
         {
             return ErrorFacts.GetMessage(MessageID.IDS_ToolName, Culture);
-        }
-
-        internal override string GetAssemblyFileVersion()
-        {
-            return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
-        }
-
-        internal override Version GetAssemblyVersion()
-        {
-            return Assembly.GetExecutingAssembly().GetName().Version;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineParser.cs
@@ -976,7 +976,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!noStdLib)
             {
-                metadataReferences.Insert(0, new CommandLineReference(typeof(object).Assembly.Location, MetadataReferenceProperties.Assembly));
+                metadataReferences.Insert(0, new CommandLineReference(Path.Combine(sdkDirectory, "mscorlib.dll"), MetadataReferenceProperties.Assembly));
             }
 
             if (!platform.Requires64Bit())

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -213,8 +213,9 @@ public class C { }").Path;
 
                 filelist.Add(source1);
                 var outWriter = new StringWriter();
-                var cmd = new CSharpCompilerServer(null,
+                var cmd = new CSharpCompilerServer(
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
+                    null,
                     _baseDirectory,
                     RuntimeEnvironment.GetRuntimeDirectory(),
                     s_libDirectory);

--- a/src/Compilers/CSharp/csc/Csc.cs
+++ b/src/Compilers/CSharp/csc/Csc.cs
@@ -12,17 +12,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 {
     internal sealed class Csc : CSharpCompiler
     {
-        internal Csc(string responseFile, string baseDirectory, string sdkDirectory, string[] args)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
+        internal Csc(string responseFile, string clientDirectory, string baseDirectory, string sdkDirectory, string[] args)
+            : base(CSharpCommandLineParser.Default, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
         {
         }
 
-        internal static int Run(string clientDir, string sdkDirectory, string[] args)
+        internal static int Run(string clientDirectory, string sdkDirectory, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
-            var responseFile = Path.Combine(clientDir, CSharpCompiler.ResponseFileName);
-            Csc compiler = new Csc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
+            var responseFile = Path.Combine(clientDirectory, CSharpCompiler.ResponseFileName);
+            Csc compiler = new Csc(responseFile, clientDirectory, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
             return ConsoleUtil.RunWithOutput(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
         }

--- a/src/Compilers/Core/Desktop/Interop/IClrStrongName.cs
+++ b/src/Compilers/Core/Desktop/Interop/IClrStrongName.cs
@@ -8,7 +8,7 @@ using System.Security;
 
 namespace Microsoft.CodeAnalysis.Interop
 {
-    [ComImport, ComConversionLoss, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D"), SuppressUnmanagedCodeSecurity]
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("9FD93CCF-3280-4391-B3A9-96E1CDE77C8D"), SuppressUnmanagedCodeSecurity]
     internal interface IClrStrongName
     {
         void GetHashFromAssemblyFile(

--- a/src/Compilers/Core/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Core/VBCSCompiler/CSharpCompilerServer.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class CSharpCompilerServer : CSharpCompiler
     {
-        internal CSharpCompilerServer(string responseFile, string[] args, string baseDirectory, string sdkDirectory, string libDirectory)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, libDirectory)
+        internal CSharpCompilerServer(string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string libDirectory)
+            : base(CSharpCommandLineParser.Default, clientDirectory != null ? Path.Combine(clientDirectory, ResponseFileName) : null, args, clientDirectory, baseDirectory, sdkDirectory, libDirectory)
         {
         }
 
         public static int RunCompiler(
-            string responseFileDirectory,
+            string clientDirectory,
             string[] args,
             string baseDirectory,
             string sdkDirectory,
@@ -28,8 +28,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             CancellationToken cancellationToken,
             out bool utf8output)
         {
-            var responseFile = Path.Combine(responseFileDirectory, CSharpCompiler.ResponseFileName);
-            var compiler = new CSharpCompilerServer(responseFile, args, baseDirectory, sdkDirectory, libDirectory);
+            var compiler = new CSharpCompilerServer(args, clientDirectory, baseDirectory, sdkDirectory, libDirectory);
             utf8output = compiler.Arguments.Utf8Output;
             return compiler.Run(output, cancellationToken);
         }

--- a/src/Compilers/Core/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Core/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -15,13 +15,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class VisualBasicCompilerServer : VisualBasicCompiler
     {
-        internal VisualBasicCompilerServer(string responseFile, string[] args, string baseDirectory, string sdkDirectory, string libDirectory)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, libDirectory)
+        internal VisualBasicCompilerServer(string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string libDirectory)
+            : base(VisualBasicCommandLineParser.Default, clientDirectory != null ? Path.Combine(clientDirectory, ResponseFileName) : null, args, clientDirectory, baseDirectory, sdkDirectory, libDirectory)
         {
         }
 
         public static int RunCompiler(
-            string responseFileDirectory,
+            string clientDirectory,
             string[] args,
             string baseDirectory,
             string sdkDirectory,
@@ -30,8 +30,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             CancellationToken cancellationToken,
             out bool utf8output)
         {
-            var responseFile = Path.Combine(responseFileDirectory, VisualBasicCompiler.ResponseFileName);
-            var compiler = new VisualBasicCompilerServer(responseFile, args, baseDirectory, sdkDirectory, libDirectory);
+            var compiler = new VisualBasicCompilerServer(args, clientDirectory, baseDirectory, sdkDirectory, libDirectory);
             utf8output = compiler.Arguments.Utf8Output;
             return compiler.Run(output, cancellationToken);
         }

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         }
 
         public MockCSharpCompiler(string responseFile, string baseDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers)
-            : base(CSharpCommandLineParser.Default, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
+            : base(CSharpCommandLineParser.Default, responseFile, args, Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
         {
             _analyzers = analyzers;
         }

--- a/src/Compilers/Test/Utilities/CSharp/MockCsi.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCsi.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -13,8 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
     internal class MockCsi : CSharpCompiler
     {
-        public MockCsi(string responseFIle, string baseDirectory, string[] args)
-            : base(CSharpCommandLineParser.Interactive, responseFIle, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null)
+        public MockCsi(string responseFile, string baseDirectory, string[] args)
+            : base(CSharpCommandLineParser.Interactive, responseFile, args, Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null)
         {
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.IO
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -9,7 +10,7 @@ Friend Class MockVbi
     Inherits VisualBasicCompiler
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing)
+        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing)
 
     End Sub
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -22,7 +22,7 @@ Friend Class MockVisualBasicCompiler
     End Sub
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"))
 
         _analyzers = analyzers
     End Sub

--- a/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Desktop/CommandLine/VisualBasicCompiler.vb
@@ -18,10 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _responseFile As String
         Private ReadOnly _diagnosticFormatter As CommandLineDiagnosticFormatter
 
-        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String)
-            MyBase.New(parser, responseFile, args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
-            Debug.Assert(responseFile Is Nothing OrElse Path.IsPathRooted(responseFile))
-            _responseFile = responseFile
+        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), clientDirectory As String, baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String)
+            MyBase.New(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, additionalReferenceDirectories)
             _diagnosticFormatter = New CommandLineDiagnosticFormatter(baseDirectory)
         End Sub
 
@@ -177,14 +175,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Overrides Function GetToolName() As String
             Return ErrorFactory.IdToString(ERRID.IDS_ToolName, Culture)
-        End Function
-
-        Friend Overrides Function GetAssemblyFileVersion() As String
-            Return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion
-        End Function
-
-        Friend Overrides Function GetAssemblyVersion() As Version
-            Return Assembly.GetExecutingAssembly().GetName().Version
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -167,10 +167,11 @@ End Class
                 folderList.Add(touchedDir.Path)
 
                 Dim outWriter = New StringWriter()
-                Dim cmd = New VisualBasicCompilerServer(Nothing,
+                Dim cmd = New VisualBasicCompilerServer(
                     {"/nologo",
                      "/touchedfiles:" + touchedBase,
                      source1},
+                    Nothing,
                     _baseDirectory,
                     RuntimeEnvironment.GetRuntimeDirectory(),
                     s_libDirectory)

--- a/src/Compilers/VisualBasic/vbc/Vbc.cs
+++ b/src/Compilers/VisualBasic/vbc/Vbc.cs
@@ -11,17 +11,17 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 {
     internal sealed class Vbc : VisualBasicCompiler
     {
-        internal Vbc(string responseFile, string baseDirectory, string sdkDirectory, string[] args)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
+        internal Vbc(string responseFile, string clientDirectory, string baseDirectory, string sdkDirectory, string[] args)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, Environment.GetEnvironmentVariable("LIB"))
         {
         }
 
-        internal static int Run(string clientDir, string sdkDirectory, string[] args)
+        internal static int Run(string clientDirectory, string sdkDirectory, string[] args)
         {
             FatalError.Handler = FailFast.OnFatalException;
 
-            var responseFile = Path.Combine(clientDir, VisualBasicCompiler.ResponseFileName);
-            Vbc compiler = new Vbc(responseFile, Directory.GetCurrentDirectory(), sdkDirectory, args);
+            var responseFile = Path.Combine(clientDirectory, VisualBasicCompiler.ResponseFileName);
+            Vbc compiler = new Vbc(responseFile, clientDirectory, Directory.GetCurrentDirectory(), sdkDirectory, args);
 
             return ConsoleUtil.RunWithOutput(compiler.Arguments.Utf8Output, (textWriterOut, _) => compiler.Run(textWriterOut));
         }

--- a/src/Interactive/csi/Csi.cs
+++ b/src/Interactive/csi/Csi.cs
@@ -20,7 +20,7 @@ namespace CSharpInteractive
         private const string InteractiveResponseFileName = "csi.rsp";
 
         internal Csi(string responseFile, string baseDirectory, string[] args)
-            : base(CSharpCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: what to pass as additionalReferencePaths? */)
+            : base(CSharpCommandLineParser.Interactive, responseFile, args, Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: what to pass as additionalReferencePaths? */)
         {
         }
 

--- a/src/Interactive/vbi/Vbi.vb
+++ b/src/Interactive/vbi/Vbi.vb
@@ -18,7 +18,7 @@ Friend NotInheritable Class Vbi
     Friend Const InteractiveResponseFileName As String = "vbi.rsp"
 
     Friend Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing) ' TODO: what to pass as additionalReferencePaths?
+        MyBase.New(VisualBasicCommandLineParser.Interactive, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing) ' TODO: what to pass as additionalReferencePaths?
     End Sub
 
     Public Shared Function Main(args As String()) As Integer


### PR DESCRIPTION
This has a number of small changes necessary for CoreFx support:

- Thread through the client directory to CommonCompiler.  This is
necessary for loading items like the SqmData.
- Move GetAssemblyVersion and GetAssemblyFileVersion into
CommonCompiler.  There is no need to specialize this for each compiler.
- Change the implementation of the above methods to not rely on
Assembly.Location which isn't present in CoreFx.