### PR TITLE
Add support for "dynamic" in the expression compiler

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpCompileResult.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpCompileResult.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+{
+    internal sealed class CSharpCompileResult : CompileResult
+    {
+        private readonly MethodSymbol _method;
+
+        internal CSharpCompileResult(
+            byte[] assembly,
+            MethodSymbol method,
+            ReadOnlyCollection<string> formatSpecifiers)
+            : base(assembly, method.ContainingType.MetadataName, method.MetadataName, formatSpecifiers)
+        {
+            Debug.Assert(method is EEMethodSymbol); // Expected but not required.
+            _method = method;
+        }
+
+        public override CustomTypeInfo GetCustomTypeInfo() =>
+            new CustomTypeInfo(DynamicFlagsCustomTypeInfo.PayloadTypeId, _method.GetCustomTypeInfoPayload());
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -62,7 +62,9 @@
     <Compile Include="Binders\EEMethodBinder.cs" />
     <Compile Include="Binders\WithTypeArgumentsBinder.cs" />
     <Compile Include="Binders\PlaceholderLocalBinder.cs" />
+    <Compile Include="CSharpCompileResult.cs" />
     <Compile Include="CSharpInScopeHoistedLocals.cs" />
+    <Compile Include="CSharpLocalAndMethod.cs" />
     <Compile Include="SymUnmanagedReaderExtensions.cs" />
     <Compile Include="CompilationContext.cs" />
     <Compile Include="CompilationExtensions.cs" />

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLocalAndMethod.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpLocalAndMethod.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+{
+    internal sealed class CSharpLocalAndMethod : LocalAndMethod
+    {
+        private readonly MethodSymbol _method;
+
+        public CSharpLocalAndMethod(string localName, MethodSymbol method, DkmClrCompilationResultFlags flags)
+            : base(localName, method.Name, flags)
+        {
+            Debug.Assert(method is EEMethodSymbol); // Expected but not required.
+            _method = method;
+        }
+
+        public override CustomTypeInfo GetCustomTypeInfo() =>
+            new CustomTypeInfo(DynamicFlagsCustomTypeInfo.PayloadTypeId, _method.GetCustomTypeInfoPayload());
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                             {
                                 var methodName = GetNextMethodName(methodBuilder);
                                 var method = this.GetPseudoVariableMethod(typeNameDecoder, container, methodName, alias);
-                                localBuilder.Add(new LocalAndMethod(alias.FullName, methodName, alias.GetLocalResultFlags()));
+                                localBuilder.Add(new CSharpLocalAndMethod(alias.FullName, method, alias.GetLocalResultFlags()));
                                 methodBuilder.Add(method);
                             }
                         }
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         {
                             var methodName = GetNextMethodName(methodBuilder);
                             var method = this.GetThisMethod(container, methodName);
-                            localBuilder.Add(new LocalAndMethod("this", methodName, DkmClrCompilationResultFlags.None)); // Note: writable in dev11.
+                            localBuilder.Add(new CSharpLocalAndMethod("this", method, DkmClrCompilationResultFlags.None)); // Note: writable in dev11.
                             methodBuilder.Add(method);
                         }
                     }
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                             var methodName = GetNextMethodName(methodBuilder);
                             var returnType = typeVariablesType.Construct(allTypeParameters.Cast<TypeParameterSymbol, TypeSymbol>());
                             var method = this.GetTypeVariablesMethod(container, methodName, returnType);
-                            localBuilder.Add(new LocalAndMethod(ExpressionCompilerConstants.TypeVariablesLocalName, methodName, DkmClrCompilationResultFlags.ReadOnlyResult));
+                            localBuilder.Add(new CSharpLocalAndMethod(ExpressionCompilerConstants.TypeVariablesLocalName, method, DkmClrCompilationResultFlags.ReadOnlyResult));
                             methodBuilder.Add(method);
                         }
                     }
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             name = SyntaxHelpers.EscapeKeywordIdentifiers(name);
             var methodName = GetNextMethodName(methodBuilder);
             var method = getMethod(container, methodName, name, localOrParameterIndex);
