### PR TITLE
Show C# snippets with no SnippetType

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
                 Guids.CSharpLanguageServiceId,
                 bstrTypes: surroundWith ? new[] { "SurroundsWith" } : new[] { "Expansion", "SurroundsWith" },
                 iCountTypes: surroundWith ? 1 : 2,
-                fIncludeNULLType: 0,
+                fIncludeNULLType: 1,
                 bstrKinds: null,
                 iCountKinds: 0,
                 fIncludeNULLKind: 0,


### PR DESCRIPTION
Fixes internal TFS bug #1156267. The behavior now matches that of Visual
Studio 2013.

There is a separate closed-source code review for the updated tests.

Reviewers: @Pilchie @jasonmalinowski @balajikris @balajikris @brettfo @rchande