### PR TITLE
Do not crash when highlighting alias symbols defined via global imports.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
@@ -130,12 +130,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
             bool addAllDefinitions = true;
 
             // Add definitions
+            // Filter out definitions that cannot be highlighted. e.g: alias symbols defined via project property pages.
             if (symbol.Kind == SymbolKind.Alias &&
                 symbol.Locations.Length > 0)
             {
-                // For alias symbol we want to get the tag only for the alias definition, not the target symbol's definition.
-                await AddLocationSpan(symbol.Locations.First(), solution, spanSet, tagMap, HighlightSpanKind.Definition, cancellationToken).ConfigureAwait(false);
                 addAllDefinitions = false;
+
+                if (symbol.Locations.First().IsInSource)
+                {
+                    // For alias symbol we want to get the tag only for the alias definition, not the target symbol's definition.
+                    await AddLocationSpan(symbol.Locations.First(), solution, spanSet, tagMap, HighlightSpanKind.Definition, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             // Add references and definitions

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/VisualBasicReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/VisualBasicReferenceHighlightingTests.vb
@@ -272,5 +272,27 @@ End Class
 
             VerifyHighlights(input)
         End Sub
+
+        <WorkItem(1904, "https://github.com/dotnet/roslyn/issues/1904")>
+        <WorkItem(2079, "https://github.com/dotnet/roslyn/issues/2079")>
+        <Fact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Sub VerifyHighlightsForVisualBasicGlobalImportAliasedNamespace()
+            VerifyHighlights(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <CompilationOptions><GlobalImport>VB = Microsoft.VisualBasic</GlobalImport></CompilationOptions>
+                        <Document>
+                            Class Test
+                                Public Sub TestMethod()
+                                    ' Add reference tags to verify after #2079 is fixed
+                                    Console.Write(NameOf($$VB))
+                                    Console.Write(NameOf(VB))
+                                    Console.Write(NameOf(Microsoft.VisualBasic))
+                                End Sub
+                            End Class
+                        </Document>
+                    </Project>
+                </Workspace>)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #1904 

The crash happens because we try to highlight the definition of this alias symbol, but it does not have a source location. It is defined in the project property pages. We shouldn't try to highlight such definitions. This change addresses that. However, we should still highlight references of that alias symbol and its targets. That is not addressed by this PR, that will be addressed by #2079 