### PR TITLE
Use shared build client (if enabled) when ToolPath is empty

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
-            if (!UseSharedCompilation || this.ToolPath != null )
+            if (!UseSharedCompilation || !String.IsNullOrEmpty(this.ToolPath))
             {
                 return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -1910,7 +1910,7 @@ class Hello
 
             Assert.True(WaitForProcessExitAsync(_compilerServerExecutable).Wait(timeout),
                 string.Format("Compiler server did not exit after {0} seconds, number of vbcscompiler.exe proccesses found: {1}",
-                    timeout.Milliseconds / 1000,
+                    timeout.TotalSeconds,
                     GetProcessesByFullPath(_compilerServerExecutable).Count));
 
             // Run another build using the analyzer
@@ -2162,7 +2162,6 @@ class Hello
         public void ExecuteCscBuildTaskWithServer()
         {
             var csc = new Csc();
-            csc.ToolPath = _compilerDirectory;
             var srcFile = _tempDirectory.CreateFile(s_helloWorldSrcCs[0].Key).WriteAllText(s_helloWorldSrcCs[0].Value).Path;
             var exeFile = Path.Combine(_tempDirectory.Path, "hello.exe");
 
@@ -2192,7 +2191,6 @@ class Hello
         public void ExecuteVbcBuildTaskWithServer()
         {
             var vbc = new Vbc();
-            vbc.ToolPath = _compilerDirectory;
             var srcFile = _tempDirectory.CreateFile(s_helloWorldSrcVb[0].Key).WriteAllText(s_helloWorldSrcVb[0].Value).Path;
             var exeFile = Path.Combine(_tempDirectory.Path, "hello.exe");
 


### PR DESCRIPTION
The `ToolPath` for the csc and vbc compilers in these tests is first being set to a path containing a copy of the current build's binaries and then cleared again before actually being used.

When the path is not explicitly provided, it uses the logic in `GenerateFullPathToTool` (in [MSBuildTask\Csc.cs](https://github.com/dotnet/roslyn/blob/6e7ddc3f6a9f70900a2daf29277575f1c635a47a/src/Compilers/Core/MSBuildTask/Csc.cs#L189) and in [MSBuildTask\Vbc.cs](https://github.com/dotnet/roslyn/blob/6e7ddc3f6a9f70900a2daf29277575f1c635a47a/src/Compilers/Core/MSBuildTask/Vbc.cs#L337)) to determine which one to use, which defaults to the installed version.

With this change, the current build's c# and vb compilers are used for these tests.