### PR TITLE
Reduce likelyhood of race in EventMap

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -27,28 +27,39 @@ namespace Microsoft.CodeAnalysis.UnitTests.Workspaces
 
         private static void WaitForWorkspaceOperationsToComplete(TestWorkspace workspace)
         {
-            var workspasceWaiter = workspace.ExportProvider
+            var workspaceWaiter = workspace.ExportProvider
                 .GetExports<IAsynchronousOperationListener, FeatureMetadata>()
                 .First(l => l.Metadata.FeatureName == FeatureAttribute.Workspace).Value as IAsynchronousOperationWaiter;
-            workspasceWaiter.CreateWaitTask().PumpingWait();
+            workspaceWaiter.CreateWaitTask().PumpingWait();
         }
 
         [Fact]
-        public void TestEmptySolutionUpdate()
+        public void TestEmptySolutionUpdateDoesNotFireEvents()
         {
             using (var workspace = CreateWorkspace())
             {
                 var project = new TestHostProject(workspace);
                 workspace.AddTestProject(project);
-                var solution = workspace.CurrentSolution;
-                bool workspaceChanged = false;
-                workspace.WorkspaceChanged += (s, e) => workspaceChanged = true;
 
-                workspace.OnParseOptionsChanged(project.Id, project.ParseOptions);
+                // wait for all previous operations to complete
                 WaitForWorkspaceOperationsToComplete(workspace);
 
+                var solution = workspace.CurrentSolution;
+                bool workspaceChanged = false;
+
+                workspace.WorkspaceChanged += (s, e) => workspaceChanged = true;
+
+                // make an 'empty' update by claiming something changed, but its the same as before
+                workspace.OnParseOptionsChanged(project.Id, project.ParseOptions);
+
+                // wait for any new outstanding operations to complete (there shouldn't be any)
+                WaitForWorkspaceOperationsToComplete(workspace);
+
+                // same solution instance == nothing changed
                 Assert.Equal(solution, workspace.CurrentSolution);
-                Assert.True(workspaceChanged);
+
+                // no event was fired because nothing was changed
+                Assert.False(workspaceChanged);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Workspaces
                 WaitForWorkspaceOperationsToComplete(workspace);
 
                 Assert.Equal(solution, workspace.CurrentSolution);
-                Assert.False(workspaceChanged);
+                Assert.True(workspaceChanged);
             }
         }
 

--- a/src/Features/Core/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticService.cs
@@ -58,18 +58,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void RaiseDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs args)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName))
             {
                 var eventToken = _listener.BeginAsyncOperation(DiagnosticsUpdatedEventName);
                 _eventQueue.ScheduleTask(() =>
                 {
                     UpdateDataMap(sender, args);
-
-                    foreach (var handler in handlers)
-                    {
-                        handler(sender, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName, handler => handler(sender, args));
                 }).CompletesAsyncOperation(eventToken);
             }
         }

--- a/src/Features/Core/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticService.cs
@@ -58,13 +58,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void RaiseDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs args)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName);
+            if (ev.HasHandlers)
             {
                 var eventToken = _listener.BeginAsyncOperation(DiagnosticsUpdatedEventName);
                 _eventQueue.ScheduleTask(() =>
                 {
                     UpdateDataMap(sender, args);
-                    _eventMap.RaiseEvent<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName, handler => handler(sender, args));
+                    ev.RaiseEvent(handler => handler(sender, args));
                 }).CompletesAsyncOperation(eventToken);
             }
         }

