### PR TITLE
Fix UnreachableException during Debugging

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -3136,6 +3136,42 @@ class C
             VerifyPreserveLocalVariables(edits, preserveLocalVariables: true);
         }
 
+        [WorkItem(1087305)]
+        [Fact]
+        public void MethodUpdate_LabeledStatement()
+        {
+            string src1 = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        goto Label1;
+ 
+    Label1:
+        {
+            Console.WriteLine(1);
+        }
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        goto Label1;
+ 
+    Label1:
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics();
+        }
+
         #endregion
 
         #region Operators

--- a/src/Features/CSharp/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/EditAndContinue/StatementSyntaxComparer.cs
@@ -767,6 +767,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return true;
 
                 case SyntaxKind.Block:
+                case SyntaxKind.LabeledStatement:
                     distance = ComputeWeightedBlockDistance(leftBlock, rightBlock);
                     return true;
 


### PR DESCRIPTION
When computing the distance between blocks for EnC, there was a missing case for LabeledStatement, causing UnreachableException. This PR fixes this issue.