-            localBuilder.Add(new LocalAndMethod(name, methodName, resultFlags));
+            localBuilder.Add(new CSharpLocalAndMethod(name, method, resultFlags));
             methodBuilder.Add(method);
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     internal sealed class EEAssemblyBuilder : PEAssemblyBuilderBase
     {
-        private readonly ImmutableHashSet<MethodSymbol> _methods;
+        internal readonly ImmutableHashSet<MethodSymbol> Methods;
 
         public EEAssemblyBuilder(
             SourceAssemblySymbol sourceAssembly,
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                   assemblySymbolMapper: null,
                   additionalTypes: additionalTypes)
         {
-            _methods = ImmutableHashSet.CreateRange(methods);
+            Methods = ImmutableHashSet.CreateRange(methods);
 
             if (testData != null)
             {
@@ -71,13 +71,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol symbol)
         {
             var method = symbol as EEMethodSymbol;
-            if (((object)method != null) && _methods.Contains(method))
+            if (((object)method != null) && Methods.Contains(method))
             {
                 var defs = GetLocalDefinitions(method.Locals);
                 return new SlotAllocator(defs);
             }
 
-            Debug.Assert(!_methods.Contains(symbol));
+            Debug.Assert(!Methods.Contains(symbol));
             return null;
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (syntax == null)
             {
                 resultProperties = default(ResultProperties);
-                return default(CompileResult);
+                return null;
             }
 
             var context = this.CreateCompilationContext(syntax);
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (moduleBuilder == null)
             {
                 resultProperties = default(ResultProperties);
-                return default(CompileResult);
+                return null;
             }
 
             using (var stream = new MemoryStream())
@@ -265,16 +265,22 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 if (diagnostics.HasAnyErrors())
                 {
                     resultProperties = default(ResultProperties);
-                    return default(CompileResult);
+                    return null;
                 }
 
                 resultProperties = properties;
-                return new CompileResult(
+                return new CSharpCompileResult(
                     stream.ToArray(),
-                    typeName: TypeName,
-                    methodName: MethodName,
+                    GetSynthesizedMethod(moduleBuilder),
                     formatSpecifiers: formatSpecifiers);
             }
+        }
+
+        private static MethodSymbol GetSynthesizedMethod(CommonPEModuleBuilder moduleBuilder)
+        {
+            var method = ((EEAssemblyBuilder)moduleBuilder).Methods.Single(m => m.MetadataName == MethodName);
+            Debug.Assert(method.ContainingType.MetadataName == TypeName);
+            return method;
         }
 
         private static CSharpSyntaxNode Parse(
@@ -324,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (assignment == null)
             {
                 resultProperties = default(ResultProperties);
-                return default(CompileResult);
+                return null;
             }
 
             var context = this.CreateCompilationContext(assignment);
@@ -333,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (moduleBuilder == null)
             {
                 resultProperties = default(ResultProperties);
-                return default(CompileResult);
+                return null;
             }
 
             using (var stream = new MemoryStream())
@@ -351,14 +357,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 if (diagnostics.HasAnyErrors())
                 {
                     resultProperties = default(ResultProperties);
-                    return default(CompileResult);
+                    return null;
                 }
 
                 resultProperties = properties;
-                return new CompileResult(
+                return new CSharpCompileResult(
                     stream.ToArray(),
-                    typeName: TypeName,
-                    methodName: MethodName,
+                    GetSynthesizedMethod(moduleBuilder),
                     formatSpecifiers: null);
             }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
@@ -13,6 +17,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             method.ContainingType.GetAllTypeParameters(builder);
             builder.AddRange(method.TypeParameters);
             return builder.ToImmutableAndFree();
+        }
+
+        internal static ReadOnlyCollection<byte> GetCustomTypeInfoPayload(this MethodSymbol method)
+        {
+            bool[] dynamicFlags = CSharpCompilation.DynamicTransformsEncoder.Encode(method.ReturnType, method.ReturnTypeCustomModifiers.Length, RefKind.None).ToArray();
+            var dynamicFlagsInfo = new DynamicFlagsCustomTypeInfo(new BitArray(dynamicFlags));
+            return dynamicFlagsInfo.GetCustomTypeInfoPayload();
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             result = context.CompileExpression(InspectionContextFactory.Empty, "string.Empty, nq;", DkmEvaluationFlags.None, DiagnosticFormatter.Instance, out resultProperties, out error, out missingAssemblyIdentities, EnsureEnglishUICulture.PreferredOrNull, testData);
             Assert.Empty(missingAssemblyIdentities);
             Assert.Equal(error, "(1,13): error CS1002: ; expected");
-            Assert.Equal(result.FormatSpecifiers, null);
+            Assert.Null(result);
 
             // Assignment without ';' as statement.
             testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 methodName: "C.M");
             string error;
             var result = context.CompileExpression("M(", out error);
-            Assert.Null(result.Assembly);
+            Assert.Null(result);
             Assert.Equal(error, "(1,3): error CS1026: ) expected");
         }
 
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     out missingAssemblyIdentities,
                     preferredUICulture: null,
                     testData: null);
