### PR TITLE
More improvements to the ?. codegen.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -971,6 +971,7 @@
   <Node Name="BoundLoweredConditionalAccess" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Receiver" Type="BoundExpression"/>
+    <Field Name="HasValueMethodOpt" Type="MethodSymbol" Null="allow"/>
     <Field Name="WhenNotNull" Type="BoundExpression"/>
     <Field Name="WhenNullOpt" Type="BoundExpression" Null="allow"/>
     <!-- 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case BoundKind.ConditionalReceiver:
                     // do nothing receiver ref must be already pushed
                     Debug.Assert(!expression.Type.IsReferenceType);
-                    Debug.Assert(!expression.Type.IsValueType);
+                    Debug.Assert(!expression.Type.IsValueType || expression.Type.IsNullableType());
                     break;
 
                 case BoundKind.ComplexConditionalReceiver:

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1233,10 +1233,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
+                // compensate for the whenNull that we are not visiting.
                 _counter += 1;
             }
 
-            return node.Update(receiver, whenNotNull, whenNull, node.Id, node.Type);
+            return node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNull, node.Id, node.Type);
         }
 
         public override BoundNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -274,6 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         arguments[i] = F.Convert(manager.System_Object,
                                                  new BoundLoweredConditionalAccess(F.Syntax,
                                                                             F.Field(F.This(), property.BackingField),
+                                                                            null,
                                                                             F.Call(new BoundConditionalReceiver(
                                                                                 F.Syntax, 
                                                                                 id: i, 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -773,9 +773,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundAssignmentOperator tempAssignment;
             var boundTemp = _factory.StoreToTemp(operand, out tempAssignment);
-            MethodSymbol get_HasValue = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_get_HasValue);
             MethodSymbol getValueOrDefault = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
-            BoundExpression condition = BoundCall.Synthesized(syntax, boundTemp, get_HasValue);
+            BoundExpression condition = MakeNullableHasValue(syntax, boundTemp);
             BoundExpression consequence = new BoundObjectCreationExpression(
                 syntax,
                 GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
@@ -1005,11 +1004,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundAssignmentOperator tempAssignment;
             BoundLocal boundTemp = _factory.StoreToTemp(rewrittenOperand, out tempAssignment);
-            MethodSymbol get_HasValue = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_get_HasValue);
             MethodSymbol getValueOrDefault = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
 
             // temp.HasValue
-            BoundExpression condition = BoundCall.Synthesized(syntax, boundTemp, get_HasValue);
+            BoundExpression condition = MakeNullableHasValue(syntax, boundTemp);
 
             // temp.GetValueOrDefault()
             BoundCall callGetValueOrDefault = BoundCall.Synthesized(syntax, boundTemp, getValueOrDefault);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -12,50 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitNullCoalescingOperator(BoundNullCoalescingOperator node)
         {
-            // check for common pattern   a?.b ?? c  where b is a value type
-            // in such cases the result of the expression is either b or c
-            // we can skip nullable wrapping/unwrapping
-
-            BoundConditionalAccess conditionalAccess;
-            var leftConversion = node.LeftConversion;
-
-            if ((leftConversion.IsIdentity || leftConversion.Kind == ConversionKind.ExplicitNullable) &&
-                TryGetOptimizableNullableConditionalAccess(node.LeftOperand, out conditionalAccess))
-            {
-                return FuseNodes(conditionalAccess, node);
-            }
-
             BoundExpression rewrittenLeft = (BoundExpression)Visit(node.LeftOperand);
             BoundExpression rewrittenRight = (BoundExpression)Visit(node.RightOperand);
             TypeSymbol rewrittenResultType = VisitType(node.Type);
 
             return MakeNullCoalescingOperator(node.Syntax, rewrittenLeft, rewrittenRight, node.LeftConversion, rewrittenResultType);
-        }
-
-        private BoundNode FuseNodes(BoundConditionalAccess conditionalAccess, BoundNullCoalescingOperator node)
-        {
-            var type = node.RightOperand.Type;
-            conditionalAccess = conditionalAccess.Update(conditionalAccess.Receiver, conditionalAccess.AccessExpression, type);
-
-            var whenNull = (BoundExpression)Visit(node.RightOperand);
-            if (whenNull.IsDefaultValue() && whenNull.Type.SpecialType != SpecialType.System_Decimal)
-            {
-                whenNull = null;
-            }
-
-            return RewriteConditionalAccess(conditionalAccess, used: true, rewrittenWhenNull: whenNull);
-        }
-
-        private bool TryGetOptimizableNullableConditionalAccess(BoundExpression operand, out BoundConditionalAccess conditionalAccess)
-        {
-            if (operand.Kind != BoundKind.ConditionalAccess || _inExpressionLambda )
-            {
-                conditionalAccess = null;
-                return false;
-            }
-
-            conditionalAccess = (BoundConditionalAccess)operand;
-            return conditionalAccess.Type.IsNullableType() && !conditionalAccess.AccessExpression.Type.IsNullableType();
         }
 
         private BoundExpression MakeNullCoalescingOperator(
@@ -79,17 +40,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // first we can make a small optimization:
+            // If left is a constant then we already know whether it is null or not. If it is null then we 
+            // can simply generate "right". If it is not null then we can simply generate
+            // MakeConversion(left).
 
-            ConstantValue leftConstantValue = rewrittenLeft.ConstantValue;
-            if (leftConstantValue != null)
+            if (rewrittenLeft.IsDefaultValue())
             {
-                // If left is a constant then we already know whether it is null or not. If it is null then we 
-                // can simply generate "right". If it is not null then we can simply generate
-                // MakeConversion(left).
+                return rewrittenRight;
+            }
 
-                return leftConstantValue.IsNull ?
-                    rewrittenRight :
-                    GetConvertedLeftForNullCoalescingOperator(rewrittenLeft, leftConversion, rewrittenResultType);
+            if (rewrittenLeft.ConstantValue != null)
+            {
+                Debug.Assert(!rewrittenLeft.ConstantValue.IsNull);
+
+                return GetConvertedLeftForNullCoalescingOperator(rewrittenLeft, leftConversion, rewrittenResultType);
             }
 
             // if left conversion is intrinsic implicit (always succeeds) and results in a reference type
@@ -128,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         return conditionalAccess.Update(
                             conditionalAccess.Receiver,
+                            conditionalAccess.HasValueMethodOpt,
                             whenNotNull: notNullAccess,
                             whenNullOpt: whenNullOpt,
                             id: conditionalAccess.Id,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -308,9 +308,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (isNullableValueType)
             {
-                MethodSymbol hasValue = GetNullableMethod(syntax, local.Type, SpecialMember.System_Nullable_T_get_HasValue);
                 // local.HasValue
-                ifCondition = BoundCall.Synthesized(syntax, local, hasValue);
+                ifCondition = MakeNullableHasValue(syntax, local);
             }
             else if (local.Type.IsValueType)
             {


### PR DESCRIPTION
Better handling of unary operators (like:  - foo?.Bar  )
Better lowering strategy for nullable receiver - we no longer rewrite to a ternary ?: in such cases which leads to more optimization opportunities.