### PR TITLE
Dont Force Format VB on save, paste and OnFocusLost

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
@@ -246,7 +246,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 ' Did we paste content that changed the number of lines?
                 If oldVersion.Changes IsNot Nothing AndAlso oldVersion.Changes.IncludesLineChanges Then
                     Try
-                        _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)
+                        _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
                     Catch ex As OperationCanceledException
                         ' If the commit was cancelled, we still want the paste to go through
                     End Try
@@ -268,7 +268,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     allowCancel:=True,
                     action:=Sub(waitContext)
                                 Using transaction = _textUndoHistoryRegistry.GetHistory(args.TextView.TextBuffer).CreateTransaction(VBEditorResources.FormatOnSave)
-                                    _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)
+                                    _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
 
                                     ' We should only create the transaction if anything actually happened
                                     If transaction.UndoPrimitives.Any() Then

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitViewManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitViewManager.vb
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 action:=
                 Sub(waitContext)
                     For Each buffer In _view.BufferGraph.GetTextBuffers(Function(b) b.ContentType.IsOfType(ContentTypeNames.VisualBasicContentType))
-                        _commitBufferManagerFactory.CreateForBuffer(buffer).CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)
+                        _commitBufferManagerFactory.CreateForBuffer(buffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
                     Next
                 End Sub)
         End Sub


### PR DESCRIPTION
Fix #1944 : VB Command handlers for save, paste and OnFocusLost was
forcing formatting. This change modifies the behavior to not force it.