-                Assert.Null(result.Assembly);
+                Assert.Null(result);
                 Assert.Equal(error, "LCID=1031, Code=1026");
                 Assert.Empty(missingAssemblyIdentities);
             }
@@ -544,8 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CheckFormatSpecifiers(result, "g", "h");
             // Format specifiers on assignment value.
             result = context.CompileAssignment("x", "null, y", out error);
-            Assert.Null(result.Assembly);
-            Assert.Null(result.FormatSpecifiers);
+            Assert.Null(result);
             Assert.Equal(error, "(1,1): error CS1073: Unexpected token ','");
             // Trailing semicolon, no format specifiers.
             result = context.CompileExpression("x; ", out error);
@@ -1628,7 +1627,7 @@ class C
             var testData = new CompilationTestData();
             var result = context.CompileExpression(expr, out resultProperties, out error, testData);
             Assert.Equal(expectedError, error);
-            Assert.NotEqual(expectedError == null, result.Assembly == null);
+            Assert.NotEqual(expectedError == null, result == null);
             Assert.Equal(expectedFlags, resultProperties.Flags);
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -599,7 +599,7 @@ class C
                     numRetries++;
                     Assert.InRange(numRetries, 0, 2); // We don't want to loop forever... 
                     diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
-                    return default(CompileResult);   
+                    return null;   
                 }, 
                 (AssemblyIdentity assemblyIdentity, out uint uSize) => 
                 { 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CompileResult.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CompileResult.cs
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal struct CompileResult
+    internal abstract class CompileResult
     {
+        internal readonly byte[] Assembly; // [] rather than ReadOnlyCollection<> to allow caller to create Stream easily
+        internal readonly string TypeName;
+        internal readonly string MethodName;
+        internal readonly ReadOnlyCollection<string> FormatSpecifiers;
+
         internal CompileResult(
             byte[] assembly,
             string typeName,
@@ -18,9 +24,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             this.FormatSpecifiers = formatSpecifiers;
         }
 
-        internal readonly byte[] Assembly; // [] rather than ReadOnlyCollection<> to allow caller to create Stream easily
-        internal readonly string TypeName;
-        internal readonly string MethodName;
-        internal readonly ReadOnlyCollection<string> FormatSpecifiers;
+        public abstract CustomTypeInfo GetCustomTypeInfo();
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CustomTypeInfo.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    /// <remarks>
+    /// We can't instantiate <see cref="DkmClrCustomTypeInfo"/> in the unit tests
+    /// (since we run against a reference assembly), so we use this type as an
+    /// intermediary.
+    /// </remarks>
+    internal struct CustomTypeInfo
+    {
+        public Guid PayloadTypeId;
+        public ReadOnlyCollection<byte> Payload;
+
+        public CustomTypeInfo(Guid payloadTypeId, ReadOnlyCollection<byte> payload)
+        {
+            this.PayloadTypeId = payloadTypeId;
+            this.Payload = payload;
+        }
+
+        public DkmClrCustomTypeInfo ToDkmClrCustomTypeInfo()
+        {
+            return Payload == null
+                ? null
+                : DkmClrCustomTypeInfo.Create(PayloadTypeId, Payload);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 Access: resultProperties.AccessType,
                 StorageType: resultProperties.StorageType,
                 TypeModifierFlags: resultProperties.ModifierFlags,
-                CustomTypeInfo: null);
+                CustomTypeInfo: compResult.GetCustomTypeInfo().ToDkmClrCustomTypeInfo());
         }
 
         internal static ResultProperties GetResultProperties<TSymbol>(this TSymbol symbol, DkmClrCompilationResultFlags flags, bool isConstant)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
         }
 
