### PR TITLE
CodeModel now completely handles Conversion operator declarations

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     case SyntaxKind.ConstructorDeclaration:
                     case SyntaxKind.DestructorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
+                    case SyntaxKind.ConversionOperatorDeclaration:
                         return GetStartPoint(text, (BaseMethodDeclarationSyntax)node, part);
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.IndexerDeclaration:
@@ -95,6 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     case SyntaxKind.ConstructorDeclaration:
                     case SyntaxKind.DestructorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
+                    case SyntaxKind.ConversionOperatorDeclaration:
                         return GetEndPoint(text, (BaseMethodDeclarationSyntax)node, part);
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.IndexerDeclaration:

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -578,6 +578,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 case SyntaxKind.ConstructorDeclaration:
                 case SyntaxKind.DestructorDeclaration:
                 case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
                     return (EnvDTE.CodeElement)CodeFunction.CreateUnknown(state, fileCodeModel, node.RawKind, GetName(node));
 
                 case SyntaxKind.PropertyDeclaration:

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_Events.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_Events.cs
@@ -136,7 +136,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return result;
         }
 
-        private void GetElementsForCodeModelEvent(CodeModelEvent codeModelEvent, out EnvDTE.CodeElement element, out object parentElement)
+        // internal for testing
+        internal void GetElementsForCodeModelEvent(CodeModelEvent codeModelEvent, out EnvDTE.CodeElement element, out object parentElement)
         {
             parentElement = GetParentElementForCodeModelEvent(codeModelEvent);
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -9,6 +9,48 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
     Public Class CodeFunctionTests
         Inherits AbstractCodeFunctionTests
 
+#Region "Get Start Point"
+        <WorkItem(1980, "https://github.com/dotnet/roslyn/issues/1980")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetStartPointConversionOperatorFunction()
+            Dim code =
+<Code>
+class D
+{
+    public static implicit operator $$D(double d)
+    {
+        return new D();
+    }
+}
+</Code>
+
+            TestGetStartPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartBody,
+                     TextPoint(line:=5, lineOffset:=1, absoluteOffset:=65, lineLength:=23)))
+        End Sub
+#End Region
+
+#Region "Get End Point"
+        <WorkItem(1980, "https://github.com/dotnet/roslyn/issues/1980")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetEndPointConversionOperatorFunction()
+            Dim code =
+<Code>
+class D
+{
+    public static implicit operator $$D(double d)
+    {
+        return new D();
+    }
+}
+</Code>
+
+            TestGetEndPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartBody,
+                     TextPoint(line:=6, lineOffset:=1, absoluteOffset:=89, lineLength:=5)))
+        End Sub
+#End Region
+
 #Region "Access tests"
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>


### PR DESCRIPTION
Fix #1980 : CodeModel was not handling Conversion operator declarations
in few areas. This change addresses these issues