### PR TITLE
Display a tooltip for hyperlinks in error list and preview pane

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticStateTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticStateTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 Assert.Equal(items1[i].Id, items2[i].Id);
                 Assert.Equal(items1[i].Category, items2[i].Category);
                 Assert.Equal(items1[i].Message, items2[i].Message);
-                Assert.Equal(items1[i].MessageFormat, items2[i].MessageFormat);
+                Assert.Equal(items1[i].ENUMessageForBingSearch, items2[i].ENUMessageForBingSearch);
                 Assert.Equal(items1[i].Severity, items2[i].Severity);
                 Assert.Equal(items1[i].IsEnabledByDefault, items2[i].IsEnabledByDefault);
                 Assert.Equal(items1[i].WarningLevel, items2[i].WarningLevel);

--- a/src/Features/Core/Diagnostics/DiagnosticData.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticData.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -28,8 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public readonly IReadOnlyList<string> CustomTags;
         public readonly ImmutableDictionary<string, string> Properties;
 
-        // temporary until we make diagnostic data to point back to diagnostic descriptor
-        public readonly string MessageFormat;
+        public readonly string ENUMessageForBingSearch;
 
         public readonly Workspace Workspace;
         public readonly ProjectId ProjectId;
@@ -60,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             string id,
             string category,
             string message,
-            string messageFormat,
+            string enuMessageForBingSearch,
             DiagnosticSeverity severity,
             bool isEnabledByDefault,
             int warningLevel,
