### PR TITLE
Update EventMap.Registry.HasHandler to use .Equals

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/EventMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EventMap.cs
@@ -116,12 +116,27 @@ namespace Roslyn.Utilities
 
             public bool HasHandler(TEventHandler handler)
             {
-                return this.handler == handler;
+                return handler.Equals(this.handler);
             }
 
             public bool Equals(Registry<TEventHandler> other)
             {
-                return other != null && other.handler == this.handler;
+                if (other == null)
+                {
+                    return false;
+                }
+
+                if (other.handler == null && this.handler == null)
+                {
+                    return true;
+                }
+                
+                if (other.handler == null || this.handler == null)
+                {
+                    return false;
+                }
+
+                return other.handler.Equals(this.handler);
             }
 
             public override bool Equals(object obj)
@@ -131,7 +146,7 @@ namespace Roslyn.Utilities
 
             public override int GetHashCode()
             {
-                return this.handler.GetHashCode();
+                return this.handler == null ? 0 : this.handler.GetHashCode();
             }
         }
 


### PR DESCRIPTION
This fixes internal TFS issue #1161343

The event handlers being tracked by EventMap may not be reference equal,
so use .Equals to compare them instead of ==. This fixes an event
handler leak and matches the equals behavior from before commit
7cda9431a8b24693e6e047a7dcef7e6047bfc151, when we used List.Remove.

This change also adds some more careful null handling for when a
Registry<TEventHandler> has a null handler.