### PR TITLE
Keep track of “bad” attribute applications to prevent PE generation in their presence.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2343,6 +2343,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
+                if (moduleBeingBuilt.SourceModule.HasBadAttributes)
+                {
+                    // If there were errors but no declaration diagnostics, explicitly add a "Failed to emit module" error.
+                    diagnostics.Add(ErrorCode.ERR_ModuleEmitFailure, NoLocation.Singleton, ((Cci.INamedEntity)moduleBeingBuilt).Name);
+                    return false;
+                }
+
                 SynthesizedMetadataCompiler.ProcessSynthesizedMembers(this, moduleBeingBuilt, cancellationToken);
             }
             else

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we depend on an invalid type or constant from another module), then explicitly add a diagnostic.
             // This diagnostic is not very helpful to the user, but it will prevent us from emitting an invalid
             // module or crashing.
-            if (moduleBeingBuiltOpt != null && methodCompiler._globalHasErrors && !diagnostics.HasAnyErrors() && !hasDeclarationErrors)
+            if (moduleBeingBuiltOpt != null && (methodCompiler._globalHasErrors || moduleBeingBuiltOpt.SourceModule.HasBadAttributes) && !diagnostics.HasAnyErrors() && !hasDeclarationErrors)
             {
                 diagnostics.Add(ErrorCode.ERR_ModuleEmitFailure, NoLocation.Singleton, ((Cci.INamedEntity)moduleBeingBuiltOpt).Name);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -541,6 +541,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(target is SourceAssemblySymbol || target.ContainingAssembly is SourceAssemblySymbol);
 
+            if (HasErrors)
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+
             // Attribute type is conditionally omitted if both the following are true:
             //  (a) It has at least one applied/inherited conditional attribute AND
             //  (b) None of conditional symbols are defined in the source file where the given attribute was defined.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -37,6 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<Location> _locations;
         private NamespaceSymbol _globalNamespace;
 
+        private bool _hasBadAttributes;
+
         internal SourceModuleSymbol(
             SourceAssemblySymbol assemblySymbol,
             DeclarationTable declarations,
@@ -47,6 +49,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _assemblySymbol = assemblySymbol;
             _sources = declarations;
             _name = moduleName;
+        }
+
+        internal void RecordPresenceOfBadAttributes()
+        {
+            _hasBadAttributes = true;
+        }
+
+        internal bool HasBadAttributes
+        {
+            get
+            {
+                return _hasBadAttributes;
+            }
         }
 
         internal override int Ordinal

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -348,6 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool lazyAttributesStoredOnThisThread = false;
             if (lazyCustomAttributesBag.SetAttributes(boundAttributes))
             {
+                this.RecordPresenceOfBadAttributes(boundAttributes);
                 this.AddDeclarationDiagnostics(diagnostics);
                 lazyAttributesStoredOnThisThread = true;
                 if (lazyCustomAttributesBag.IsEmpty) lazyCustomAttributesBag = CustomAttributesBag<CSharpAttributeData>.Empty;
@@ -358,6 +359,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             return lazyAttributesStoredOnThisThread;
         }
 
+        private void RecordPresenceOfBadAttributes(ImmutableArray<CSharpAttributeData> boundAttributes)
+        {
+            foreach (var attribute in boundAttributes)
+            {
+                if (attribute.HasErrors)
+                {
+                    CSharpCompilation compilation = this.DeclaringCompilation;
+                    Debug.Assert(compilation != null);
+                    ((SourceModuleSymbol)compilation.SourceModule).RecordPresenceOfBadAttributes();
+                    break;
+                }
+            }
+        }
+        
         /// <summary>
         /// Method to merge attributes from the given attributesSyntaxLists and filter out attributes by attribute target.
         /// This is the first step in attribute binding.

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -246,7 +246,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If moduleBeingBuiltOpt IsNot Nothing Then
                 moduleBeingBuiltOpt.SetEntryPoint(entryPoint)
 
-                If compiler.GlobalHasErrors AndAlso Not hasDeclarationErrors AndAlso Not diagnostics.HasAnyErrors Then
+                If (compiler.GlobalHasErrors OrElse moduleBeingBuiltOpt.SourceModule.HasBadAttributes) AndAlso Not hasDeclarationErrors AndAlso Not diagnostics.HasAnyErrors Then
                     ' If there were errors but no diagnostics, explicitly add
                     ' a "Failed to emit module" error to prevent emitting.
                     diagnostics.Add(ERRID.ERR_ModuleEmitFailure, NoLocation.Singleton, moduleBeingBuiltOpt.SourceModule.Name)

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2204,6 +2204,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return False
                 End If
 
+                If moduleBeingBuilt.SourceModule.HasBadAttributes Then
+                    ' If there were errors but no declaration diagnostics, explicitly add a "Failed to emit module" error.
+                    diagnostics.Add(ERRID.ERR_ModuleEmitFailure, NoLocation.Singleton, moduleBeingBuilt.SourceModule.Name)
+                    Return False
+                End If
+
                 SynthesizedMetadataCompiler.ProcessSynthesizedMembers(Me, moduleBeingBuilt, cancellationToken)
             Else
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -489,6 +489,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function ShouldEmitAttribute(target As Symbol, isReturnType As Boolean, emittingAssemblyAttributesInNetModule As Boolean) As Boolean
             Debug.Assert(TypeOf target Is SourceAssemblySymbol OrElse TypeOf target.ContainingAssembly Is SourceAssemblySymbol)
 
+            If HasErrors Then
+                Throw ExceptionUtilities.Unreachable
+            End If
+
             ' Attribute type is conditionally omitted if both the following are true:
             '  (a) It has at least one applied conditional attribute AND
             '  (b) None of conditional symbols are true at the attribute source location.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -51,6 +51,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         'Private m_diagnosticBagCompile As New DiagnosticBag()
         'Private m_diagnosticBagEmit As New DiagnosticBag()
 
+        Private _hasBadAttributes As Boolean
+
         Friend ReadOnly Property Options As VisualBasicCompilationOptions
             Get
                 Return _options
@@ -933,6 +935,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(attributesBag IsNot Nothing)
             Debug.Assert(Not attributesToStore.IsDefault)
 
+            RecordPresenceOfBadAttributes(attributesToStore)
+
             If diagBag Is Nothing OrElse diagBag.IsEmptyWithoutResolution Then
                 attributesBag.SetAttributes(attributesToStore)
             Else
@@ -954,6 +958,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End SyncLock
             End If
         End Sub
+
+        Private Sub RecordPresenceOfBadAttributes(attributes As ImmutableArray(Of VisualBasicAttributeData))
+            If Not _hasBadAttributes Then
+                For Each attribute In attributes
+                    If attribute.HasErrors Then
+                        _hasBadAttributes = True
+                        Exit For
+                    End If
+                Next
+            End If
+        End Sub
+
+        Friend ReadOnly Property HasBadAttributes As Boolean
+            Get
+                Return _hasBadAttributes
+            End Get
+        End Property
 
         ' same as AtomicStoreReferenceAndDiagnostics, but without storing any references
         Friend Sub AddDiagnostics(diagBag As DiagnosticBag, stage As CompilationStage)


### PR DESCRIPTION
In some scenarios, an attribute application can be “bad” due to an error type in referenced compilation, but without any diagnostics reported for the referencing compilation.

@VSadov, @gafter, @jaredpar, @agocke Please review.  