### PR TITLE
PropertySymbolKey considers indexer metadata name

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.PropertySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.PropertySymbolKey.cs
@@ -32,10 +32,10 @@ namespace Microsoft.CodeAnalysis
             {
                 var container = _containerKey.Resolve(compilation, ignoreAssemblyKey, cancellationToken);
                 var namedTypes = GetAllSymbols<INamedTypeSymbol>(container);
-                var properties = _isIndexer
-                    ? namedTypes.SelectMany(t => t.GetMembers()).OfType<IPropertySymbol>().Where(p => p.IsIndexer)
-                    : namedTypes.SelectMany(t => t.GetMembers(_metadataName)).OfType<IPropertySymbol>();
-                properties = properties.Where(p => p.Parameters.Length == _refKinds.Length);
+                var properties = namedTypes
+                    .SelectMany(t => t.GetMembers())
+                    .OfType<IPropertySymbol>()
+                    .Where(p => p.Parameters.Length == _refKinds.Length && p.MetadataName == _metadataName && p.IsIndexer == _isIndexer);
 
                 var comparisonOptions = new ComparisonOptions(compilation.IsCaseSensitive, ignoreAssemblyKey, compareMethodTypeParametersByName: true);
                 var matchingProperties = properties.Where(p =>


### PR DESCRIPTION
Fixes internal bug #916341

Update PropertySymbolKey.Resolve to consider the metadata name of
indexers. Prior to this change, resolving regular properties considered
the metadata name but resolving indexers did not. Checking the metadata
name for indexers is important for distinguishing between explicit
interface implementations.

Reviewers: @Pilchie @jasonmalinowski @balajikris @basoundr @brettfo @rchande