### PR TITLE
Replace CreateStreamOnHGlobal with a custom COM Memory Stream

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -334,6 +334,7 @@
     <Compile Include="MetadataReference\ReferenceDirective.cs" />
     <Compile Include="MetadataReference\UnresolvedMetadataReference.cs" />
     <Compile Include="PEWriter\ComMemoryStream.cs" />
+    <Compile Include="PEWriter\IUnsafeComStream.cs" />
     <Compile Include="PEWriter\MetadataHeapsBuilder.cs" />
     <Compile Include="PEWriter\ITypeReferenceExtensions.cs" />
     <Compile Include="PEWriter\NoPiaReferenceIndexer.cs" />

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -333,6 +333,7 @@
     <Compile Include="MetadataReference\PortableExecutableReference.cs" />
     <Compile Include="MetadataReference\ReferenceDirective.cs" />
     <Compile Include="MetadataReference\UnresolvedMetadataReference.cs" />
+    <Compile Include="PEWriter\ComMemoryStream.cs" />
     <Compile Include="PEWriter\MetadataHeapsBuilder.cs" />
     <Compile Include="PEWriter\ITypeReferenceExtensions.cs" />
     <Compile Include="PEWriter\NoPiaReferenceIndexer.cs" />

--- a/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Roslyn.Utilities
+{
+    internal class ComMemoryStream : IStream
+    {
+#if DEBUG
+        private const int ChunkSize = 509; // Small prime number for debugging chunking
+#else
+        private const int ChunkSize = 32768;
+#endif
+        private List<byte[]> _chunks = new List<byte[]>();
+        private int _position;
+        private int _length;
+
+        public unsafe void Read(byte[] pv, int cb, IntPtr pcbRead)
+        {
+            int chunkIndex = _position / ChunkSize;
+            int chunkOffset = _position % ChunkSize;
+            int destinationIndex = 0;
+            int bytesRead = 0;
+
+            while (true)
+            {
+                int bytesToCopy = Math.Min(_length - _position, Math.Min(cb, ChunkSize - chunkOffset));
+                if (bytesToCopy == 0)
+                {
+                    break;
+                }
+
+                if (chunkIndex < _chunks.Count)
+                {
+                    Array.Copy(_chunks[chunkIndex], chunkOffset, pv, destinationIndex, bytesToCopy);
+                }
+                else
+                {
+                    Array.Clear(pv, destinationIndex, bytesToCopy);
+                }
+
+                bytesRead += bytesToCopy;
+                _position += bytesToCopy;
+                cb -= bytesToCopy;
+                if (cb == 0 || (_length - _position) == 0)
+                {
+                    break;
+                }
+
+                destinationIndex += bytesToCopy;
+                chunkIndex++;
+                chunkOffset = 0;
+            }
+
+            if (pcbRead != IntPtr.Zero)
+            {
+                *(int*)pcbRead = bytesRead;
+            }
+        }
+
+        private int SetPosition(int newPos)
+        {
+            if (newPos < 0)
+            {
+                newPos = 0;
+            }
+
+            _position = newPos;
+
+            if (newPos > _length)
+            {
+                _length = newPos;
+            }
+
+            return newPos;
+        }
+
+        public unsafe void Seek(long dlibMove, int origin, IntPtr plibNewPosition)
+        {
+            int newPosition;
+
+            switch (origin)
+            {
+                case 0: // STREAM_SEEK_SET
+                    newPosition = SetPosition((int)dlibMove);
+                    break;
+
+                case 1: // STREAM_SEEK_CUR
+                    newPosition = SetPosition(_position + (int)dlibMove);
+                    break;
+
+                case 2: // STREAM_SEEK_END
+                    newPosition = SetPosition(_length + (int)dlibMove);
+                    break;
+
+                default:
+                    throw new ArgumentException(nameof(origin));
+            }
+
+            if (plibNewPosition != IntPtr.Zero)
+            {
+                *(long*)plibNewPosition = newPosition;
+            }
+        }
+
+        public void SetSize(long libNewSize)
+        {
+            _length = (int)libNewSize;
+        }
+
+        public void Stat(out STATSTG pstatstg, int grfStatFlag)
+        {
+            pstatstg = new STATSTG()
+            {
+                cbSize = _length
+            };
+        }
+
+        public unsafe void Write(byte[] pv, int cb, IntPtr pcbWritten)
+        {
+            int chunkIndex = _position / ChunkSize;
+            int chunkOffset = _position % ChunkSize;
+            int bytesWritten = 0;
+            while (true)
+            {
+                int bytesToCopy = Math.Min(cb, ChunkSize - chunkOffset);
+                if (bytesToCopy == 0)
+                {
+                    break;
+                }
+
+                while (chunkIndex >= _chunks.Count)
+                {
+                    _chunks.Add(new byte[ChunkSize]);
+                }
+
+                Array.Copy(pv, bytesWritten, _chunks[chunkIndex], chunkOffset, bytesToCopy);
+                bytesWritten += bytesToCopy;
+                _position += bytesToCopy;
+                cb -= bytesToCopy;
+                if (cb == 0)
+                {
+                    break;
+                }
+
+                chunkIndex++;
+                chunkOffset = 0;
+            }
+
+            if (_position > _length)
+            {
+                _length = _position;
+            }
+
+            if (pcbWritten != IntPtr.Zero)
+            {
+                *(int*)pcbWritten = bytesWritten;
+            }
+        }
+
+        public void CopyTo(Stream stream)
+        {
+            int size = _length;
+
+            // If the target stream allows seeking set its length upfront.
+            // When writing to a large file, it helps to give a hint to the OS how big the file is going to be.
+            if (stream.CanSeek)
+            {
+                stream.SetLength(stream.Position + size);
+            }
+
+            int chunkIndex = 0;
+            for (int cb = size; cb > 0;)
+            {
+                int bytesToCopy = Math.Min(ChunkSize, cb);
+                if (chunkIndex < _chunks.Count)
+                {
+                    stream.Write(_chunks[chunkIndex++], 0, bytesToCopy);
+                }
+                else
+                {
+                    // Fill remaining space with zero bytes
+                    for (int i = 0; i < bytesToCopy; i++)
+                    {
+                        stream.WriteByte(0);
+                    }
+                }
+
+                cb -= bytesToCopy;
+            }
+        }
+
+        public void Commit(int grfCommitFlags)
+        {
+        }
+
+        public void Clone(out IStream ppstm)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void LockRegion(long libOffset, long cb, int lockType)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Revert()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void UnlockRegion(long libOffset, long cb, int lockType)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
@@ -32,9 +32,9 @@ namespace Roslyn.Utilities
             }
 
             int chunkIndex = 0;
-            for (int cb = _length; cb > 0;)
+            for (int remainingBytes = _length; remainingBytes > 0;)
             {
-                int bytesToCopy = Math.Min(ChunkSize, cb);
+                int bytesToCopy = Math.Min(ChunkSize, remainingBytes);
                 if (chunkIndex < _chunks.Count)
                 {
                     stream.Write(_chunks[chunkIndex++], 0, bytesToCopy);
@@ -48,7 +48,7 @@ namespace Roslyn.Utilities
                     }
                 }
 
-                cb -= bytesToCopy;
+                remainingBytes -= bytesToCopy;
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ComMemoryStream.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.InteropServices.ComTypes;

--- a/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
@@ -8,14 +8,14 @@ namespace Roslyn.Utilities
 {
     /// <summary>
     /// This is a re-definition of COM's IStream interface. The important change is that
-    /// the Write method takes an <see cref="IntPtr"/> instead of a byte[] to avoid the
+    /// the Read and Write methods take an <see cref="IntPtr"/> instead of a byte[] to avoid the
     /// allocation cost when called from native code.
     /// </summary>
     [Guid("0000000c-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
     internal interface IUnsafeComStream
     {
         // ISequentialStream portion
-        void Read([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1), Out] byte[] pv, int cb, IntPtr pcbRead);
+        void Read(IntPtr pv, int cb, IntPtr pcbRead);
         void Write(IntPtr pv, int cb, IntPtr pcbWritten);
 
         // IStream portion

--- a/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 

--- a/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IUnsafeComStream.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// This is a re-definition of COM's IStream interface. The important change is that
+    /// the Write method takes an <see cref="IntPtr"/> instead of a byte[] to avoid the
+    /// allocation cost when called from native code.
+    /// </summary>
+    [Guid("0000000c-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
+    internal interface IUnsafeComStream
+    {
+        // ISequentialStream portion
+        void Read([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1), Out] byte[] pv, int cb, IntPtr pcbRead);
+        void Write(IntPtr pv, int cb, IntPtr pcbWritten);
+
+        // IStream portion
+        void Seek(long dlibMove, int dwOrigin, IntPtr plibNewPosition);
+        void SetSize(long libNewSize);
+        void CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten);
+        void Commit(int grfCommitFlags);
+        void Revert();
+        void LockRegion(long libOffset, long cb, int dwLockType);
+        void UnlockRegion(long libOffset, long cb, int dwLockType);
+        void Stat(out STATSTG pstatstg, int grfStatFlag);
+        void Clone(out IStream ppstm);
+    }
+
+}

--- a/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Cci
 
         private readonly string _fileName;
         private readonly Func<object> _symWriterFactory;
-        private IStream _nativeStream;
+        private ComMemoryStream _pdbStream;
         private MetadataWriter _metadataWriter;
         private ISymUnmanagedWriter2 _symWriter;
 
@@ -55,16 +55,6 @@ namespace Microsoft.Cci
         private uint[] _sequencePointEndLines;
         private uint[] _sequencePointEndColumns;
 
-        [DllImport("Ole32", ExactSpelling = true)]
-        private static extern int CreateStreamOnHGlobal(IntPtr hGlobal, bool fDeleteOnRelease, out IStream stream);
-
-        private static IStream CreateNativeStream()
-        {
-            IStream stream = null;
-            Marshal.ThrowExceptionForHR(CreateStreamOnHGlobal(IntPtr.Zero, fDeleteOnRelease: true, stream: out stream));
-            return stream;
-        }
-
         public PdbWriter(string fileName, Func<object> symWriterFactory = null)
         {
             _fileName = fileName;
@@ -74,7 +64,7 @@ namespace Microsoft.Cci
 
         public unsafe void WriteTo(Stream stream)
         {
-            Debug.Assert(_nativeStream != null);
+            Debug.Assert(_pdbStream != null);
             Debug.Assert(_symWriter != null);
 
             try
@@ -82,34 +72,7 @@ namespace Microsoft.Cci
                 // SymWriter flushes data to the native stream on close:
                 _symWriter.Close();
                 _symWriter = null;
-
-                var statStg = default(STATSTG);
-                _nativeStream.Stat(out statStg, grfStatFlag: 3 /*STATFLAG_NONAME | STATFLAG_NOOPEN*/);
-                _nativeStream.Seek(0L, 0, IntPtr.Zero);
-
-                int size = (int)statStg.cbSize;
-
-                // If the target stream allows seeking set its length upfront.
-                // When writing to a large file, it helps to give a hint to the OS how big the file is going to be.
-                if (stream.CanSeek)
-                {
-                    stream.SetLength(stream.Position + size);
-                }
-
-                // Copy unmanagedStream contents to stream in chunks
-                var buffer = new byte[Math.Min(size, 4096)];
-                while (true)
-                {
-                    int bytesRead = 0;
-                    _nativeStream.Read(buffer, buffer.Length, (IntPtr)(&bytesRead));
-
-                    if (bytesRead <= 0)
-                    {
-                        break;
-                    }
-
-                    stream.Write(buffer, 0, bytesRead);
-                }
+                _pdbStream.CopyTo(stream);
             }
             catch (Exception ex)
             {
@@ -134,12 +97,7 @@ namespace Microsoft.Cci
             {
                 _symWriter?.Close();
                 _symWriter = null;
-
-                if (_nativeStream != null)
-                {
-                    Marshal.ReleaseComObject(_nativeStream);
-                    _nativeStream = null;
-                }
+                _pdbStream = null;
             }
             catch (Exception ex)
             {
@@ -605,11 +563,9 @@ namespace Microsoft.Cci
 
                 // Correctness: If the stream is not specified or if it is non-empty the SymWriter appends data to it (provided it contains valid PDB)
                 // and the resulting PDB has Age = existing_age + 1.
-                // PERF: Use a native stream for the write and copy it at the end. This reduces the total GC
-                // allocations for the COM interop and geometric growth of the underlying managed stream.
-                _nativeStream = CreateNativeStream();
+                _pdbStream = new ComMemoryStream();
 
-                instance.Initialize(new PdbMetadataWrapper(metadataWriter), _fileName, _nativeStream, fullBuild: true);
+                instance.Initialize(new PdbMetadataWrapper(metadataWriter), _fileName, _pdbStream, fullBuild: true);
 
                 _metadataWriter = metadataWriter;
                 _symWriter = instance;


### PR DESCRIPTION
CreateStreamOnHGlobal turns out to have terrible performance for the access pattern used by DiaSymReader (lots of small "SetSize" calls)

So, now we implement the stream in managed code. The main advantage of this implementation is that it uses byte[] chunks rather than trying to keep a contiguous memory block.

Also, we redefine the IStream interface with a small tweak to "Write" to avoid allocating byte[] when called from native code.