### PR TITLE
Fix a few issues with our cross platform tests

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -132,13 +132,22 @@ test_roslyn()
         return
     fi
     
-    XUNIT_RUNNER=packages/xunit.runners.$XUNIT_VERSION/tools/xunit.console.x86.exe
-    mono $XUNIT_RUNNER Binaries/Debug/Roslyn.Compilers.CSharp.Syntax.UnitTests.dll -noshadow
-    mono $XUNIT_RUNNER Binaries/Debug/Roslyn.Compilers.CSharp.CommandLine.UnitTests.dll -noshadow
-    mono $XUNIT_RUNNER Binaries/Debug/Roslyn.Compilers.VisualBasic.Syntax.UnitTests.dll -noshadow
+    local xunit_runner=packages/xunit.runners.$XUNIT_VERSION/tools/xunit.console.x86.exe
+    local test_binaries=(
+        Roslyn.Compilers.CSharp.Syntax.UnitTests
+        Roslyn.Compilers.CSharp.CommandLine.UnitTests
+        Roslyn.Compilers.VisualBasic.Syntax.UnitTests)
+    local any_failed=false
+    for i in "${test_binaries[@]}"
+    do
+        mono $xunit_runner Binaries/Debug/$i.dll -xml Binaries/Debug/$i.TestResults.xml -noshadow
+        if [ $? -ne 0 ]; then
+            any_failed=true
+        fi
+    done
 
-    if [ $? -ne 0 ]; then
-        echo Unit tests failed
+    if [ "$any_failed" = "true" ]; then
+        echo Unit test failed
         exit 1
     fi
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5312,7 +5312,7 @@ class C
         }
 
         [WorkItem(544926, "DevDiv")]
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly))]
         public void ResponseFilesWithNoconfig_01()
         {
             string source = Temp.CreateFile("a.cs").WriteAllText(@"


### PR DESCRIPTION
Handles the following issues:

- Correctly detect when an xunit run fails.  Previously only checking
the last run.
- Generate the xml results file for our xunit runs.  This will give us
better Jenkins output for cross plat runs.
- Disable a test which was failing due to the first issue I fixed.