@@ -77,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             string description = null,
             string helpLink = null) :
                 this(
-                    id, category, message, messageFormat,
+                    id, category, message, enuMessageForBingSearch,
                     severity, severity, isEnabledByDefault, warningLevel,
                     ImmutableArray<string>.Empty, ImmutableDictionary<string, string>.Empty,
                     workspace, projectId, documentId, span,
@@ -91,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             string id,
             string category,
             string message,
-            string messageFormat,
+            string enuMessageForBingSearch,
             DiagnosticSeverity severity,
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
@@ -119,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             this.Id = id;
             this.Category = category;
             this.Message = message;
-            this.MessageFormat = messageFormat;
+            this.ENUMessageForBingSearch = enuMessageForBingSearch;
 
             this.Severity = severity;
             this.DefaultSeverity = defaultSeverity;
@@ -291,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 diagnostic.Id,
                 diagnostic.Descriptor.Category,
                 diagnostic.GetMessage(CultureInfo.CurrentUICulture),
-                diagnostic.Descriptor.MessageFormat.ToString(USCultureInfo),
+                diagnostic.GetMessage(USCultureInfo), // We use the ENU version of the message for bing search.
                 diagnostic.Severity,
                 diagnostic.DefaultSeverity,
                 diagnostic.Descriptor.IsEnabledByDefault,
@@ -313,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 diagnostic.Id,
                 diagnostic.Descriptor.Category,
                 diagnostic.GetMessage(CultureInfo.CurrentUICulture),
-                diagnostic.Descriptor.MessageFormat.ToString(USCultureInfo),
+                diagnostic.GetMessage(USCultureInfo), // We use the ENU version of the message for bing search.
                 diagnostic.Severity,
                 diagnostic.DefaultSeverity,
                 diagnostic.Descriptor.IsEnabledByDefault,
@@ -350,7 +349,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 diagnostic.Id,
                 diagnostic.Descriptor.Category,
                 diagnostic.GetMessage(CultureInfo.CurrentUICulture),
-                diagnostic.Descriptor.MessageFormat.ToString(USCultureInfo),
+                diagnostic.GetMessage(USCultureInfo), // We use the ENU version of the message for bing search.
                 diagnostic.Severity,
                 diagnostic.DefaultSeverity,
                 diagnostic.Descriptor.IsEnabledByDefault,

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         writer.WriteString(item.Category);
 
                         writer.WriteString(item.Message);
-                        writer.WriteString(item.MessageFormat);
+                        writer.WriteString(item.ENUMessageForBingSearch);
                         writer.WriteString(item.Title);
                         writer.WriteString(item.Description);
                         writer.WriteString(item.HelpLink);

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 diagnostic.Id,
                 diagnostic.Category,
                 diagnostic.Message,
-                diagnostic.MessageFormat,
+                diagnostic.ENUMessageForBingSearch,
                 diagnostic.Severity,
                 diagnostic.DefaultSeverity,
                 diagnostic.IsEnabledByDefault,

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Navigation;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Text.Differencing;
@@ -17,8 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         private static readonly string s_dummyThreeLineTitle = "A" + Environment.NewLine + "A" + Environment.NewLine + "A";
         private static readonly Size s_infiniteSize = new Size(double.PositiveInfinity, double.PositiveInfinity);
 
-        private readonly string _errorId;
-        private readonly bool _telemetry;
+        private readonly string _id;
+        private readonly bool _logIdVerbatimInTelemetry;
 
         private readonly IServiceProvider _serviceProvider;
 
@@ -26,13 +25,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         private double _heightForThreeLineTitle;
         private IWpfDifferenceViewer _previewDiffViewer;
 
-        public PreviewPane(Image severityIcon, string id, string title, string helpMessage, string description, string helpLink,
-            bool telemetry, object previewContent, IServiceProvider serviceProvider)
+        public PreviewPane(Image severityIcon, string id, string title, string description, Uri helpLink, string helpLinkToolTipText,
+            object previewContent, bool logIdVerbatimInTelemetry, IServiceProvider serviceProvider)
         {
             InitializeComponent();
 
-            InitializeHyperlinkStyles();
+            _id = id;
+            _logIdVerbatimInTelemetry = logIdVerbatimInTelemetry;
+            _serviceProvider = serviceProvider;
 
+            // Initialize header portion.
             if ((severityIcon != null) && !string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(title))
             {
                 HeaderStackPanel.Visibility = Visibility.Visible;
@@ -48,15 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 // Now set the actual title text.
                 TitleRun.Text = title;
 
-                Uri helpUri;
-                if (BrowserHelper.TryGetUri(helpLink, out helpUri))
-                {
-                    InitializeDiagnosticIdHyperLink(id, helpUri, bingLink: false);
-                }
-                else
-                {
-                    InitializeDiagnosticIdHyperLink(id, BrowserHelper.CreateBingQueryUri(id, helpMessage), bingLink: true);
-                }
+                InitializeHyperlinks(helpLink, helpLinkToolTipText);
 
                 if (!string.IsNullOrWhiteSpace(description))
                 {
@@ -64,13 +58,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 }
             }
 
+            // Initialize preview (i.e. diff view) portion.
             InitializePreviewElement(previewContent);
-
-            _serviceProvider = serviceProvider;
-            _errorId = id;
-
-            // save permission whether we are allowed to save data as it is or not.
-            _telemetry = telemetry;
         }
 
         private void InitializePreviewElement(object previewContent)
@@ -109,20 +98,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             AdjustWidthAndHeight(previewElement);
         }
 
-        private void InitializeHyperlinkStyles()
+        private void InitializeHyperlinks(Uri helpLink, string helpLinkToolTipText)
         {
-            this.IdHyperlink.SetVSHyperLinkStyle();
-            this.LearnMoreHyperlink.SetVSHyperLinkStyle();
-        }
+            IdHyperlink.SetVSHyperLinkStyle();
+            LearnMoreHyperlink.SetVSHyperLinkStyle();
 
-        private void InitializeDiagnosticIdHyperLink(string id, Uri helpUri, bool bingLink)
-        {
-            IdHyperlink.Inlines.Add(id);
-            IdHyperlink.NavigateUri = helpUri;
+            IdHyperlink.Inlines.Add(_id);
+            IdHyperlink.NavigateUri = helpLink;
             IdHyperlink.IsEnabled = true;
+            IdHyperlink.ToolTip = helpLinkToolTipText;
 
-            LearnMoreHyperlink.Inlines.Add(string.Format(ServicesVSResources.LearnMoreLinkText, id));
-            LearnMoreHyperlink.NavigateUri = helpUri;
+            LearnMoreHyperlink.Inlines.Add(string.Format(ServicesVSResources.LearnMoreLinkText, _id));
+            LearnMoreHyperlink.NavigateUri = helpLink;
+            LearnMoreHyperlink.ToolTip = helpLinkToolTipText;
         }
 
         public static Border GetPreviewForString(string previewContent, bool useItalicFontStyle = false, bool centerAlignTextHorizontally = false)
