### PR TITLE
Update RenameTracking state after isRenamableIdentifierTask

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -100,16 +100,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     {
                         // Continuing an existing tracking session. If there may have been a tag
                         // showing, then update the tags.
-                        if (this.TrackingSession.IsDefinitelyRenamableIdentifier())
-                        {
-                            this.TrackingSession.CheckNewIdentifier(this, _buffer.CurrentSnapshot);
-                            TrackingSessionUpdated();
-                        }
+                        UpdateTrackingSessionIfRenamable();
                     }
                     else
                     {
                         StartTrackingSession(e);
                     }
+                }
+            }
+
+            public void UpdateTrackingSessionIfRenamable()
+            {
+                AssertIsForeground();
+                if (this.TrackingSession.IsDefinitelyRenamableIdentifier())
+                {
+                    this.TrackingSession.CheckNewIdentifier(this, _buffer.CurrentSnapshot);
+                    TrackingSessionUpdated();
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -71,6 +71,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                         _cancellationToken,
                         TaskScheduler.Default);
 
+                    var asyncToken = _asyncListener.BeginAsyncOperation(GetType().Name + ".UpdateTrackingSessionAfterIsRenamableIdentifierTask");
+
+                    _isRenamableIdentifierTask.SafeContinueWith(
+                        t => stateMachine.UpdateTrackingSessionIfRenamable(),
+                        _cancellationToken,
+                       TaskContinuationOptions.OnlyOnRanToCompletion,
+                       ForegroundTaskScheduler).CompletesAsyncOperation(asyncToken);
+
                     QueueUpdateToStateMachine(stateMachine, _isRenamableIdentifierTask);
                 }
                 else
@@ -86,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
             private void QueueUpdateToStateMachine(StateMachine stateMachine, Task task)
             {
-                var asyncToken = _asyncListener.BeginAsyncOperation(GetType().Name + ".Start");
+                var asyncToken = _asyncListener.BeginAsyncOperation($"{GetType().Name}.{nameof(QueueUpdateToStateMachine)}");
 
                 task.SafeContinueWith(t =>
                    {

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1118,5 +1118,27 @@ class C
                 state.AssertNoTag();
             }
         }
+
+        [Fact]
+        [WorkItem(762964)]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_NoTagWhenFirstEditChangesReferenceToAnotherSymbol()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        int abc = 7;
+        int ab = 8;
+        int z = abc$$;
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.AssertNoTag();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes internal bug #762964

Rename tracking usually triggers the TrackingSessionUpdated event
whenever the buffer changes, except for buffer changes that occur before
the _isRenamableIdentifierTask completes. Prior to this change, rename
tracking would get stuck in its initial state between the completion of
_isRenamableIdentifierTask and the next buffer change. We now also
update the session when _isRenamableIdentifierTask completes.

Reviewers: @pilchie @jasonmalinowski @balajikris @basoundr @brettfo @rchande