### PR TITLE
Fix for #2272 - use of default enum method parameter throws exception

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -11436,6 +11436,30 @@ public class Test
 }");
         }
 
+        [Fact]
+        public void Bug2272()
+        {
+            string source = @"
+using System;
+
+public class Parent
+{
+    public int Foo(ConsoleKey e = ConsoleKey.A) { return e == ConsoleKey.A ? 0 : 1; }
+}
+
+public class Test
+{
+    public static int Main()
+    {
+        var ret = new Parent().Foo();
+        Console.WriteLine(ret);
+        return ret;
+    }
+}
+";
+            CompileAndVerify(source, expectedOutput: @"0");
+        }
+
         [WorkItem(543089, "DevDiv")]
         [Fact()]
         public void NoOutAttributeOnMethodReturn()

--- a/src/Scripting/Core/Emit/ReflectionEmitter.cs
+++ b/src/Scripting/Core/Emit/ReflectionEmitter.cs
@@ -2037,7 +2037,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
 
                             if (paramType.IsEnum)
                             {
-                                paramType = paramType.UnderlyingSystemType;
+                                paramType = Enum.GetUnderlyingType(paramType);
                             }
 
                             rawValue = Convert.ChangeType(rawValue, paramType, System.Globalization.CultureInfo.InvariantCulture);

--- a/src/Scripting/Core/Emit/ReflectionEmitter.cs
+++ b/src/Scripting/Core/Emit/ReflectionEmitter.cs
@@ -2037,7 +2037,9 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
 
                             if (paramType.IsEnum)
                             {
-                                paramType = Enum.GetUnderlyingType(paramType);
+                                // If emitting the enum, it isn't "created" as this stage so Enum.GetUnderlyingType() will throw
+                                // Otherwise, if the enum is already defined, we should use Enum.GetUnderlyingType() to get the correct type
+                                paramType = paramType is TypeBuilder ? paramType.UnderlyingSystemType : Enum.GetUnderlyingType(paramType);
                             }
 
                             rawValue = Convert.ChangeType(rawValue, paramType, System.Globalization.CultureInfo.InvariantCulture);


### PR DESCRIPTION
This PR should fix issue #2272 