### PR TITLE
LocalRewriter.VisitDynamicObjectCreationExpression - preserve initializers, if any.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -12,7 +12,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
             var loweredArguments = VisitList(node.Arguments);
-            return _dynamicFactory.MakeDynamicConstructorInvocation(node.Syntax, node.Type, loweredArguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt).ToExpression();
+            var constructorInvocation = _dynamicFactory.MakeDynamicConstructorInvocation(node.Syntax, node.Type, loweredArguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt).ToExpression();
+
+            if (node.InitializerExpressionOpt == null || node.InitializerExpressionOpt.HasErrors)
+            {
+                return constructorInvocation;
+            }
+
+            return MakeObjectCreationWithInitializer(node.Syntax, constructorInvocation, node.InitializerExpressionOpt, node.Type);
         }
 
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
@@ -2291,5 +2291,45 @@ class C
                 Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             }
         }
+
+        [Fact, WorkItem(2046, "https://github.com/dotnet/roslyn/issues/2046")]
+        public void ObjectInitializerTest_DynamicPassedToConstructor()
+        {
+            var source = @"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        DoesNotWork();
+    }
+
+    public static void DoesNotWork()
+    {
+        var cc = new Cc(1, (dynamic)new object())
+        {
+            C = ""Initialized""
+        };
+        Console.WriteLine(cc.C ?? ""Uninitialized !!!"");
+    }
+}
+
+public class Cc{
+
+    public int A { get; set; }
+    public dynamic B { get; set; }
+
+    public string C { get; set; }
+
+    public Cc(int a, dynamic b)
+    {
+        A = a;
+        B = b;
+    }
+}
+";
+            CompileAndVerify(source, new[] { CSharpRef, SystemCoreRef }, expectedOutput: "Initialized");
+        }
     }
 }


### PR DESCRIPTION
Fixes #2046.

@VSadov, @gafter, @jaredpar, @agocke Please review. 