@@ -257,7 +245,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 return;
             }
 
-            DiagnosticLogger.LogHyperlink(hyperlink.Name ?? "Preview", _errorId, HasDescription, _telemetry, e.Uri.AbsoluteUri);
+            DiagnosticLogger.LogHyperlink(hyperlink.Name ?? "Preview", _id, HasDescription, _logIdVerbatimInTelemetry, e.Uri.AbsoluteUri);
         }
 
         private void ExpanderToggleButton_CheckedChanged(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             return this;
         }
 
-        private Image GetSeverityIconForDiagnostic(Diagnostic diagnostic)
+        private static Image GetSeverityIconForDiagnostic(Diagnostic diagnostic)
         {
             ImageMoniker? moniker = null;
             switch (diagnostic.Severity)
@@ -63,6 +64,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             return null;
         }
 
+        private static Uri GetHelpLink(Diagnostic diagnostic, out string helpLinkToolTipText)
+        {
+            var isBing = false;
+            helpLinkToolTipText = string.Empty;
+
+            Uri helpLink;
+            if (!BrowserHelper.TryGetUri(diagnostic.Descriptor.HelpLinkUri, out helpLink))
+            {
+                // We use the ENU version of the message for bing search.
+                helpLink = BrowserHelper.CreateBingQueryUri(diagnostic.Id, diagnostic.GetMessage(DiagnosticData.USCultureInfo));
+                isBing = true;
+            }
+
+            if (helpLink != null)
+            {
+                helpLinkToolTipText =
+                    string.Format(ServicesVSResources.DiagnosticIdHyperlinkTooltipText, diagnostic.Id,
+                        isBing ? ServicesVSResources.FromBing : null, Environment.NewLine, helpLink);
+            }
+
+            return helpLink;
+        }
+
         object IPreviewPaneService.GetPreviewPane(Diagnostic diagnostic, object previewContent)
         {
             var title = diagnostic?.GetMessage();
@@ -77,19 +101,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 }
 
                 return new PreviewPane(
-                    severityIcon: null, id: null, title: null, helpMessage: null,
-                    description: null, helpLink: null, telemetry: false,
-                    previewContent: previewContent, serviceProvider: _serviceProvider);
+                    severityIcon: null, id: null, title: null, description: null, helpLink: null, helpLinkToolTipText: null,
+                    previewContent: previewContent, logIdVerbatimInTelemetry: false, serviceProvider: _serviceProvider);
             }
 
+            var helpLinkToolTipText = string.Empty;
+            Uri helpLink = GetHelpLink(diagnostic, out helpLinkToolTipText);
+
             return new PreviewPane(
-                GetSeverityIconForDiagnostic(diagnostic),
-                diagnostic.Id, title,
-                diagnostic.Descriptor.MessageFormat.ToString(DiagnosticData.USCultureInfo),
-                diagnostic.Descriptor.Description.ToString(CultureInfo.CurrentUICulture),
-                diagnostic.Descriptor.HelpLinkUri,
-                diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
-                previewContent, _serviceProvider);
+                severityIcon: GetSeverityIconForDiagnostic(diagnostic),
+                id: diagnostic.Id, title: title,
+                description: diagnostic.Descriptor.Description.ToString(CultureInfo.CurrentUICulture),
+                helpLink: helpLink,
+                helpLinkToolTipText: helpLinkToolTipText,
+                previewContent: previewContent,
+                logIdVerbatimInTelemetry: diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
+                serviceProvider: _serviceProvider);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -284,8 +284,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             case StandardTableKeyNames.ErrorCode:
                                 content = item.Id;
                                 return true;
+                            case StandardTableKeyNames.ErrorCodeToolTip:
+                                content = GetHelpLinkToolTipText(item);
+                                return content != null;
                             case StandardTableKeyNames.HelpLink:
