### PR TITLE
Change sibling check to use similarity instead of exact match

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -321,7 +321,7 @@ class C
             Assert.Equal("this.", changes[0].NewText);
         }
 
-        [Fact(Skip = "463"), WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
+        [Fact, WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
         public void TestReplaceWithBuiltInType()
         {
             var original = @"
@@ -364,8 +364,6 @@ public class TestClass
         private void TestReplaceWithBuiltInTypeCore(SyntaxNode root, int index)
         {
             var oldTree = root.SyntaxTree;
-
-            var nodesToReplace = root.DescendantNodes().Where(n => n is SimpleNameSyntax && n.ToString() == "Object");
 
             var span = new TextSpan(index, 6);
             var node = root.FindNode(span, getInnermostNodeForTie: true) as SimpleNameSyntax;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -242,12 +242,17 @@ namespace Microsoft.CodeAnalysis
                     // either there is no match for the first new-node in the old-list or the 
                     // the similarity of the first old-node in the new-list is much greater
 
+                    // if we find a match for the old node in the new list, that probably means nodes were inserted before it.
                     if (indexOfOldInNew > 0)
                     {
                         // look ahead to see if the old node also appears again later in its own list
-                        var oldHasIdenticalSibling = FindExactMatch(_oldNodes, _oldNodes.Peek(), 1) >= 1;
+                        int indexOfOldInOld;
+                        int similarityOfOldInOld;
+                        FindBestMatch(_oldNodes, _oldNodes.Peek(), out indexOfOldInOld, out similarityOfOldInOld, 1);
 
-                        if (!oldHasIdenticalSibling)
+                        // don't declare an insert if the node also appeared later in the original list
+                        var oldHasSimilarSibling = (indexOfOldInOld >= 1 && similarityOfOldInOld >= similarityOfOldInNew);
+                        if (!oldHasSimilarSibling)
                         {
                             return new DiffAction(DiffOp.InsertNew, indexOfOldInNew);
                         }
@@ -331,28 +336,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static int FindExactMatch(Stack<SyntaxNodeOrToken> stack, SyntaxNodeOrToken node, int startIndex)
-        {
-            int i = 0;
-            foreach (var stackNode in stack)
-            {
-                if (i >= MaxSearchLength)
-                {
-                    break;
-                }
-
-                if (i >= startIndex && AreIdentical(stackNode, node))
-                {
-                    return i;
-                }
-
-                i++;
-            }
-
-            return -1;
-        }
-
-        private void FindBestMatch(Stack<SyntaxNodeOrToken> stack, SyntaxNodeOrToken node, out int index, out int similarity)
+        private void FindBestMatch(Stack<SyntaxNodeOrToken> stack, SyntaxNodeOrToken node, out int index, out int similarity, int startIndex = 0)
         {
             index = -1;
             similarity = -1;
@@ -365,64 +349,67 @@ namespace Microsoft.CodeAnalysis
                     break;
                 }
 
-                if (AreIdentical(stackNode, node))
+                if (i >= startIndex)
                 {
-                    var sim = node.FullSpan.Length;
-                    if (sim > similarity)
+                    if (AreIdentical(stackNode, node))
                     {
-                        index = i;
-                        similarity = sim;
-                        return;
-                    }
-                }
-                else if (AreSimilar(stackNode, node))
-                {
-                    var sim = GetSimilarity(stackNode, node);
-
-                    // Are these really the same? This may be expensive so only check this if 
-                    // similarity is rated equal to them being identical.
-                    if (sim == node.FullSpan.Length && node.IsToken)
-                    {
-                        if (stackNode.ToFullString() == node.ToFullString())
+                        var sim = node.FullSpan.Length;
+                        if (sim > similarity)
                         {
                             index = i;
                             similarity = sim;
                             return;
                         }
                     }
-
-                    if (sim > similarity)
+                    else if (AreSimilar(stackNode, node))
                     {
-                        index = i;
-                        similarity = sim;
-                    }
-                }
-                else
-                {
-                    // check one level deep inside list node's children
-                    int j = 0;
-                    foreach (var child in stackNode.ChildNodesAndTokens())
-                    {
-                        if (j >= MaxSearchLength)
-                        {
-                            break;
-                        }
+                        var sim = GetSimilarity(stackNode, node);
 
-                        j++;
-
-                        if (AreIdentical(child, node))
+                        // Are these really the same? This may be expensive so only check this if 
+                        // similarity is rated equal to them being identical.
+                        if (sim == node.FullSpan.Length && node.IsToken)
                         {
-                            index = i;
-                            similarity = node.FullSpan.Length;
-                            return;
-                        }
-                        else if (AreSimilar(child, node))
-                        {
-                            var sim = GetSimilarity(child, node);
-                            if (sim > similarity)
+                            if (stackNode.ToFullString() == node.ToFullString())
                             {
                                 index = i;
                                 similarity = sim;
+                                return;
+                            }
+                        }
+
+                        if (sim > similarity)
+                        {
+                            index = i;
+                            similarity = sim;
+                        }
+                    }
+                    else
+                    {
+                        // check one level deep inside list node's children
+                        int j = 0;
+                        foreach (var child in stackNode.ChildNodesAndTokens())
+                        {
+                            if (j >= MaxSearchLength)
+                            {
+                                break;
+                            }
+
+                            j++;
+
+                            if (AreIdentical(child, node))
+                            {
+                                index = i;
+                                similarity = node.FullSpan.Length;
+                                return;
+                            }
+                            else if (AreSimilar(child, node))
+                            {
+                                var sim = GetSimilarity(child, node);
+                                if (sim > similarity)
+                                {
+                                    index = i;
+                                    similarity = sim;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fix for #463 

The syntax differ algorithm tries to determine if an insert occurred by noticing that the old version of the sub-tree it is considering appears later in the local region of the new tree.  

For example, there used to be an 'X' here but now there is a 'Y'.  However, there is an 'X' that appears right after the 'Y'.  In this case, the algorithm decides that the 'Y' was inserted.  

Yet, the algorithm is easily fooled if the original has multiple of the same nodes. In this case, the original had 'XX' and the new tree has 'YX'.  Instead of assuming that the 'Y' was inserted and later deducing that an 'X' is missing (a delete), it is better to consider that the 'X' was turned into a 'Y'.

The original fix was to not consider the change an insert if the original tree had nearby duplicates. However, it required the green nodes to exactly match to consider the two nodes as duplicates.

The new fix changes what it means to be a duplicate. It now uses the same similarity measure that was used to determine if the old nodes has a match further on in the new tree, and only if this match is better than the similarity between the two old tree nodes does it determine that an insert has occurred.