-        public DkmClrCustomTypeInfo GetCustomTypeInfo()
+        internal ReadOnlyCollection<byte> GetCustomTypeInfoPayload()
         {
             if (!Any())
             {
@@ -69,7 +69,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
             }
 
-            return DkmClrCustomTypeInfo.Create(PayloadTypeId, new ReadOnlyCollection<byte>(bytes));
+            return new ReadOnlyCollection<byte>(bytes);
+        }
+
+        public DkmClrCustomTypeInfo GetCustomTypeInfo()
+        {
+            var payload = GetCustomTypeInfoPayload();
+            return payload == null ? null : DkmClrCustomTypeInfo.Create(PayloadTypeId, payload);
         }
 
         public DynamicFlagsCustomTypeInfo SkipOne()

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -34,6 +34,7 @@
     </Compile>
     <Compile Include="AssemblyReaders.cs" />
     <Compile Include="AssemblyReference.cs" />
+    <Compile Include="CustomTypeInfo.cs" />
     <Compile Include="DynamicFlagsCustomTypeInfo.cs" />
     <Compile Include="Placeholders.cs" />
     <Compile Include="ReflectionHelpers.cs" />

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LocalAndMethod.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LocalAndMethod.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     /// The name of a local or argument and the name of
     /// the corresponding method to access that object.
     /// </summary>
-    internal struct LocalAndMethod
+    internal abstract class LocalAndMethod
     {
         public readonly string LocalName;
         public readonly string MethodName;
@@ -20,5 +20,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             this.MethodName = methodName;
             this.Flags = flags;
         }
+
+        public abstract CustomTypeInfo GetCustomTypeInfo();
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -108,6 +108,8 @@
     <Compile Include="Symbols\TypeSubstitutionExtensions.vb" />
     <Compile Include="SyntaxHelpers.vb" />
     <Compile Include="TypeParameterChecker.vb" />
+    <Compile Include="VisualBasicCompileResult.vb" />
+    <Compile Include="VisualBasicLocalAndMethod.vb" />
     <Compile Include="VisualBasicMetadataContext.vb" />
     <Compile Include="VisualBasicExpressionCompiler.vb" />
     <Compile Include="VisualBasicFrameDecoder.vb" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -237,7 +237,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             For Each [alias] In aliases
                                 Dim methodName = GetNextMethodName(methodBuilder)
                                 Dim method = GetPseudoVariableMethod(typeNameDecoder, container, methodName, [alias])
-                                localBuilder.Add(New LocalAndMethod([alias].FullName, methodName, [alias].GetLocalResultFlags()))
+                                localBuilder.Add(New VisualBasicLocalAndMethod([alias].FullName, methodName, [alias].GetLocalResultFlags()))
                                 methodBuilder.Add(method)
                             Next
                         End If
@@ -247,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         If Not m.IsShared AndAlso (Not m.ContainingType.IsClosureOrStateMachineType() OrElse _displayClassVariables.ContainsKey(GeneratedNames.MakeStateMachineCapturedMeName())) Then
                             Dim methodName = GetNextMethodName(methodBuilder)
                             Dim method = Me.GetMeMethod(container, methodName)
-                            localBuilder.Add(New LocalAndMethod("Me", methodName, DkmClrCompilationResultFlags.None)) ' NOTE: writable in Dev11.
+                            localBuilder.Add(New VisualBasicLocalAndMethod("Me", methodName, DkmClrCompilationResultFlags.None)) ' NOTE: writable in Dev11.
                             methodBuilder.Add(method)
                         End If
                     End If
@@ -297,7 +297,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             Dim methodName = GetNextMethodName(methodBuilder)
                             Dim returnType = typeVariablesType.Construct(ImmutableArrayExtensions.Cast(Of TypeParameterSymbol, TypeSymbol)(allTypeParameters))
                             Dim method = Me.GetTypeVariableMethod(container, methodName, returnType)
-                            localBuilder.Add(New LocalAndMethod(ExpressionCompilerConstants.TypeVariablesLocalName, methodName, DkmClrCompilationResultFlags.ReadOnlyResult))
+                            localBuilder.Add(New VisualBasicLocalAndMethod(ExpressionCompilerConstants.TypeVariablesLocalName, methodName, DkmClrCompilationResultFlags.ReadOnlyResult))
                             methodBuilder.Add(method)
                         End If
                     End If