--- a/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -106,11 +106,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private Task RaiseEvent(string eventName)
             {
                 // this method name doesnt have Async since it should work as async void.
-                if (_eventMap.HasEventHandlers<EventHandler>(eventName))
+                var ev = _eventMap.GetEventHandlers<EventHandler>(eventName);
+                if (ev.HasHandlers)
                 {
                     return _eventQueue.ScheduleTask(() =>
                     {
-                        _eventMap.RaiseEvent<EventHandler>(eventName, handler => handler(this, EventArgs.Empty));
+                        ev.RaiseEvent(handler => handler(this, EventArgs.Empty));
                     });
                 }
 

--- a/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -106,15 +106,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private Task RaiseEvent(string eventName)
             {
                 // this method name doesnt have Async since it should work as async void.
-                var handlers = _eventMap.GetEventHandlers<EventHandler>(eventName);
-                if (handlers.Length > 0)
+                if (_eventMap.HasEventHandlers<EventHandler>(eventName))
                 {
                     return _eventQueue.ScheduleTask(() =>
                     {
-                        foreach (var handler in handlers)
-                        {
-                            handler(this, EventArgs.Empty);
-                        }
+                        _eventMap.RaiseEvent<EventHandler>(eventName, handler => handler(this, EventArgs.Empty));
                     });
                 }
 

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
@@ -49,11 +49,12 @@ namespace Microsoft.CodeAnalysis.Notification
 
         protected virtual Task RaiseGlobalOperationStarted()
         {
-            if (_eventMap.HasEventHandlers<EventHandler>(GlobalOperationStartedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler>(GlobalOperationStartedEventName);
+            if (ev.HasHandlers)
             {
                 return _eventQueue.ScheduleTask(() =>
                 {
-                    _eventMap.RaiseEvent<EventHandler>(GlobalOperationStartedEventName, handler => handler(this, EventArgs.Empty));
+                    ev.RaiseEvent(handler => handler(this, EventArgs.Empty));
                 });
             }
 
@@ -62,13 +63,14 @@ namespace Microsoft.CodeAnalysis.Notification
 
         protected virtual Task RaiseGlobalOperationStopped(IReadOnlyList<string> operations, bool cancelled)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName);
+            if (ev.HasHandlers)
             {
                 var args = new GlobalOperationEventArgs(operations, cancelled);
 
                 return _eventQueue.ScheduleTask(() =>
                 {
-                    _eventMap.RaiseEvent<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName, handler => handler(this, args));
+                    ev.RaiseEvent(handler => handler(this, args));
                 });
             }
 

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
@@ -49,15 +49,11 @@ namespace Microsoft.CodeAnalysis.Notification
 
         protected virtual Task RaiseGlobalOperationStarted()
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler>(GlobalOperationStartedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler>(GlobalOperationStartedEventName))
             {
                 return _eventQueue.ScheduleTask(() =>
                 {
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, EventArgs.Empty);
-                    }
+                    _eventMap.RaiseEvent<EventHandler>(GlobalOperationStartedEventName, handler => handler(this, EventArgs.Empty));
                 });
             }
 
@@ -66,17 +62,13 @@ namespace Microsoft.CodeAnalysis.Notification
 
         protected virtual Task RaiseGlobalOperationStopped(IReadOnlyList<string> operations, bool cancelled)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName))
             {
                 var args = new GlobalOperationEventArgs(operations, cancelled);
 
                 return _eventQueue.ScheduleTask(() =>
                 {
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName, handler => handler(this, args));
                 });
             }
 

