### PR TITLE
Ignore enums in OverrideMethodsOnComparable

### DIFF
--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -31,7 +31,8 @@ namespace System.Runtime.Analyzers
 
             var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             var typeSymbol = model.GetDeclaredSymbol(declaration) as INamedTypeSymbol;
-            if (typeSymbol == null)
+            if (typeSymbol?.TypeKind != TypeKind.Class &&
+                typeSymbol?.TypeKind != TypeKind.Struct)
             {
                 return;
             }

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.cs
@@ -56,7 +56,7 @@ namespace System.Runtime.Analyzers
 
         private static void AnalyzeSymbol(INamedTypeSymbol namedTypeSymbol, INamedTypeSymbol comparableType, INamedTypeSymbol genericComparableType, Action<Diagnostic> addDiagnostic)
         {
-            if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Private || namedTypeSymbol.TypeKind == TypeKind.Interface)
+            if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Private || namedTypeSymbol.TypeKind == TypeKind.Interface || namedTypeSymbol.TypeKind == TypeKind.Enum)
             {
                 return;
             }

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/OverrideMethodsOnComparableTypesTests.cs
@@ -869,6 +869,24 @@ End Class
             GetCA1036BasicResultAt(8, 18));
         }
 
+        [WorkItem(1994, "https://github.com/dotnet/roslyn/issues/1994")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void Bug1994CSharp()
+        {
+            VerifyCSharp("enum MyEnum {}");
+        }
+
+        [WorkItem(1994, "https://github.com/dotnet/roslyn/issues/1994")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void Bug1994VisualBasic()
+        {
+            VerifyBasic(@"
+Enum MyEnum
+    ValueOne
+    ValueTwo
+End Enum");
+        }
+
         internal static string CA1036Name = "CA1036";
         internal static string CA1036Message = "Overload operator Equals and comparison operators when implementing System.IComparable";
 


### PR DESCRIPTION
Ignore enums in OverrideMethodsOnComparable analyzer and codefixer.
fixes #1994