### PR TITLE
Dont generate Getter/Setter when Writeonly/Readonly for VB Properties

### DIFF
--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_Properties.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_Properties.vb
@@ -121,6 +121,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
         ''' <param name="accessorToIgnore">An existing getter to ignore. When we are checking for existing getters, we
         ''' might be in the middle of typing one that would be a false positive. </param>
         Private Function NeedsGetAccessor(propertyDeclaration As PropertyStatementSyntax, Optional accessorToIgnore As AccessorBlockSyntax = Nothing) As Boolean
+            If propertyDeclaration.Modifiers.Any(Function(m) m.IsKind(SyntaxKind.WriteOnlyKeyword)) Then
+                Return False
+            End If
+
             Dim propertyBlock = propertyDeclaration.GetAncestor(Of PropertyBlockSyntax)()
             If propertyBlock Is Nothing Then
                 Return True
@@ -132,7 +136,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
             Next
 
-            Return Not propertyBlock.PropertyStatement.Modifiers.Any(Function(modifier) modifier.Kind = SyntaxKind.WriteOnlyKeyword)
+            Return True
         End Function
 
         Private Function GenerateGetAccessor(propertyDeclaration As PropertyStatementSyntax, snapshot As ITextSnapshot) As String()
@@ -149,6 +153,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
         ''' <param name="accessorToIgnore">An existing getter to ignore. When we are checking for existing getters, we
         ''' might be in the middle of typing one that would be a false positive. </param>
         Private Function NeedsSetAccessor(propertyDeclaration As PropertyStatementSyntax, Optional accessorToIgnore As AccessorBlockSyntax = Nothing) As Boolean
+            If propertyDeclaration.Modifiers.Any(Function(m) m.IsKind(SyntaxKind.ReadOnlyKeyword)) Then
+                Return False
+            End If
+
             Dim propertyBlock = propertyDeclaration.GetAncestor(Of PropertyBlockSyntax)()
             If propertyBlock Is Nothing Then
                 Return True
@@ -160,7 +168,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
             Next
 
-            Return Not propertyBlock.PropertyStatement.Modifiers.Any(Function(modifier) modifier.Kind = SyntaxKind.ReadOnlyKeyword)
+            Return True
         End Function
 
         Private Function GenerateSetAccessor(propertyDeclaration As PropertyStatementSyntax, snapshot As ITextSnapshot) As String()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
@@ -275,5 +275,41 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
                        "End Interface"},
                 caret:={1, -1})
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
+        <WorkItem(2096, "https://github.com/dotnet/roslyn/issues/2096")>
+        Public Sub DontGenerateSetForReadonlyProperty()
+            VerifyStatementEndConstructApplied(
+                before:={"Class c1",
+                         "    Readonly Property foo(arg as Integer) As Integer",
+                         "End Class"},
+                beforeCaret:={1, -1},
+                after:={"Class c1",
+                        "    Readonly Property foo(arg as Integer) As Integer",
+                        "        Get",
+                        "",
+                        "        End Get",
+                        "    End Property",
+                        "End Class"},
+                afterCaret:={3, -1})
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
+        <WorkItem(2096, "https://github.com/dotnet/roslyn/issues/2096")>
+        Public Sub DontGenerateGetForWriteonlyProperty()
+            VerifyStatementEndConstructApplied(
+                before:={"Class c1",
+                         "    Writeonly Property foo(arg as Integer) As Integer",
+                         "End Class"},
+                beforeCaret:={1, -1},
+                after:={"Class c1",
+                        "    Writeonly Property foo(arg as Integer) As Integer",
+                        "        Set(value As Integer)",
+                        "",
+                        "        End Set",
+                        "    End Property",
+                        "End Class"},
+                afterCaret:={3, -1})
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
fix #2096 Dont generate  a getter for a Writeonly property and dont
generate a setter for a Readonly properly in VB during End Construct
generation