--- a/src/Workspaces/Core/Portable/Utilities/EventMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EventMap.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Roslyn.Utilities
 {
@@ -10,7 +11,7 @@ namespace Roslyn.Utilities
     {
         private readonly NonReentrantLock _guard = new NonReentrantLock();
 
-        private readonly Dictionary<string, object> _eventNameToHandlers =
+        private readonly Dictionary<string, object> _eventNameToRegistries =
             new Dictionary<string, object>();
 
         public EventMap()
@@ -18,64 +19,133 @@ namespace Roslyn.Utilities
         }
 
         public void AddEventHandler<TEventHandler>(string eventName, TEventHandler eventHandler)
+            where TEventHandler : class
         {
             using (_guard.DisposableWait())
             {
-                var handlers = GetEvents_NoLock<TEventHandler>(eventName);
-                var newHandlers = handlers.Add(eventHandler);
-                SetEvents_NoLock(eventName, newHandlers);
+                var registries = GetRegistries_NoLock<TEventHandler>(eventName);
+                var newHandlers = registries.Add(new Registry<TEventHandler>(eventHandler));
+                SetRegistries_NoLock(eventName, newHandlers);
             }
         }
 
         public void RemoveEventHandler<TEventHandler>(string eventName, TEventHandler eventHandler)
+            where TEventHandler : class
         {
             using (_guard.DisposableWait())
             {
-                var handlers = GetEvents_NoLock<TEventHandler>(eventName);
-                var newHandlers = handlers.Remove(eventHandler);
-                if (newHandlers != handlers)
+                var registries = GetRegistries_NoLock<TEventHandler>(eventName);
+
+                // remove disabled registrations from list
+                var newRegistries = registries.RemoveAll(r => r.HasHandler(eventHandler));
+
+                if (newRegistries != registries)
                 {
-                    SetEvents_NoLock(eventName, newHandlers);
+                    // disable all registrations of this handler (so pending raise events can be squelched)
+                    // This does not guarantee no race condition between Raise and Remove but greatly reduces it.
+                    foreach (var registery in registries.Where(r => r.HasHandler(eventHandler)))
+                    {
+                        registery.Unregister();
+                    }
+
+                    SetRegistries_NoLock(eventName, newRegistries);
                 }
             }
         }
 
-        public ImmutableArray<TEventHandler> GetEventHandlers<TEventHandler>(string eventName)
+        public bool HasEventHandlers<TEventHandler>(string eventName)
+            where TEventHandler : class
+        {
+            return this.GetRegistries<TEventHandler>(eventName).Length > 0;
+        }
+
+        public void RaiseEvent<TEventHandler>(string eventName, Action<TEventHandler> invoker)
+            where TEventHandler : class
+        {
+            var registries = GetRegistries<TEventHandler>(eventName);
+            if (registries.Length > 0)
+            {
+                foreach (var registry in registries)
+                {
+                    registry.Invoke(invoker);
+                }
+            }
+        }
+
+        private ImmutableArray<Registry<TEventHandler>> GetRegistries<TEventHandler>(string eventName)
+            where TEventHandler : class
         {
             using (_guard.DisposableWait())
             {
-                return GetEvents_NoLock<TEventHandler>(eventName);
+                return GetRegistries_NoLock<TEventHandler>(eventName);
             }
         }
 
-        public void RaiseEvent<TEventArgs>(string eventName, object sender, TEventArgs args)
-            where TEventArgs : EventArgs
-        {
-            var handlers = GetEventHandlers<EventHandler<TEventArgs>>(eventName);
-            foreach (var handler in handlers)
-            {
-                handler(sender, args);
-            }
-        }
-
-        private ImmutableArray<TEventHandler> GetEvents_NoLock<TEventHandler>(string eventName)
+        private ImmutableArray<Registry<TEventHandler>> GetRegistries_NoLock<TEventHandler>(string eventName)
+            where TEventHandler : class
         {
             _guard.AssertHasLock();
 
-            object handlers;
-            if (_eventNameToHandlers.TryGetValue(eventName, out handlers))
+            object registries;
+            if (_eventNameToRegistries.TryGetValue(eventName, out registries))
             {
-                return (ImmutableArray<TEventHandler>)handlers;
+                return (ImmutableArray<Registry<TEventHandler>>)registries;
             }
 
-            return ImmutableArray.Create<TEventHandler>();
+            return ImmutableArray.Create<Registry<TEventHandler>>();
         }
 
-        private void SetEvents_NoLock<TEventHandler>(string name, ImmutableArray<TEventHandler> events)
+        private void SetRegistries_NoLock<TEventHandler>(string name, ImmutableArray<Registry<TEventHandler>> events)
+            where TEventHandler : class
         {
             _guard.AssertHasLock();
 
-            _eventNameToHandlers[name] = events;
+            _eventNameToRegistries[name] = events;
+        }
+
+        private class Registry<TEventHandler> : IEquatable<Registry<TEventHandler>>
+            where TEventHandler : class
+        {
+            private TEventHandler handler;
+
+            public Registry(TEventHandler handler)
+            {
+                this.handler = handler;
+            }
+
+            public void Unregister()
+            {
+                this.handler = null;
+            }
+
+            public void Invoke(Action<TEventHandler> invoker)
+            {
+                var handler = this.handler;
+                if (handler != null)
+                {
+                    invoker(handler);
+                }
+            }
+
+            public bool HasHandler(TEventHandler handler)
+            {
+                return this.handler == handler;
+            }
+
+            public bool Equals(Registry<TEventHandler> other)
+            {
+                return other != null && other.handler == this.handler;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Registry<TEventHandler>);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.handler.GetHashCode();
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/EventMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EventMap.cs
@@ -43,9 +43,9 @@ namespace Roslyn.Utilities
                 {
                     // disable all registrations of this handler (so pending raise events can be squelched)
                     // This does not guarantee no race condition between Raise and Remove but greatly reduces it.
-                    foreach (var registery in registries.Where(r => r.HasHandler(eventHandler)))
+                    foreach (var registry in registries.Where(r => r.HasHandler(eventHandler)))
                     {
-                        registery.Unregister();
+                        registry.Unregister();
                     }
 
                     SetRegistries_NoLock(eventName, newRegistries);

--- a/src/Workspaces/Core/Portable/Utilities/EventMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EventMap.cs
@@ -24,8 +24,8 @@ namespace Roslyn.Utilities
             using (_guard.DisposableWait())
             {
                 var registries = GetRegistries_NoLock<TEventHandler>(eventName);
-                var newHandlers = registries.Add(new Registry<TEventHandler>(eventHandler));
-                SetRegistries_NoLock(eventName, newHandlers);
+                var newRegistries = registries.Add(new Registry<TEventHandler>(eventHandler));
+                SetRegistries_NoLock(eventName, newRegistries);
             }
         }
 
@@ -95,12 +95,12 @@ namespace Roslyn.Utilities
             return ImmutableArray.Create<Registry<TEventHandler>>();
         }
 
-        private void SetRegistries_NoLock<TEventHandler>(string name, ImmutableArray<Registry<TEventHandler>> events)
+        private void SetRegistries_NoLock<TEventHandler>(string eventName, ImmutableArray<Registry<TEventHandler>> registries)
             where TEventHandler : class
         {
             _guard.AssertHasLock();
 
-            _eventNameToRegistries[name] = events;
+            _eventNameToRegistries[eventName] = registries;
         }
 
         private class Registry<TEventHandler> : IEquatable<Registry<TEventHandler>>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -48,12 +48,13 @@ namespace Microsoft.CodeAnalysis
                 projectId = documentId.ProjectId;
             }
 
