### PR TITLE
Updated - More use of nameof() operator in ArgumentException and derived classes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -774,7 +774,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (compilationUnit != syntaxTree.GetRoot())
                 {
-                    throw new ArgumentOutOfRangeException("compilationUnit", "node not part of tree");
+                    throw new ArgumentOutOfRangeException(nameof(compilationUnit), "node not part of tree");
                 }
 
                 var extraInfo = inUsing

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (index < 0 || index > list.Count)
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             if (items == null)

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -42,12 +42,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (!languageVersion.IsValid())
             {
-                throw new ArgumentOutOfRangeException("languageVersion");
+                throw new ArgumentOutOfRangeException(nameof(languageVersion));
             }
 
             if (!kind.IsValid())
             {
-                throw new ArgumentOutOfRangeException("kind");
+                throw new ArgumentOutOfRangeException(nameof(kind));
             }
 
             if (preprocessorSymbols != null)
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!kind.IsValid())
             {
-                throw new ArgumentOutOfRangeException("kind");
+                throw new ArgumentOutOfRangeException(nameof(kind));
             }
 
             return new CSharpParseOptions(this) { Kind = kind };
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!version.IsValid())
             {
-                throw new ArgumentOutOfRangeException("version");
+                throw new ArgumentOutOfRangeException(nameof(version));
             }
 
             return new CSharpParseOptions(this) { LanguageVersion = version };
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!documentationMode.IsValid())
             {
-                throw new ArgumentOutOfRangeException("documentationMode");
+                throw new ArgumentOutOfRangeException(nameof(documentationMode));
             }
 
             return new CSharpParseOptions(this) { DocumentationMode = documentationMode };

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1237,7 +1237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (specialType <= SpecialType.None || specialType > SpecialType.Count)
             {
-                throw new ArgumentOutOfRangeException("specialType");
+                throw new ArgumentOutOfRangeException(nameof(specialType));
             }
 
             var result = Assembly.GetSpecialType(specialType);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (trees == null)
             {
-                throw new ArgumentNullException("trees");
+                throw new ArgumentNullException(nameof(trees));
             }
 
             if (trees.IsEmpty())
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (trees == null)
             {
-                throw new ArgumentNullException("trees");
+                throw new ArgumentNullException(nameof(trees));
             }
 
             if (trees.IsEmpty())
@@ -811,7 +811,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (oldTree == null)
             {
-                throw new ArgumentNullException("oldTree");
+                throw new ArgumentNullException(nameof(oldTree));
             }
 
             if (newTree == null)
@@ -917,7 +917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (reference == null)
             {
-                throw new ArgumentNullException("reference");
+                throw new ArgumentNullException(nameof(reference));
             }
 
             if (reference.Properties.Kind == MetadataImageKind.Assembly)
@@ -1557,12 +1557,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             var cssource = source.EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>("source");
@@ -1580,7 +1580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)elementType == null)
             {
-                throw new ArgumentNullException("elementType");
+                throw new ArgumentNullException(nameof(elementType));
             }
 
             return new ArrayTypeSymbol(this.Assembly, elementType, ImmutableArray<CustomModifier>.Empty, rank);
@@ -1593,7 +1593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)elementType == null)
             {
-                throw new ArgumentNullException("elementType");
+                throw new ArgumentNullException(nameof(elementType));
             }
 
             return new PointerTypeSymbol(elementType);
@@ -1610,7 +1610,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (syntaxTree == null)
             {
-                throw new ArgumentNullException("tree");
+                throw new ArgumentNullException(nameof(syntaxTree));
             }
 
             if (!this.SyntaxTrees.Contains((SyntaxTree)syntaxTree))
@@ -2742,7 +2742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (trees == null)
             {
-                throw new ArgumentNullException("trees");
+                throw new ArgumentNullException(nameof(trees));
             }
 
             return this.AddSyntaxTrees(trees.Cast<SyntaxTree>());
@@ -2758,7 +2758,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (trees == null)
             {
-                throw new ArgumentNullException("trees");
+                throw new ArgumentNullException(nameof(trees));
             }
 
             return this.RemoveSyntaxTrees(trees.Cast<SyntaxTree>());

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1079,7 +1079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return fullStart;
             }
 
-            throw new ArgumentOutOfRangeException("position", position,
+            throw new ArgumentOutOfRangeException(nameof(position), position,
                 string.Format(CSharpResources.PositionIsNotWithinSyntax, Root.FullSpan));
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (expression == null)
             {
-                throw new ArgumentNullException("expression");
+                throw new ArgumentNullException(nameof(expression));
             }
 
             crefSymbols = default(ImmutableArray<Symbol>);
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (attribute == null)
             {
-                throw new ArgumentNullException("attribute");
+                throw new ArgumentNullException(nameof(attribute));
             }
 
             binder = this.GetSpeculativeBinderForAttribute(position);
@@ -672,7 +672,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (constructorInitializer == null)
             {
-                throw new ArgumentNullException("speculativeConstructorInitializer");
+                throw new ArgumentNullException(nameof(constructorInitializer));
             }
 
             // NOTE: since we're going to be depending on a MemberModel to do the binding for us,
@@ -1130,7 +1130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (syntax == null)
             {
-                throw new ArgumentNullException("syntax");
+                throw new ArgumentNullException(nameof(syntax));
             }
 
             if (!IsInTree(syntax))
@@ -1144,7 +1144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (syntax == null)
             {
-                throw new ArgumentNullException("syntax");
+                throw new ArgumentNullException(nameof(syntax));
             }
 
             if (this.IsSpeculativeSemanticModel)
@@ -1577,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)symbol == null)
             {
-                throw new ArgumentNullException("symbol");
+                throw new ArgumentNullException(nameof(symbol));
             }
 
             var cssymbol = symbol.EnsureCSharpSymbolOrNull<ISymbol, Symbol>("symbol");
@@ -2359,7 +2359,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             var cdestination = destination.EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>("destination");
@@ -2423,7 +2423,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             position = CheckAndAdjustPosition(position);
@@ -4219,7 +4219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             var expression = node as ExpressionSyntax;
@@ -4265,7 +4265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             var expression = node as ExpressionSyntax;
@@ -4299,7 +4299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             var expression = node as ExpressionSyntax;
@@ -4550,12 +4550,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (firstStatement == null)
             {
-                throw new ArgumentNullException("firstStatement");
+                throw new ArgumentNullException(nameof(firstStatement));
             }
 
             if (lastStatement == null)
             {
-                throw new ArgumentNullException("lastStatement");
+                throw new ArgumentNullException(nameof(lastStatement));
             }
 
             if (!(firstStatement is StatementSyntax))
@@ -4575,7 +4575,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (statement == null)
             {
-                throw new ArgumentNullException("statement");
+                throw new ArgumentNullException(nameof(statement));
             }
 
             if (!(statement is StatementSyntax))
@@ -4590,12 +4590,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (firstStatement == null)
             {
-                throw new ArgumentNullException("firstStatement");
+                throw new ArgumentNullException(nameof(firstStatement));
             }
 
             if (lastStatement == null)
             {
-                throw new ArgumentNullException("lastStatement");
+                throw new ArgumentNullException(nameof(lastStatement));
             }
 
             if (!(firstStatement is StatementSyntax))
