### PR TITLE
When classifying xml nodes in VB, use FullSpan

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Classification/AbstractVisualBasicClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/AbstractVisualBasicClassifierTests.vb
@@ -86,9 +86,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
             Dim start = allCode.IndexOf(code, StringComparison.Ordinal)
             Dim length = code.Length
             Dim span = New TextSpan(start, length)
+            Test(code, allCode, span, expected)
+
+        End Sub
+
+        Protected Sub Test(
+            code As String,
+            allCode As String,
+            span As TextSpan,
+            ParamArray expected As Tuple(Of String, String)())
 
             Dim actual = GetClassificationSpans(allCode, span).ToList()
-
             actual.Sort(Function(t1, t2) t1.TextSpan.Start - t2.TextSpan.Start)
 
             For i = 0 To Math.Max(expected.Length, actual.Count) - 1
@@ -156,6 +164,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
             Dim allCode = "Class " & className & vbCrLf & "    Sub " & methodName & "()" & vbCrLf & "        " &
                 code & vbCrLf & "    End Sub" & vbCrLf & "End Class"
             Test(code, allCode, expected)
+        End Sub
+
+        <DebuggerStepThrough()>
+        Protected Sub TestInMethod(
+            className As String,
+            methodName As String,
+            code As String,
+            codeToClassify As String,
+            ParamArray expected As Tuple(Of String, String)())
+
+            Dim allCode = "Class " & className & vbCrLf & "    Sub " & methodName & "()" & vbCrLf & "        " &
+                code & vbCrLf & "    End Sub" & vbCrLf & "End Class"
+            Dim start = allCode.IndexOf(codeToClassify)
+            Dim length = codeToClassify.Length
+            Test(code, allCode, new TextSpan(start, length), expected)
         End Sub
 
         <DebuggerStepThrough()>

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -3830,5 +3830,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
                  Keyword("Module"))
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        <WorkItem(2126, "https://github.com/dotnet/roslyn/issues/2126")>
+        Public Sub CommentBeforeXmlAccessExpression()
+            TestInMethod("C",
+                         "M",
+                         " ' Comment
+                           x.@Name = ""Text""",
+                         "' Comment",
+                         Comment("' Comment"))
+        End Sub
+
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.XmlClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.XmlClassifier.vb
@@ -22,7 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             End Sub
 
             Friend Sub ClassifyNode(node As SyntaxNode)
-                If Not _worker._textSpan.OverlapsWith(node.Span) Then
+                ' Note: Use FullSpan in case we need to classify trivia around the span of the node.
+                If Not _worker._textSpan.OverlapsWith(node.FullSpan) Then
                     Return
                 End If
 


### PR DESCRIPTION
Since the editor calls us line by line, if we get called to classify a
comment trivia on the line before an xml node, we would not do so as part
of that line, because it doesn't overlap the Span.  We would later do so,
but not actually return the spans to the editor, since they didn't
overlap the span requested.

Fixes #2126.