### PR TITLE
Dont Case Correct Identifier to Symbols that the identifier cannot bind

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CaseCorrecting/CaseCorrectionServiceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CaseCorrecting/CaseCorrectionServiceTests.vb
@@ -841,6 +841,24 @@ End Class
             Test(input, expected)
         End Sub
 
+        <WorkItem(1949, "https://github.com/dotnet/roslyn/issues/1949")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CaseCorrection)>
+        Public Sub TestUnResolvedTypeDoesNotBindToAnyAccessibleSymbol()
+            Dim unchangeCode = <Code>
+Option Strict On
+Class C
+    Property prop As Integer
+    Sub GetIt(arg As Integer)
+        Dim var1 As Var1
+        Dim var2 As Arg
+        Dim var3 As Prop
+    End Sub
+End Class
+</Code>
+
+            Test(unchangeCode, unchangeCode)
+        End Sub
+
 #End Region
 
 #Region "Keywords and type suffixes"

--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -132,6 +132,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                     Return newToken
                 End If
 
+                Dim expression = TryCast(token.Parent, ExpressionSyntax)
+                If expression IsNot Nothing AndAlso SyntaxFacts.IsInNamespaceOrTypeContext(expression) AndAlso Not IsNamespaceOrTypeRelatedSymbol(symbol) Then
+                    Return newToken
+                End If
+
                 If TypeOf symbol Is ITypeSymbol AndAlso DirectCast(symbol, ITypeSymbol).TypeKind = TypeKind.Error Then
                     Return newToken
                 End If
@@ -148,6 +153,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                 End If
 
                 Return CaseCorrectIdentifierIfNamesDiffer(token, newToken, symbol)
+            End Function
+
+            Private Shared Function IsNamespaceOrTypeRelatedSymbol(symbol As ISymbol) As Boolean
+                Return TypeOf symbol Is INamespaceOrTypeSymbol OrElse
+                    (TypeOf symbol Is IAliasSymbol AndAlso TypeOf DirectCast(symbol, IAliasSymbol).Target Is INamespaceOrTypeSymbol) OrElse
+                    (symbol.IsKind(SymbolKind.Method) AndAlso DirectCast(symbol, IMethodSymbol).MethodKind = MethodKind.Constructor)
             End Function
 
             Private Function GetAliasOrAnySymbol(model As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ISymbol


### PR DESCRIPTION
Fix #1949 : Identifiers in the TypeOrNamespace context should not be
case corrected by binding the identifier to any random symbol like
locals, parameters, properties and others.