### PR TITLE
Invoke SetAdditionalFiles on compiler inputs when initializing from msbu...

### DIFF
--- a/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/CSharp/Desktop/MSBuild/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -246,6 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 compilerInputs.SetReferences(this.GetMetadataReferencesFromModel(executedProject).ToArray());
                 compilerInputs.SetAnalyzers(this.GetAnalyzerReferencesFromModel(executedProject).ToArray());
+                compilerInputs.SetAdditionalFiles(this.GetAdditionalFilesFromModel(executedProject).ToArray());
                 compilerInputs.SetSources(this.GetDocumentsFromModel(executedProject).ToArray());
 
                 string errorMessage;

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -218,6 +218,11 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return executedProject.GetItems("Analyzer");
         }
 
+        protected virtual IEnumerable<MSB.Framework.ITaskItem> GetAdditionalFilesFromModel(MSB.Execution.ProjectInstance executedProject)
+        {
+            return executedProject.GetItems("AdditionalFiles");
+        }
+
         public MSB.Evaluation.ProjectProperty GetProperty(string name)
         {
             return _loadedProject.GetProperty(name);

--- a/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
+++ b/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
@@ -238,6 +238,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 compilerInputs.SetReferences(Me.GetMetadataReferencesFromModel(executedProject).ToArray())
                 compilerInputs.SetAnalyzers(Me.GetAnalyzerReferencesFromModel(executedProject).ToArray())
+                compilerInputs.SetAdditionalFiles(Me.GetAdditionalFilesFromModel(executedProject).ToArray())
                 compilerInputs.SetSources(Me.GetDocumentsFromModel(executedProject).ToArray())
 
                 compilerInputs.EndInitialization()


### PR DESCRIPTION
...ild csc task fails and we fall back to initializing from model.

This should fix the local unit test failures in MSBuildWorkspace additional file unit tests that some developers are hitting.