-            if (_eventMap.HasEventHandlers<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName);
+            if (ev.HasHandlers)
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
-                    _eventMap.RaiseEvent<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName, handler => handler(this, args));
+                    ev.RaiseEvent(handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else
@@ -81,10 +82,11 @@ namespace Microsoft.CodeAnalysis
 
         protected internal virtual void OnWorkspaceFailed(WorkspaceDiagnostic diagnostic)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName);
+            if (ev.HasHandlers)
             {
                 var args = new WorkspaceDiagnosticEventArgs(diagnostic);
-                _eventMap.RaiseEvent<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName, handler => handler(this, args));
+                ev.RaiseEvent(handler => handler(this, args));
             }
         }
 
@@ -106,12 +108,13 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentOpenedEventAsync(Document document)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName);
+            if (ev.HasHandlers)
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName, handler => handler(this, args));
+                    ev.RaiseEvent(handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else
@@ -138,12 +141,13 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentClosedEventAsync(Document document)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentClosedEventName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentClosedEventName);
+            if (ev.HasHandlers)
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentClosedEventName, handler => handler(this, args));
+                    ev.RaiseEvent(handler => handler(this, args));
                 }, "Workspace.DocumentClosed");
             }
             else
@@ -171,12 +175,13 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentActiveContextChangedEventAsync(Document document)
         {
-            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName))
+            var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName);
+            if (ev.HasHandlers)
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName, handler => handler(this, args));
+                    ev.RaiseEvent(handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -48,16 +48,12 @@ namespace Microsoft.CodeAnalysis
                 projectId = documentId.ProjectId;
             }
 
-            var handlers = _eventMap.GetEventHandlers<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName))
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<WorkspaceChangeEventArgs>>(WorkspaceChangeEventName, handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else
@@ -85,14 +81,10 @@ namespace Microsoft.CodeAnalysis
 
         protected internal virtual void OnWorkspaceFailed(WorkspaceDiagnostic diagnostic)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName))
             {
                 var args = new WorkspaceDiagnosticEventArgs(diagnostic);
-                foreach (var handler in handlers)
-                {
-                    handler(this, args);
-                }
+                _eventMap.RaiseEvent<EventHandler<WorkspaceDiagnosticEventArgs>>(WorkspaceFailedEventName, handler => handler(this, args));
             }
         }
 
@@ -114,16 +106,12 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentOpenedEventAsync(Document document)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName))
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName, handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else
@@ -150,16 +138,12 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentClosedEventAsync(Document document)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentClosedEventName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentClosedEventName))
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentClosedEventName, handler => handler(this, args));
                 }, "Workspace.DocumentClosed");
             }
             else
@@ -187,16 +171,12 @@ namespace Microsoft.CodeAnalysis
 
         protected Task RaiseDocumentActiveContextChangedEventAsync(Document document)
         {
-            var handlers = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName);
-            if (handlers.Length > 0)
+            if (_eventMap.HasEventHandlers<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName))
             {
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    foreach (var handler in handlers)
-                    {
-                        handler(this, args);
-                    }
+                    _eventMap.RaiseEvent<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName, handler => handler(this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else


### PR DESCRIPTION
Possible fix for TFS devdiv bug 1154956

This change makes it so that in-flight events that have not yet fired (due to asynchronous scheduling), will not be fired on handlers that have unsubscribed from the event.  

It is still possible that an event handler can be entered after it has been unsubscribed from a thread that is different than the one that fires the event.

@Pilchie please take a look