### PR TITLE
Do not consider DirectCast(Nothing, <ValueType>) to be equivalent to a default value.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundExpressionExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundExpressionExtensions.vb
@@ -39,8 +39,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return constValue IsNot Nothing AndAlso constValue.IsNothing
 
                 Case BoundKind.DirectCast
-                    constValue = DirectCast(node, BoundDirectCast).Operand.ConstantValueOpt
-                    Return constValue IsNot Nothing AndAlso constValue.IsNothing
+                    ' DirectCast(Nothing, <ValueType>) is emitted as an unbox on a null reference.
+                    ' It is not equivalent to a default value
+                    If node.Type.IsTypeParameter() OrElse Not node.Type.IsValueType Then
+                        constValue = DirectCast(node, BoundDirectCast).Operand.ConstantValueOpt
+                        Return constValue IsNot Nothing AndAlso constValue.IsNothing
+                    End If
 
                 Case BoundKind.TryCast
                     constValue = DirectCast(node, BoundTryCast).Operand.ConstantValueOpt

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -4684,5 +4684,47 @@ BC30439: Constant expression not representable in type 'Integer?'.
             AssertTheseDiagnostics(compilation, expectedError)
         End Sub
 
+        <WorkItem(2094, "https://github.com/dotnet/roslyn/issues/2094")>
+        <Fact()>
+        Public Sub DirectCastNothingToAStructure()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class Program
+    Shared Sub Main()
+        Try
+            Dim val = DirectCast(Nothing, S)
+            System.Console.WriteLine("Unexpected - 1 !!!")
+        Catch e as System.NullReferenceException
+            System.Console.WriteLine("Expected - 1")
+        End Try
+
+        Try
+            M(DirectCast(Nothing, S))
+            System.Console.WriteLine("Unexpected - 2 !!!")
+        Catch e as System.NullReferenceException
+            System.Console.WriteLine("Expected - 2")
+        End Try
+    End Sub
+
+    Shared Sub M(val as S)
+    End Sub
+End Class
+
+Structure S
+End Structure
+    ]]></file>
+    </compilation>, options:=TestOptions.ReleaseExe)
+
+            Dim expectedOutput = <![CDATA[
+Expected - 1
+Expected - 2
+]]>
+            CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()
+
+            compilation = compilation.WithOptions(TestOptions.DebugExe)
+            CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #2094.

@VSadov, @gafter, @jaredpar, @agocke Please review.