### PR TITLE
Be tolerant of msbuild failures 

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
@@ -846,7 +846,16 @@ namespace Microsoft.CodeAnalysis.MSBuild
         private async Task<MetadataReference> GetProjectMetadata(string projectFilePath, ImmutableArray<string> aliases, IDictionary<string, string> globalProperties, CancellationToken cancellationToken)
         {
             // use loader service to determine output file for project if possible
-            var outputFilePath = await ProjectFileLoader.GetOutputFilePathAsync(projectFilePath, globalProperties, cancellationToken).ConfigureAwait(false);
+            string outputFilePath = null;
+
+            try
+            {
+                outputFilePath = await ProjectFileLoader.GetOutputFilePathAsync(projectFilePath, globalProperties, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                this.OnWorkspaceFailed(new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, e.Message));
+            }
 
             if (outputFilePath != null && File.Exists(outputFilePath))
             {


### PR DESCRIPTION
Fix for #762 

Catch exceptions from MSBuild when attempting to load project files of unsupported languages to determine output paths for finding built metadata files.

@KirillOsenkov, @Pilchie  please review.