### PR TITLE
added explicit DocumentCloseAsync to IIncrementalAnalyzer so that re-analy...

### DIFF
--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -206,6 +206,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             return SpecializedTasks.EmptyTask;
         }
 
+        public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.EmptyTask;
+        }
+
         public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyTask;

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1000,6 +1000,11 @@ End Class";
                 return SpecializedTasks.EmptyTask;
             }
 
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
+
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 return SpecializedTasks.EmptyTask;

--- a/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/BaseDiagnosticIncrementalAnalyzer.cs
@@ -62,7 +62,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <returns></returns>
         public abstract Task DocumentOpenAsync(Document document, CancellationToken cancellationToken);
         /// <summary>
-        /// Flush cached diagnostics produced by a prior analysis of a document.
+        /// Respond to a document being closed in the host.
+        /// </summary>
+        /// <param name="document">The closed document.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public abstract Task DocumentCloseAsync(Document document, CancellationToken cancellationToken);
+        /// <summary>
+        /// Flush cached diagnostics produced by a prior analysis of a document. 
+        /// This will be called in a case where we need to re-analyze a document without textual, syntactic or semantic change of a solution.
+        /// For example, engine or analyzer's option changes.
         /// </summary>
         /// <param name="document">The document whose diagnostics are to be flushed.</param>
         /// <param name="cancellationToken"></param>

--- a/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -96,6 +96,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return Analyzer.DocumentOpenAsync(document, cancellationToken);
             }
 
+            public override Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return Analyzer.DocumentCloseAsync(document, cancellationToken);
+            }
+
             public override Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 return Analyzer.DocumentResetAsync(document, cancellationToken);

--- a/src/Features/Core/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -44,6 +44,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             return SpecializedTasks.EmptyTask;
         }
 
+        public override Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.EmptyTask;
+        }
+
         public override Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyTask;

--- a/src/Features/Core/Notification/SemanticChangeNotificationService.cs
+++ b/src/Features/Core/Notification/SemanticChangeNotificationService.cs
@@ -85,6 +85,11 @@ namespace Microsoft.CodeAnalysis.Notification
                 return SpecializedTasks.EmptyTask;
             }
 
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
+
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
                 return SpecializedTasks.EmptyTask;

--- a/src/Features/Core/SolutionCrawler/AggregateIncrementalAnalyzer.cs
+++ b/src/Features/Core/SolutionCrawler/AggregateIncrementalAnalyzer.cs
@@ -49,6 +49,15 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
+        public async Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+        {
+            IIncrementalAnalyzer analyzer;
+            if (TryGetAnalyzer(document.Project, out analyzer))
+            {
+                await analyzer.DocumentCloseAsync(document, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
         {
             // TODO: Is this correct?

--- a/src/Features/Core/SolutionCrawler/IIncrementalAnalyzer.cs
+++ b/src/Features/Core/SolutionCrawler/IIncrementalAnalyzer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken);
 
         Task DocumentOpenAsync(Document document, CancellationToken cancellationToken);
+        Task DocumentCloseAsync(Document document, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resets all the document state cached by the analyzer.

--- a/src/Features/Core/SolutionCrawler/IncrementalAnalyzerBase.cs
+++ b/src/Features/Core/SolutionCrawler/IncrementalAnalyzerBase.cs
@@ -24,6 +24,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             return SpecializedTasks.EmptyTask;
         }
 
+        public virtual Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.EmptyTask;
+        }
+
         public virtual Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyTask;

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         SolutionCrawlerLogger.LogProcessCloseDocument(this.Processor._logAggregator, document.Id.Id);
 
-                        await RunAnalyzersAsync(analyzers, document, (a, d, c) => a.DocumentResetAsync(d, c), cancellationToken).ConfigureAwait(false);
+                        await RunAnalyzersAsync(analyzers, document, (a, d, c) => a.DocumentCloseAsync(d, c), cancellationToken).ConfigureAwait(false);
                     }
 
                     private async Task ProcessReanalyzeDocumentAsync(WorkItem workItem, Document document, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
@@ -307,6 +307,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             return SpecializedTasks.EmptyTask;
         }
 
+        public System.Threading.Tasks.Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.EmptyTask;
+        }
+
         public System.Threading.Tasks.Task AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyTask;

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -112,6 +112,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 return SpecializedTasks.EmptyTask;
             }
 
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return DocumentResetAsync(document, cancellationToken);
+            }
+
             private void RaiseEmptyDiagnosticUpdated(DocumentId documentId)
             {
                 _service.RaiseDiagnosticsUpdated(new DiagnosticsUpdatedArgs(ValueTuple.Create(this, documentId), _workspace, null, documentId.ProjectId, documentId, ImmutableArray<DiagnosticData>.Empty));

--- a/src/VisualStudio/Core/Def/Implementation/SolutionSize/SolutionSizeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SolutionSize/SolutionSizeTracker.cs
@@ -149,6 +149,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionSize
                 return SpecializedTasks.EmptyTask;
             }
 
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
+
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 return SpecializedTasks.EmptyTask;

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
@@ -108,6 +108,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return SpecializedTasks.EmptyTask;
             }
 
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
+
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 return SpecializedTasks.EmptyTask;

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Diagnostics_DocumentOpen,
         Diagnostics_RemoveDocument,
         Diagnostics_RemoveProject,
+        Diagnostics_DocumentClose,
 
         // add new values after this
         Run_Environment,


### PR DESCRIPTION
...sis and close action have different behavior.

outcome of this change is that, when a user closes a document without saving, diagnostics will be cleared as expected.