### PR TITLE
Comment out the cross-langauge assembly load parts of perf tests.

### DIFF
--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefs.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefs.xml
@@ -24,8 +24,8 @@
       <WaitForCodeMarkers />
       <ExecuteCommand Command="Window.ActivateDocumentWindow" />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefsIEnumerable.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefsIEnumerable.xml
@@ -24,8 +24,8 @@
       <WaitForCodeMarkers />
       <ExecuteCommand Command="Window.ActivateDocumentWindow" />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfNavigateToRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfNavigateToRoslyn.xml
@@ -20,8 +20,8 @@
       <WaitForCodeMarkers />
       <CloseNavigateToWindow />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfPaste.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfPaste.xml
@@ -32,8 +32,8 @@
       <ExecuteCommand Command="Edit.Paste" />
       <MeasureTimeStop />
       
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
   

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameRoslyn.xml
@@ -26,8 +26,8 @@
       <PerfRename NewName="qualifiedName" Language="CSharp" />
       <WaitForCodeMarkers />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameTypeRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameTypeRoslyn.xml
@@ -26,8 +26,8 @@
       <PerfRename NewName="ImmutableArray" Language="CSharp" />
       <WaitForCodeMarkers />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfSolutionLoad.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfSolutionLoad.xml
@@ -23,8 +23,8 @@
       <WaitForIdleCPU />
       <MeasureTimeStop />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefs.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefs.xml
@@ -27,8 +27,8 @@
       <ExecuteCommand Command="View.FindSymbolResults" />
       <ExecuteCommand Command="Window.ActivateDocumentWindow" />
       
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefsIEnumerable.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefsIEnumerable.xml
@@ -27,8 +27,8 @@
       <ExecuteCommand Command="View.FindSymbolResults" />
       <ExecuteCommand Command="Window.ActivateDocumentWindow" />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfNavigateToRoslyn.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfNavigateToRoslyn.xml
@@ -28,8 +28,8 @@
       <WaitForCodeMarkers />
       <CloseNavigateToWindow />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfPaste.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfPaste.xml
@@ -32,8 +32,8 @@
       <ExecuteCommand Command="Edit.Paste" />
       <MeasureTimeStop />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
   

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfRenameRoslyn.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfRenameRoslyn.xml
@@ -27,8 +27,8 @@
       <WaitForCodeMarkers />
       <CollectPerfViewTrace Action="Stop"/>
       
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfSolutionLoad.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfSolutionLoad.xml
@@ -23,8 +23,8 @@
       <WaitForIdleCPU />
       <MeasureTimeStop />
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!--<VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
+      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />-->
     </Scenario>
   </ScenarioList>
 


### PR DESCRIPTION
These have been firing so often lately that we haven't had any good performance data in a long time. I'm disabling the scenarios for now and I'll enter an issue to track down the root cause of the problem and re-enable them.

@rchande @heejaechang for review.