### PR TITLE
Remove Win10 check from assembly reference resolution...

### DIFF
--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -843,7 +843,7 @@ namespace Microsoft.CodeAnalysis
             {
                 for (int i = definitionOffset; i < definitions.Length; i++)
                 {
-                    if (IsWindowsRuntime(definitions[i]))
+                    if (definitions[i].Identity.IsWindowsRuntime())
                     {
                         return new AssemblyReferenceBinding(reference, i);
                     }
@@ -861,19 +861,6 @@ namespace Microsoft.CodeAnalysis
             }
 
             return new AssemblyReferenceBinding(reference);
-        }
-
-        private static bool IsWindowsRuntime(AssemblyData definition)
-        {
-            if (!definition.Identity.IsWindowsRuntime())
-            {
-                return false;
-            }
-            int majorVersion;
-            int minorVersion;
-            return definition.GetWinMdVersion(out majorVersion, out minorVersion) &&
-                (majorVersion == 1) &&
-                (minorVersion >= 4);
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -387,22 +387,22 @@ public class B
                 var contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
 
                 // Duplicate type in namespace, at type scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
 
                 GetContextState(runtime, "B.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
                 contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
 
                 // Duplicate type in namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C1()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C1()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
 
                 // Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.True(errorMessage.StartsWith("error CS0433: The type 'C2' exists in both "));
 
                 // Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.Equal(errorMessage, "(1,3): error CS0121: The call is ambiguous between the following methods or properties: 'N.E.F(A)' and 'N.E.F(A)'");
 
                 // Same tests as above but in library that does not directly reference duplicates.
@@ -410,7 +410,7 @@ public class B
                 contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
 
                 // Duplicate type in namespace, at type scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.Null(errorMessage);
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 methodData.VerifyIL(
@@ -426,7 +426,7 @@ public class B
                 contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
 
                 // Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.Null(errorMessage);
                 methodData = testData.GetMethodData("<>x.<>m0");
                 methodData.VerifyIL(
@@ -441,7 +441,7 @@ public class B
                 Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
 
                 // Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, out errorMessage, out testData);
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
                 Assert.Null(errorMessage);
                 methodData = testData.GetMethodData("<>x.<>m0");
                 methodData.VerifyIL(

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -102,6 +102,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ImmutableArray<MetadataBlock> metadataBlocks,
             string expr,
             ExpressionCompiler.CreateContextDelegate createContext,
+            DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,
             out string errorMessage,
             out CompilationTestData testData)
         {
@@ -122,8 +123,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         td);
                     return new CompileExpressionResult(compileResult, td);
                 },
-                getMetaDataBytesPtr: null,
-                errorMessage: out errorMessage);
+                getMetaDataBytesPtr,
+                out errorMessage);
             testData = r.TestData;
             return r.CompileResult;
         }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -233,22 +233,22 @@ End Class"
                 ' Duplicate type in namespace, at type scope.
                 Dim testData As CompilationTestData = Nothing
                 Dim errorMessage As String = Nothing
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New N.C1()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New N.C1()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Equal(errorMessage, "(1,6): error BC30560: 'C1' is ambiguous in the namespace 'N'.")
 
                 GetContextState(runtime, "B.Main", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
                 contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken)
 
                 ' Duplicate type in namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C1()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C1()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Equal(errorMessage, "(1,6): error BC30560: 'C1' is ambiguous in the namespace 'N'.")
 
                 ' Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C2()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C2()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Equal(errorMessage, "(1,6): error BC30554: 'C2' is ambiguous.")
 
                 ' Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.True(errorMessage.StartsWith("(1,4): error BC30521: Overload resolution failed because no accessible 'F' is most specific for these arguments:"))
 
                 ' Same tests as above but in library that does not directly reference duplicates.
@@ -256,7 +256,7 @@ End Class"
                 contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken)
 
                 ' Duplicate type in namespace, at type scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New N.C1()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New N.C1()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Null(errorMessage)
                 Dim methodData = testData.GetMethodData("<>x.<>m0")
                 methodData.VerifyIL(
@@ -272,7 +272,7 @@ End Class"
                 contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken)
 
                 ' Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C2()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "New C2()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Null(errorMessage)
                 methodData = testData.GetMethodData("<>x.<>m0")
                 methodData.VerifyIL(
@@ -287,7 +287,7 @@ End Class"
                 Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName())
 
                 ' Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Null(errorMessage)
                 methodData = testData.GetMethodData("<>x.<>m0")
                 methodData.VerifyIL(
@@ -377,7 +377,7 @@ End Class"
                 Assert.Equal(errorMessage, "(1,2): error BC30562: 'F' is ambiguous between declarations in Modules 'N.M, N.M'.")
 
                 Dim contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken)
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "F()", contextFactory, errorMessage, testData)
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "F()", contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
                 Assert.Null(errorMessage)
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 "{


### PR DESCRIPTION
In Windows 8 (and 8.1), runtime winmds may contain assembly refs pointing
to other runtime winmds (for example, types defined in Windows.UI.Xaml
point to Windows.UI).  However, when the EE sees these assembly refs it
must redirect them back to the compile time contract assembly (Windows),
because the Compilation used by the EE only references the contract Assembly,
not the various runtime Assemblies.  Previously, we only did this redirection
for Windows 10.  Non-EE cases should only see the contract assembly at
compile time, so this change will not affect them.