### PR TITLE
Linux setup scripts

### DIFF
--- a/src/Tools/setup-snapshot.sh
+++ b/src/Tools/setup-snapshot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+PCL_NAME=PortableReferenceAssemblies-2014-04-14
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: This script must be run as root"
+    exit 1
+fi
+
+apt-get -y install mono-snapshot-latest
+
+. mono-snapshot mono 
+if [ ! -d "$MONO_PREFIX" ]; then
+    echo "Error: Mono snapshot did not load correctly"
+    exit 1
+fi
+
+PCL_TARGET=$MONO_PREFIX/lib/mono/xbuild-frameworks/.NETPortable
+if [ -d "$PCL_TARGET" ]; then
+    echo "Error: PCL already installed at $PCL_TARGET"
+    exit 1
+fi
+
+# Now to install the PCL on the snapshot 
+cd /tmp 
+wget http://storage.bos.xamarin.com/bot-provisioning/$PCL_NAME.zip -O /tmp/pcl.zip
+unzip pcl.zip 
+if [ ! -d "$PCL_NAME" ]; then
+    echo "Error: Did not unzip the PCL correctly"
+    exit 1
+fi
+
+echo "Installing to $PCL_TARGET"
+mkdir $PCL_TARGET
+mv $PCL_NAME/* $PCL_TARGET

--- a/src/Tools/setup.sh
+++ b/src/Tools/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+# Install the certs so NuGet.exe can function correctly
+mozroots --import --machine --sync
+echo "Y" | certmgr -ssl https://go.microsoft.com
+echo "Y" | certmgr -ssl https://nugetgallery.blob.core.windows.net
+echo "Y" | certmgr -ssl https://nuget.org
+
+# Setup apt-get for grabbing mono snapshot builds
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://jenkins.mono-project.com/repo/debian sid main" | tee /etc/apt/sources.list.d/mono-jenkins.list
+apt-get update > /dev/null
+
+# Now that we are all setup get the latest snapshot up and running
+source setup-snapshot.sh
+


### PR DESCRIPTION
This adds two scripts that setup a Linux box for building Roslyn. This
represents the steps used to configure our Jenkins CI system for Linux.
The scripts do the following:

- setup.sh: One time machine setup to enable NuGet usage and consumption
  of mono CI builds
- setup-snapshot.sh: Install the latest mono CI package and setup the
  PCL for that build.

These scripts are brand new and should be considered experimental.