### PR TITLE
Introduce Constants should not be offered for Null Literals

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -613,13 +613,12 @@ class M
         }
 
         [WorkItem(544577)]
+        [WorkItem(909152)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestExpressionTLambda()
         {
-            Test(
-@"using System ; using System . Linq . Expressions ; class Program { static Expression < Func < int ? , char ? > > e1 = c => [|null|] ; } ",
-@"using System ; using System . Linq . Expressions ; class Program { private const char ? {|Rename:P|} = null ; static Expression < Func < int ? , char ? > > e1 = c => P ; } ",
-index: 1);
+            TestMissing(
+@"using System ; using System . Linq . Expressions ; class Program { static Expression < Func < int ? , char ? > > e1 = c => [|null|] ; } ");
         }
 
         [WorkItem(544915)]
@@ -2322,6 +2321,24 @@ class TestClass
 }";
 
             Test(code, expected, index: 2, compareTokens: false);
+        }
+
+        [WorkItem(909152)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestMissingOnNullLiteral()
+        {
+            TestMissing(
+@"class C1 { }
+class C2 { }
+class Test
+{
+    void M()
+    {
+        C1 c1 = [|null|];
+        C2 c2 = null;
+    }
+}
+");
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -794,11 +794,10 @@ index:=1)
         End Sub
 
         <WorkItem(543529)>
+        <WorkItem(909152)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInStatementlessConstructorParameter()
-            Test(
-NewLines("Class C1 \n Sub New(Optional ByRef x As String = [|Nothing|]) \n End Sub \n End Class"),
-NewLines("Class C1 \n Private Const {|Rename:P|} As String = Nothing \n Sub New(Optional ByRef x As String = P) \n End Sub \n End Class"))
+            TestMissing(NewLines("Class C1 \n Sub New(Optional ByRef x As String = [|Nothing|]) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543650)>
@@ -910,12 +909,10 @@ NewLines("Module M \n Sub Main() \n Dim x = <[|x|]/> \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(545262)>
+        <WorkItem(909152)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInTernaryConditional()
-            Test(
-NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Nothing \n Dim Obj1 = If(New With {.a = True}.a, p, [|Nothing|]) \n End Sub \n End Module"),
-NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Nothing \n Const {|Rename:P1|} As Object = Nothing \n Dim Obj1 = If(New With {.a = True}.a, p, P1) \n End Sub \n End Module"),
-index:=2)
+            TestMissing(NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Nothing \n Dim Obj1 = If(New With {.a = True}.a, p, [|Nothing|]) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(545316)>
@@ -1399,6 +1396,24 @@ End Module
 </File>
 
             Test(code, expected, index:=3, compareTokens:=False)
+        End Sub
+
+        <WorkItem(909152)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub TestMissingOnNothingLiteral()
+            TestMissing(
+<File>
+Imports System
+Module Program
+    Sub Main(args As String())
+        Main([|Nothing|])
+        M(Nothing)
+    End Sub
+
+    Sub M(i As Integer)
+    End Sub
+End Module
+</File>)
         End Sub
 
         <WorkItem(1065661)>

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -96,9 +96,20 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             return false;
         }
 
+        /// <summary>
+        /// Checks for conditions where we should not generate a variable for an expression
+        /// </summary>
         protected override bool CanIntroduceVariableFor(ExpressionSyntax expression)
         {
+            // (a) If that's the only expression in a statement.
+            // Otherwise we'll end up with something like "v;" which is not legal in C#.
             if (expression.WalkUpParentheses().IsParentKind(SyntaxKind.ExpressionStatement))
+            {
+                return false;
+            }
+
+            // (b) For Null Literals, as AllOccurences could introduce semantic errors.
+            if (expression is LiteralExpressionSyntax && ((LiteralExpressionSyntax)expression).IsKind(SyntaxKind.NullLiteralExpression))
             {
                 return false;
             }

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             }
 
             // (b) For Null Literals, as AllOccurences could introduce semantic errors.
-            if (expression is LiteralExpressionSyntax && ((LiteralExpressionSyntax)expression).IsKind(SyntaxKind.NullLiteralExpression))
+            if (expression.IsKind(SyntaxKind.NullLiteralExpression))
             {
                 return false;
             }

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -216,9 +216,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             private bool CanIntroduceVariable(
                 CancellationToken cancellationToken)
             {
-                // Don't generate a variable for an expression that's the only expression in a
-                // statement.  Otherwise we'll end up with something like "v;" which is not
-                // legal in C#.
                 if (!_service.CanIntroduceVariableFor(this.Expression))
                 {
                     return false;

--- a/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
+++ b/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
@@ -77,6 +77,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                 Return False
             End If
 
+            ' For Nothing Literals, AllOccurences could introduce semantic errors.
+            If expression.IsKind(SyntaxKind.NothingLiteralExpression) Then
+                Return False
+            End If
+
             Return True
         End Function
 


### PR DESCRIPTION
Fixes internal bug 909152.

Don't offer Introduce Constants on NullLiterals. They could cause
semantic errors when used in a replace all occurrences context and
offer no value anyway.

This change is for C# only. VB works correctly.