### PR TITLE
Add handling of ArrowExpressionClauseSyntax nodes to LocalBinderFactory.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -120,6 +120,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+        {
+            // Do nothing, expressions do not need special binders.
+        }
+
         public override void VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)
         {
             VisitBlock(node.Block);


### PR DESCRIPTION
Fixes #971.

@VSadov, @gafter, @agocke, @jaredpar Please review. 