### PR TITLE
Add skipped test for another repro case for #463

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -253,7 +254,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("struct", changes[0].NewText);
         }
 
-        [Fact]
+        [Fact, WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
         public void TestQualifyWithThis()
         {
             var original = @"
@@ -318,6 +319,70 @@ class C
             Assert.NotNull(changes);
             Assert.Equal(1, changes.Count);
             Assert.Equal("this.", changes[0].NewText);
+        }
+
+        [Fact(Skip = "463"), WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
+        public void TestReplaceWithBuiltInType()
+        {
+            var original = @"
+using System;
+using System.Collections.Generic;
+
+public class TestClass
+{
+    public void TestMethod()
+    {
+        var dictionary = new Dictionary<Object, Object>();
+        dictionary[new Object()] = new Object();
+    }
+}";
+            var oldTree = SyntaxFactory.ParseSyntaxTree(original);
+            var root = oldTree.GetRoot();
+
+            var indexText = "Object";
+
+            // Expected behavior: Replacing identifier 'Object' with 'object' and doing a diff between trees 
+            // should return a single text change for character replace.
+
+            // Works as expected for first index
+            var index = original.IndexOf(indexText, StringComparison.Ordinal);
+            TestReplaceWithBuiltInTypeCore(root, index);
+
+            // Works as expected for last index
+            index = original.LastIndexOf(indexText, StringComparison.Ordinal);
+            TestReplaceWithBuiltInTypeCore(root, index);
+
+            // Doesn't work as expected for the third index.
+            // It returns 2 changes with add followed by delete, 
+            // causing the 2 isolated edits to seem conflicting edits, even though they are not.
+            // See https://github.com/dotnet/roslyn/issues/320 for details.
+            indexText = "Object()";
+            index = original.IndexOf(indexText, StringComparison.Ordinal);
+            TestReplaceWithBuiltInTypeCore(root, index);
+        }
+
+        private void TestReplaceWithBuiltInTypeCore(SyntaxNode root, int index)
+        {
+            var oldTree = root.SyntaxTree;
+
+            var nodesToReplace = root.DescendantNodes().Where(n => n is SimpleNameSyntax && n.ToString() == "Object");
+
+            var span = new TextSpan(index, 6);
+            var node = root.FindNode(span, getInnermostNodeForTie: true) as SimpleNameSyntax;
+            Assert.NotNull(node);
+            Assert.Equal("Object", node.Identifier.ValueText);
+
+            var leadingTrivia = node.GetLeadingTrivia();
+            var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword))
+                .WithLeadingTrivia(leadingTrivia);
+
+            var newRoot = root.ReplaceNode(node, newNode);
+            var newTree = newRoot.SyntaxTree;
+
+            var changes = newTree.GetChanges(oldTree);
+            Assert.NotNull(changes);
+            Assert.Equal(1, changes.Count);
+            Assert.Equal("o", changes[0].NewText);
         }
     }
 }


### PR DESCRIPTION
Add test for another repro of #463 in SyntaxTree.GetChanges(tree)

@mattwar I am going to re-open #463, you can repro the bug through this unit test.

This test is derived from https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/723 reported by @AArnott 

/cc @sharwell 