### PR TITLE
Commit rename on more editing cmds and refactorings

### DIFF
--- a/src/EditorFeatures/CSharp/EncapsulateField/EncapsulateFieldCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/EncapsulateField/EncapsulateFieldCommandHandler.cs
@@ -8,8 +8,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EncapsulateField
 {
-    [ExportCommandHandler("EncapsulateField",
-        ContentTypeNames.CSharpContentType)]
+    [ExportCommandHandler(PredefinedCommandHandlerNames.EncapsulateField, ContentTypeNames.CSharpContentType)]
     [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
     internal class EncapsulateFieldCommandHandler : AbstractEncapsulateFieldCommandHandler
     {

--- a/src/EditorFeatures/Core/Commands/MoveSelectedLinesDownCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/MoveSelectedLinesDownCommandArgs.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.Commands
+{
+    /// <summary>
+    /// Arguments for move selected lines down command
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal class MoveSelectedLinesDownCommandArgs : CommandArgs
+    {
+        public MoveSelectedLinesDownCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Commands/MoveSelectedLinesUpCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/MoveSelectedLinesUpCommandArgs.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.Commands
+{
+    /// <summary>
+    /// Arguments for move selected lines up command
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal class MoveSelectedLinesUpCommandArgs : CommandArgs
+    {
+        public MoveSelectedLinesUpCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -144,6 +144,8 @@
     <Compile Include="CommandHandlers\QuickInfoCommandHandlerAndSourceProvider.cs" />
     <Compile Include="CommandHandlers\QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs" />
     <Compile Include="CommandHandlers\SignatureHelpCommandHandler.cs" />
+    <Compile Include="Commands\MoveSelectedLinesDownCommandArgs.cs" />
+    <Compile Include="Commands\MoveSelectedLinesUpCommandArgs.cs" />
     <Compile Include="Commands\AutomaticLineEnderCommandArgs.cs" />
     <Compile Include="Commands\BackspaceKeyCommandArgs.cs" />
     <Compile Include="Commands\BackTabKeyCommandArgs.cs" />
@@ -401,6 +403,8 @@
     <Compile Include="Implementation\InlineRename\AbstractInlineRenameUndoManager.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_BackspaceDeleteHandler.cs" />
+    <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_RefactoringWithCommandHandler.cs" />
+    <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_MoveSelectedLinesHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_EscapeHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_LineStartEndHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_OpenLineBelowHandler.cs" />
@@ -410,6 +414,7 @@
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_SaveHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_TabHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_OpenLineAboveHandler.cs" />
+    <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_CutPasteHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_TypeCharHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_UndoRedoHandler.cs" />
     <Compile Include="Implementation\InlineRename\CommandHandlers\RenameCommandHandler_WordDeleteHandler.cs" />

--- a/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
@@ -48,6 +48,11 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string DocumentationComments = "Documentation Comments Command Handler";
 
         /// <summary>
+        /// Command handler name for Encapsulate Field.
+        /// </summary>
+        public const string EncapsulateField = "EncapsulateField";
+
+        /// <summary>
         /// Command handler name for End Construct.
         /// </summary>
         public const string EndConstruct = "End Construct Command Handler";

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_CutPasteHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_CutPasteHandler.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.Commands;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+{
+    internal partial class RenameCommandHandler :
+        ICommandHandler<CutCommandArgs>, ICommandHandler<PasteCommandArgs>
+    {
+        public CommandState GetCommandState(CutCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(CutCommandArgs args, Action nextHandler)
+        {
+            HandlePossibleTypingCommand(args, nextHandler, span =>
+            {
+                nextHandler();
+            });
+        }
+
+        public CommandState GetCommandState(PasteCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(PasteCommandArgs args, Action nextHandler)
+        {
+            HandlePossibleTypingCommand(args, nextHandler, span =>
+            {
+                nextHandler();
+            });
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.Commands;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+{
+    internal partial class RenameCommandHandler :
+        ICommandHandler<MoveSelectedLinesUpCommandArgs>, ICommandHandler<MoveSelectedLinesDownCommandArgs>
+    {
+        public CommandState GetCommandState(MoveSelectedLinesUpCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(MoveSelectedLinesUpCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+
+        public CommandState GetCommandState(MoveSelectedLinesDownCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(MoveSelectedLinesDownCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.Commands;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+{
+    internal partial class RenameCommandHandler :
+        ICommandHandler<ReorderParametersCommandArgs>,
+        ICommandHandler<RemoveParametersCommandArgs>,
+        ICommandHandler<ExtractInterfaceCommandArgs>,
+        ICommandHandler<EncapsulateFieldCommandArgs>
+    {
+        public CommandState GetCommandState(ReorderParametersCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(ReorderParametersCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+
+        public CommandState GetCommandState(RemoveParametersCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(RemoveParametersCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+
+        public CommandState GetCommandState(ExtractInterfaceCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(ExtractInterfaceCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+
+        public CommandState GetCommandState(EncapsulateFieldCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+
+        public void ExecuteCommand(EncapsulateFieldCommandArgs args, Action nextHandler)
+        {
+            CommitIfActiveAndCallNextHandler(args, nextHandler);
+        }
+    }
+}

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
@@ -1031,6 +1032,229 @@ partial class [|Program|]
 
                 ' Rename session was indeed commited and is no longer active
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
+            End Using
+        End Sub
+
+        <Fact>
+        <WorkItem(1142701)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MoveSelectedLinesUpDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New MoveSelectedLinesUpCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <WorkItem(1142701)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub MoveSelectedLinesDownDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New MoveSelectedLinesDownCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <WorkItem(991517)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub ReorderParametersDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New ReorderParametersCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <WorkItem(991517)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RemoveParametersDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New RemoveParametersCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <WorkItem(991517)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub ExtractInterfaceDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New ExtractInterfaceCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <WorkItem(991517)>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub EncapsulateFieldDuringRename()
+            VerifyCommandCommitsRenameSessionAndExecutesCommand(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New EncapsulateFieldCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub CutDuringRename_InsideIdentifier()
+            VerifySessionActiveAfterCutPasteInsideIdentifier(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub PasteDuringRename_InsideIdentifier()
+            VerifySessionActiveAfterCutPasteInsideIdentifier(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub CutDuringRename_OutsideIdentifier()
+            VerifySessionCommittedAfterCutPasteOutsideIdentifier(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub PasteDuringRename_OutsideIdentifier()
+            VerifySessionCommittedAfterCutPasteOutsideIdentifier(
+                Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
+                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler)
+                End Sub)
+        End Sub
+
+        Private Sub VerifyCommandCommitsRenameSessionAndExecutesCommand(executeCommand As Action(Of RenameCommandHandler, IWpfTextView, Action))
+            Using workspace = CreateWorkspaceWithWaiter(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+// Comment
+class [|C$$|]
+{
+    [|C|] f;
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+
+                Dim view = workspace.Documents.Single().GetTextView()
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
+
+                Dim renameService = workspace.GetService(Of InlineRenameService)()
+                Dim commandHandler As New RenameCommandHandler(
+                    renameService,
+                    workspace.GetService(Of IEditorOperationsFactoryService),
+                    workspace.GetService(Of IWaitIndicator))
+
+                Dim session = StartSession(workspace)
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
+
+                ' Type first in the main identifier
+                view.Selection.Clear()
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c), Sub() editorOperations.InsertText("D"))
+
+                ' Then execute the command
+                Dim commandInvokedString = "/*Command Invoked*/"
+                executeCommand(commandHandler, view, Sub() editorOperations.InsertText(commandInvokedString))
+
+                ' Verify rename session was committed.
+                Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
+                Assert.Contains("D f", view.TextBuffer.CurrentSnapshot.GetText())
+
+                ' Verify the command was routed to the editor.
+                Assert.Contains(commandInvokedString, view.TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        Private Sub VerifySessionActiveAfterCutPasteInsideIdentifier(executeCommand As Action(Of RenameCommandHandler, IWpfTextView, Action))
+            Using workspace = CreateWorkspaceWithWaiter(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+// Comment
+class [|C$$|]
+{
+    [|C|] f;
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+
+                Dim view = workspace.Documents.Single().GetTextView()
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
+
+                Dim renameService = workspace.GetService(Of InlineRenameService)()
+                Dim commandHandler As New RenameCommandHandler(
+                    renameService,
+                    workspace.GetService(Of IEditorOperationsFactoryService),
+                    workspace.GetService(Of IWaitIndicator))
+
+                Dim session = StartSession(workspace)
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
+
+                ' Then execute the command
+                Dim commandInvokedString = "commandInvoked"
+                executeCommand(commandHandler, view, Sub() editorOperations.InsertText(commandInvokedString))
+
+                ' Verify rename session is still active
+                Assert.NotNull(workspace.GetService(Of IInlineRenameService).ActiveSession)
+                VerifyTagsAreCorrect(workspace, commandInvokedString)
+            End Using
+        End Sub
+
+        Private Sub VerifySessionCommittedAfterCutPasteOutsideIdentifier(executeCommand As Action(Of RenameCommandHandler, IWpfTextView, Action))
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+// Comment
+class [|C$$|]
+{
+    [|C|] f;
+}
+                        </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim view = workspace.Documents.Single().GetTextView()
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
+
+                Dim renameService = workspace.GetService(Of InlineRenameService)()
+                Dim commandHandler As New RenameCommandHandler(
+                    renameService,
+                    workspace.GetService(Of IEditorOperationsFactoryService),
+                    workspace.GetService(Of IWaitIndicator))
+
+                Dim session = StartSession(workspace)
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
+
+                ' Type first in the main identifier
+                view.Selection.Clear()
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c), Sub() editorOperations.InsertText("D"))
+
+                ' Then execute the command
+                Dim commandInvokedString = "commandInvoked"
+                Dim selectionStart = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value - 6
+
+                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, selectionStart))
+                view.SetSelection(New SnapshotSpan(view.TextBuffer.CurrentSnapshot, New Span(selectionStart, 2)))
+
+                executeCommand(commandHandler, view, Sub() editorOperations.InsertText(commandInvokedString))
+
+                ' Verify rename session was committed
+                Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
+                Assert.Contains("D f", view.TextBuffer.CurrentSnapshot.GetText())
+                Assert.Contains(commandInvokedString, view.TextBuffer.CurrentSnapshot.GetText())
             End Using
         End Sub
     End Class

--- a/src/EditorFeatures/VisualBasic/EncapsulateField/EncapsulateFieldCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/EncapsulateField/EncapsulateFieldCommandHandler.vb
@@ -7,7 +7,7 @@ Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EncapsulateField
-    <ExportCommandHandler("EncapsulateField", ContentTypeNames.VisualBasicContentType)>
+    <ExportCommandHandler(PredefinedCommandHandlerNames.EncapsulateField, ContentTypeNames.VisualBasicContentType)>
     <Order(After:=PredefinedCommandHandlerNames.DocumentationComments)>
     Friend Class EncapsulateFieldCommandHandler
         Inherits AbstractEncapsulateFieldCommandHandler


### PR DESCRIPTION
Fixes internal bugs 991517 and 1142701

Commit rename on the following commands:

- Cut/Paste, if the operation occurs outside a rename span
- MoveSelectedLines
- Command-based refactorings (Change Signature, Extract Interface, and
Encapsulate Field)

Tagging reviewers: @Pilchie @jasonmalinowski @balajikris @basoundr @brettfo @rchande