@@ -4615,7 +4615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (statementOrExpression == null)
             {
-                throw new ArgumentNullException("statementOrExpression");
+                throw new ArgumentNullException(nameof(statementOrExpression));
             }
 
             if (statementOrExpression is StatementSyntax)
@@ -4636,7 +4636,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             return node is ExpressionSyntax

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             var csdestination = destination.EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>("destination");
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             var binder = this.GetEnclosingBinder(expression, GetAdjustedNodePosition(expression));

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!this.Compilation.SyntaxTrees.Contains(syntaxTree))
             {
-                throw new ArgumentOutOfRangeException("tree", CSharpResources.TreeNotPartOfCompilation);
+                throw new ArgumentOutOfRangeException(nameof(syntaxTree), CSharpResources.TreeNotPartOfCompilation);
             }
 
             _binderFactory = compilation.GetBinderFactory(SyntaxTree);

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             // TODO(cyrusn): Check arguments.  This is a public entrypoint, so we must do appropriate
@@ -505,7 +505,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
 
             var model = this.GetMemberModel(expression);
@@ -1837,7 +1837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (typeParameter == null)
             {
-                throw new ArgumentNullException("typeParameter");
+                throw new ArgumentNullException(nameof(typeParameter));
             }
 
             if (!IsInTree(typeParameter))
@@ -1902,12 +1902,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (firstStatement == null)
             {
-                throw new ArgumentNullException("firstStatement");
+                throw new ArgumentNullException(nameof(firstStatement));
             }
 
             if (lastStatement == null)
             {
-                throw new ArgumentNullException("lastStatement");
+                throw new ArgumentNullException(nameof(lastStatement));
             }
 
             if (!IsInTree(firstStatement))
@@ -1930,7 +1930,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (expression == null)
             {
-                throw new ArgumentNullException("expression");
+                throw new ArgumentNullException(nameof(expression));
             }
 
             if (!IsInTree(expression))

--- a/src/Compilers/CSharp/Portable/Errors/CSDiagnostic.cs
+++ b/src/Compilers/CSharp/Portable/Errors/CSDiagnostic.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (location == null)
             {
-                throw new ArgumentNullException("location");
+                throw new ArgumentNullException(nameof(location));
             }
 
             if (location != this.Location)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             var useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes);

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (symbol == null)
             {
-                throw new ArgumentNullException("symbol");
+                throw new ArgumentNullException(nameof(symbol));
             }
 
             if (minimal)

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (fullyQualifiedMetadataName == null)
             {
-                throw new ArgumentNullException("fullyQualifiedMetadataName");
+                throw new ArgumentNullException(nameof(fullyQualifiedMetadataName));
             }
 
             var emittedName = MetadataTypeName.FromFullName(fullyQualifiedMetadataName);
