### PR TITLE
Serialize left out Shared Formatting Options

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpLanguageSettingsSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpLanguageSettingsSerializer.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
-    [ExportLanguageSpecificOptionSerializer(LanguageNames.CSharp, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), Shared]
+    [ExportLanguageSpecificOptionSerializer(LanguageNames.CSharp, FormattingOptions.FormattingFeatureName, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), Shared]
     internal class CSharpLanguageSettingsSerializer : AbstractLanguageSettingsSerializer
     {
         [ImportingConstructor]

--- a/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicLanguageSettingsSerializer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicLanguageSettingsSerializer.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.Options
 Imports System.Composition
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
-    <ExportLanguageSpecificOptionSerializer(LanguageNames.VisualBasic, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), [Shared]>
+    <ExportLanguageSpecificOptionSerializer(LanguageNames.VisualBasic, FormattingOptions.FormattingFeatureName, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), [Shared]>
     Friend NotInheritable Class VisualBasicLanguageSettingsSerializer
         Inherits AbstractLanguageSettingsSerializer
 

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptionsProvider.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptionsProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    [ExportOptionProvider, Shared]
+    internal class FormattingOptionsProvider : IOptionProvider
+    {
+        private IEnumerable<IOption> _options = new List<IOption>
+        {
+            FormattingOptions.UseTabs,
+            FormattingOptions.TabSize,
+            FormattingOptions.IndentationSize,
+            FormattingOptions.SmartIndent
+        }.ToImmutableArray();
+
+        public IEnumerable<IOption> GetOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -377,6 +377,7 @@
     <Compile Include="FindSymbols\DeclaredSymbolInfo.cs" />
     <Compile Include="FindSymbols\SyntaxTree\AbstractSyntaxTreeInfo.cs" />
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeDeclarationInfo.cs" />
+    <Compile Include="Formatting\FormattingOptionsProvider.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileMergeSessionResult.cs" />
     <Compile Include="LinkedFileDiffMerging\DefaultDocumentTextDifferencingService.cs" />
     <Compile Include="Log\AggregateLogger.cs" />


### PR DESCRIPTION
Fix #2218 : The Formatting Options UseTab, TabSize, IndentSize and
IndentStyle were not getting persisted. This change fixes it. The
integration tests will be added.