### PR TITLE
Smart Indent appropriately inside MultiLine Literal in VB

### DIFF
--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -143,6 +143,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             Private Function GetIndentationOfCurrentPosition(token As SyntaxToken, position As Integer, extraSpaces As Integer) As IndentationResult
                 ' special case for multi-line string
                 Dim containingToken = Tree.FindTokenOnLeftOfPosition(position, CancellationToken)
+                If containingToken.IsKind(SyntaxKind.InterpolatedStringTextToken) OrElse
+                   containingToken.IsKind(SyntaxKind.InterpolatedStringText) OrElse
+                    (containingToken.IsKind(SyntaxKind.CloseBraceToken) AndAlso token.Parent.IsKind(SyntaxKind.Interpolation)) Then
+                     Return IndentFromStartOfLine(0)
+                End If
                 If containingToken.Kind = SyntaxKind.StringLiteralToken AndAlso containingToken.FullSpan.Contains(position) Then
                     Return IndentFromStartOfLine(0)
                 End If

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 
             ' now, regular case. ask formatting rule to see whether we should use token formatter or not
             Dim lineOperation = FormattingOperations.GetAdjustNewLinesOperation(formattingRules, previousToken, token, optionSet)
-            If lineOperation IsNot Nothing Then
+            If lineOperation IsNot Nothing AndAlso lineOperation.Option <> AdjustNewLinesOption.ForceLinesIfOnSingleLine Then
                 Return True
             End If
 

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2521,6 +2521,108 @@ End Module
                 expectedIndentation:=8)
         End Sub
 
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideInterpolatedMultiLineString_0()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"
+            "
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideInterpolatedMultiLineString_1()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"
+     {0} what"
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideInterpolatedMultiLineString_2()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"what
+            "
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideInterpolatedMultiLineString_3()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"what
+            {0}"
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideInterpolatedMultiLineString_4()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"what{0}
+            "
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
+        <WorkItem(2231, "https://github.com/dotnet/roslyn/issues/2231")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentInsideMultiLineString()
+            Dim code = <code>Module Module1
+    Sub Main()
+        Dim c2() = $"1
+            2"
+    End Sub
+End Module
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=3,
+                expectedIndentation:=0)
+        End Sub
+
         Private Shared Sub AssertSmartIndentIndentationInProjection(markup As String,
                                                                     expectedIndentation As Integer)
             Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromLines({markup})


### PR DESCRIPTION
Fix #2231 : Smart indent appropriately inside VB MultiLine literals