### PR TITLE
[Localize] partially localize a part of strings like "finally clause"

### DIFF
--- a/src/Features/CSharp/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/CSharpFeaturesResources.resx
@@ -305,39 +305,50 @@
   </data>
   <data name="TryBlock" xml:space="preserve">
     <value>try block</value>
+    <comment>{Locked="try"} "try" is a C# keyword and should not be localized.</comment>       
   </data>
   <data name="CatchClause" xml:space="preserve">
     <value>catch clause</value>
+    <comment>{Locked="catch"} "catch" is a C# keyword and should not be localized.</comment>
   </data>
   <data name="FilterClause" xml:space="preserve">
     <value>filter clause</value>
   </data>
   <data name="FinallyClause" xml:space="preserve">
     <value>finally clause</value>
+    <comment>{Locked="finally"} "finally" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="FixedStatement" xml:space="preserve">
     <value>fixed statement</value>
+    <comment>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="UsingStatement" xml:space="preserve">
     <value>using statement</value>
+    <comment>{Locked="using"} "using" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="LockStatement" xml:space="preserve">
     <value>lock statement</value>
+    <comment>{Locked="lock"} "lock" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="ForEachStatement" xml:space="preserve">
     <value>foreach statement</value>
+    <comment>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="CheckedStatement" xml:space="preserve">
     <value>checked statement</value>
+    <comment>{Locked="checked"} "checked" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="UncheckedStatement" xml:space="preserve">
     <value>unchecked statement</value>
+    <comment>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="YieldStatement" xml:space="preserve">
     <value>yield statement</value>
+    <comment>{Locked="yield"} "yield" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="AwaitExpression" xml:space="preserve">
     <value>await expression</value>
+    <comment>{Locked="await"} "await" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="Lambda" xml:space="preserve">
     <value>lambda</value>
@@ -350,30 +361,38 @@
   </data>
   <data name="JoinClause" xml:space="preserve">
     <value>join clause</value>
+    <comment>{Locked="join"} "join" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="LetClause" xml:space="preserve">
     <value>let clause</value>
+    <comment>{Locked="let"} "let" is a C# keyword and should not be localized.</comment>        
   </data>
   <data name="WhereClause" xml:space="preserve">
     <value>where clause</value>
+    <comment>{Locked="where"} "where" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="OrderByClause" xml:space="preserve">
     <value>orderby clause</value>
+    <comment>{Locked="orderby"} "orderby" is a C# keyword and should not be localized.</comment>    
   </data>
   <data name="SelectClause" xml:space="preserve">
     <value>select clause</value>
+    <comment>{Locked="select"} "select" is a C# keyword and should not be localized.</comment>        
   </data>
   <data name="GroupByClause" xml:space="preserve">
     <value>groupby clause</value>
+    <comment>{Locked="groupby"} "groupby" is a C# keyword and should not be localized.</comment>            
   </data>
   <data name="QueryBody" xml:space="preserve">
-    <value>query body</value>
+    <value>query body</value>                
   </data>
   <data name="IntoClause" xml:space="preserve">
     <value>into clause</value>
+    <comment>{Locked="into"} "into" is a C# keyword and should not be localized.</comment>                
   </data>
   <data name="GlobalStatement" xml:space="preserve">
     <value>global statement</value>
+    <comment>{Locked="global"} "global" is a C# keyword and should not be localized.</comment>                   
   </data>
   <data name="UsingNamespace" xml:space="preserve">
     <value>using namespace</value>

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -789,6 +789,7 @@ Do you want to continue?</value>
   </data>
   <data name="EnumValue" xml:space="preserve">
     <value>enum value</value>
+    <comment>{Locked="enum"} "enum" is a C#/VB keyword and should not be localized.</comment>  
   </data>
   <data name="Delegate" xml:space="preserve">
     <value>delegate</value>
@@ -796,6 +797,7 @@ Do you want to continue?</value>
   </data>
   <data name="ConstField" xml:space="preserve">
     <value>const field</value>
+    <comment>{Locked="const"} "const" is a C#/VB keyword and should not be localized.</comment>
   </data>
   <data name="Field" xml:space="preserve">
     <value>field</value>
@@ -820,7 +822,7 @@ Do you want to continue?</value>
     <comment>{Locked}</comment>    
   </data>
   <data name="EventAccessor" xml:space="preserve">
-    <value>event accessor</value>
+    <value>event accessor</value> 
   </data>
   <data name="TypeConstraint" xml:space="preserve">
     <value>type constraint</value>

--- a/src/Features/VisualBasic/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/VBFeaturesResources.resx
@@ -1053,90 +1053,117 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   </data>
   <data name="TryBlock" xml:space="preserve">
     <value>Try block</value>
