### PR TITLE
Formatting Service should honor Smart Indent Option

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.Text.BraceCompletion;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.Formatting.FormattingOptions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
 {
@@ -146,17 +147,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                 }
             }
 
-            // skip whitespace
-            while (startPosition >= 0 && char.IsWhiteSpace(snapshot[startPosition]))
+            if (session.SubjectBuffer.GetOption(SmartIndent) != IndentStyle.None)
             {
-                startPosition--;
-            }
+                // skip whitespace
+                while (startPosition >= 0 && char.IsWhiteSpace(snapshot[startPosition]))
+                {
+                    startPosition--;
+                }
 
-            // skip token
-            startPosition--;
-            while (startPosition >= 0 && !char.IsWhiteSpace(snapshot[startPosition]))
-            {
+                // skip token
                 startPosition--;
+                while (startPosition >= 0 && !char.IsWhiteSpace(snapshot[startPosition]))
+                {
+                    startPosition--;
+                }
             }
 
             session.SubjectBuffer.Format(TextSpan.FromBounds(Math.Max(startPosition, 0), endPosition), rules);

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation;
@@ -85,7 +86,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             }
 
             var smartTokenformattingRules = (new SmartTokenFormattingRule()).Concat(_formattingRules);
-            return Formatter.GetFormattedTextChanges(_root, new TextSpan[] { TextSpan.FromBounds(previousToken.SpanStart, adjustedEndPosition) }, workspace, _optionSet, smartTokenformattingRules, cancellationToken);
+            var adjustedStartPosition = previousToken.SpanStart;
+            if (token.IsKind(SyntaxKind.OpenBraceToken) && token.IsFirstTokenOnLine(token.SyntaxTree.GetText()) &&
+                workspace.Options.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp) == FormattingOptions.IndentStyle.None)
+            {
+                adjustedStartPosition = token.SpanStart;
+            }
+
+            return Formatter.GetFormattedTextChanges(_root, new TextSpan[] { TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition) }, workspace, _optionSet, smartTokenformattingRules, cancellationToken);
         }
 
         private class NoLineChangeFormattingRule : AbstractFormattingRule

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -789,6 +789,35 @@ class Foo
             }
         }
 
+        [WorkItem(2224, "https://github.com/dotnet/roslyn/issues/2224")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NoSmartOrBlockIndentationWithAutomaticBraceFormattingDisabled()
+        {
+            var code = @"namespace NS1
+{
+    public class C1
+$$
+}";
+
+            var expected = @"namespace NS1
+{
+    public class C1
+{ }
+}";
+
+            var optionSet = new Dictionary<OptionKey, object>
+                            {
+                                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.None }
+                            };
+            using (var session = CreateSession(code, optionSet))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                Assert.Equal(expected, session.Session.SubjectBuffer.CurrentSnapshot.GetText());
+            }
+        }
+
         internal Holder CreateSession(string code, Dictionary<OptionKey, object> optionSet = null)
         {
             return CreateSession(


### PR DESCRIPTION
Fix #2224 : Formatting Service should not format the whitespaces before
Braces if Smart Indentation Option is set to None