### PR TITLE
Avoid a hang in CompileWithRetry...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -456,6 +456,47 @@ class C
             Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
         }
 
+        [WorkItem(1154988)] 
+        [Fact] 
+        public void CompileWithRetrySameErrorReported()
+        { 
+            var source = @" 
+class C 
+{ 
+    void M() 
+    { 
+    } 
+}"; 
+            var comp = CreateCompilationWithMscorlib(source); 
+            var runtime = CreateRuntimeInstance(comp); 
+            var context = CreateMethodContext(runtime, "C.M"); 
+ 
+            var missingModule = runtime.Modules.First(); 
+            var missingIdentity = missingModule.MetadataReader.ReadAssemblyIdentityOrThrow(); 
+ 
+            var numRetries = 0; 
+            string errorMessage;
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry( 
+                runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(), 
+                context, 
+                (_, diagnostics) => 
+                {
+                    numRetries++;
+                    Assert.InRange(numRetries, 0, 2); // We don't want to loop forever... 
+                    diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
+                    return default(CompileResult);   
+                }, 
+                (AssemblyIdentity assemblyIdentity, out uint uSize) => 
+                { 
+                    uSize = (uint)missingModule.MetadataLength; 
+                    return missingModule.MetadataAddress; 
+                }, 
+                out errorMessage); 
+ 
+            Assert.Equal(2, numRetries); // Ensure that we actually retried and that we bailed out on the second retry if the same identity was seen in the diagnostics.
+            Assert.Equal($"error CS0012: The type 'MissingType' is defined in an assembly that is not referenced. You must add a reference to assembly '{missingIdentity}'.", errorMessage); 
+        } 
+
         private EvaluationContext CreateMethodContextWithReferences(Compilation comp, string methodName, params MetadataReference[] references)
         {
             return CreateMethodContextWithReferences(comp, methodName, ImmutableArray.CreateRange(references));

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
@@ -290,6 +291,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             errorMessage = null;
             TResult compileResult;
 
+            PooledHashSet<AssemblyIdentity> assembliesLoadedInRetryLoop = null;
             bool tryAgain;
             do
             {
@@ -322,11 +324,23 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     }
                     else
                     {
-                        tryAgain = ShouldTryAgainWithMoreMetadataBlocks(getMetaDataBytesPtr, missingAssemblyIdentities, ref metadataBlocks);
+                        if (!missingAssemblyIdentities.IsEmpty)
+                        {
+                            if (assembliesLoadedInRetryLoop == null)
+                            {
+                                assembliesLoadedInRetryLoop = PooledHashSet<AssemblyIdentity>.GetInstance();
+                            }
+                            // If any identities failed to add (they were already in the list), then don't retry. 
+                            if (assembliesLoadedInRetryLoop.AddAll(missingAssemblyIdentities))
+                            {
+                                tryAgain = ShouldTryAgainWithMoreMetadataBlocks(getMetaDataBytesPtr, missingAssemblyIdentities, ref metadataBlocks);
+                            }
+                        }
                     }
                 }
                 diagnostics.Free();
             } while (tryAgain);
+            assembliesLoadedInRetryLoop?.Free();
 
             return compileResult;
         }

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -100,6 +100,22 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal static CompileResult CompileExpressionWithRetry(
             ImmutableArray<MetadataBlock> metadataBlocks,
+            EvaluationContextBase context,
+            ExpressionCompiler.CompileDelegate<CompileResult> compile,
+            DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,
+            out string errorMessage)
+        {
+            return ExpressionCompiler.CompileWithRetry(
+                metadataBlocks,
+                DiagnosticFormatter.Instance,
+                (blocks, useReferencedModulesOnly) => context,
+                compile,
+                getMetaDataBytesPtr,
+                out errorMessage);
+        }
+
+        internal static CompileResult CompileExpressionWithRetry(
+            ImmutableArray<MetadataBlock> metadataBlocks,
             string expr,
             ExpressionCompiler.CreateContextDelegate createContext,
             DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,


### PR DESCRIPTION
Don't attempt to retry if we're asked to load an assembly that we already reference.  Adding the same reference won't help anything, and we will almost certainly never terminate the retry loop.