### PR TITLE
Retry with System.Core.dll on ERR_NoSuchMemberOrExtension.

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -565,6 +565,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         }
                     }
                     break;
+                case ErrorCode.ERR_NoSuchMemberOrExtension: // Commonly, but not always, caused by absence of System.Core.
                 case ErrorCode.ERR_DynamicAttributeMissing:
                 case ErrorCode.ERR_DynamicRequiredTypesMissing:
                 // MSDN says these might come from System.Dynamic.Runtime

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -3615,9 +3615,22 @@ class C
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
+
+            ResultProperties resultProperties;
             string error;
-            var result = context.CompileExpression("o.First()", out error);
+            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+            var result = context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "o.First()",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
             Assert.Equal(error, "error CS1061: 'object[]' does not contain a definition for 'First' and no extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)");
+            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
         }
 
         [Fact]
@@ -3816,12 +3829,46 @@ class C
                 methodName: "C.M");
 
             // Expression references ambiguous modules.
+            ResultProperties resultProperties;
             string error;
-            context.CompileExpression("x.F0 + y.F0", out error);
+            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "x.F0 + y.F0",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
             Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
-            context.CompileExpression("y.F0", out error);
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "y.F0",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
             Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
-            context.CompileExpression("z.F1", out error);
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "z.F1",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            Assert.Empty(missingAssemblyIdentities);
             Assert.Equal("error CS7079: The type 'A1' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
 
             // Expression does not reference ambiguous modules.
@@ -5259,7 +5306,7 @@ class C
             ResultProperties resultProperties;
             string error;
             ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            var result = context.CompileExpression(
+            context.CompileExpression(
                 DefaultInspectionContext.Instance,
                 "from c in \"ABC\" select c",
                 DkmEvaluationFlags.TreatAsExpression,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void ErrorsRequiringSystemCore()
         {
             var identity = EvaluationContextBase.SystemCoreIdentity;
+            Assert.Same(identity, GetMissingAssemblyIdentity(ErrorCode.ERR_NoSuchMemberOrExtension));
             Assert.Same(identity, GetMissingAssemblyIdentity(ErrorCode.ERR_DynamicAttributeMissing));
             Assert.Same(identity, GetMissingAssemblyIdentity(ErrorCode.ERR_DynamicRequiredTypesMissing));
             Assert.Same(identity, GetMissingAssemblyIdentity(ErrorCode.ERR_QueryNoProviderStandard));
@@ -134,6 +135,120 @@ public class C
                 EnsureEnglishUICulture.PreferredOrNull,
                 testData: null);
             Assert.Equal(expectedError, actualError);
+            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+        }
+
+        [WorkItem(1151888, "DevDiv")]
+        [Fact]
+        public void ERR_NoSuchMemberOrExtension_CompilationReferencesSystemCore()
+        {
+            var source = @"
+using System.Linq;
+
+public class C
+{
+    public void M(int[] array)
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef);
+
+            var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
+            var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
+
+            ResultProperties resultProperties;
+            string actualError;
+            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "array.Count()",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out actualError,
+                out actualMissingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
+            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "array.NoSuchMethod()",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out actualError,
+                out actualMissingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
+            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+        }
+
+        /// <remarks>
+        /// The fact that the compilation does not reference System.Core has no effect since
+        /// this test only covers our ability to identify an assembly to attempt to load, not
+        /// our ability to actually load or consume it.
+        /// </remarks>
+        [WorkItem(1151888, "DevDiv")]
+        [Fact]
+        public void ERR_NoSuchMemberOrExtension_CompilationDoesNotReferenceSystemCore()
+        {
+            var source = @"
+using System.Linq;
+
+public class C
+{
+    public void M(int[] array)
+    {
+    }
+}
+
+namespace System.Linq
+{
+    public class Dummy
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            var context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef);
+
+            var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
+            var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
+
+            ResultProperties resultProperties;
+            string actualError;
+            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "array.Count()",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out actualError,
+                out actualMissingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
+            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "array.NoSuchMethod()",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out actualError,
+                out actualMissingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
             Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using Xunit;
 using Roslyn.Test.PdbUtilities;
+using Microsoft.VisualStudio.Debugger.Evaluation;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -209,8 +210,18 @@ public interface I
 
                 // Binding to method on original PIA should fail
                 // since it was not included in embedded type.
-                testData = new CompilationTestData();
-                context.CompileExpression("x.F()", out resultProperties, out error, testData);
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                context.CompileExpression(
+                    DefaultInspectionContext.Instance,
+                    "x.F()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    DiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
                 Assert.Equal(error, "error CS1061: 'I' does not contain a definition for 'F' and no extension method 'F' accepting a first argument of type 'I' could be found (are you missing a using directive or an assembly reference?)");
 
                 // Binding to method on original PIA should succeed

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -70,15 +70,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
     }
 }";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
+
             ResultProperties resultProperties;
             string error;
-            var testData = Evaluate(
-                source,
-                OutputKind.DynamicallyLinkedLibrary,
-                methodName: "C.M",
-                expr: "this.$exception",
-                resultProperties: out resultProperties,
-                error: out error);
+            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+            context.CompileExpression(
+                DefaultInspectionContext.Instance,
+                "this.$exception",
+                DkmEvaluationFlags.TreatAsExpression,
+                DiagnosticFormatter.Instance,
+                out resultProperties,
+                out error,
+                out missingAssemblyIdentities,
+                EnsureEnglishUICulture.PreferredOrNull,
+                testData: null);
+            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
             Assert.Equal(error, "error CS1061: 'C' does not contain a definition for '$exception' and no extension method '$exception' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)");
         }
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -632,6 +632,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             ' across different versions of (desktop) windows.
                             Dim identity = New AssemblyIdentity($"{containingNamespace.ToDisplayString}.{namespaceName}", contentType:=AssemblyContentType.WindowsRuntime)
                             Return ImmutableArray.Create(identity)
+                        Else
+                            ' Maybe it's a missing Linq extension method.  Let's try adding System.Core and see if that helps.
+                            Return ImmutableArray.Create(SystemCoreIdentity)
                         End If
                     End If
                 Case ERRID.ERR_UndefinedType1


### PR DESCRIPTION
It's a guess, but it's commonly correct.