### PR TITLE
Make C# snippet completion obey the "SendEnterThroughToEditor" option

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
@@ -116,6 +116,17 @@ class C
             VerifyItemInLinkedFiles(markup, MockSnippetInfoService.SnippetShortcut, null);
         }
 
+        [WorkItem(1140893)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void CommitWithEnterObeysOption()
+        {
+            VerifySendEnterThroughToEnter("try", "tr", sendThroughEnterEnabled: true, expected: false);
+            VerifySendEnterThroughToEnter("try", "try", sendThroughEnterEnabled: true, expected: true);
+
+            VerifySendEnterThroughToEnter("try", "tr", sendThroughEnterEnabled: false, expected: false);
+            VerifySendEnterThroughToEnter("try", "try", sendThroughEnterEnabled: false, expected: false);
+        }
+
         private class MockSnippetInfoService : ISnippetInfoService
         {
             internal const string SnippetShortcut = "SnippetShortcut";

--- a/src/Features/CSharp/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override bool SendEnterThroughToEditor(CompletionItem completionItem, string textTypedSoFar)
         {
-            return false;
+            return CompletionUtilities.SendEnterThroughToEditor(completionItem, textTypedSoFar);
         }
 
         protected override async Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken)
@@ -138,11 +138,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            return snippets.Select(snippet => new CompletionItem(
+            return snippets.Select(snippet => new CSharpCompletionItem(
+                workspace,
                 this,
                 displayText: isPreProcessorContext ? snippet.Shortcut.Substring(1) : snippet.Shortcut,
                 sortText: isPreProcessorContext ? snippet.Shortcut.Substring(1) : snippet.Shortcut,
-                description: (snippet.Title + Environment.NewLine + snippet.Description).ToSymbolDisplayParts(),
+                descriptionFactory: c => Task.FromResult((snippet.Title + Environment.NewLine + snippet.Description).ToSymbolDisplayParts()),
                 filterSpan: CompletionUtilities.GetTextChangeSpan(text, position),
                 glyph: Glyph.Snippet,
                 shouldFormatOnCommit: service.ShouldFormatSnippet(snippet)));


### PR DESCRIPTION
Use the standard logic to determine whether to send enter through to the
editor, which requires using CSharpCompletionItems.

Fixes internal bug #1140893.