### PR TITLE
re-filter signature help providers if the file's content type has changed

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
@@ -22,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
         private readonly IList<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> _allProviders;
         private IList<ISignatureHelpProvider> _providers;
+        private IContentType _lastSeenContentType;
 
         public Controller(
             ITextView textView,
@@ -108,13 +110,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
         {
             this.AssertIsForeground();
 
-            if (_providers == null)
+            var snapshot = this.SubjectBuffer.CurrentSnapshot;
+            var currentContentType = snapshot.ContentType;
+
+            // if a file's content-type changes (e.g., File.cs is renamed to File.vb) after the list of providers has been populated, then we need to re-filter
+            if (_providers == null || currentContentType != _lastSeenContentType)
             {
-                var snapshot = this.SubjectBuffer.CurrentSnapshot;
                 var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document != null)
                 {
                     _providers = document.Project.LanguageServices.WorkspaceServices.SelectMatchingExtensionValues(_allProviders, this.SubjectBuffer);
+                    _lastSeenContentType = currentContentType;
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/NavigationBar/NavigationBarClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/NavigationBar/NavigationBarClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
             int selectionIndex;
             var selectedItemPreviewText = string.Empty;
 
-            if (_dropdownBar.GetCurrentSelection(iCombo, out selectionIndex) == VSConstants.S_OK)
+            if (_dropdownBar.GetCurrentSelection(iCombo, out selectionIndex) == VSConstants.S_OK && selectionIndex >= 0)
             {
                 selectedItemPreviewText = GetItem(iCombo, selectionIndex).Text;
             }


### PR DESCRIPTION
When a file is opened and the user types a character, the list of all signature help providers is filtered based on the buffer's content type and cached.  If the content type is then changed without closing the file (e.g., renaming File1.cs to File1.vb) then another character is typed, the cached list of signature help providers is stale and any of those providers could be invoked based on `ISignatureHelpProvider.IsTriggerCharacter()` and `IsRetriggerCharacter()` which could ultimately lead to a crash when/if a syntax node is explicitly cast to a language-specific syntax node that doesn't match.

The fix is to also track the content type used to initially filter the list and invalidate the cache if the content type has changed.  There is also the added benefit with this change that after renaming a file extension, signature help continues to work as expected.

Writing a unit test for this ended up being very code-intensive and contrived, but I could be convinced to add an internal integration test for this scenario if people think it's important enough.

This also fixes another crashing bug I found while working on this where the mis-matched content type could cause the navigation bars to try to navigate with a negative index.  I audited all other instances of calling `GetCurrentSelection(int, out int)` and we either explicitly check for a negative index before navigation or we're appropriately guarded otherwise.

Fixes #1940.