-                                content = GetHelpLink(item);
+                                var isBing = false;
+                                content = GetHelpLink(item, out isBing);
                                 return content != null;
                             case StandardTableKeyNames.ErrorCategory:
                                 content = item.Category;
@@ -454,8 +458,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         };
                     }
 
-                    private string GetHelpLink(DiagnosticData item)
+                    private static string GetHelpLink(DiagnosticData item, out bool isBing)
                     {
+                        isBing = false;
+
                         Uri link;
                         if (BrowserHelper.TryGetUri(item.HelpLink, out link))
                         {
@@ -464,8 +470,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
                         if (!string.IsNullOrWhiteSpace(item.Id))
                         {
-                            // TODO: once we link descriptor with diagnostic, get en-us message for Uri creation
-                            return BrowserHelper.CreateBingQueryUri(item.Id, item.MessageFormat).AbsoluteUri;
+                            isBing = true;
+                            return BrowserHelper.CreateBingQueryUri(item.Id, item.ENUMessageForBingSearch).AbsoluteUri;
+                        }
+
+                        return null;
+                    }
+
+                    private static string GetHelpLinkToolTipText(DiagnosticData item)
+                    {
+                        var isBing = false;
+                        var helpLink = GetHelpLink(item, out isBing);
+
+                        if (helpLink != null)
+                        {
+                            return string.Format(ServicesVSResources.DiagnosticIdHyperlinkTooltipText, item.Id,
+                                isBing ? ServicesVSResources.FromBing : null, Environment.NewLine, helpLink);
                         }
 
                         return null;

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -228,7 +228,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 id: errorId,
                 category: WellKnownDiagnosticTags.Build,
                 message: message,
-                messageFormat: message,
+                enuMessageForBingSearch: message, // Unfortunately, there is no way to get ENU text for this since this is an external error.
                 severity: severity,
                 defaultSeverity: severity,
                 isEnabledByDefault: true,

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -205,6 +205,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Get help for &apos;{0}&apos;{1}{2}{3}.
+        /// </summary>
+        internal static string DiagnosticIdHyperlinkTooltipText {
+            get {
+                return ResourceManager.GetString("DiagnosticIdHyperlinkTooltipText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to C#/VB Diagnostics Table Data Source.
         /// </summary>
         internal static string DiagnosticsTableSourceName {
@@ -363,6 +372,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string FilePathCannotUseReservedKeywords {
             get {
                 return ResourceManager.GetString("FilePathCannotUseReservedKeywords", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  from Bing.
+        /// </summary>
+        internal static string FromBing {
+            get {
+                return ResourceManager.GetString("FromBing", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -465,4 +465,10 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="NoChanges" xml:space="preserve">
     <value>No Changes</value>
   </data>
+  <data name="DiagnosticIdHyperlinkTooltipText" xml:space="preserve">
+    <value>Get help for '{0}'{1}{2}{3}</value>
+  </data>
+  <data name="FromBing" xml:space="preserve">
+    <value> from Bing</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -51,7 +51,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(1, e.Diagnostics.Length)
                 Dim diagnostic As DiagnosticData = e.Diagnostics.First()
                 Assert.Equal("BC42378", diagnostic.Id)
-                Assert.Equal(ServicesVSResources.WRN_UnableToLoadAnalyzer, diagnostic.MessageFormat)
                 Assert.Contains(File, diagnostic.Message, StringComparison.Ordinal)
             End Sub
 


### PR DESCRIPTION
Display a tooltip containing url destination for hyperlinks in the error list and light bulb preview pane UIs.

![capture2](https://cloud.githubusercontent.com/assets/10579684/7310706/8cc0d7de-e9e5-11e4-862f-4aa5422f99d5.PNG)

![capture](https://cloud.githubusercontent.com/assets/10579684/7310701/83b09486-e9e5-11e4-9305-4b34b0e17c0d.PNG)


Also use full fidelity (i.e. substituted)  error message in the search query in the case of hyperlinks that redirect to bing search so that we can present more relevant search results.