### PR TITLE
Adding error triggers  for the add-usings fixers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -1970,6 +1970,42 @@ namespace A.C
 }");
         }
 
+        [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestAddUsingWithOtherExtensionsInScope()
+        {
+            Test(
+@"using System . Linq ; using System . Collections ; using X ; namespace X { public static class Ext { public static void ExtMethod ( this int a ) { } } } namespace Y { public static class Ext { public static void ExtMethod ( this int a , int v ) { } } } public class B { static void Main ( ) { var b = 0 ; b . [|ExtMethod|] ( 0 ) ; } } ",
+@"using System . Linq ; using System . Collections ; using X ; using Y ; namespace X { public static class Ext { public static void ExtMethod ( this int a ) { } } } namespace Y { public static class Ext { public static void ExtMethod ( this int a , int v ) { } } } public class B { static void Main ( ) { var b = 0 ; b . ExtMethod ( 0 ) ; } } ");
+        }
+
+        [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestAddUsingWithOtherExtensionsInScope2()
+        {
+            Test(
+@"using System . Linq ; using System . Collections ; using X ; namespace X { public static class Ext { public static void ExtMethod ( this int ? a ) { } } } namespace Y { public static class Ext { public static void ExtMethod ( this int ? a , int v ) { } } } public class B { static void Main ( ) { var b = new int ? ( ) ; b ? [|. ExtMethod|] ( 0 ) ; } } ",
+@"using System . Linq ; using System . Collections ; using X ; using Y ; namespace X { public static class Ext { public static void ExtMethod ( this int ? a ) { } } } namespace Y { public static class Ext { public static void ExtMethod ( this int ? a , int v ) { } } } public class B { static void Main ( ) { var b = new int ? ( ) ; b ? . ExtMethod ( 0 ) ; } } ");
+        }
+
+        [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestAddUsingWithOtherExtensionsInScope3()
+        {
+            Test(
+@"using System . Linq ; class C { int i = 0 . [|All|] ( ) ; } namespace X { static class E { public static int All ( this int o ) => 0 ; } } ",
+@"using System . Linq ; using X ; class C { int i = 0 . All ( ) ; } namespace X { static class E { public static int All ( this int o ) => 0 ; } } ");
+        }
+
+        [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestAddUsingWithOtherExtensionsInScope4()
+        {
+            Test(
+@"using System . Linq ; class C { static void Main ( string [ ] args ) { var a = new int ? ( ) ; int ? i = a ? [|. All|] ( ) ; } } namespace X { static class E { public static int ? All ( this int ? o ) => 0 ; } } ",
+@"using System . Linq ; using X ; class C { static void Main ( string [ ] args ) { var a = new int ? ( ) ; int ? i = a ? . All ( ) ; } } namespace X { static class E { public static int ? All ( this int ? o ) => 0 ; } } ");
+        }
+
         public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -1060,6 +1060,38 @@ NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime
 Nothing, 1, True, True, Nothing, False, Nothing)
         End Sub
 
+        <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Sub TestAddUsingWithOtherExtensionsInScope()
+            Test(
+NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Module Program \n Sub Main(args As String()) \n Dim i = [|0.All|]() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"),
+NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim i = 0.All() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"))
+        End Sub
+
+        <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Sub TestAddUsingWithOtherExtensionsInScope2()
+            Test(
+NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?[|.All|]() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"),
+NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?.All() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"))
+        End Sub
+
+        <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Sub TestAddUsingWithOtherExtensionsInScope3()
+            Test(
+NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = 0 \n Dim i = [|a.All|](0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer, v As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"),
+NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n Module Program \n Sub Main(args As String()) \n Dim a = 0 \n Dim i = a.All(0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer, v As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"))
+        End Sub
+
+        <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Sub TestAddUsingWithOtherExtensionsInScope4()
+            Test(
+NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?[|.All|](0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer?, v As Integer) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"),
+NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?.All(0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer?, v As Integer) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"))
+        End Sub
+
         Public Class AddImportTestsWithAddImportDiagnosticProvider
             Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 

--- a/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -80,6 +80,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         private const string CS1003 = "CS1003";
 
         /// <summary>
+        ///  No overload for method 'X' takes 'N' arguments
+        /// </summary>
+        private const string CS1501 = "CS1501";
+
+        /// <summary>
         /// cannot convert from 'int' to 'string'
         /// </summary>
         private const string CS1503 = "CS1503";
@@ -104,6 +109,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         /// </summary>
         private const string CS1584 = "CS1584";
 
+        /// <summary>
+        /// Type 'X' does not contain a valide extension method accepting 'Y'
+        /// </summary>
+        private const string CS1929 = "CS1929";
+
         public override ImmutableArray<string> FixableDiagnosticIds
         {
             get
@@ -120,11 +130,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                     CS0616,
                     CS1002,
                     CS1003,
+                    CS1501,
                     CS1503,
                     CS1574,
                     CS1580,
                     CS1581,
-                    CS1584);
+                    CS1584,
+                    CS1929);
             }
         }
 
@@ -163,6 +175,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
                     break;
                 case CS0122:
+                case CS1501:
+                    if (node is SimpleNameSyntax)
+                    {
+                        break;
+                    }
+                    else if (node is MemberBindingExpressionSyntax)
+                    {
+                        node = (node as MemberBindingExpressionSyntax).Name;
+                    }
+                    break;
+                case CS1929:
+                    var memberAccessName = (node.Parent as MemberAccessExpressionSyntax)?.Name;
+                    var conditionalAccessName = (((node.Parent as ConditionalAccessExpressionSyntax)?.WhenNotNull as InvocationExpressionSyntax).Expression as MemberBindingExpressionSyntax)?.Name;
+                    if (memberAccessName == null && conditionalAccessName == null)
+                    {
+                        return false;
+                    }
+
+                    node = memberAccessName ?? conditionalAccessName;
                     break;
 
                 case CS1503:

--- a/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         private const string CS1584 = "CS1584";
 
         /// <summary>
-        /// Type 'X' does not contain a valide extension method accepting 'Y'
+        /// Type 'X' does not contain a valid extension method accepting 'Y'
         /// </summary>
         private const string CS1929 = "CS1929";
 

--- a/src/Features/VisualBasic/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -32,6 +32,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
         Friend Const BC30456 = "BC30456"
 
         ''' <summary>
+        ''' 'X' has no parameters and its return type cannot be indexed
+        ''' </summary>
+        Friend Const BC32016 = "BC32016"
+
+        ''' <summary>
         ''' Too few type arguments
         ''' </summary>
         Friend Const BC32042 = "BC32042"
@@ -88,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30451, BC30456, BC32042, BC36593, BC32045, BC30389, BC31504, BC36610, BC36719, BC30512, BC30390, BC42309, BC30182)
+                Return ImmutableArray.Create(BC30002, BC30451, BC30456, BC32042, BC36593, BC32045, BC30389, BC31504, BC32016, BC36610, BC36719, BC30512, BC30390, BC42309, BC30182)
             End Get
         End Property
 
@@ -129,6 +134,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                     End If
 
                     Return False
+                Case BC32016
+                    Dim memberAccessName = TryCast(node, MemberAccessExpressionSyntax)?.Name
+                    Dim conditionalAccessName = TryCast(TryCast(TryCast(node, ConditionalAccessExpressionSyntax)?.WhenNotNull, InvocationExpressionSyntax)?.Expression, MemberAccessExpressionSyntax)?.Name
+
+                    If memberAccessName Is Nothing AndAlso conditionalAccessName Is Nothing Then
+                        Return False
+                    End If
+
+                    node = If(memberAccessName Is Nothing, conditionalAccessName, memberAccessName)
+                    Exit Select
                 Case Else
                     Return False
             End Select


### PR DESCRIPTION
Adding additional errors for the Add Imports/Usings fixers to react to.
Now, when we get an error on an extension method we offer to import the
correct namespace.

Fixes #935
Fixes #562