### PR TITLE
Namespace FindRefs Improvements

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/ObjectList.cs
@@ -28,10 +28,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                     return true;
 
                 case VSOBJGOTOSRCTYPE.GS_DEFINITION:
-                    return item.GlyphIndex != Glyph.Reference.GetGlyphIndex();
+                    return item.CanGoToDefinition();
 
                 case VSOBJGOTOSRCTYPE.GS_REFERENCE:
-                    return item.GlyphIndex == Glyph.Reference.GetGlyphIndex();
+                    return item.CanGoToReference();
             }
 
             return false;

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/AbstractTreeItem.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
         {
             get
             {
-                return this.Children == null || this.Children.Count == 0; 
+                return this.Children == null || this.Children.Count == 0;
             }
         }
 
@@ -50,6 +50,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
         }
 
         public abstract int GoToSource();
+
+        public virtual bool CanGoToReference()
+        {
+            return false;
+        }
+
+        public virtual bool CanGoToDefinition()
+        {
+            return false;
+        }
 
         protected void SetDisplayProperties(string filePath, int mappedLineNumber, int mappedOffset, int offset, string lineText, int spanLength, string projectNameDisambiguator)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/ExternalLanguageDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/ExternalLanguageDefinitionTreeItem.cs
@@ -56,6 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             }
         }
 
+        public override bool CanGoToDefinition()
+        {
+            return true;
+        }
+
         public override int GoToSource()
         {
             return (TryOpenFile() && TryNavigateToPosition()) ? VSConstants.S_OK : VSConstants.E_FAIL;

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceDefinitionTreeItem.cs
@@ -7,14 +7,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 {
     internal class SourceDefinitionTreeItem : AbstractSourceTreeItem
     {
+        private readonly bool _canGoToDefinition;
         private readonly string _symbolDisplay;
 
         public SourceDefinitionTreeItem(Document document, TextSpan sourceSpan, ISymbol symbol, ushort glyphIndex)
             : base(document, sourceSpan, glyphIndex)
         {
             _symbolDisplay = symbol.ToDisplayString(definitionDisplayFormat);
+            this.DisplayText = $"{GetProjectNameString()}{_symbolDisplay}";
 
-            this.DisplayText = $"[{document.Project.Name}] {_symbolDisplay}";
+            _canGoToDefinition = symbol.Kind != SymbolKind.Namespace;
+        }
+
+        public override bool CanGoToDefinition()
+        {
+            return _canGoToDefinition;
         }
 
         internal override void SetReferenceCount(int referenceCount)
@@ -23,7 +30,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
                 ? ServicesVSResources.ReferenceCountSingular
                 : string.Format(ServicesVSResources.ReferenceCountPlural, referenceCount);
 
-            this.DisplayText = $"[{_projectName}] {_symbolDisplay} ({referenceCountDisplay})";
+            this.DisplayText = $"{GetProjectNameString()}{_symbolDisplay} ({referenceCountDisplay})";
+        }
+
+        private string GetProjectNameString()
+        {
+            return (_projectName != null && _canGoToDefinition) ? $"[{_projectName}] " : string.Empty;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/SourceReferenceTreeItem.cs
@@ -29,6 +29,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             }
         }
 
+        public override bool CanGoToReference()
+        {
+            return true;
+        }
+
         public override bool UseGrayText
         {
             get


### PR DESCRIPTION
- Fixes #496, an error when finding reference on namespaces defined in
metadata
- Groups all namespace definitions & references under a single node,
which itself is non-navigable. Prior to this change, there would be lots
of top-level nodes for the same namespace with 0 references.

Reviewers: @Pilchie @jasonmalinowski @rchande @brettfo @balajikris @basoundr