### PR TITLE
Adjust constraints check for reduced extension methods to avoid failures for type parameters that couldn't be inferred from the first argument.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2575,18 +2575,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Return the inferred type arguments using the original type
-        /// parameters for any type arguments that were not inferred.
+        /// Return the inferred type arguments using null
+        /// for any type arguments that were not inferred.
         /// </summary>
         private ImmutableArray<TypeSymbol> GetInferredTypeArguments()
         {
-            var typeArgs = ArrayBuilder<TypeSymbol>.GetInstance();
-            for (int i = 0; i < _methodTypeParameters.Length; i++)
-            {
-                var typeArg = _fixedResults[i] ?? _methodTypeParameters[i];
-                typeArgs.Add(typeArg);
-            }
-            return typeArgs.ToImmutableAndFree();
+            return _fixedResults.AsImmutable();
         }
 
         private static bool IsReallyAType(TypeSymbol type)


### PR DESCRIPTION
@VSadov, @gafter, @agocke, @jaredpar Please review.   