@@ -343,7 +343,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             name = SyntaxHelpers.EscapeKeywordIdentifiers(name)
             Dim methodName = GetNextMethodName(methodBuilder)
             Dim method = getMethod(container, methodName, name, localOrParameterIndex)
-            localBuilder.Add(New LocalAndMethod(name, methodName, resultFlags))
+            localBuilder.Add(New VisualBasicLocalAndMethod(name, methodName, resultFlags))
             methodBuilder.Add(method)
         End Sub
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -382,7 +382,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End If
 
                 resultProperties = properties
-                Return New CompileResult(
+                Return New VisualBasicCompileResult(
                         stream.ToArray(),
                         s_typeName,
                         s_methodName,
@@ -431,7 +431,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         properties.AccessType,
                         properties.StorageType,
                         properties.ModifierFlags)
-                Return New CompileResult(
+                Return New VisualBasicCompileResult(
                         stream.ToArray(),
                         s_typeName,
                         s_methodName,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicCompileResult.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicCompileResult.vb
@@ -1,0 +1,24 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.ObjectModel
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+
+    Friend NotInheritable Class VisualBasicCompileResult : Inherits CompileResult
+
+        Public Sub New(
+            assembly As Byte(),
+            typeName As String,
+            methodName As String,
+            formatSpecifiers As ReadOnlyCollection(Of String))
+
+            MyBase.New(assembly, typeName, methodName, formatSpecifiers)
+        End Sub
+
+        Public Overrides Function GetCustomTypeInfo() As CustomTypeInfo
+            Return Nothing
+        End Function
+    End Class
+
+End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLocalAndMethod.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLocalAndMethod.vb
@@ -1,0 +1,20 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.ObjectModel
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+
+    Friend NotInheritable Class VisualBasicLocalAndMethod : Inherits LocalAndMethod
+
+        Public Sub New(localName As String, methodName As String, flags As DkmClrCompilationResultFlags)
+            MyBase.New(localName, methodName, flags)
+        End Sub
+
+        Public Overrides Function GetCustomTypeInfo() As CustomTypeInfo
+            Return Nothing
+        End Function
+    End Class
+
+End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -90,7 +90,7 @@ End Class
 
             Dim errorMessage As String = Nothing
             Dim result = context.CompileExpression("M(", errorMessage, Nothing, VisualBasicDiagnosticFormatter.Instance)
-            Assert.Null(result.Assembly)
+            Assert.Null(result)
             Assert.Equal("(1) : error BC30201: Expression expected.", errorMessage)
         End Sub
 
@@ -124,7 +124,7 @@ End Class
                     preferredUICulture:=Nothing,
                     testData:=Nothing)
                 Assert.Empty(missingAssemblyIdentities)
-                Assert.Null(result.Assembly)
+                Assert.Null(result)
                 Assert.Equal("LCID=1031, Code=30201", errorMessage)
             Finally
                 Thread.CurrentThread.CurrentUICulture = previousUICulture
@@ -444,8 +444,7 @@ End Class
 
             ' Format specifiers on assignment value.
             result = context.CompileAssignment("x", "Nothing, y", errorMessage, Nothing, VisualBasicDiagnosticFormatter.Instance)
-            Assert.Null(result.Assembly)
-            Assert.Null(result.FormatSpecifiers)
+            Assert.Null(result)
             Assert.Equal("(1) : error BC30035: Syntax error.", errorMessage)
 
             ' Format specifiers, no expression.
@@ -1565,7 +1564,7 @@ End Class
             Dim testData = New CompilationTestData()
             Dim result = context.CompileExpression(expr, resultProperties, errorMessage, testData)
             Assert.Equal(expectedErrorMessage, errorMessage)
-            Assert.NotEqual(expectedErrorMessage Is Nothing, result.Assembly Is Nothing)
+            Assert.NotEqual(expectedErrorMessage Is Nothing, result Is Nothing)
             Assert.Equal(expectedFlags, resultProperties.Flags)
         End Sub
 


### PR DESCRIPTION
This is the second of a sequence of changes.  (The first was 3dd1f2b.)  In
this change we start returning custom type info (effectively just the
flags of DynamicAttribute packed into a byte array) from calls to the
expression compiler so that they can be consumed by the result provider.

TODO: This change does not associate custom type info with locals declared
in the Immediate window.