### PR TITLE
Self-host the C# and VB compilers in Jenkins runs

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,5 +1,17 @@
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-msbuild /v:m /m BuildAndTest.proj /p:CIBuild=true
+
+REM Build the compiler so we can self host it for the full build
+src\.nuget\NuGet.exe restore src\Toolset.sln -packagesdirectory packages
+msbuild /nologo /v:m /m src/Compilers/Core/VBCSCompiler/VBCSCompiler.csproj
+msbuild /nologo /v:m /m src/Compilers/CSharp/csc2/csc2.csproj
+msbuild /nologo /v:m /m src/Compilers/VisualBasic/vbc2/vbc2.csproj
+
+mkdir Binaries\Bootstrap
+move Binaries\Debug\* Binaries\Bootstrap
+msbuild /v:m /t:Clean src/Toolset.sln
+taskkill /F /IM vbcscompiler.exe
+
+msbuild /v:m /m /p:BootstrapBuildPath=%~dp0\Binaries\Bootstrap BuildAndTest.proj /p:CIBuild=true
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe
     echo Build failed

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -79,8 +79,10 @@
   <PropertyGroup Condition="'$(BootstrapBuildPath)' != ''">
     <CscToolPath>$(BootstrapBuildPath)</CscToolPath>
     <CscToolExe>csc.exe</CscToolExe>
+    <CscToolExe Condition="Exists('$(BootstrapBuildPath)\csc2.exe')">csc2.exe</CscToolExe>
     <VbcToolPath>$(BootstrapBuildPath)</VbcToolPath>
     <VbcToolExe>vbc.exe</VbcToolExe>
+    <VbcToolExe Condition="Exists('$(BootstrapBuildPath)\vbc2.exe')">vbc2.exe</VbcToolExe>
   </PropertyGroup>
 
   <!-- Common project settings -->


### PR DESCRIPTION
Builds in Jenkins will now self-host the compiler bits that result from
the changes being committed in the PR.  Hence if there is a bug
introduced by the change that prevents us from compiling Roslyn we will
find it out before checkin vs. the next toolset update.

This change causes the Jenkins build to roughly do the following:

1. Build the C#, VB and compiler server binaries and move them to
Binaries\Bootstrap.
2. Clean the enlistment which deletes the intermediate directories and
kill the compiler server.
3. Run our standard BuildAndTest.proj using the
/p:BootstrapBuildPath=Binaries\Bootstrap parameter to self-host the just
built compilers.

Had this been in place issue #2048 would have been caught immediately.  