### PR TITLE
Remove use of ClearTrivia on SyntaxGenerator inputs

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -89,9 +89,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers modifiers,
             SyntaxNode initializer)
         {
-            type = this.ClearTrivia(type);
-            initializer = this.ClearTrivia(initializer);
-
             return SyntaxFactory.FieldDeclaration(
                 default(SyntaxList<AttributeListSyntax>),
                 AsModifierList(accessibility, modifiers, SyntaxKind.FieldDeclaration),
@@ -106,9 +103,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode ParameterDeclaration(string name, SyntaxNode type, SyntaxNode initializer, RefKind refKind)
         {
-            type = this.ClearTrivia(type);
-            initializer = this.ClearTrivia(initializer);
-
             return SyntaxFactory.Parameter(
                 default(SyntaxList<AttributeListSyntax>),
                 GetParameterModifiers(refKind),
@@ -140,9 +134,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers modifiers,
             IEnumerable<SyntaxNode> statements)
         {
-            parameters = this.ClearTrivia(parameters);
-            returnType = this.ClearTrivia(returnType);
-
             bool hasBody = !modifiers.IsAbstract && (!modifiers.IsPartial || statements != null);
 
             return SyntaxFactory.MethodDeclaration(
@@ -173,9 +164,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> baseConstructorArguments,
             IEnumerable<SyntaxNode> statements)
         {
-            parameters = this.ClearTrivia(parameters);
-            baseConstructorArguments = this.ClearTrivia(baseConstructorArguments);
-
             return SyntaxFactory.ConstructorDeclaration(
                 default(SyntaxList<AttributeListSyntax>),
                 AsModifierList(accessibility, modifiers, SyntaxKind.ConstructorDeclaration),
@@ -193,8 +181,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> getAccessorStatements,
             IEnumerable<SyntaxNode> setAccessorStatements)
         {
-            type = this.ClearTrivia(type);
-
             var accessors = new List<AccessorDeclarationSyntax>();
             var hasGetter = !modifiers.IsWriteOnly;
             var hasSetter = !modifiers.IsReadOnly;
@@ -246,8 +232,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> getAccessorStatements,
             IEnumerable<SyntaxNode> setAccessorStatements)
         {
-            type = this.ClearTrivia(type);
-
             var accessors = new List<AccessorDeclarationSyntax>();
             var hasGetter = !modifiers.IsWriteOnly;
             var hasSetter = !modifiers.IsReadOnly;
@@ -318,8 +302,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             Accessibility accessibility,
             DeclarationModifiers modifiers)
         {
-            type = this.ClearTrivia(type);
-
             return SyntaxFactory.EventFieldDeclaration(
                 default(SyntaxList<AttributeListSyntax>),
                 AsModifierList(accessibility, modifiers, SyntaxKind.EventFieldDeclaration),
@@ -338,9 +320,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> addAccessorStatements,
             IEnumerable<SyntaxNode> removeAccessorStatements)
         {
-            type = this.ClearTrivia(type);
-            parameters = this.ClearTrivia(parameters);
-
             var accessors = new List<AccessorDeclarationSyntax>();
             if (modifiers.IsAbstract)
             {
@@ -380,8 +359,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode AsPrivateInterfaceImplementation(SyntaxNode declaration, SyntaxNode typeName)
         {
-            typeName = this.ClearTrivia(typeName);
-
             return PreserveTrivia(declaration, d =>
             {
                 var specifier = SyntaxFactory.ExplicitInterfaceSpecifier((NameSyntax)typeName);
@@ -503,9 +480,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> interfaceTypes,
             IEnumerable<SyntaxNode> members)
         {
-            baseType = this.ClearTrivia(baseType);
-            interfaceTypes = this.ClearTrivia(interfaceTypes);
-
             List<BaseTypeSyntax> baseTypes = null;
             if (baseType != null || interfaceTypes != null)
             {
@@ -569,8 +543,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> interfaceTypes,
             IEnumerable<SyntaxNode> members)
         {
-            interfaceTypes = this.ClearTrivia(interfaceTypes);
-
             var itypes = interfaceTypes != null ? interfaceTypes.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList() : null;
             if (itypes != null && itypes.Count == 0)
             {
@@ -594,8 +566,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> interfaceTypes = null,
             IEnumerable<SyntaxNode> members = null)
         {
-            interfaceTypes = this.ClearTrivia(interfaceTypes);
-
             var itypes = interfaceTypes != null ? interfaceTypes.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList() : null;
             if (itypes != null && itypes.Count == 0)
             {
@@ -656,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     case SyntaxKind.EventFieldDeclaration:
                         var ef = (EventFieldDeclarationSyntax)member;
                         this.GetAccessibilityAndModifiers(ef.Modifiers, out acc, out modifiers);
-                        var ep = this.CustomEventDeclaration(this.GetName(ef), this.GetType(ef), acc, modifiers, parameters: null, addAccessorStatements: null, removeAccessorStatements: null);
+                        var ep = this.CustomEventDeclaration(this.GetName(ef), this.ClearTrivia(this.GetType(ef)), acc, modifiers, parameters: null, addAccessorStatements: null, removeAccessorStatements: null);
                         return this.AsInterfaceMember(ep);
 
                     // convert field into property
@@ -664,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         var f = (FieldDeclarationSyntax)member;
                         this.GetAccessibilityAndModifiers(f.Modifiers, out acc, out modifiers);
                         return this.AsInterfaceMember(
-                            this.PropertyDeclaration(this.GetName(f), this.GetType(f), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
+                            this.PropertyDeclaration(this.GetName(f), this.ClearTrivia(this.GetType(f)), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
 
                     default:
                         return null;
@@ -688,8 +658,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode EnumMember(string name, SyntaxNode expression)
         {
-            expression = this.ClearTrivia(expression);
-
             return SyntaxFactory.EnumMemberDeclaration(
                 default(SyntaxList<AttributeListSyntax>),
                 name.ToIdentifierToken(),
@@ -730,9 +698,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             Accessibility accessibility = Accessibility.NotApplicable,
             DeclarationModifiers modifiers = default(DeclarationModifiers))
         {
-            parameters = this.ClearTrivia(parameters);
-            returnType = this.ClearTrivia(returnType);
-
             return SyntaxFactory.DelegateDeclaration(
                 default(SyntaxList<AttributeListSyntax>),
                 AsModifierList(accessibility, modifiers),
@@ -784,7 +749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return (AttributeArgumentSyntax)node;
         }
 
-        protected override TNode ClearTrivia<TNode>(TNode node)
+        public override TNode ClearTrivia<TNode>(TNode node)
         {
             if (node != null)
             {
@@ -864,7 +829,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode InsertAttributesInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
         {
-            var newAttributes = AsAttributeLists(ClearTrivia(attributes));
+            var newAttributes = AsAttributeLists(attributes);
 
             var existingAttributes = this.GetAttributes(declaration);
             if (index >= 0 && index < existingAttributes.Count)
@@ -899,7 +864,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode InsertReturnAttributesInternal(SyntaxNode d, int index, IEnumerable<SyntaxNode> attributes)
         {
-            var newAttributes = AsReturnAttributes(ClearTrivia(attributes));
+            var newAttributes = AsReturnAttributes(attributes);
 
             var existingAttributes = this.GetReturnAttributes(d);
             if (index >= 0 && index < existingAttributes.Count)
@@ -960,7 +925,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode InsertAttributeArgumentsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
         {
-            var newArgumentList = this.ClearTrivia(this.AsAttributeArgumentList(attributeArguments));
+            var newArgumentList = this.AsAttributeArgumentList(attributeArguments);
 
             var existingArgumentList = this.GetAttributeArgumentList(declaration);
 
@@ -1115,7 +1080,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNamespaceImports(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
-            var usings = AsUsingDirectives(this.ClearTrivia(imports));
+            var usings = AsUsingDirectives(imports);
 
             switch (declaration.Kind())
             {
@@ -1234,7 +1199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertMembers(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> members)
         {
-            var newMembers = this.ClearTrivia(this.AsMembersOf(declaration, members));
+            var newMembers = this.AsMembersOf(declaration, members);
 
             var existingMembers = this.GetMembers(declaration);
             if (index >= 0 && index < existingMembers.Count)
@@ -2418,7 +2383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertParameters(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> parameters)
         {
-            var newParameters = AsParameterList(this.ClearTrivia(parameters));
+            var newParameters = AsParameterList(parameters);
 
             var currentList = this.GetParameterList(declaration);
             if (currentList == null)
@@ -2534,7 +2499,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode WithExpressionInternal(SyntaxNode declaration, SyntaxNode expression)
         {
-            var expr = (ExpressionSyntax)this.ClearTrivia(expression);
+            var expr = (ExpressionSyntax)expression;
 
             switch (declaration.Kind())
             {
@@ -2729,7 +2694,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertAccessors(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> accessors)
         {
-            var newAccessors = AsAccessorList(this.ClearTrivia(accessors), declaration.Kind());
+            var newAccessors = AsAccessorList(accessors, declaration.Kind());
 
             var currentList = this.GetAccessorList(declaration);
             if (currentList == null)
@@ -2955,9 +2920,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        #endregion
+#endregion
 
-        #region Remove, Replace, Insert
+#region Remove, Replace, Insert
 
         public override SyntaxNode ReplaceNode(SyntaxNode root, SyntaxNode declaration, SyntaxNode newDeclaration)
         {
@@ -3237,9 +3202,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             return base.RemoveNode(root, declaration);
         }
-        #endregion
+#endregion
 
-        #region Statements and Expressions
+#region Statements and Expressions
 
         public override SyntaxNode AwaitExpression(SyntaxNode expression)
         {
@@ -3831,6 +3796,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             return list;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1226,8 +1226,8 @@ public class C { } // end").Members[0];
             VerifySyntax<AttributeListSyntax>(attrWithComment, "// comment\r\n[a]");
 
             // added attributes are stripped of trivia
-            var added2 = _g.AddAttributes(cls, attrWithComment);
-            VerifySyntax<ClassDeclarationSyntax>(added2, "// comment\r\n[a]\r\npublic class C\r\n{\r\n} // end\r\n");
+            //var added2 = _g.AddAttributes(cls, attrWithComment);
+            //VerifySyntax<ClassDeclarationSyntax>(added2, "// comment\r\n[a]\r\npublic class C\r\n{\r\n} // end\r\n");
         }
 
         [Fact]

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1224,10 +1224,6 @@ public class C { } // end").Members[0];
 
             var attrWithComment = _g.GetAttributes(added).First();
             VerifySyntax<AttributeListSyntax>(attrWithComment, "// comment\r\n[a]");
-
-            // added attributes are stripped of trivia
-            //var added2 = _g.AddAttributes(cls, attrWithComment);
-            //VerifySyntax<ClassDeclarationSyntax>(added2, "// comment\r\n[a]\r\npublic class C\r\n{\r\n} // end\r\n");
         }
 
         [Fact]

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1094,12 +1094,10 @@ namespace Microsoft.CodeAnalysis.Editing
             return root.ReplaceToken(original, combinedTriviaReplacement);
         }
 
-        protected IEnumerable<TNode> ClearTrivia<TNode>(IEnumerable<TNode> nodes) where TNode : SyntaxNode
-        {
-            return nodes != null ? nodes.Select(n => ClearTrivia(n)) : null;
-        }
-
-        protected abstract TNode ClearTrivia<TNode>(TNode node) where TNode : SyntaxNode;
+        /// <summary>
+        /// Creates a new instance of the node with the leading and trailing trivia removed and replaced with elastic markers.
+        /// </summary>
+        public abstract TNode ClearTrivia<TNode>(TNode node) where TNode : SyntaxNode;
 
         protected int IndexOf<T>(IReadOnlyList<T> list, T element)
         {

--- a/src/Workspaces/Core/Portable/PublicAPI.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.txt
@@ -293,7 +293,6 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Attribute(string name, params Mic
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AttributeArgument(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.CastExpression(Microsoft.CodeAnalysis.ITypeSymbol type, Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.CatchClause(Microsoft.CodeAnalysis.ITypeSymbol type, string identifer, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements) -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ClearTrivia<TNode>(System.Collections.Generic.IEnumerable<TNode> nodes) -> System.Collections.Generic.IEnumerable<TNode>
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.CompilationUnit(params Microsoft.CodeAnalysis.SyntaxNode[] declarations) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ConstructorDeclaration(Microsoft.CodeAnalysis.IMethodSymbol constructorMethod, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> baseConstructorArguments = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements = null) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ConvertExpression(Microsoft.CodeAnalysis.ITypeSymbol type, Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -590,9 +590,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function FieldDeclaration(name As String, type As SyntaxNode, Optional accessibility As Accessibility = Nothing, Optional modifiers As DeclarationModifiers = Nothing, Optional initializer As SyntaxNode = Nothing) As SyntaxNode
-            type = Me.ClearTrivia(type)
-            initializer = Me.ClearTrivia(initializer)
-
             Return SyntaxFactory.FieldDeclaration(
                 attributeLists:=Nothing,
                 modifiers:=GetModifierList(accessibility, modifiers And s_fieldModifiers, isField:=True),
@@ -607,9 +604,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional accessibility As Accessibility = Nothing,
             Optional modifiers As DeclarationModifiers = Nothing,
             Optional statements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-
-            parameters = MyBase.ClearTrivia(parameters)
-            returnType = Me.ClearTrivia(returnType)
 
             Dim statement = SyntaxFactory.MethodStatement(
                 kind:=If(returnType Is Nothing, SyntaxKind.SubStatement, SyntaxKind.FunctionStatement),
@@ -639,8 +633,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function ParameterDeclaration(name As String, Optional type As SyntaxNode = Nothing, Optional initializer As SyntaxNode = Nothing, Optional refKind As RefKind = Nothing) As SyntaxNode
-            type = Me.ClearTrivia(type)
-
             Return SyntaxFactory.Parameter(
                 attributeLists:=Nothing,
                 modifiers:=GetParameterModifiers(refKind, initializer),
@@ -667,8 +659,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional modifiers As DeclarationModifiers = Nothing,
             Optional getAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
             Optional setAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-
-            type = Me.ClearTrivia(type)
 
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(type, TypeSyntax))
             Dim statement = SyntaxFactory.PropertyStatement(
@@ -708,9 +698,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional getAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
             Optional setAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
-            type = ClearTrivia(type)
-            parameters = MyBase.ClearTrivia(parameters)
-
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(type, TypeSyntax))
             Dim statement = SyntaxFactory.PropertyStatement(
                 attributeLists:=Nothing,
@@ -742,8 +729,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function AccessorBlock(kind As SyntaxKind, statements As IEnumerable(Of SyntaxNode), type As SyntaxNode) As AccessorBlockSyntax
-            type = Me.ClearTrivia(type)
-
             Select Case kind
                 Case SyntaxKind.GetAccessorBlock
                     Return CreateGetAccessorBlock(statements)
@@ -767,8 +752,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function CreateSetAccessorBlock(type As SyntaxNode, statements As IEnumerable(Of SyntaxNode)) As AccessorBlockSyntax
-            type = Me.ClearTrivia(type)
-
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(type, TypeSyntax))
 
             Dim valueParameter = SyntaxFactory.Parameter(
@@ -791,8 +774,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function CreateAddHandlerAccessorBlock(delegateType As SyntaxNode, statements As IEnumerable(Of SyntaxNode)) As AccessorBlockSyntax
-            delegateType = Me.ClearTrivia(delegateType)
-
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(delegateType, TypeSyntax))
 
             Dim valueParameter = SyntaxFactory.Parameter(
@@ -815,8 +796,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function CreateRemoveHandlerAccessorBlock(delegateType As SyntaxNode, statements As IEnumerable(Of SyntaxNode)) As AccessorBlockSyntax
-            delegateType = Me.ClearTrivia(delegateType)
-
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(delegateType, TypeSyntax))
 
             Dim valueParameter = SyntaxFactory.Parameter(
@@ -839,7 +818,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function CreateRaiseEventAccessorBlock(parameters As IEnumerable(Of SyntaxNode), statements As IEnumerable(Of SyntaxNode)) As AccessorBlockSyntax
-            parameters = MyBase.ClearTrivia(parameters)
             Dim parameterList = GetParameterList(parameters)
 
             Return SyntaxFactory.AccessorBlock(
@@ -859,7 +837,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function AsPublicInterfaceImplementationInternal(declaration As SyntaxNode, typeName As SyntaxNode) As SyntaxNode
-            typeName = Me.ClearTrivia(typeName)
             Dim type = DirectCast(typeName, NameSyntax)
 
             declaration = WithBody(declaration, allowDefault:=True)
@@ -887,7 +864,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function AsPrivateInterfaceImplementationInternal(declaration As SyntaxNode, typeName As SyntaxNode) As SyntaxNode
-            typeName = Me.ClearTrivia(typeName)
             Dim type = DirectCast(typeName, NameSyntax)
 
             ' convert declaration statements to blocks
@@ -1013,9 +989,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional baseConstructorArguments As IEnumerable(Of SyntaxNode) = Nothing,
             Optional statements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
-            parameters = MyBase.ClearTrivia(parameters)
-            baseConstructorArguments = MyBase.ClearTrivia(baseConstructorArguments)
-
             Dim stats = GetStatementList(statements)
 
             If (baseConstructorArguments IsNot Nothing) Then
@@ -1039,9 +1012,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional baseType As SyntaxNode = Nothing,
             Optional interfaceTypes As IEnumerable(Of SyntaxNode) = Nothing,
             Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-
-            baseType = Me.ClearTrivia(baseType)
-            interfaceTypes = MyBase.ClearTrivia(interfaceTypes)
 
             Dim itypes = If(interfaceTypes IsNot Nothing, interfaceTypes.Cast(Of TypeSyntax), Nothing)
             If itypes IsNot Nothing AndAlso itypes.Count = 0 Then
@@ -1079,8 +1049,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional interfaceTypes As IEnumerable(Of SyntaxNode) = Nothing,
             Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
-            interfaceTypes = MyBase.ClearTrivia(interfaceTypes)
-
             Dim itypes = If(interfaceTypes IsNot Nothing, interfaceTypes.Cast(Of TypeSyntax), Nothing)
             If itypes IsNot Nothing AndAlso itypes.Count = 0 Then
                 itypes = Nothing
@@ -1115,8 +1083,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional accessibility As Accessibility = Nothing,
             Optional interfaceTypes As IEnumerable(Of SyntaxNode) = Nothing,
             Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-
-            interfaceTypes = MyBase.ClearTrivia(interfaceTypes)
 
             Dim itypes = If(interfaceTypes IsNot Nothing, interfaceTypes.Cast(Of TypeSyntax), Nothing)
             If itypes IsNot Nothing AndAlso itypes.Count = 0 Then
@@ -1211,8 +1177,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional accessibility As Accessibility = Accessibility.NotApplicable,
             Optional modifiers As DeclarationModifiers = Nothing) As SyntaxNode
 
-            parameters = MyBase.ClearTrivia(parameters)
-
             Dim kind = If(returnType Is Nothing, SyntaxKind.DelegateSubStatement, SyntaxKind.DelegateFunctionStatement)
 
             Return SyntaxFactory.DelegateStatement(
@@ -1247,13 +1211,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function NamespaceImportDeclaration(name As SyntaxNode) As SyntaxNode
-            name = Me.ClearTrivia(name)
             Return SyntaxFactory.ImportsStatement(SyntaxFactory.SingletonSeparatedList(Of ImportsClauseSyntax)(SyntaxFactory.SimpleImportsClause(DirectCast(name, NameSyntax))))
         End Function
 
         Public Overrides Function NamespaceDeclaration(name As SyntaxNode, nestedDeclarations As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            name = Me.ClearTrivia(name)
-
             Dim imps As IEnumerable(Of StatementSyntax) = AsImports(nestedDeclarations)
             Dim members As IEnumerable(Of StatementSyntax) = AsNamespaceMembers(nestedDeclarations)
 
@@ -1266,9 +1227,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function Attribute(name As SyntaxNode, Optional attributeArguments As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-            name = Me.ClearTrivia(name)
-            attributeArguments = MyBase.ClearTrivia(attributeArguments)
-
             Dim attr = SyntaxFactory.Attribute(
                 target:=Nothing,
                 name:=DirectCast(name, TypeSyntax),
@@ -1279,19 +1237,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Private Function AsArgumentList(arguments As IEnumerable(Of SyntaxNode)) As ArgumentListSyntax
             If arguments IsNot Nothing Then
-                Return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(MyBase.ClearTrivia(arguments).Select(AddressOf AsArgument)))
+                Return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(AddressOf AsArgument)))
             Else
                 Return Nothing
             End If
         End Function
 
         Public Overrides Function AttributeArgument(name As String, expression As SyntaxNode) As SyntaxNode
-            expression = Me.ClearTrivia(expression)
-
             Return Argument(name, RefKind.None, expression)
         End Function
 
-        Protected Overrides Function ClearTrivia(Of TNode As SyntaxNode)(node As TNode) As TNode
+        Public Overrides Function ClearTrivia(Of TNode As SyntaxNode)(node As TNode) As TNode
             If node IsNot Nothing Then
                 Return node.WithLeadingTrivia(SyntaxFactory.ElasticMarker).WithTrailingTrivia(SyntaxFactory.ElasticMarker)
             Else
@@ -1333,11 +1289,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function InsertAttributes(declaration As SyntaxNode, index As Integer, attributes As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Return Isolate(declaration, Function(d) InsertAttributesInternal(d, index, MyBase.ClearTrivia(attributes)))
+            Return Isolate(declaration, Function(d) InsertAttributesInternal(d, index, attributes))
         End Function
 
         Private Function InsertAttributesInternal(declaration As SyntaxNode, index As Integer, attributes As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Dim newAttributes = AsAttributeLists(MyBase.ClearTrivia(attributes))
+            Dim newAttributes = AsAttributeLists(attributes)
             Dim existingAttributes = Me.GetAttributes(declaration)
 
             If index >= 0 AndAlso index < existingAttributes.Count Then
@@ -1386,7 +1342,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function InsertReturnAttributesInternal(declaration As SyntaxNode, index As Integer, attributes As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Dim newAttributes = AsAttributeLists(MyBase.ClearTrivia(attributes))
+            Dim newAttributes = AsAttributeLists(attributes)
             Dim existingReturnAttributes = Me.GetReturnAttributes(declaration)
 
             If index >= 0 AndAlso index < existingReturnAttributes.Count Then
@@ -2723,7 +2679,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function InsertParameters(declaration As SyntaxNode, index As Integer, parameters As IEnumerable(Of SyntaxNode)) As SyntaxNode
             Dim currentList = GetParameterList(declaration)
-            Dim newList = GetParameterList(MyBase.ClearTrivia(parameters))
+            Dim newList = GetParameterList(parameters)
             If currentList IsNot Nothing Then
                 Return WithParameterList(declaration, currentList.WithParameters(currentList.Parameters.InsertRange(index, newList.Parameters)))
             Else
@@ -2843,7 +2799,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function WithExpression(declaration As SyntaxNode, expression As SyntaxNode) As SyntaxNode
-            Return Isolate(declaration, Function(d) WithExpressionInternal(d, ClearTrivia(expression)))
+            Return Isolate(declaration, Function(d) WithExpressionInternal(d, expression))
         End Function
 
         Private Function WithExpressionInternal(declaration As SyntaxNode, expression As SyntaxNode) As SyntaxNode
@@ -2941,7 +2897,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function InsertNamespaceImportsInternal(declaration As SyntaxNode, index As Integer, [imports] As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Dim newImports = AsImports(MyBase.ClearTrivia([imports]))
+            Dim newImports = AsImports([imports])
             Dim existingImports = Me.GetNamespaceImports(declaration)
 
             If index >= 0 AndAlso index < existingImports.Count Then
@@ -3007,7 +2963,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function InsertMembersInternal(declaration As SyntaxNode, index As Integer, members As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Dim newMembers = Me.AsMembersOf(declaration, MyBase.ClearTrivia(members))
+            Dim newMembers = Me.AsMembersOf(declaration, members)
             Dim existingMembers = Me.GetMembers(declaration)
 
             If index >= 0 AndAlso index < existingMembers.Count Then
@@ -3109,7 +3065,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Public Overrides Function InsertAccessors(declaration As SyntaxNode, index As Integer, accessors As IEnumerable(Of SyntaxNode)) As SyntaxNode
 
             Dim currentList = GetAccessorList(declaration)
-            Dim newList = AsAccessorList(MyBase.ClearTrivia(accessors), declaration.Kind)
+            Dim newList = AsAccessorList(accessors, declaration.Kind)
 
             If Not currentList.IsEmpty Then
                 Return WithAccessorList(declaration, currentList.InsertRange(index, newList))
@@ -3205,7 +3161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 accessor = DirectCast(Me.WithStatements(accessor, statements), AccessorBlockSyntax)
                 Return Me.WithAccessorBlock(declaration, kind, accessor)
             ElseIf Me.CanHaveAccessors(declaration.Kind)
-                accessor = Me.AccessorBlock(kind, statements, Me.GetType(declaration))
+                accessor = Me.AccessorBlock(kind, statements, Me.ClearTrivia(Me.GetType(declaration)))
                 Return Me.WithAccessorBlock(declaration, kind, accessor)
             Else
                 Return declaration

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -1754,15 +1754,6 @@ End Class ' end</x>.Value)
 <x>' comment
 &lt;a&gt;</x>.Value)
 
-            ' added attributes are stripped of trivia
-            Dim added2 = _g.AddAttributes(cls, attrWithComment)
-            VerifySyntax(Of ClassBlockSyntax)(
-                added2,
-<x>' comment
-&lt;a&gt;
-Class C
-End Class ' end</x>.Value)
-
         End Sub
 
         <Fact>


### PR DESCRIPTION
The SyntaxGenerator will no longer automatically clear the trivia from inputs to node factory methods.  The ClearTrivia method has been made public for consumers to control this manually instead.