### PR TITLE
Introduce Variable on Interpolated Strings

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2359,6 +2359,64 @@ class TestClass
             Test(code, expected, index: 2, compareTokens: false);
         }
 
+        [WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestNoConstantForInterpolatedStrings1()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    static void Test(string[] args)
+    {
+        Console.WriteLine([|$""{DateTime.Now.ToString()}Text{args[0]}""|]);
+    }
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    static void Test(string[] args)
+    {
+        var {|Rename:v|} = $""{DateTime.Now.ToString()}Text{args[0]}"";
+        Console.WriteLine(v);
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestNoConstantForInterpolatedStrings2()
+        {
+            var code =
+    @"using System;
+class TestClass
+{
+    static void Test(string[] args)
+    {
+        Console.WriteLine([|$""Text{{s}}""|]);
+        Console.WriteLine($""Text{{s}}"");
+    }
+}";
+
+            var expected =
+    @"using System;
+class TestClass
+{
+    static void Test(string[] args)
+    {
+        var {|Rename:v|} = $""Text{{s}}"";
+        Console.WriteLine(v);
+        Console.WriteLine(v);
+    }
+}";
+
+            Test(code, expected, index: 1, compareTokens: false);
+        }
+
         [WorkItem(909152)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnNullLiteral()

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1497,5 +1497,59 @@ c""|]
 End Class"
             TestSmartTagText(code, String.Format(FeaturesResources.IntroduceLocalConstantFor, """a b c"""), index:=2)
         End Sub
+
+        <WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub TestNoConstantForInterpolatedStrings1()
+            Dim code =
+<File>
+Module Program
+    Sub Main()
+        Dim args As String() = Nothing
+        Console.WriteLine([|$"{DateTime.Now.ToString()}Text{args(0)}"|])
+    End Sub
+End Module
+</File>
+
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim args As String() = Nothing
+        Dim {|Rename:v|} As String = $"{DateTime.Now.ToString()}Text{args(0)}"
+        Console.WriteLine(v)
+    End Sub
+End Module
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub TestNoConstantForInterpolatedStrings2()
+            Dim code =
+<File>
+Module Program
+    Sub Main()
+        Console.WriteLine([|$"Text{{s}}"|])
+        Console.WriteLine($"Text{{s}}")
+    End Sub
+End Module
+</File>
+
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim {|Rename:v|} As String = $"Text{{s}}"
+        Console.WriteLine(v)
+        Console.WriteLine(v)
+    End Sub
+End Module
+</File>
+
+            Test(code, expected, index:=1, compareTokens:=False)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #976.

Introduce local on interpolated string expressions should not generate a
constant, but a variable.