### PR TITLE
Script updates

### DIFF
--- a/build/linux/setup-pcl.sh
+++ b/build/linux/setup-pcl.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage()
+{
+    echo "Install PCL reference assemblies in a mono drop"
+	echo "setup-pcl.sh <path-to-mono-install>" 
+}
+
+XBUILD_FRAMEWORKS=$1/lib/mono/xbuild-frameworks
+if [ ! -d "$XBUILD_FRAMEWORKS" ]; then
+	echo "$XBUILD_FRAMEWORKS does not exist"
+	usage
+	exit 1
+fi
+
+PCL_NAME=PortableReferenceAssemblies-2014-04-14
+PCL_TARGET=$XBUILD_FRAMEWORKS/.NETPortable
+
+# Now to install the PCL on the snapshot 
+pushd /tmp 
+wget http://storage.bos.xamarin.com/bot-provisioning/$PCL_NAME.zip -O /tmp/pcl.zip
+unzip pcl.zip 
+popd
+
+if [ ! -d "/tmp/$PCL_NAME" ]; then
+    echo "Error: Did not unzip the PCL correctly"
+    exit 1
+fi
+
+echo "Installing to $PCL_TARGET"
+mkdir $PCL_TARGET
+cp -r /tmp/$PCL_NAME/* $PCL_TARGET
+
+rm -rf /tmp/$PCL_NAME
+rm /tmp/pcl.zip
+

--- a/build/linux/setup-snapshot.sh
+++ b/build/linux/setup-snapshot.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-PCL_NAME=PortableReferenceAssemblies-2014-04-14
-
 if [ "$EUID" -ne 0 ]; then
     echo "Error: This script must be run as root"
     exit 1
@@ -15,21 +13,5 @@ if [ ! -d "$MONO_PREFIX" ]; then
     exit 1
 fi
 
-PCL_TARGET=$MONO_PREFIX/lib/mono/xbuild-frameworks/.NETPortable
-if [ -d "$PCL_TARGET" ]; then
-    echo "Error: PCL already installed at $PCL_TARGET"
-    exit 1
-fi
-
-# Now to install the PCL on the snapshot 
-cd /tmp 
-wget http://storage.bos.xamarin.com/bot-provisioning/$PCL_NAME.zip -O /tmp/pcl.zip
-unzip pcl.zip 
-if [ ! -d "$PCL_NAME" ]; then
-    echo "Error: Did not unzip the PCL correctly"
-    exit 1
-fi
-
-echo "Installing to $PCL_TARGET"
-mkdir $PCL_TARGET
-mv $PCL_NAME/* $PCL_TARGET
+# Now install the PCL assemblies on the snapshot
+source setup-pcl $MONO_PREFIX

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -13,8 +13,10 @@ usage()
     echo ""
     echo "Options"
     echo "  --mono-path <path>  Path to the mono installation to use for the run" 
+	echo "  --os <os>			OS to run (Linux / Darwin)"
 }
 
+OS_NAME=$(uname -s)
 while [[ $# > 0 ]]
 do
     opt="$1"
@@ -27,6 +29,10 @@ do
         CUSTOM_MONO_PATH=$2
         shift 2
         ;;
+		--os)
+		OS_NAME=$2
+		shift 2
+		;;
         *)
         usage 
         exit 1


### PR DESCRIPTION
Couple of changes to the scripts:

- Factored out installing the PCL libraries to setup-pcl.sh.  Makes it
much easier to install PCL against custom builds of mono
- cibuild.sh accepts an optional `—os` option now. Makes it easier to
customize Jenkins based on the OS target.