### PR TITLE
Format triggered by Rename picks Correct Dirty Span

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -153,6 +153,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Dim finalSpanStart = dirtySpan.Start.Position
             Dim finalSpanEnd = dirtySpan.End.Position
 
+            ' If an identifier is modified then we should format just around the identifier
+            If ContainingStatementInfo.isIdentifierDirty(dirtySpan, tree, cancellationToken) Then
+                formattingInfo.SpanToFormat = New SnapshotSpan(dirtySpan.Snapshot, Span.FromBounds(finalSpanStart, finalSpanEnd))
+                Return True
+            End If
+
             ' Find the containing statements
             Dim startingStatementInfo = ContainingStatementInfo.GetInfo(dirtySpan.Start, tree, cancellationToken)
             If startingStatementInfo IsNot Nothing Then

--- a/src/EditorFeatures/VisualBasic/LineCommit/ContainingStatementInfo.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ContainingStatementInfo.vb
@@ -183,5 +183,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' attributes
             Return New ContainingStatementInfo(node, TextSpan.FromBounds(attributes.Last.Span.End, node.Span.End))
         End Function
+
+        Friend Shared Function isIdentifierDirty(dirtySpan As SnapshotSpan, tree As SyntaxTree, cancellationToken As CancellationToken) As Boolean
+            Dim token = tree.GetRoot(cancellationToken).FindToken(dirtySpan.Start, findInsideTrivia:=True)
+            Return token.SpanStart = dirtySpan.Start.Position AndAlso token.Span.End = dirtySpan.End.Position AndAlso
+                token.Parent.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso token.Parent.Parent.IsKind(SyntaxKind.Parameter)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -278,6 +278,37 @@ End Class
             End Using
         End Sub
 
+        <WorkItem(1945, "https://github.com/dotnet/roslyn/issues/1945")>
+        <Fact, Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub RenameFormatsOnlyModifiedSpan()
+            Using testData = New CommitTestData(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document><![CDATA[
+Class Foo
+    Sub M([|abc$$|] As Integer)
+        Dim a     = 7
+        Dim bbbbb = 7
+    End Sub
+End Class
+                        ]]></Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.Backspace()
+                testData.EditorOperations.Backspace()
+                testData.EditorOperations.Backspace()
+                testData.EditorOperations.InsertText("def")
+                testData.EditorOperations.MoveLineDown(extendSelection:=False)
+
+                testData.AssertHadCommit(True)
+
+                Dim originalText = testData.Workspace.Documents.Single().InitialTextSnapshot.GetLineFromLineNumber(3).GetText()
+                Assert.Equal(originalText, testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(3).GetText())
+
+            End Using
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.LineCommit)>
         <WorkItem(539599)>


### PR DESCRIPTION
Fix #1945 : Formatting triggered by Rename should pick the correct span
to format by checking if the dirty span is just span of an identifier.