### PR TITLE
Use VB core on our build tools

### DIFF
--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
@@ -14,6 +14,7 @@
     <StartupObject>Microsoft.CodeAnalysis.VisualBasic.Internal.VBErrorFactsGenerator.Program</StartupObject>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Internal.VBErrorFactsGenerator</RootNamespace>
     <AssemblyName>VBErrorFactsGenerator</AssemblyName>
+    <VBRuntime>Embed</VBRuntime>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>On</OptionStrict>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
@@ -18,6 +18,7 @@
     <OptionInfer>On</OptionInfer>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <VBRuntime>Embed</VBRuntime>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Currently these build tools takes a dependency on Microsoft.VisualBasic.dll.  There is no good implementation of this DLL on Linux which prevented these tools from running there.  This in turn prevented us from builing VBC on Linux because they are used in the build process.  Change them to instead embed the runtime removing our dependency on Microsoft.VisualBasic.dll.