### PR TITLE
Removed a duplicated row for the metadata token TypeRef

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -453,7 +453,6 @@ namespace Microsoft.Cci
             rowCounts[(int)TableIndex.ClassLayout] = _classLayoutTable.Count;
             rowCounts[(int)TableIndex.Constant] = _constantTable.Count;
             rowCounts[(int)TableIndex.CustomAttribute] = _customAttributeTable.Count;
-            rowCounts[(int)TableIndex.TypeRef] = _typeRefTable.Count;
             rowCounts[(int)TableIndex.DeclSecurity] = _declSecurityTable.Count;
             rowCounts[(int)TableIndex.EncLog] = _encLogTable.Count;
             rowCounts[(int)TableIndex.EncMap] = _encMapTable.Count;


### PR DESCRIPTION
The method `GetRowCounts` in the class `MetadataWriter.cs` creates and initializes an array of metadata tokens. There was a duplicated entry in that table that I removed (the second entry would just overwrite the first one).
This change makes that code a little clearer  by getting rid of that duplicated row.