### PR TITLE
Cross plat build

### DIFF
--- a/build/linux/setup-pcl.sh
+++ b/build/linux/setup-pcl.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage()
+{
+    echo "Install PCL reference assemblies in a mono drop"
+	echo "setup-pcl.sh <path-to-mono-install>" 
+}
+
+XBUILD_FRAMEWORKS=$1/lib/mono/xbuild-frameworks
+if [ ! -d "$XBUILD_FRAMEWORKS" ]; then
+	echo "$XBUILD_FRAMEWORKS does not exist"
+	usage
+	exit 1
+fi
+
+PCL_NAME=PortableReferenceAssemblies-2014-04-14
+PCL_TARGET=$XBUILD_FRAMEWORKS/.NETPortable
+
+# Now to install the PCL on the snapshot 
+pushd /tmp 
+wget http://storage.bos.xamarin.com/bot-provisioning/$PCL_NAME.zip -O /tmp/pcl.zip
+unzip pcl.zip 
+popd
+
+if [ ! -d "/tmp/$PCL_NAME" ]; then
+    echo "Error: Did not unzip the PCL correctly"
+    exit 1
+fi
+
+echo "Installing to $PCL_TARGET"
+mkdir $PCL_TARGET
+cp -r /tmp/$PCL_NAME/* $PCL_TARGET
+
+rm -rf /tmp/$PCL_NAME
+rm /tmp/pcl.zip
+

--- a/build/linux/setup-snapshot.sh
+++ b/build/linux/setup-snapshot.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-PCL_NAME=PortableReferenceAssemblies-2014-04-14
-
 if [ "$EUID" -ne 0 ]; then
     echo "Error: This script must be run as root"
     exit 1
@@ -15,21 +13,5 @@ if [ ! -d "$MONO_PREFIX" ]; then
     exit 1
 fi
 
-PCL_TARGET=$MONO_PREFIX/lib/mono/xbuild-frameworks/.NETPortable
-if [ -d "$PCL_TARGET" ]; then
-    echo "Error: PCL already installed at $PCL_TARGET"
-    exit 1
-fi
-
-# Now to install the PCL on the snapshot 
-cd /tmp 
-wget http://storage.bos.xamarin.com/bot-provisioning/$PCL_NAME.zip -O /tmp/pcl.zip
-unzip pcl.zip 
-if [ ! -d "$PCL_NAME" ]; then
-    echo "Error: Did not unzip the PCL correctly"
-    exit 1
-fi
-
-echo "Installing to $PCL_TARGET"
-mkdir $PCL_TARGET
-mv $PCL_NAME/* $PCL_TARGET
+# Now install the PCL assemblies on the snapshot
+source setup-pcl $MONO_PREFIX

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -13,8 +13,10 @@ usage()
     echo ""
     echo "Options"
     echo "  --mono-path <path>  Path to the mono installation to use for the run" 
+	echo "  --os <os>			OS to run (Linux / Darwin)"
 }
 
+OS_NAME=$(uname -s)
 while [[ $# > 0 ]]
 do
     opt="$1"
@@ -27,6 +29,10 @@ do
         CUSTOM_MONO_PATH=$2
         shift 2
         ;;
+		--os)
+		OS_NAME=$2
+		shift 2
+		;;
         *)
         usage 
         exit 1

--- a/src/Test/Utilities/CLRHelpers.cs
+++ b/src/Test/Utilities/CLRHelpers.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -47,6 +48,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return null;
         }
 
+        public static bool IsRunningOnMono()
+        {
+            return Type.GetType ("Mono.Runtime") != null;
+        }
+
+        public static object GetRuntimeInterfaceAsObject(Guid clsid, Guid riid)
+        {
+            // This API isn't available on Mono hence we must use reflection to access it.  
+            Debug.Assert(!IsRunningOnMono());
+
+            var getRuntimeInterfaceAsObject = typeof(RuntimeEnvironment).GetMethod("GetRuntimeInterfaceasObject", BindingFlags.Public | BindingFlags.Static);
+            return getRuntimeInterfaceAsObject.Invoke(null, new object[] { clsid, riid });
+        }
+
         /// <summary>
         /// Verifies the specified image. Subscribe to <see cref="ReflectionOnlyAssemblyResolve"/> to provide a loader for dependent assemblies.
         /// </summary>
@@ -68,6 +83,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private static string[] PeVerify(byte[] peImage, int domainId, string assemblyPath)
         {
+            if (IsRunningOnMono())
+            {
+                // PEverify is currently unsupported on Mono hence return an empty 
+                // set of messages
+                return new string[] { };
+            }
+
             lock (s_guard)
             {
                 GCHandle pinned = GCHandle.Alloc(peImage, GCHandleType.Pinned);
@@ -75,10 +97,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     IntPtr buffer = pinned.AddrOfPinnedObject();
 
-                    ICLRValidator validator = (ICLRValidator)RuntimeEnvironment.GetRuntimeInterfaceAsObject(s_clsIdClrRuntimeHost, typeof(ICLRRuntimeHost).GUID);
+                    ICLRValidator validator = (ICLRValidator)GetRuntimeInterfaceAsObject(s_clsIdClrRuntimeHost, typeof(ICLRRuntimeHost).GUID);
                     ValidationErrorHandler errorHandler = new ValidationErrorHandler(validator);
 
-                    IMetaDataDispenser dispenser = (IMetaDataDispenser)RuntimeEnvironment.GetRuntimeInterfaceAsObject(s_clsIdCorMetaDataDispenser, typeof(IMetaDataDispenser).GUID);
+                    IMetaDataDispenser dispenser = (IMetaDataDispenser)GetRuntimeInterfaceAsObject(s_clsIdCorMetaDataDispenser, typeof(IMetaDataDispenser).GUID);
 
                     // the buffer needs to be pinned during validation
                     Guid riid = typeof(IMetaDataImport).GUID;

--- a/src/Test/Utilities/TestUtilities.csproj
+++ b/src/Test/Utilities/TestUtilities.csproj
@@ -106,9 +106,6 @@
     <Reference Include="xunit">
       <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="ReachFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/GenerateCompilerInternals.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/GenerateCompilerInternals.targets
@@ -33,6 +33,10 @@
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
+
+  <PropertyGroup>
+	<MonoPrefix Condition="'$(OS)' != 'Windows_NT'">mono </MonoPrefix>
+  </PropertyGroup>
   
   <Target
     Name="GenerateSyntaxModel"
@@ -40,14 +44,9 @@
     Outputs="@(SyntaxDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')"
     Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
   >
-    <PropertyGroup Condition="'$(Language)' == 'VB'">
-      <SyntaxGenerator>"$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Language)' == 'C#'">
-      <SyntaxGenerator Condition=" '$(OS)' == 'Windows_NT' ">"$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
-      <SyntaxGenerator Condition=" '$(OS)' != 'Windows_NT' ">mono $(CSharpSyntaxGeneratorToolPath)</SyntaxGenerator>
-    </PropertyGroup>
     <PropertyGroup>
+      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
       <GeneratedSyntaxModel>@(SyntaxDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedSyntaxModel>
     </PropertyGroup>
 
@@ -78,8 +77,6 @@
   >
     <PropertyGroup>
       <SyntaxGenerator>"$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
-    </PropertyGroup>
-    <PropertyGroup>
       <GeneratedSyntaxModelGetText>@(SyntaxGetTextDefinition -> '$(IntermediateOutputPath)\%(FileName)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedSyntaxModelGetText>
     </PropertyGroup>
 
@@ -109,14 +106,9 @@
     Outputs="@(SyntaxTestDefinition -> '$(IntermediateOutputPath)\%(FileName)%(Extension).Generated$(DefaultLanguageSourceExtension)')"
     Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
   >
-    <PropertyGroup Condition="'$(Language)' == 'VB'">
-      <SyntaxGenerator>"$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Language)' == 'C#'">
-      <SyntaxGenerator Condition=" '$(OS)' == 'Windows_NT' ">"$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
-      <SyntaxGenerator Condition=" '$(OS)' != 'Windows_NT' ">mono $(CSharpSyntaxGeneratorToolPath)</SyntaxGenerator>      
-    </PropertyGroup>
     <PropertyGroup>
+      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
       <GeneratedSyntaxModelTests>@(SyntaxTestDefinition -> '$(IntermediateOutputPath)\%(FileName)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedSyntaxModelTests>
     </PropertyGroup>
 
@@ -147,8 +139,7 @@
     Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
   >
     <PropertyGroup>
-      <BoundTreeGenerator Condition=" '$(OS)' == 'Windows_NT' ">"$(BoundTreeGeneratorToolPath)"</BoundTreeGenerator>
-      <BoundTreeGenerator Condition=" '$(OS)' != 'Windows_NT' ">mono $(BoundTreeGeneratorToolPath)</BoundTreeGenerator>
+      <BoundTreeGenerator>$(MonoPrefix) "$(BoundTreeGeneratorToolPath)"</BoundTreeGenerator>
       <GeneratedBoundTree>@(BoundTreeDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedBoundTree>
     </PropertyGroup>
 
@@ -183,16 +174,9 @@
     Outputs="@(ErrorCode -> '$(IntermediateOutputPath)ErrorFacts.Generated$(DefaultLanguageSourceExtension)')"
     Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
   >
-    <PropertyGroup Condition="'$(Language)' == 'VB'">
-      <ErrorFactsGenerator>"$(VBErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Language)' == 'C#'">
-      <ErrorFactsGenerator Condition=" '$(OS)' == 'Windows_NT' ">"$(CSharpErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
-      <ErrorFactsGenerator Condition=" '$(OS)' != 'Windows_NT' ">mono $(CSharpErrorFactsGeneratorToolPath)</ErrorFactsGenerator>
-    </PropertyGroup>
-
     <PropertyGroup>
+      <ErrorFactsGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
+      <ErrorFactsGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
       <GeneratedErrorFacts>@(ErrorCode -> '$(IntermediateOutputPath)ErrorFacts.Generated$(DefaultLanguageSourceExtension)')</GeneratedErrorFacts>
     </PropertyGroup>
 


### PR DESCRIPTION

Fixes a number of cross platform build issues:

- Managed tools which run as a part of build are now prefixed with
`mono ` in a standardized fashion.  This is now uniformly applied to
all tools for generating bound trees, syntax nodes, etc …
- Remove WPF references from TestUtiliites.csproj.
- Used reflection to access the GetRuntimeInterfaceAsObject API as it
is unavailable in the Mono APIs.