@@ -505,7 +505,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (fullyQualifiedMetadataName == null)
             {
-                throw new ArgumentNullException("fullyQualifiedMetadataName");
+                throw new ArgumentNullException(nameof(fullyQualifiedMetadataName));
             }
 
             return this.GetTypeByMetadataName(fullyQualifiedMetadataName, includeReferences: false, isWellKnownType: false);

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if ((object)receiverType == null)
             {
-                throw new ArgumentNullException("receiverType");
+                throw new ArgumentNullException(nameof(receiverType));
             }
 
             if (!this.IsExtensionMethod || this.MethodKind == MethodKind.ReducedExtension)
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (typeArguments.IsDefault)
             {
-                throw new ArgumentNullException("typeArguments");
+                throw new ArgumentNullException(nameof(typeArguments));
             }
 
             if (typeArguments.Any(NamedTypeSymbol.TypeSymbolIsNullFunction))

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (namespaceSymbol == null)
             {
-                throw new ArgumentNullException("namespaceSymbol");
+                throw new ArgumentNullException(nameof(namespaceSymbol));
             }
 
             var moduleNs = namespaceSymbol as NamespaceSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (arguments.IsDefault)
             {
-                throw new ArgumentNullException("typeArguments");
+                throw new ArgumentNullException(nameof(arguments));
             }
 
             if (arguments.Any(TypeSymbolIsNullFunction))

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if ((object)interfaceMember == null)
             {
-                throw new ArgumentNullException("interfaceMember");
+                throw new ArgumentNullException(nameof(interfaceMember));
             }
 
             return FindImplementationForInterfaceMemberWithDiagnostics(interfaceMember).Symbol;

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!FullSpan.Contains(position))
             {
-                throw new ArgumentOutOfRangeException("position");
+                throw new ArgumentOutOfRangeException(nameof(position));
             }
 
             SyntaxNodeOrToken childNodeOrToken = ChildSyntaxList.ChildThatContainsPosition(this, position);
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!this.FullSpan.Contains(position))
             {
-                throw new ArgumentOutOfRangeException("position");
+                throw new ArgumentOutOfRangeException(nameof(position));
             }
 
             return this.FindTokenInternal(position);

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (stream == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             if (!stream.CanWrite)
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (stream == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             if (!stream.CanRead)

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (root == null)
             {
-                throw new ArgumentNullException("root");
+                throw new ArgumentNullException(nameof(root));
             }
 
             var directives = root.Kind() == SyntaxKind.CompilationUnit ?
@@ -371,12 +371,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             options = options ?? CSharpParseOptions.Default;
@@ -429,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (changes == null)
             {
-                throw new ArgumentNullException("changes");
+                throw new ArgumentNullException(nameof(changes));
             }
 
             var oldTree = this;
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (oldTree == null)
             {
-                throw new ArgumentNullException("oldTree");
+                throw new ArgumentNullException(nameof(oldTree));
             }
 
             return SyntaxDiffer.GetPossiblyDifferentTextSpans(oldTree, this);
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (oldTree == null)
             {
-                throw new ArgumentNullException("oldTree");
+                throw new ArgumentNullException(nameof(oldTree));
             }
 
             return SyntaxDiffer.GetTextChanges(oldTree, this);
@@ -620,7 +620,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             return GetDiagnostics(node.Green, node.Position);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             switch (kind)
@@ -1001,7 +1001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (nodesAndTokens == null)
             {
-                throw new ArgumentNullException("nodesAndTokens");
+                throw new ArgumentNullException(nameof(nodesAndTokens));
             }
 
             var builder = new SyntaxNodeOrTokenListBuilder(8);
@@ -1736,7 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (tree == null)
             {
-                throw new ArgumentNullException("tree");
+                throw new ArgumentNullException(nameof(tree));
             }
 
             if (!tree.HasCompilationUnitRoot)

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCommandLineArguments.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (metadataResolver == null)
             {
-                throw new ArgumentNullException("metadataResolver");
+                throw new ArgumentNullException(nameof(metadataResolver));
             }
 
             return ResolveMetadataReferences(metadataResolver, diagnosticsOpt: null, messageProviderOpt: null);

--- a/src/Compilers/Core/Desktop/SourceFileResolver.cs
+++ b/src/Compilers/Core/Desktop/SourceFileResolver.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (searchPaths.IsDefault)
             {
-                throw new ArgumentNullException("searchPaths");
+                throw new ArgumentNullException(nameof(searchPaths));
             }
 
             if (baseDirectory != null && PathUtilities.GetPathKind(baseDirectory) != PathKind.Absolute)

--- a/src/Compilers/Core/Portable/Text/LinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Text/LinePositionSpan.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             if (end < start)
             {
-                throw new ArgumentException("end", CodeAnalysisResources.EndMustNotBeLessThanStart);
+                throw new ArgumentException(CodeAnalysisResources.EndMustNotBeLessThanStart, nameof(end));
             }
 
             _start = start;

--- a/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
+++ b/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             if (arguments.Length > ushort.MaxValue)
             {
-                throw new ArgumentOutOfRangeException("arguments",
+                throw new ArgumentOutOfRangeException(nameof(arguments),
                     "Too many arguments: maximum of "
                     + ushort.MaxValue + " arguments allowed.");
             }

--- a/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
+++ b/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (displayName == null)
             {
-                throw new ArgumentNullException("displayName");
+                throw new ArgumentNullException(nameof(displayName));
             }
 
             location = null;

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             if (!(occurrence > 0))
             {
-                throw new ArgumentException("Specified value must be greater than zero.", "occurrence");
+                throw new ArgumentException("Specified value must be greater than zero.", nameof(occurrence));
             }
             SyntaxNodeOrToken foundNode = default(SyntaxNodeOrToken);
             if (TryFindNodeOrToken(syntaxTree.GetCompilationUnitRoot(), kind, ref occurrence, ref foundNode))

--- a/src/Compilers/Test/Utilities/Core2/DirectoryHelper.cs
+++ b/src/Compilers/Test/Utilities/Core2/DirectoryHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             if (!Directory.Exists(path))
             {
-                throw new ArgumentException("Directory '" + path + "' does not exist.", "path");
+                throw new ArgumentException("Directory '" + path + "' does not exist.", nameof(path));
             }
 
             _rootPath = path;

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -584,7 +584,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function WithOptions(newOptions As VisualBasicCompilationOptions) As VisualBasicCompilation
             If newOptions Is Nothing Then
-                Throw New ArgumentNullException("options")
+                Throw New ArgumentNullException(NameOf(newOptions))
             End If
 
             Dim c As VisualBasicCompilation = Nothing
@@ -964,7 +964,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shadows Function ReplaceSyntaxTree(oldTree As SyntaxTree, newTree As SyntaxTree) As VisualBasicCompilation
             If oldTree Is Nothing Then
-                Throw New ArgumentNullException("oldSyntaxTree")
+                Throw New ArgumentNullException(NameOf(oldTree))
             End If
 
             If newTree Is Nothing Then

--- a/src/Diagnostics/FxCop/Core/Shared/Extensions/IEnumerableExtensions.cs
+++ b/src/Diagnostics/FxCop/Core/Shared/Extensions/IEnumerableExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Utilities
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             return source as ISet<T> ?? new HashSet<T>(source);

--- a/src/Diagnostics/FxCop/Core/Shared/WordParser.cs
+++ b/src/Diagnostics/FxCop/Core/Shared/WordParser.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Utilities
 
             if (options < WordParserOptions.None || options > (WordParserOptions.IgnoreMnemonicsIndicators | WordParserOptions.SplitCompoundWords))
             {
-                throw new InvalidEnumArgumentException("options", (int)options, typeof(WordParserOptions));
+                throw new InvalidEnumArgumentException(nameof(options), (int)options, typeof(WordParserOptions));
             }
 
             _text = text;

--- a/src/Diagnostics/FxCop/Core/Shared/WordParser.cs
+++ b/src/Diagnostics/FxCop/Core/Shared/WordParser.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Utilities
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             if (options < WordParserOptions.None || options > (WordParserOptions.IgnoreMnemonicsIndicators | WordParserOptions.SplitCompoundWords))
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Utilities
         {
             if (words == null)
             {
-                throw new ArgumentNullException("words");
+                throw new ArgumentNullException(nameof(words));
             }
 
             WordParser parser = new WordParser(text, options, prefix);

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             if (expectedSymbols <= 1)
             {
-                throw new ArgumentOutOfRangeException("expectedSymbols");
+                throw new ArgumentOutOfRangeException(nameof(expectedSymbols));
             }
 
             return "+" + NonBreakingSpace + (expectedSymbols - 1) + NonBreakingSpace + FeaturesResources.Overload;

--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 if (editorSnapshot == null)
                 {
-                    throw new ArgumentNullException("textSnapshot");
+                    throw new ArgumentNullException(nameof(editorSnapshot));
                 }
 
                 return s_textSnapshotMap.GetValue(editorSnapshot, s_createTextCallback);
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 if (changes == null)
                 {
-                    throw new ArgumentNullException("changes");
+                    throw new ArgumentNullException(nameof(changes));
                 }
 
                 if (!changes.Any())
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Text
                 {
                     if (oldText == null)
                     {
-                        throw new ArgumentNullException("oldText");
+                        throw new ArgumentNullException(nameof(oldText));
                     }
 
                     // if they are the same text there is no change.
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 if (oldText == null)
                 {
-                    throw new ArgumentNullException("oldText");
+                    throw new ArgumentNullException(nameof(oldText));
                 }
 
                 // if they are the same text there is no change.

--- a/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
+++ b/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 if (buffer == null)
                 {
-                    throw new ArgumentNullException("buffer");
+                    throw new ArgumentNullException(nameof(buffer));
                 }
 
                 return s_textContainerMap.GetValue(buffer, s_createContainerCallback);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var type = typeAndInfo.Type;
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             var dynamicFlags = new DynamicFlagsCustomTypeInfo(typeAndInfo.Info);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrValue.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             if (RawValue == null)
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             // The real version does some sort of dynamic dispatch that ultimately calls this method.
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             return _formatter.HasUnderlyingString(this, inspectionContext);
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             return _formatter.GetUnderlyingString(this, inspectionContext);
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             // This is a rough approximation of the real functionality.  Basically,
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             var pooled = PooledStringBuilder.GetInstance();
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (InspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(InspectionContext));
             }
 
             if (this.IsError())
@@ -525,7 +525,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             var array = (System.Array)RawValue;
@@ -585,7 +585,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             var lmrType = proxyType.GetLmrType();
@@ -616,7 +616,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 
             if (inspectionContext == null)
             {
-                throw new ArgumentNullException("inspectionContext");
+                throw new ArgumentNullException(nameof(inspectionContext));
             }
 
             var appDomain = enumerableType.AppDomain;

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmDataContainer.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmDataContainer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.Debugger
             {
                 if (_dataItems.ContainsKey(key))
                 {
-                    throw new ArgumentException("Data item already exists", "item");
+                    throw new ArgumentException("Data item already exists", nameof(item));
                 }
             }
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmDataContainer.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmDataContainer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Debugger
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
 
             Guid key = item.GetType().GUID;

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluateDebuggerDisplayStringAsyncResult.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluateDebuggerDisplayStringAsyncResult.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (result == null)
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
             _result = result;

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationAsyncResult.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationAsyncResult.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         {
             if (Result == null)
             {
-                throw new ArgumentNullException("Result");
+                throw new ArgumentNullException(nameof(Result));
             }
 
             _result = Result;

--- a/src/Features/Core/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
+++ b/src/Features/Core/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
@@ -29,12 +29,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (languages == null)
             {
-                throw new ArgumentNullException("languages");
+                throw new ArgumentNullException(nameof(languages));
             }
 
             if (languages.Length == 0)

--- a/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             var newSemanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/SolutionCrawler/Extensibility/ExportIncrementalAnalyzerProviderAttribute.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/ExportIncrementalAnalyzerProviderAttribute.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             if (workspaceKinds == null)
             {
-                throw new ArgumentNullException("workspaceKinds");
+                throw new ArgumentNullException(nameof(workspaceKinds));
             }
 
             this.WorkspaceKinds = workspaceKinds;

--- a/src/Features/Core/SolutionCrawler/Extensibility/ExportPerLanguageIncrementalAnalyzerProviderAttribute.cs
+++ b/src/Features/Core/SolutionCrawler/Extensibility/ExportPerLanguageIncrementalAnalyzerProviderAttribute.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             this.Name = name;

--- a/src/Features/Core/Workspace/FileTracker.cs
+++ b/src/Features/Core/Workspace/FileTracker.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Host
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             using (_guard.DisposableWait())

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 {
                     if (value == null)
                     {
-                        throw new ArgumentNullException("value");
+                        throw new ArgumentNullException(nameof(value));
                     }
 
                     _formattingOptions = value;

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 var oldOutput = Interlocked.Exchange(ref _output, value);
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 var oldOutput = Interlocked.Exchange(ref _errorOutput, value);
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             return Async<RemoteExecutionResult>((service, operation) => service.ExecuteFileAsync(operation, path));

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
                 if (value == null)
                 {
-                    throw new ArgumentNullException("engine");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 if (_engine != value)

--- a/src/InteractiveWindow/Editor/SmartIndent/InteractiveSmartIndenterProvider.cs
+++ b/src/InteractiveWindow/Editor/SmartIndent/InteractiveSmartIndenterProvider.cs
@@ -22,12 +22,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         {
             if (editorFactory == null)
             {
-                throw new ArgumentNullException("editorFactory");
+                throw new ArgumentNullException(nameof(editorFactory));
             }
 
             if (indentProviders == null)
             {
-                throw new ArgumentNullException("indentProviders");
+                throw new ArgumentNullException(nameof(indentProviders));
             }
 
             _editorFactory = editorFactory;

--- a/src/InteractiveWindow/Editor/SubmissionBufferAddedEventArgs.cs
+++ b/src/InteractiveWindow/Editor/SubmissionBufferAddedEventArgs.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         {
             if (newBuffer == null)
             {
-                throw new ArgumentNullException("newBuffer");
+                throw new ArgumentNullException(nameof(newBuffer));
             }
 
             _newBuffer = newBuffer;

--- a/src/Scripting/Core/InteractiveAssemblyLoader.cs
+++ b/src/Scripting/Core/InteractiveAssemblyLoader.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
             if (!PathUtilities.IsAbsolute(path))
             {
-                throw new ArgumentException("Path must be absolute", "path");
+                throw new ArgumentException("Path must be absolute", nameof(path));
             }
 
             try

--- a/src/Scripting/Core/InteractiveAssemblyLoader.cs
+++ b/src/Scripting/Core/InteractiveAssemblyLoader.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             if (!PathUtilities.IsAbsolute(path))
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (dependency == null)
             {
-                throw new ArgumentNullException("dependency");
+                throw new ArgumentNullException(nameof(dependency));
             }
 
             if (string.IsNullOrEmpty(location))

--- a/src/Scripting/Core/MetadataShadowCopyProvider.cs
+++ b/src/Scripting/Core/MetadataShadowCopyProvider.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (kind < MetadataImageKind.Assembly || kind > MetadataImageKind.Module)
             {
-                throw new ArgumentOutOfRangeException("kind");
+                throw new ArgumentOutOfRangeException(nameof(kind));
             }
 
             FileKey key = FileKey.Create(fullPath);

--- a/src/Scripting/Core/ObjectFormattingOptions.cs
+++ b/src/Scripting/Core/ObjectFormattingOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (!memberFormat.IsValid())
             {
-                throw new ArgumentOutOfRangeException("memberFormat");
+                throw new ArgumentOutOfRangeException(nameof(memberFormat));
             }
 
             this.MemberFormat = memberFormat;

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             {
                 if (_globalsType != null && globals == null)
                 {
-                    throw new ArgumentNullException("globals");
+                    throw new ArgumentNullException(nameof(globals));
                 }
                 else if (globals != null && _globalsType != null)
                 {

--- a/src/Scripting/Test/ScriptEngine.cs
+++ b/src/Scripting/Test/ScriptEngine.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (hostObject == null)
             {
-                throw new ArgumentNullException("hostObject");
+                throw new ArgumentNullException(nameof(hostObject));
             }
 
             return new Session(this, _options, hostObject, hostObject.GetType());
@@ -133,12 +133,12 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (hostObject == null)
             {
-                throw new ArgumentNullException("hostObject");
+                throw new ArgumentNullException(nameof(hostObject));
             }
 
             if (hostObjectType == null)
             {
-                throw new ArgumentNullException("hostObjectType");
+                throw new ArgumentNullException(nameof(hostObjectType));
             }
 
             Type actualType = hostObject.GetType();
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (hostObject == null)
             {
-                throw new ArgumentNullException("hostObject");
+                throw new ArgumentNullException(nameof(hostObject));
             }
 
             return new Session(this, _options, hostObject, typeof(THostObject));

--- a/src/Scripting/Test/ScriptEngine.cs
+++ b/src/Scripting/Test/ScriptEngine.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
             if (!@namespace.IsValidClrNamespaceName())
             {
-                throw new ArgumentException("Invalid namespace name", "namespace");
+                throw new ArgumentException("Invalid namespace name", nameof(@namespace));
             }
         }
 

--- a/src/Scripting/Test/Session.cs
+++ b/src/Scripting/Test/Session.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             string code = File.ReadAllText(path);

--- a/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
+++ b/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
@@ -413,9 +413,9 @@ namespace Roslyn.Test.PdbUtilities
             internal IntHashTable(int capacity, int loadFactorPerc)
             {
                 if (capacity < 0)
-                    throw new ArgumentOutOfRangeException("capacity", "ArgumentOutOfRange_NeedNonNegNum");
+                    throw new ArgumentOutOfRangeException(nameof(capacity), "ArgumentOutOfRange_NeedNonNegNum");
                 if (!(loadFactorPerc >= 10 && loadFactorPerc <= 100))
-                    throw new ArgumentOutOfRangeException("loadFactorPerc", String.Format("ArgumentOutOfRange_IntHashTableLoadFactor", 10, 100));
+                    throw new ArgumentOutOfRangeException(nameof(loadFactorPerc), String.Format("ArgumentOutOfRange_IntHashTableLoadFactor", 10, 100));
 
                 // Based on perf work, .72 is the optimal load factor for this table.
                 _loadFactorPerc = (loadFactorPerc * 72) / 100;

--- a/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
+++ b/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
@@ -540,7 +540,7 @@ namespace Roslyn.Test.PdbUtilities
                 }
                 if (nvalue == null)
                 {
-                    throw new ArgumentNullException("nvalue", "ArgumentNull_Value");
+                    throw new ArgumentNullException(nameof(nvalue), "ArgumentNull_Value");
                 }
                 if (_count >= _loadsize)
                 {

--- a/src/Test/Utilities/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/DiagnosticExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (expected == null)
             {
-                throw new ArgumentException("Must specify expected errors.", "expected");
+                throw new ArgumentException("Must specify expected errors.", nameof(expected));
             }
 
             var unmatched = actual.Select(d => new DiagnosticDescription(d, errorCodeOnly)).ToList();

--- a/src/Test/Utilities/ProcessLauncher.cs
+++ b/src/Test/Utilities/ProcessLauncher.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             string workingDirectory = null,
             IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVars = null)
         {
-            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
 
             var startInfo = new ProcessStartInfo
             {
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             if (fileName == null)
             {
-                throw new ArgumentNullException("fileName");
+                throw new ArgumentNullException(nameof(fileName));
             }
 
             var startInfo = new ProcessStartInfo

--- a/src/Test/Utilities/SharedCompilationUtils.cs
+++ b/src/Test/Utilities/SharedCompilationUtils.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public static void IlasmTempAssembly(string declarations, bool appendDefaultHeader, bool includePdb, out string assemblyPath, out string pdbPath)
         {
-            if (declarations == null) throw new ArgumentNullException("declarations");
+            if (declarations == null) throw new ArgumentNullException(nameof(declarations));
 
             using (var sourceFile = new DisposableFile(extension: ".il"))
             {
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// </returns>
         public static string RunPEVerify(byte[] assembly)
         {
-            if (assembly == null) throw new ArgumentNullException("assembly");
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
 
             var pathToPEVerify = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),

--- a/src/Test/Utilities/TestHelpers.cs
+++ b/src/Test/Utilities/TestHelpers.cs
@@ -14,7 +14,7 @@ namespace Roslyn.Test.Utilities
         {
             if (assembly == null || interfaceType == null || !interfaceType.IsInterface)
             {
-                throw new ArgumentException("interfaceType is not an interface.", "interfaceType");
+                throw new ArgumentException("interfaceType is not an interface.", nameof(interfaceType));
             }
 
             return assembly.GetTypes().Where((t) =>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -741,7 +741,7 @@ namespace CSharpSyntaxGenerator
                 if (!IsAnyList(field.Type) && !IsOptional(field))
                 {
                     WriteLine("      if ({0} == null)", CamelCase(field.Name));
-                    WriteLine("        throw new ArgumentNullException(\"{0}\");", CamelCase(field.Name));
+                    WriteLine("        throw new ArgumentNullException(nameof({0}));", CamelCase(field.Name));
                 }
                 if (field.Type == "SyntaxToken" && field.Kinds != null && field.Kinds.Count > 0)
                 {
@@ -1594,7 +1594,7 @@ namespace CSharpSyntaxGenerator
                 else if (!IsAnyList(field.Type) && !IsOptional(field))
                 {
                     WriteLine("      if ({0} == null)", CamelCase(field.Name));
-                    WriteLine("        throw new ArgumentNullException(\"{0}\");", CamelCase(field.Name));
+                    WriteLine("        throw new ArgumentNullException(nameof({0}));", CamelCase(field.Name));
                 }
             }
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/RedNodes/RedNodeFactoryWriter.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/RedNodes/RedNodeFactoryWriter.vb
@@ -438,7 +438,7 @@ Friend Class RedNodeFactoryWriter
 
     Private Sub CheckParam(name As String)
         _writer.WriteLine("            if {0} Is Nothing Then", name)
-        _writer.WriteLine("                Throw New ArgumentNullException(""{0}"")", name)
+        _writer.WriteLine("                Throw New ArgumentNullException(NameOf({0}))", name)
         _writer.WriteLine("            End If")
     End Sub
 

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSCompilerConfig.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSCompilerConfig.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             if (optionID < 0 || optionID >= CompilerOptions.LARGEST_OPTION_ID)
             {
-                throw new ArgumentOutOfRangeException("optionID");
+                throw new ArgumentOutOfRangeException(nameof(optionID));
             }
 
             Marshal.GetNativeVariantForObject(_options[(int)optionID], variant);

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/CodeElementSnapshot.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/CodeElementSnapshot.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             {
                 if (index < 0 || index >= _elements.Length)
                 {
-                    throw new ArgumentOutOfRangeException("index");
+                    throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
                 return _elements[index];

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/NodeSnapshot.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/NodeSnapshot.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             {
                 if (index < 0 || index >= _nodes.Length)
                 {
-                    throw new ArgumentOutOfRangeException("index");
+                    throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
                 var node = _nodes[index];

--- a/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             {
                 // Note: An ordinal value of -1 is special -- it means that this is the node
                 // key for an "unknown" code model element.
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
 
             _name = name;

--- a/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             if (directive == null)
             {
-                throw new ArgumentNullException("directive");
+                throw new ArgumentNullException(nameof(directive));
             }
 
             var directiveSyntaxMap = GetDirectiveInfo(directive, cancellationToken).DirectiveMap;
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             if (directive == null)
             {
-                throw new ArgumentNullException("directive");
+                throw new ArgumentNullException(nameof(directive));
             }
 
             var directiveConditionalMap = GetDirectiveInfo(directive, cancellationToken).ConditionalMap;

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             // we could check up front that index is within FullSpan,
             // but we wan to optimize for the common case where position is valid.
             Debug.Assert(!self.FullSpan.Contains(position), "Position is valid. How could we not find a child?");
-            throw new ArgumentOutOfRangeException("position");
+            throw new ArgumentOutOfRangeException(nameof(position));
         }
 
         public static SyntaxNode GetParent(this SyntaxNode node)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (position < 0 || position > root.Span.End)
             {
-                throw new ArgumentOutOfRangeException("position");
+                throw new ArgumentOutOfRangeException(nameof(position));
             }
 
             return root

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (root == null)
             {
-                throw new ArgumentNullException("root");
+                throw new ArgumentNullException(nameof(root));
             }
 
             if (position < 0 || position > root.Span.End)

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Documentation/DocumentationProviderServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Documentation/DocumentationProviderServiceFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 if (assemblyPath == null)
                 {
-                    throw new ArgumentNullException("assemblyPath");
+                    throw new ArgumentNullException(nameof(assemblyPath));
                 }
 
                 assemblyPath = Path.ChangeExtension(assemblyPath, "xml");

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (exportProvider == null)
             {
-                throw new ArgumentNullException("exportProvider");
+                throw new ArgumentNullException(nameof(exportProvider));
             }
 
             return new MefV1HostServices(exportProvider);
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (assemblies == null)
             {
-                throw new ArgumentNullException("assemblies");
+                throw new ArgumentNullException(nameof(assemblies));
             }
 
             var catalog = new AggregateCatalog(assemblies.Select(a => new AssemblyCatalog(a)));

--- a/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Host
                         var target = _start + value;
                         if (target < _start || target >= _end)
                         {
-                            throw new ArgumentOutOfRangeException("value");
+                            throw new ArgumentOutOfRangeException(nameof(value));
                         }
 
                         _current = target;
@@ -359,17 +359,17 @@ namespace Microsoft.CodeAnalysis.Host
                                 break;
 
                             default:
-                                throw new ArgumentOutOfRangeException("origin");
+                                throw new ArgumentOutOfRangeException(nameof(origin));
                         }
                     }
                     catch (OverflowException)
                     {
-                        throw new ArgumentOutOfRangeException("offset");
+                        throw new ArgumentOutOfRangeException(nameof(offset));
                     }
 
                     if (target < _start || target >= _end)
                     {
-                        throw new ArgumentOutOfRangeException("offset");
+                        throw new ArgumentOutOfRangeException(nameof(offset));
                     }
 
                     _current = target;

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
@@ -81,12 +81,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             if (properties == null)
             {
-                throw new ArgumentNullException("properties");
+                throw new ArgumentNullException(nameof(properties));
             }
 
             if (hostServices == null)
             {
-                throw new ArgumentNullException("hostServices");
+                throw new ArgumentNullException(nameof(hostServices));
             }
 
             return new MSBuildWorkspace(hostServices, properties.ToImmutableDictionary());
@@ -128,12 +128,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             if (projectFileExtension == null)
             {
-                throw new ArgumentNullException("projectFileExtension");
+                throw new ArgumentNullException(nameof(projectFileExtension));
             }
 
             using (_dataGuard.DisposableWait())
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             if (projectFilePath == null)
             {
-                throw new ArgumentNullException("projectFilePath");
+                throw new ArgumentNullException(nameof(projectFilePath));
             }
 
             string fullPath;

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileLoader.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             // load project file async

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SolutionFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SolutionFile.cs
@@ -26,17 +26,17 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             if (headerLines == null)
             {
-                throw new ArgumentNullException("headerLines");
+                throw new ArgumentNullException(nameof(headerLines));
             }
 
             if (projectBlocks == null)
             {
-                throw new ArgumentNullException("projectBlocks");
+                throw new ArgumentNullException(nameof(projectBlocks));
             }
 
             if (globalSectionBlocks == null)
             {
-                throw new ArgumentNullException("globalSectionBlocks");
+                throw new ArgumentNullException(nameof(globalSectionBlocks));
             }
 
             _headerLines = headerLines.ToList().AsReadOnly();

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             if (changedSolution == null)
             {
-                throw new ArgumentNullException("changedSolution");
+                throw new ArgumentNullException(nameof(changedSolution));
             }
 
             _changedSolution = changedSolution;

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/OpenDocumentOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/OpenDocumentOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             if (documentId == null)
             {
-                throw new ArgumentNullException("documentId");
+                throw new ArgumentNullException(nameof(documentId));
             }
 
             _documentId = documentId;

--- a/src/Workspaces/Core/Portable/CodeCleanup/CodeCleaner.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/CodeCleaner.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             var service = document.Project.LanguageServices.GetService<ICodeCleanerService>();

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/ExportCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/ExportCodeCleanupProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
         {
             if (languages == null)
             {
-                throw new ArgumentNullException("languages");
+                throw new ArgumentNullException(nameof(languages));
             }
 
             if (languages.Length == 0)

--- a/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
@@ -34,12 +34,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             if (firstLanguage == null)
             {
-                throw new ArgumentNullException("firstLanguage");
+                throw new ArgumentNullException(nameof(firstLanguage));
             }
 
             if (additionalLanguages == null)
             {
-                throw new ArgumentNullException("additionalLanguages");
+                throw new ArgumentNullException(nameof(additionalLanguages));
             }
 
             this.Name = null;

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             if (namespaceOrType == null)
             {
-                throw new ArgumentNullException("namespaceOrType");
+                throw new ArgumentNullException(nameof(namespaceOrType));
             }
 
             if (namespaceOrType is INamespaceSymbol)

--- a/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         {
             if (firstLanguage == null)
             {
-                throw new ArgumentNullException("firstLanguage");
+                throw new ArgumentNullException(nameof(firstLanguage));
             }
 
             if (additionalLanguages == null)
             {
-                throw new ArgumentNullException("additionalLanguages");
+                throw new ArgumentNullException(nameof(additionalLanguages));
             }
 
             this.Name = null;

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -381,12 +381,12 @@ namespace Microsoft.CodeAnalysis.Differencing
         {
             if (oldNodes == null)
             {
-                throw new ArgumentNullException("oldNodes");
+                throw new ArgumentNullException(nameof(oldNodes));
             }
 
             if (newNodes == null)
             {
-                throw new ArgumentNullException("newNodes");
+                throw new ArgumentNullException(nameof(newNodes));
             }
 
             var oldList = (oldNodes as IReadOnlyList<TNode>) ?? oldNodes.ToList();

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1420,7 +1420,7 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             if (dottedName == null)
             {
-                throw new ArgumentNullException("dottedName");
+                throw new ArgumentNullException(nameof(dottedName));
             }
 
             var parts = dottedName.Split(s_dotSeparator);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -377,12 +377,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             if (containingAssembly == null)
             {
-                throw new ArgumentNullException("containingAssembly");
+                throw new ArgumentNullException(nameof(containingAssembly));
             }
 
             if (project == null)
             {
-                throw new ArgumentNullException("project");
+                throw new ArgumentNullException(nameof(project));
             }
 
             if (sourceProject != null)

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -156,12 +156,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             if (symbol == null)
             {
-                throw new ArgumentNullException("symbol");
+                throw new ArgumentNullException(nameof(symbol));
             }
 
             if (compilation == null)
             {
-                throw new ArgumentNullException("compilation");
+                throw new ArgumentNullException(nameof(compilation));
             }
 
             var key = symbol.GetSymbolKey();

--- a/src/Workspaces/Core/Portable/Formatting/AbstractSyntaxFormattingService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/AbstractSyntaxFormattingService.cs
@@ -132,17 +132,17 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             if (spans == null)
             {
-                throw new ArgumentNullException("spans");
+                throw new ArgumentNullException(nameof(spans));
             }
 
             if (options == null)
             {
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
             }
 
             if (rules == null)

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             var service = document.Project.LanguageServices.GetService<ISyntaxFormattingService>();
@@ -53,12 +53,12 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (workspace == null)
             {
-                throw new ArgumentNullException("workspace");
+                throw new ArgumentNullException(nameof(workspace));
             }
 
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             var service = workspace.Services.GetLanguageServices(language).GetService<ISyntaxFormattingService>();
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -126,12 +126,12 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             if (spans == null)
             {
-                throw new ArgumentNullException("spans");
+                throw new ArgumentNullException(nameof(spans));
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -155,12 +155,12 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (document == null)
             {
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             }
 
             if (annotation == null)
             {
-                throw new ArgumentNullException("annotation");
+                throw new ArgumentNullException(nameof(annotation));
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -185,17 +185,17 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             if (workspace == null)
             {
-                throw new ArgumentNullException("workspace");
+                throw new ArgumentNullException(nameof(workspace));
             }
 
             if (node == null)
             {
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
             }
 
             if (annotation == null)
             {
-                throw new ArgumentNullException("annotation");
+                throw new ArgumentNullException(nameof(annotation));
             }
 
             var spans = (annotation == SyntaxAnnotation.ElasticAnnotation)

--- a/src/Workspaces/Core/Portable/Formatting/Rules/ExportFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/ExportFormattingRule.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         {
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             this.Name = name;

--- a/src/Workspaces/Core/Portable/Options/OptionKey.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionKey.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (option == null)
             {
-                throw new ArgumentNullException("option");
+                throw new ArgumentNullException(nameof(option));
             }
 
             if (language != null && !option.IsPerLanguage)

--- a/src/Workspaces/Core/Portable/Options/OptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionService.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (optionSet == null)
             {
-                throw new ArgumentNullException("OptionSet");
+                throw new ArgumentNullException(nameof(optionSet));
             }
 
             var changedOptions = new List<OptionChangedEventArgs>();

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (string.IsNullOrWhiteSpace(feature))
             {
-                throw new ArgumentNullException("feature");
+                throw new ArgumentNullException(nameof(feature));
             }
 
             if (string.IsNullOrWhiteSpace(name))

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (string.IsNullOrWhiteSpace(feature))
             {
-                throw new ArgumentNullException("feature");
+                throw new ArgumentNullException(nameof(feature));
             }
 
             if (string.IsNullOrWhiteSpace(name))

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -13,12 +13,12 @@ namespace Microsoft.CodeAnalysis.Rename
         {
             if (solution == null)
             {
-                throw new ArgumentNullException("solution");
+                throw new ArgumentNullException(nameof(solution));
             }
 
             if (symbol == null)
             {
-                throw new ArgumentNullException("symbol");
+                throw new ArgumentNullException(nameof(symbol));
             }
 
             if (string.IsNullOrEmpty(newName))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICollectionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (collection == null)
             {
-                throw new ArgumentNullException("collection");
+                throw new ArgumentNullException(nameof(collection));
             }
 
             if (items != null)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IComparerExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IComparerExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (comparer == null)
             {
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
             }
 
             return new InverseComparer<T>(comparer);

--- a/src/Workspaces/Core/Portable/Shared/NormalizedTextSpanCollection.cs
+++ b/src/Workspaces/Core/Portable/Shared/NormalizedTextSpanCollection.cs
@@ -61,12 +61,12 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (left == null)
             {
-                throw new ArgumentNullException("left");
+                throw new ArgumentNullException(nameof(left));
             }
 
             if (right == null)
             {
-                throw new ArgumentNullException("right");
+                throw new ArgumentNullException(nameof(right));
             }
 
             if (left.Count == 0)
@@ -135,12 +135,12 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (left == null)
             {
-                throw new ArgumentNullException("left");
+                throw new ArgumentNullException(nameof(left));
             }
 
             if (right == null)
             {
-                throw new ArgumentNullException("right");
+                throw new ArgumentNullException(nameof(right));
             }
 
             if (left.Count == 0)
@@ -195,12 +195,12 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (left == null)
             {
-                throw new ArgumentNullException("left");
+                throw new ArgumentNullException(nameof(left));
             }
 
             if (right == null)
             {
-                throw new ArgumentNullException("right");
+                throw new ArgumentNullException(nameof(right));
             }
 
             if (left.Count == 0)
@@ -253,12 +253,12 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (left == null)
             {
-                throw new ArgumentNullException("left");
+                throw new ArgumentNullException(nameof(left));
             }
 
             if (right == null)
             {
-                throw new ArgumentNullException("right");
+                throw new ArgumentNullException(nameof(right));
             }
 
             if (left.Count == 0)
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (set == null)
             {
-                throw new ArgumentNullException("set");
+                throw new ArgumentNullException(nameof(set));
             }
 
             for (int index1 = 0, index2 = 0; (index1 < this.Count) && (index2 < set.Count);)
@@ -450,7 +450,7 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (set == null)
             {
-                throw new ArgumentNullException("set");
+                throw new ArgumentNullException(nameof(set));
             }
 
             for (int index1 = 0, index2 = 0; (index1 < this.Count) && (index2 < set.Count);)
@@ -584,7 +584,7 @@ namespace Microsoft.CodeAnalysis.Shared
         {
             if (spans == null)
             {
-                throw new ArgumentNullException("spans");
+                throw new ArgumentNullException(nameof(spans));
             }
 
             List<TextSpan> sorted = new List<TextSpan>(spans);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             if (bitArray == null)
             {
-                throw new ArgumentNullException("bitArray");
+                throw new ArgumentNullException(nameof(bitArray));
             }
 
             _bitArray = bitArray;

--- a/src/Workspaces/Core/Portable/Utilities/ICollectionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ICollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Roslyn.Utilities
         {
             if (collection == null)
             {
-                throw new ArgumentNullException("collection");
+                throw new ArgumentNullException(nameof(collection));
             }
 
             if (values != null)

--- a/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
@@ -207,7 +207,7 @@ namespace Roslyn.Utilities
                 {
                     if (value < 0 || value >= length)
                     {
-                        throw new ArgumentOutOfRangeException("value");
+                        throw new ArgumentOutOfRangeException(nameof(value));
                     }
 
                     this.position = value;
@@ -234,17 +234,17 @@ namespace Roslyn.Utilities
                             break;
 
                         default:
-                            throw new ArgumentOutOfRangeException("origin");
+                            throw new ArgumentOutOfRangeException(nameof(origin));
                     }
                 }
                 catch (OverflowException)
                 {
-                    throw new ArgumentOutOfRangeException("offset");
+                    throw new ArgumentOutOfRangeException(nameof(offset));
                 }
 
                 if (target < 0)
                 {
-                    throw new ArgumentOutOfRangeException("offset");
+                    throw new ArgumentOutOfRangeException(nameof(offset));
                 }
 
                 position = target;
@@ -378,7 +378,7 @@ namespace Roslyn.Utilities
                 {
                     if (value < 0)
                     {
-                        throw new ArgumentOutOfRangeException("value");
+                        throw new ArgumentOutOfRangeException(nameof(value));
                     }
 
                     this.position = value;

--- a/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (solutionInfo == null)
             {
-                throw new ArgumentNullException("solutionInfo");
+                throw new ArgumentNullException(nameof(solutionInfo));
             }
 
             this.OnSolutionAdded(solutionInfo);
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectInfo == null)
             {
-                throw new ArgumentNullException("projectInfo");
+                throw new ArgumentNullException(nameof(projectInfo));
             }
 
             this.OnProjectAdded(projectInfo);
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectInfos == null)
             {
-                throw new ArgumentNullException("projectInfos");
+                throw new ArgumentNullException(nameof(projectInfos));
             }
 
             foreach (var info in projectInfos)
@@ -112,17 +112,17 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectId == null)
             {
-                throw new ArgumentNullException("projectId");
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             var id = DocumentId.CreateNewId(projectId);
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (documentInfo == null)
             {
-                throw new ArgumentNullException("documentInfo");
+                throw new ArgumentNullException(nameof(documentInfo));
             }
 
             this.OnDocumentAdded(documentInfo);

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
@@ -38,12 +38,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             this.ServiceType = type.AssemblyQualifiedName;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceFactoryAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceFactoryAttribute.cs
@@ -38,12 +38,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             this.ServiceType = type.AssemblyQualifiedName;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (serviceType == null)
             {
-                throw new ArgumentNullException("serviceType");
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             if (layer == null)
             {
-                throw new ArgumentNullException("layer");
+                throw new ArgumentNullException(nameof(layer));
             }
 
             this.ServiceType = serviceType.AssemblyQualifiedName;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceFactoryAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceFactoryAttribute.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (serviceType == null)
             {
-                throw new ArgumentNullException("serviceType");
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             if (layer == null)
             {
-                throw new ArgumentNullException("layer");
+                throw new ArgumentNullException(nameof(layer));
             }
 
             this.ServiceType = serviceType.AssemblyQualifiedName;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefHostServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefHostServices.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         {
             if (assemblies == null)
             {
-                throw new ArgumentNullException("assemblies");
+                throw new ArgumentNullException(nameof(assemblies));
             }
 
             var compositionConfiguration = new ContainerConfiguration().WithAssemblies(assemblies);

--- a/src/Workspaces/Core/Portable/Workspace/PrimaryWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/PrimaryWorkspace.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (workspace == null)
             {
-                throw new ArgumentNullException("workspace");
+                throw new ArgumentNullException(nameof(workspace));
             }
 
             using (s_registryGate.DisposableWrite())

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -62,12 +62,12 @@ namespace Microsoft.CodeAnalysis
         {
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             this.Id = id;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (options == null)
             {
-                throw new ArgumentNullException("OptionSet");
+                throw new ArgumentNullException(nameof(options));
             }
 
             var newTreeSource = CreateLazyFullyParsedTree(
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newText == null)
             {
-                throw new ArgumentNullException("newText");
+                throw new ArgumentNullException(nameof(newText));
             }
 
             // check to see if this docstate has already been branched before with the same text.
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newTextAndVersion == null)
             {
-                throw new ArgumentNullException("newTextAndVesion");
+                throw new ArgumentNullException(nameof(newTextAndVersion));
             }
 
             var newTextSource = mode == PreservationMode.PreserveIdentity
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (loader == null)
             {
-                throw new ArgumentNullException("loader");
+                throw new ArgumentNullException(nameof(loader));
             }
 
             var newTextSource = (mode == PreservationMode.PreserveIdentity)
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newRoot == null)
             {
-                throw new ArgumentNullException("newRoot");
+                throw new ArgumentNullException(nameof(newRoot));
             }
 
             var newTextVersion = this.GetNewerVersion();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (oldProject == null)
             {
-                throw new ArgumentNullException("oldProject");
+                throw new ArgumentNullException(nameof(oldProject));
             }
 
             return new ProjectChanges(this, oldProject);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectId == null)
             {
-                throw new ArgumentNullException("projectId");
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             ImmutableHashSet<ProjectId> projectIds;
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectId == null)
             {
-                throw new ArgumentNullException("projectId");
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             if (_lazyReverseReferencesMap == null)
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectId == null)
             {
-                throw new ArgumentNullException("projectId");
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             // first try without lock for speed
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (projectId == null)
             {
-                throw new ArgumentNullException("projectId");
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             // first try without lock for speed

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -116,22 +116,22 @@ namespace Microsoft.CodeAnalysis
         {
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (name == null)
             {
-                throw new ArgumentNullException("displayName");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (assemblyName == null)
             {
-                throw new ArgumentNullException("assemblyName");
+                throw new ArgumentNullException(nameof(assemblyName));
             }
 
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             this.Id = id;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -588,13 +588,13 @@ namespace Microsoft.CodeAnalysis
             var language = projectInfo.Language;
             if (language == null)
             {
-                throw new ArgumentNullException("language");
+                throw new ArgumentNullException(nameof(language));
             }
 
             var displayName = projectInfo.Name;
             if (displayName == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(displayName));
             }
 
             CheckNotContainsProject(projectId);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextAndVersion.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             return new TextAndVersion(text, version, filePath);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newTextAndVersion == null)
             {
-                throw new ArgumentNullException("newTextAndVesion");
+                throw new ArgumentNullException(nameof(newTextAndVersion));
             }
 
             var newTextSource = mode == PreservationMode.PreserveIdentity
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newText == null)
             {
-                throw new ArgumentNullException("newText");
+                throw new ArgumentNullException(nameof(newText));
             }
 
             var newVersion = this.GetNewerVersion();
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (loader == null)
             {
-                throw new ArgumentNullException("loader");
+                throw new ArgumentNullException(nameof(loader));
             }
 
             // don't blow up on non-text documents.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (textAndVersion == null)
             {
-                throw new ArgumentNullException("textAndVersion");
+                throw new ArgumentNullException(nameof(textAndVersion));
             }
 
             return new TextDocumentLoader(textAndVersion);
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (container == null)
             {
-                throw new ArgumentNullException("container");
+                throw new ArgumentNullException(nameof(container));
             }
 
             return new TextContainerLoader(container, version, filePath);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TreeAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TreeAndVersion.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (tree == null)
             {
-                throw new ArgumentNullException("tree");
+                throw new ArgumentNullException(nameof(tree));
             }
 
             return new TreeAndVersion(tree, version);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (container == null)
             {
-                throw new ArgumentNullException("container");
+                throw new ArgumentNullException(nameof(container));
             }
 
             using (_stateLock.DisposableWait())

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (newSolution == null)
             {
-                throw new ArgumentNullException("newSolution");
+                throw new ArgumentNullException(nameof(newSolution));
             }
 
             if (oldSolution == newSolution)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (textContainer == null)
             {
-                throw new ArgumentNullException("textContainer");
+                throw new ArgumentNullException(nameof(textContainer));
             }
 
             var registration = GetWorkspaceRegistration(textContainer);
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (textContainer == null)
             {
-                throw new ArgumentNullException("textContainer");
+                throw new ArgumentNullException(nameof(textContainer));
             }
 
             GetWorkspaceRegistration(textContainer).SetWorkspaceAndRaiseEvents(this);
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (textContainer == null)
             {
-                throw new ArgumentNullException("textContainer");
+                throw new ArgumentNullException(nameof(textContainer));
             }
 
             GetWorkspaceRegistration(textContainer).SetWorkspaceAndRaiseEvents(null);
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (textContainer == null)
             {
-                throw new ArgumentNullException("textContainer");
+                throw new ArgumentNullException(nameof(textContainer));
             }
 
             return s_bufferToWorkspaceRegistrationMap.GetValue(textContainer, s_createRegistration);


### PR DESCRIPTION
Replaces #2179, because it did not merge anymore.

Switched from quoted argument names to nameof() operator, correcting a dozen or so in this manual process. RoslynLight.sln builds in VS2015 CTP6 and BuildAndTest.proj runs all tests without errors.

Note I did not update cases like: new ArgumentException("symbol") because according to the signature, the first parameter holds message and second holds parameter name. Not sure how the team would like to change this. Mostly affects code generated from Syntax.xml.