### PR TITLE
Fix Locals in async lambdas...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -619,7 +619,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 BinderFlags.UncheckedRegion |
                 BinderFlags.AllowManagedAddressOf |
                 BinderFlags.AllowAwaitInUnsafeContext);
-            var hasImports = !importRecordGroups.IsDefault;
+            var hasImports = !importRecordGroups.IsDefaultOrEmpty;
             var numImportStringGroups = hasImports ? importRecordGroups.Length : 0;
             var currentStringGroup = numImportStringGroups - 1;
 


### PR DESCRIPTION
We shouldn't ignore custom debug info for a method just because it doesn't contain import records.  It may still contain info about local variable scopes, dynamic info, etc...

Note:  VB did not have a problem with this scenario, but I added a unit test for good measure.

(fixes #2240)