### PR TITLE
Use a recent Unicode version for case mapping by relying on a neutral culture

### DIFF
--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -14,69 +14,89 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public static class CaseInsensitiveComparison
     {
+        // PERF: Cache a TextInfo for Unicode ToLower since this will be accessed very frequently
+        private static readonly TextInfo s_unicodeCultureTextInfo = GetUnicodeCulture().TextInfo;
+
+        private static CultureInfo GetUnicodeCulture()
+        {
+            try
+            {
+                // We use the "en" culture to get the Unicode ToLower mapping, as it implements
+                // a much more recent Unicode version (6.0+) than the invariant culture (1.0),
+                // and it matches the Unicode version used for character categorization.
+                return new CultureInfo("en");
+            }
+            catch (ArgumentException) // System.Globalization.CultureNotFoundException not on all platforms
+            {
+                // If "en" is not available, fall back to the invariant culture. Although it has bugs
+                // specific to the invariant culture (e.g. being version-locked to Unicode 1.0), at least
+                // we can rely on it being present on all platforms.
+                return CultureInfo.InvariantCulture;
+            }
+
+        }
+
         /// <summary>
-        /// This class seeks to perform one-to-one lowercase Unicode case mappings, which should be culture invariant.
+        /// ToLower implements the Unicode lowercase mapping
+        /// as descriped in ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt.
+        /// VB uses these mappings for case-insensitive comparison.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns>If <paramref name="c"/> is upper case, then this returns its Unicode lower case equivalent. Otherwise, <paramref name="c"/> is returned unmodified.</returns>
+        public static char ToLower(char c)
+        {
+            // PERF: This is a very hot code path in VB, optimize for ASCII
+
+            // Perform a range check with a single compare by using unsigned arithmetic
+            if (unchecked((uint)(c - 'A')) <= ('Z' - 'A'))
+            {
+                return (char)(c | 0x20);
+            }
+
+            if (c < 0xC0) // Covers ASCII (U+0000 - U+007F) and up to the next upper-case codepoint (Latin Capital Letter A with Grave)
+            {
+                return c;
+            }
+
+            return ToLowerNonAscii(c);
+        }
+
+        private static char ToLowerNonAscii(char c)
+        {
+            if (c == '\u0130')
+            {
+                // Special case Turkish I (LATIN CAPITAL LETTER I WITH DOT ABOVE)
+                // This corrects for the fact that the invariant culture only supports Unicode 1.0
+                // and therefore does not "know about" this character.
+                return 'i';
+            }
+
+            return s_unicodeCultureTextInfo.ToLower(c);
+        }
+
+        /// <summary>
+        /// This class seeks to perform the lowercase Unicode case mapping.
         /// </summary>
         private sealed class OneToOneUnicodeComparer : StringComparer
         {
-            // PERF: Grab the TextInfo for the invariant culture since this will be accessed very frequently
-            private static readonly TextInfo s_invariantCultureTextInfo = CultureInfo.InvariantCulture.TextInfo;
-
-            /// <summary>
-            /// ToLower implements the one-to-one Unicode lowercase mapping
-            /// as descriped in ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt.
-            /// The VB spec states that these mappings are used for case-insensitive
-            /// comparison
-            /// </summary>
-            /// <param name="c"></param>
-            /// <returns>If <paramref name="c"/> is upper case, then this returns its lower case equivalent. Otherwise, <paramref name="c"/> is returned unmodified.</returns>
-            public static char ToLower(char c)
-            {
-                // PERF: This is a very hot code path in VB, optimize for ASCII
-
-                // Perform a range check with a single compare by using unsigned arithmetic
-                if (unchecked((uint)(c - 'A')) <= ('Z' - 'A'))
-                {
-                    return (char)(c | 0x20);
-                }
-
-                if (c < 0xC0) // Covers ASCII (U+0000 - U+007F) and up to the next upper-case codepoint (Latin Capital Letter A with Grave)
-                {
-                    return c;
-                }
-
-                return ToLowerNonAscii(c);
-            }
-
-            private static char ToLowerNonAscii(char c)
-            {
-                if (c == '\u0130')
-                {
-                    // Special case Turkish I, see bug 531346
-                    return 'i';
-                }
-
-                return s_invariantCultureTextInfo.ToLower(c);
-            }
-
-            private static int CompareLowerInvariant(char c1, char c2)
+            private static int CompareLowerUnicode(char c1, char c2)
             {
                 return (c1 == c2) ? 0 : ToLower(c1) - ToLower(c2);
             }
 
             public override int Compare(string str1, string str2)
             {
-                if (ReferenceEquals(str1, str2))
+                if ((object)str1 == str2)
                 {
                     return 0;
                 }
 
-                if (str1 == null)
+                if ((object)str1 == null)
                 {
                     return -1;
                 }
 
-                if (str2 == null)
+                if ((object)str2 == null)
                 {
                     return 1;
                 }
@@ -84,7 +104,7 @@ namespace Microsoft.CodeAnalysis
                 int len = Math.Min(str1.Length, str2.Length);
                 for (int i = 0; i < len; i++)
                 {
-                    int ordDiff = CompareLowerInvariant(str1[i], str2[i]);
+                    int ordDiff = CompareLowerUnicode(str1[i], str2[i]);
                     if (ordDiff != 0)
                     {
                         return ordDiff;
@@ -95,19 +115,19 @@ namespace Microsoft.CodeAnalysis
                 return str1.Length - str2.Length;
             }
 
-            private static bool AreEqualLowerInvariant(char c1, char c2)
+            private static bool AreEqualLowerUnicode(char c1, char c2)
             {
                 return c1 == c2 || ToLower(c1) == ToLower(c2);
             }
 
             public override bool Equals(string str1, string str2)
             {
-                if (ReferenceEquals(str1, str2))
+                if ((object)str1 == str2)
                 {
                     return true;
                 }
 
-                if (str1 == null || str2 == null)
+                if ((object)str1 == null || (object)str2 == null)
                 {
                     return false;
                 }
@@ -119,7 +139,7 @@ namespace Microsoft.CodeAnalysis
 
                 for (int i = 0; i < str1.Length; i++)
                 {
-                    if (!AreEqualLowerInvariant(str1[i], str2[i]))
+                    if (!AreEqualLowerUnicode(str1[i], str2[i]))
                     {
                         return false;
                     }
@@ -130,12 +150,12 @@ namespace Microsoft.CodeAnalysis
 
             public static bool EndsWith(string value, string possibleEnd)
             {
-                if (ReferenceEquals(value, possibleEnd))
+                if ((object)value == possibleEnd)
                 {
                     return true;
                 }
 
-                if (value == null || possibleEnd == null)
+                if ((object)value == null || (object)possibleEnd == null)
                 {
                     return false;
                 }
@@ -150,7 +170,7 @@ namespace Microsoft.CodeAnalysis
 
                 while (j >= 0)
                 {
-                    if (!AreEqualLowerInvariant(value[i], possibleEnd[j]))
+                    if (!AreEqualLowerUnicode(value[i], possibleEnd[j]))
                     {
                         return false;
                     }
@@ -222,13 +242,13 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Convert a string to lower case in culture invariant way
+        /// Convert a string to lower case per Unicode
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
         public static string ToLower(string value)
         {
-            if (value == null)
+            if ((object)value == null)
                 return null;
 
             if (value.Length == 0)
@@ -244,7 +264,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// In-place convert string in StringBuilder to lower case in culture invariant way
+        /// In-place convert string in StringBuilder to lower case per Unicode rules
         /// </summary>
         /// <param name="builder"></param>
         public static void ToLower(StringBuilder builder)
@@ -254,7 +274,7 @@ namespace Microsoft.CodeAnalysis
 
             for (int i = 0; i < builder.Length; i++)
             {
-                builder[i] = OneToOneUnicodeComparer.ToLower(builder[i]);
+                builder[i] = ToLower(builder[i]);
             }
         }
     }

--- a/src/Compilers/Core/Portable/PublicAPI.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.txt
@@ -1901,6 +1901,7 @@ static Microsoft.CodeAnalysis.CaseInsensitiveComparison.EndsWith(string value, s
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(string left, string right) -> bool
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.GetHashCode(string value) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.ToLower(System.Text.StringBuilder builder) -> void
+static Microsoft.CodeAnalysis.CaseInsensitiveComparison.ToLower(char c) -> char
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.ToLower(string value) -> string
 static Microsoft.CodeAnalysis.ChildSyntaxList.operator !=(Microsoft.CodeAnalysis.ChildSyntaxList list1, Microsoft.CodeAnalysis.ChildSyntaxList list2) -> bool
 static Microsoft.CodeAnalysis.ChildSyntaxList.operator ==(Microsoft.CodeAnalysis.ChildSyntaxList list1, Microsoft.CodeAnalysis.ChildSyntaxList list2) -> bool

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
@@ -906,6 +906,20 @@ End Class
         </errors>)
     End Sub
 
+    <WorkItem(620, "https://github.com/dotnet/roslyn/issues/620")>
+    <Fact>
+    Public Sub TestRecentUnicodeVersion()
+        ' Ensure that the characters Ǉ and ǈ are considered matching under case insensitivity
+        ParseAndVerify(<![CDATA[
+#Const Ǉ = True
+#if ǈ
+Class MissingEnd
+#end if
+        ]]>,
+        Diagnostic(ERRID.ERR_ExpectedEndClass, "Class MissingEnd").WithLocation(4, 1)
+        )
+    End Sub
+
     <WorkItem(893259, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30012_ParsePreProcessorIfIncompleteExpression()

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static int IndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
         {
             var length = text.Length - value.Length;
-            var normalized = caseSensitive ? value : value.ToLowerInvariant();
+            var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
 
             for (var i = startIndex; i <= length; i++)
             {
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static int LastIndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
         {
-            var normalized = caseSensitive ? value : value.ToLowerInvariant();
+            var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
             startIndex = startIndex + normalized.Length > text.Length
                 ? text.Length - normalized.Length
                 : startIndex;
@@ -181,11 +181,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return -1;
         }
 
-        private static readonly TextInfo s_invariantTextInfo = CultureInfo.InvariantCulture.TextInfo;
-
         private static bool Match(char nomalizedLeft, char right, bool caseSensitive)
         {
-            return caseSensitive ? nomalizedLeft == right : nomalizedLeft == s_invariantTextInfo.ToLower(right);
+            return caseSensitive ? nomalizedLeft == right : nomalizedLeft == CaseInsensitiveComparison.ToLower(right);
         }
     }
 }


### PR DESCRIPTION
instead of the not-so-neutral invarant culture.
Fixes #2116, #620
See also #1070

@ellismg @jaredpar @AlekseyTs : Please review
/cc @VladimirReshetnikov