### PR TITLE
Change Signature: Update all documents from the base solution

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -167,6 +170,92 @@ public class DP20<T>
 }";
 
             TestChangeSignatureViaCommand(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(1102830)]
+        [WorkItem(784, "https://github.com/dotnet/roslyn/issues/784")]
+        public void RemoveParameters_ExtensionMethodInAnotherFile()
+        {
+            var workspaceXml = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSharpAssembly"" CommonReferences=""true"">";
+            
+            for (int i = 0; i <= 4; i++)
+            {
+                workspaceXml += $@"
+<Document FilePath = ""C{i}.cs"">
+class C{i}
+{{
+    void M()
+    {{
+        C5 c = new C5();
+        c.Ext(1, ""two"");
+    }}
+}}
+</Document>";
+            }
+
+            workspaceXml += @"
+<Document FilePath = ""C5.cs"">
+public class C5
+{
+}
+
+public static class C5Ext
+{
+    public void $$Ext(this C5 c, int i, string s)
+    {
+    }
+}
+</Document>";
+
+            for (int i = 6; i <= 9; i++)
+            {
+                workspaceXml += $@"
+<Document FilePath = ""C{i}.cs"">
+class C{i}
+{{
+    void M()
+    {{
+        C5 c = new C5();
+        c.Ext(1, ""two"");
+    }}
+}}
+</Document>";
+            }
+
+            workspaceXml += @"
+    </Project>
+</Workspace>";
+
+            // Ext(this F f, int i, string s) --> Ext(this F f, string s)
+            // If a reference does not bind correctly, it will believe Ext is not an extension
+            // method and remove the string argument instead of the int argument.
+
+            var updatedSignature = new[] { 0, 2 };
+
+            using (var testState = new ChangeSignatureTestState(XElement.Parse(workspaceXml)))
+            {
+                testState.TestChangeSignatureOptionsService.IsCancelled = false;
+                testState.TestChangeSignatureOptionsService.UpdatedSignature = updatedSignature;
+                var result = testState.ChangeSignature();
+
+                Assert.True(result.Succeeded);
+                Assert.Null(testState.ErrorMessage);
+
+                foreach (var updatedDocument in testState.Workspace.Documents.Select(d => result.UpdatedSolution.GetDocument(d.Id)))
+                {
+                    if (updatedDocument.Name == "C5.cs")
+                    {
+                        Assert.Contains("void Ext(this C5 c, string s)", updatedDocument.GetTextAsync(CancellationToken.None).Result.ToString());
+                    }
+                    else
+                    {
+                        Assert.Contains(@"c.Ext(""two"");", updatedDocument.GetTextAsync(CancellationToken.None).Result.ToString());
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Features/Core/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/ChangeSignature/AbstractChangeSignatureService.cs
@@ -259,6 +259,8 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     }
                 }
 
+                // Find and annotate all the relevant definitions
+
                 if (includeDefinitionLocations)
                 {
                     foreach (var def in symbolWithSyntacticParameters.Locations)
@@ -279,7 +281,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     }
                 }
 
-                // TODO: Find references to containing type for Add methods & collection initializers (for example)
+                // Find and annotate all the relevant references
 
                 foreach (var location in symbol.Locations)
                 {
@@ -314,6 +316,9 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                 }
             }
 
+            // Construct all the relevant syntax trees from the base solution
+
+            var updatedRoots = new Dictionary<DocumentId, SyntaxNode>();
             foreach (var docId in nodesToUpdate.Keys)
             {
                 var doc = updatedSolution.GetDocument(docId);
@@ -337,7 +342,14 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     rules: GetFormattingRules(doc),
                     cancellationToken: CancellationToken.None);
 
-                updatedSolution = updatedSolution.WithDocumentSyntaxRoot(docId, formattedRoot);
+                updatedRoots[docId] = formattedRoot;
+            }
+
+            // Update the documents using the updated syntax trees
+
+            foreach (var docId in nodesToUpdate.Keys)
+            {
+                updatedSolution = updatedSolution.WithDocumentSyntaxRoot(docId, updatedRoots[docId]);
             }
 
             return true;


### PR DESCRIPTION
Fixes #784 and internal TFS issue 1102830

In change signature, when we needed to update 10 documents, we would
update the first document and replace it in the solution, then update
the second document and replace it in the solution, etc. However, if the
definition document is updated before a reference document, then trying
to bind the reference to the definition will not work correctly. Most of
the update process is syntactic so it usually doesn't matter, but we do
bind method references to see the invocation uses a reduced extension
method. This caused reduced extension method references to sometimes get
updated incorrectly.

We now produce all of the updated syntax trees from the same base
solution, and then apply them all at the end.