### PR TITLE
Disable failing assertions until an issue is addressed with SemanticModel.GetEnclosingSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -48,7 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (map.ContainsKey(key))
                     {
-#if DEBUG
+// below used to be #if DEBUG, but due to issue #1504 we are disabling these checks for now.
+#if BUG_1504_FIXED
                         // It's possible that AddToMap was previously called with a subtree of root.  If this is the case,
                         // then we'll see an entry in the map.  Since the incremental binder should also have seen the
                         // pre-existing map entry, the entry in addition map should be identical.
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         var existing = map[key];
                         var added = additionMap[key];
-                        FailFast.Assert(existing.Length == added.Length, "existing.Length == added.Length");
+                        Debug.Assert(existing.Length == added.Length, "existing.Length == added.Length");
                         for (int i = 0; i < existing.Length; i++)
                         {
                             // TODO: it would be great if we could check !ReferenceEquals(existing[i], added[i]) (DevDiv #11584).
@@ -76,12 +77,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             //      since nothing is cached for the statement syntax.
                             if (existing[i].Kind != added[i].Kind)
                             {
-                                FailFast.Assert(!(key is StatementSyntax), "!(key is StatementSyntax)");
+                                Debug.Assert(!(key is StatementSyntax), "!(key is StatementSyntax)");
 
                                 // This also seems to be happening when we get equivalent BoundTypeExpression and BoundTypeOrValueExpression nodes.
                                 if (existing[i].Kind == BoundKind.TypeExpression && added[i].Kind == BoundKind.TypeOrValueExpression)
                                 {
-                                    FailFast.Assert(
+                                    Debug.Assert(
                                         ((BoundTypeExpression)existing[i]).Type == ((BoundTypeOrValueExpression)added[i]).Type,
                                         string.Format(
                                             CultureInfo.InvariantCulture,
@@ -89,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else if (existing[i].Kind == BoundKind.TypeOrValueExpression && added[i].Kind == BoundKind.TypeExpression)
                                 {
-                                    FailFast.Assert(
+                                    Debug.Assert(
                                         ((BoundTypeOrValueExpression)existing[i]).Type == ((BoundTypeExpression)added[i]).Type,
                                         string.Format(
                                             CultureInfo.InvariantCulture,
@@ -97,12 +98,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else
                                 {
-                                    FailFast.Assert(false, "New bound node does not match existing bound node");
+                                    Debug.Assert(false, "New bound node does not match existing bound node");
                                 }
                             }
                             else
                             {
-                                FailFast.Assert(
+                                Debug.Assert(
                                     (object)existing[i] == added[i] || !(key is StatementSyntax),
                                     string.Format(
                                         CultureInfo.InvariantCulture,

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -48,8 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (map.ContainsKey(key))
                     {
-// below used to be #if DEBUG, but due to issue #1504 we are disabling these checks for now.
-#if BUG_1504_FIXED
+#if DEBUG
                         // It's possible that AddToMap was previously called with a subtree of root.  If this is the case,
                         // then we'll see an entry in the map.  Since the incremental binder should also have seen the
                         // pre-existing map entry, the entry in addition map should be identical.
@@ -103,15 +102,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
+#if BUG_1504_FIXED // due to issue #1504 we are disabling these checks for now.
                                 Debug.Assert(
                                     (object)existing[i] == added[i] || !(key is StatementSyntax),
                                     string.Format(
                                         CultureInfo.InvariantCulture,
                                         "(object)existing[{0}] == added[{0}] || !(key is StatementSyntax)", i));
+#else
+                                // A weakened form of the assertion until #1504 is fixed
+                                Debug.Assert(existing[i].Kind == added[i].Kind);
+#endif
                             }
                         }
 #endif
-                    }
+                            }
                     else
                     {
                         map[key] = additionMap[key];

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -3327,6 +3327,92 @@ namespace Microsoft.Conformance.Expressions
                 );
         }
 
+        [Fact, WorkItem(1504, "https://github.com/dotnet/roslyn/issues/1504")]
+        public void ContainingSymbol02()
+        {
+            var source =
+@"using System;
+
+class C
+{
+    static bool G<T>(Func<T> f) => true;
+    static void F()
+    {
+        Exception x1 = null;
+        try
+        {
+            G(() => x1);
+        }
+        catch (Exception x2) when (G(() => x2))
+        {
+        }
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            var model = compilation.GetSemanticModel(compilation.SyntaxTrees.Single());
+            for (var match = System.Text.RegularExpressions.Regex.Match(source, " => x"); match.Success; match = match.NextMatch())
+            {
+                var discarded = model.GetEnclosingSymbol(match.Index);
+            }
+        }
+
+        [Fact, WorkItem(1504, "https://github.com/dotnet/roslyn/issues/1504")]
+        public void ContainingSymbol03()
+        {
+            var source =
+@"using System;
+
+class C
+{
+    static bool G<T>(Func<T> f) => true;
+    static void F()
+    {
+        Exception x1 = null, x2 = null;
+        do
+        {
+            G(() => x1);
+        }
+        while (G(() => x2));
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+            for (var match = System.Text.RegularExpressions.Regex.Match(source, " => x"); match.Success; match = match.NextMatch())
+            {
+                var x = tree.GetRoot().FindToken(match.Index + 4).Parent;
+                var discarded = model.GetEnclosingSymbol(match.Index);
+                var disc = model.GetSymbolInfo(x);
+            }
+        }
+
+        [Fact, WorkItem(1504, "https://github.com/dotnet/roslyn/issues/1504")]
+        public void ContainingSymbol04()
+        {
+            var source =
+@"using System;
+
+class C
+{
+    static bool G<T>(Func<T> f) => true;
+    static void F()
+    {
+        Exception x1 = null, x2 = null;
+        if (G(() => x1));
+        {
+            G(() => x2);
+        }
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            var model = compilation.GetSemanticModel(compilation.SyntaxTrees.Single());
+            var discarded1 = model.GetEnclosingSymbol(source.LastIndexOf(" => x"));
+            var discarded2 = model.GetEnclosingSymbol(source.IndexOf(" => x"));
+        }
+
         #region "regression helper"
         private void Regression(string text)
         {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -3053,7 +3053,8 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemanticDiagnostics();
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x0", "lambda", "x1", "x0"));
         }
 
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -3003,7 +3003,7 @@ class C
                 Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", "lambda", "x0", "x1"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/1504"), WorkItem(1504)]
+        [Fact, WorkItem(1504, "https://github.com/dotnet/roslyn/issues/1504")]
         public void Lambdas_Insert_CatchFilter1()
         {
             var src1 = @"
@@ -3013,8 +3013,8 @@ class C
 {
     static bool G<T>(Func<T> f) => true;
     
-    static void F()                       
-    {                              
+    static void F()
+    {
         Exception x1 = null;
     
         try
@@ -3034,8 +3034,8 @@ class C
 {
     static bool G<T>(Func<T> f) => true;
     
-    static void F()                       
-    {                 
+    static void F()
+    {
         Exception x1 = null;
              
         try


### PR DESCRIPTION
Includes unit tests for #1504.

@agocke @VSadov @AlekseyTs @jaredpar Please Review