### PR TITLE
[Test/loc] Fix test failures with non-English language

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -367,6 +367,7 @@ class C
                 ImmutableArray.Create(WinRtRefs),
                 ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI", "Windows.UI.Xaml")));  
             string errorMessage;
+            DiagnosticBag diagnostics;
             var testData = new CompilationTestData();
             ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
                 runtime.Modules.SelectAsArray(m => m.MetadataBlock),
@@ -382,6 +383,7 @@ class C
                     throw ExceptionUtilities.Unreachable;
                 },
                 out errorMessage,
+                out diagnostics,
                 out testData);
             Assert.Null(errorMessage);
             testData.GetMethodData("<>x.<>m0").VerifyIL(

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
@@ -1431,36 +1431,39 @@ class C
         get { throw new E(); }
     }
 }";
-            var runtime = new DkmClrRuntimeInstance(ReflectionUtilities.GetMscorlibAndSystemCore(GetAssembly(source)));
-            using (runtime.Load())
+            using (new EnsureEnglishUICulture())
             {
-                var type = runtime.GetType("C");
-                var value = CreateDkmClrValue(type.Instantiate(), type: type);
-                var evalResult = FormatResult("o", value);
-                Verify(evalResult,
-                    EvalResult("o", "{C}", "C", "o", DkmEvaluationResultFlags.Expandable));
-                var children = GetChildren(evalResult);
-                Verify(children,
-                    EvalResult(
-                        "P",
-                        "'o.P' threw an exception of type 'System.NotImplementedException'",
-                        "System.Collections.IEnumerable {System.NotImplementedException}",
-                        "o.P",
-                        DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly | DkmEvaluationResultFlags.ExceptionThrown),
-                    EvalResult(
-                        "Q",
-                        "'o.Q' threw an exception of type 'E'",
-                        "System.Collections.IEnumerable {E}",
-                        "o.Q",
-                        DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly | DkmEvaluationResultFlags.ExceptionThrown));
-                children = GetChildren(children[1]);
-                Verify(children[6],
-                    EvalResult(
-                        "Message",
-                        "\"Exception of type 'E' was thrown.\"",
-                        "string",
-                        null,
-                        DkmEvaluationResultFlags.RawString | DkmEvaluationResultFlags.ReadOnly));
+                var runtime = new DkmClrRuntimeInstance(ReflectionUtilities.GetMscorlibAndSystemCore(GetAssembly(source)));
+                using (runtime.Load())
+                {
+                    var type = runtime.GetType("C");
+                    var value = CreateDkmClrValue(type.Instantiate(), type: type);
+                    var evalResult = FormatResult("o", value);
+                    Verify(evalResult,
+                        EvalResult("o", "{C}", "C", "o", DkmEvaluationResultFlags.Expandable));
+                    var children = GetChildren(evalResult);
+                    Verify(children,
+                        EvalResult(
+                            "P",
+                            "'o.P' threw an exception of type 'System.NotImplementedException'",
+                            "System.Collections.IEnumerable {System.NotImplementedException}",
+                            "o.P",
+                            DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly | DkmEvaluationResultFlags.ExceptionThrown),
+                        EvalResult(
+                            "Q",
+                            "'o.Q' threw an exception of type 'E'",
+                            "System.Collections.IEnumerable {E}",
+                            "o.Q",
+                            DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly | DkmEvaluationResultFlags.ExceptionThrown));
+                    children = GetChildren(children[1]);
+                    Verify(children[6],
+                        EvalResult(
+                            "Message",
+                            "\"Exception of type 'E' was thrown.\"",
+                            "string",
+                            null,
+                            DkmEvaluationResultFlags.RawString | DkmEvaluationResultFlags.ReadOnly));
+                }
             }
         }
 

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -128,8 +128,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ExpressionCompiler.CreateContextDelegate createContext,
             DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,
             out string errorMessage,
+            out DiagnosticBag diagnosticBag,
             out CompilationTestData testData)
         {
+            DiagnosticBag diaBag = DiagnosticBag.GetInstance();
             var r = ExpressionCompiler.CompileWithRetry(
                 metadataBlocks,
                 DiagnosticFormatter.Instance,
@@ -145,11 +147,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         diagnostics,
                         out resultProperties,
                         td);
+                    diaBag.AddRange(diagnostics);
                     return new CompileExpressionResult(compileResult, td);
                 },
                 getMetaDataBytesPtr,
                 out errorMessage);
             testData = r.TestData;
+            diagnosticBag = diaBag;
             return r.CompileResult;
         }
 


### PR DESCRIPTION
Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests.dll (#1851)
Roslyn.ExpressionEvaluator.CSharp.ExpressionCompiler.UnitTests.dll (#1854)
Roslyn.ExpressionEvaluator.VisualBasic.ExpressionCompiler.UnitTests.dll (#1855)