+    <comment>{Locked="Try"} "Try" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="CatchClause" xml:space="preserve">
     <value>Catch clause</value>
+    <comment>{Locked="Catch"} "Catch" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="FinallyClause" xml:space="preserve">
     <value>Finally clause</value>
+    <comment>{Locked="Finally"} "Finally" is a VB keyword and should not be localized.</comment>        
   </data>
   <data name="UsingStatement" xml:space="preserve">
     <value>Using statement</value>
+    <comment>{Locked="Using"} "Using" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="UsingBlock" xml:space="preserve">
     <value>Using block</value>
+    <comment>{Locked="Using"} "Using" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="WithStatement" xml:space="preserve">
     <value>With statement</value>
+    <comment>{Locked="With"} "With" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="WithBlock" xml:space="preserve">
     <value>With block</value>
+    <comment>{Locked="With"} "With" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="SyncLockStatement" xml:space="preserve">
     <value>SyncLock statement</value>
+    <comment>{Locked="SyncLock"} "SyncLock" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="SyncLockBlock" xml:space="preserve">
     <value>SyncLock block</value>
+    <comment>{Locked="SyncLock"} "SyncLock" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="ForEachStatement" xml:space="preserve">
     <value>For Each statement</value>
+    <comment>{Locked="For Each"} "For Each" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="ForEachBlock" xml:space="preserve">
     <value>For Each block</value>
+    <comment>{Locked="For Each"} "For Each" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="OnErrorStatement" xml:space="preserve">
     <value>On Error statement</value>
+    <comment>{Locked="On Error"} "On Error" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="ResumeStatement" xml:space="preserve">
     <value>Resume statement</value>
+    <comment>{Locked="Resume"} "Resume" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="YieldStatement" xml:space="preserve">
     <value>Yield statement</value>
+    <comment>{Locked="Yield"} "Yield" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="AwaitExpression" xml:space="preserve">
     <value>Await expression</value>
+    <comment>{Locked="Await"} "Await" is a VB keyword and should not be localized.</comment>        
   </data>
   <data name="LambdaExpression" xml:space="preserve">
     <value>Lambda</value>
   </data>
   <data name="WhereClause" xml:space="preserve">
     <value>Where clause</value>
+    <comment>{Locked="Where"} "Where" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="SelectClause" xml:space="preserve">
     <value>Select clause</value>
+    <comment>{Locked="Select"} "Select" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="FromClause" xml:space="preserve">
     <value>From clause</value>
+    <comment>{Locked="From"} "From" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="AggregateClause" xml:space="preserve">
     <value>Aggregate clause</value>
+    <comment>{Locked="Aggregate"} "Aggregate" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="LetClause" xml:space="preserve">
     <value>Let clause</value>
+    <comment>{Locked="Let"} "Let" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="SimpleJoinClause" xml:space="preserve">
     <value>Join clause</value>
+    <comment>{Locked="Join"} "Join" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="GroupJoinClause" xml:space="preserve">
     <value>Group Join clause</value>
+    <comment>{Locked="Group Join"} "Group Join" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="GroupByClause" xml:space="preserve">
     <value>Group By clause</value>
+    <comment>{Locked="Group By"} "Group By" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="FunctionAggregation" xml:space="preserve">
     <value>Function aggregation</value>
   </data>
   <data name="TakeWhileClause" xml:space="preserve">
     <value>Take While clause</value>
+    <comment>{Locked="Take While"} "Take While" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="SkipWhileClause" xml:space="preserve">
     <value>Skip While clause</value>
+    <comment>{Locked="Skip While"} "Skip While" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="OrderingClause" xml:space="preserve">
     <value>Ordering clause</value>
+    <comment>{Locked="Ordering"} "Ordering" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="JoinCondition" xml:space="preserve">
     <value>Join condition</value>
+    <comment>{Locked="Join"} "Join" is a VB keyword and should not be localized.</comment>       
   </data>
   <data name="OptionStatement" xml:space="preserve">
     <value>option</value>
@@ -1156,12 +1183,14 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   </data>
   <data name="WithEventsFieldStatement" xml:space="preserve">
     <value>WithEvents field</value>
+    <comment>{Locked="WithEvents"} "WithEvents" is a VB keyword and should not be localized.</comment>      
   </data>
   <data name="PropertyAccessor" xml:space="preserve">
     <value>property accessor</value>
   </data>
   <data name="AsClause" xml:space="preserve">
     <value>as clause</value>
+    <comment>{Locked="as"} "as" is a VB keyword and should not be localized.</comment>    
   </data>
   <data name="TypeParameterList" xml:space="preserve">
     <value>type parameters</value>


### PR DESCRIPTION
We use resource commenting "locked" to define what to localize. It fixes #2215.

