### PR TITLE
Fix an incorrect tautological if condition

### DIFF
--- a/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -542,8 +542,8 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     return false;
                 }
 
-                if (member1.DeclaredAccessibility != member1.DeclaredAccessibility ||
-                    member1.IsStatic != member1.IsStatic)
+                if (member1.DeclaredAccessibility != member2.DeclaredAccessibility ||
+                    member1.IsStatic != member2.IsStatic)
                 {
                     return false;
                 }


### PR DESCRIPTION
member1 was being compared to itself.