### PR TITLE
Use default item metadata so that this works in C# as well.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -970,9 +970,7 @@
     <Compile Include="Compilation\ModuleCompilationState.vb" />
     <PublicAPI Include="PublicAPI.txt" />
     <Content Include="Symbols\SymbolsAndNoPia.docx" />
-    <ErrorCode Include="Errors\Errors.vb">
-      <Visible>false</Visible>
-    </ErrorCode>
+    <ErrorCode Include="Errors\Errors.vb" />
     <SyntaxDefinition Include="Syntax\Syntax.xml">
       <SubType>Designer</SubType>
     </SyntaxDefinition>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/GenerateCompilerInternals.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/GenerateCompilerInternals.targets
@@ -171,6 +171,12 @@
     <Delete Files="$(GeneratedBoundTree)" />
   </Target>
 
+  <ItemDefinitionGroup>
+    <ErrorCode>
+      <Visible>false</Visible>
+    </ErrorCode>
+  </ItemDefinitionGroup>
+
   <Target
     Name="GenerateErrorFacts"
     Inputs="@(ErrorCode);$(CSharpErrorFactsGeneratorToolPath);$(VBErrorFactsGeneratorToolPath)"


### PR DESCRIPTION
Fixes #1876 for C# as well in "The Right Way"(TM).

(tag @jasonmalinowski)