### PR TITLE
EnC: Avoid dups in a map during analysis of captured lambda parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -3812,6 +3812,56 @@ class C
             edits.VerifySemanticDiagnostics();
         }
 
+        [Fact, WorkItem(2223, "https://github.com/dotnet/roslyn/issues/2223")]
+        public void Lambdas_Update_CapturedParameters2()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    void F(int x1)
+    {
+        var f1 = new Func<int, int, int>((a1, a2) => 
+        {
+            var f2 = new Func<int, int>(a3 => x1 + a2);
+            return a1;
+        });
+
+        var f3 = new Func<int, int, int>((a1, a2) => 
+        {
+            var f4 = new Func<int, int>(a3 => x1 + a2);
+            return a1;
+        });
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    void F(int x1)
+    {
+        var f1 = new Func<int, int, int>((a1, a2) => 
+        {
+            var f2 = new Func<int, int>(a3 => x1 + a2 + 1);
+            return a1;
+        });
+
+        var f3 = new Func<int, int, int>((a1, a2) => 
+        {
+            var f4 = new Func<int, int>(a3 => x1 + a2 + 1);
+            return a1;
+        });
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
         [Fact]
         public void Lambdas_Update_CeaseCapture_Closure1()
         {

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
@@ -3252,6 +3252,48 @@ End Class
             edits.VerifySemanticDiagnostics()
         End Sub
 
+        <Fact, WorkItem(2223, "https://github.com/dotnet/roslyn/issues/2223")>
+        Public Sub Lambdas_Update_CapturedParameters2()
+            Dim src1 = "
+Imports System
+Class C
+    Sub F(x1 As Integer)
+        Dim f1 = New Func(Of Integer, Integer, Integer)(
+            Function(a1, a2)
+                Dim f2 = New Func(Of Integer, Integer)(Function(a3) x1 + a2)
+                Return a1
+            End Function)
+
+        Dim f3 = New Func(Of Integer, Integer, Integer)(
+            Function(a1, a2)
+                Dim f4 = New Func(Of Integer, Integer)(Function(a3) x1 + a2)
+                Return a1
+            End Function)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Class C
+    Sub F(x1 As Integer)
+        Dim f1 = New Func(Of Integer, Integer, Integer)(
+            Function(a1, a2)
+                Dim f2 = New Func(Of Integer, Integer)(Function(a3) x1 + a2 + 1)
+                Return a1
+            End Function)
+
+        Dim f3 = New Func(Of Integer, Integer, Integer)(
+            Function(a1, a2)
+                Dim f4 = New Func(Of Integer, Integer)(Function(a3) x1 + a2 + 1)
+                Return a1
+            End Function)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics()
+        End Sub
+
         <Fact>
         Public Sub Lambdas_Update_CeaseCapture_Closure1()
             Dim src1 = "
@@ -3366,9 +3408,8 @@ End Class
 "
             Dim edits = GetTopEdits(src1, src2)
 
-            ' TODO: better location
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.NotCapturingVariable, "F", "a1"))
+                Diagnostic(RudeEditKind.NotCapturingVariable, "a1", "a1"))
         End Sub
 
         <Fact>

--- a/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1241,6 +1241,25 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return TextSpan.FromBounds((modifiers.Count != 0) ? modifiers.First().SpanStart : start.SpanStart, end.Span.End);
         }
 
+        internal override TextSpan GetLambdaParameterDiagnosticSpan(SyntaxNode lambda, int ordinal)
+        {
+            switch (lambda.Kind())
+            {
+                case SyntaxKind.ParenthesizedLambdaExpression:
+                    return ((ParenthesizedLambdaExpressionSyntax)lambda).ParameterList.Parameters[ordinal].Identifier.Span;
+
+                case SyntaxKind.SimpleLambdaExpression:
+                    Debug.Assert(ordinal == 0);
+                    return ((SimpleLambdaExpressionSyntax)lambda).Parameter.Identifier.Span;
+
+                case SyntaxKind.AnonymousMethodExpression:
+                    return ((AnonymousMethodExpressionSyntax)lambda).ParameterList.Parameters[ordinal].Identifier.Span;
+
+                default:
+                    return lambda.Span;
+            }
+        }
+
         protected override string GetTopLevelDisplayName(SyntaxNode node, EditKind editKind)
         {
             return GetTopLevelDisplayNameImpl(node, editKind);

--- a/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -1351,6 +1351,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return TextSpan.FromBounds(startToken.SpanStart, endToken.Span.End)
         End Function
 
+        Friend Overrides Function GetLambdaParameterDiagnosticSpan(lambda As SyntaxNode, ordinal As Integer) As TextSpan
+            Select Case lambda.Kind
+                Case SyntaxKind.MultiLineFunctionLambdaExpression,
+                     SyntaxKind.SingleLineFunctionLambdaExpression,
+                     SyntaxKind.MultiLineSubLambdaExpression,
+                     SyntaxKind.SingleLineSubLambdaExpression
+                    Return DirectCast(lambda, LambdaExpressionSyntax).SubOrFunctionHeader.ParameterList.Parameters(ordinal).Identifier.Span
+
+                Case Else
+                    Return lambda.Span
+            End Select
+        End Function
+
         Protected Overrides Function GetTopLevelDisplayName(node As SyntaxNode, editKind As EditKind) As String
             Return GetTopLevelDisplayNameImpl(node)
         End Function


### PR DESCRIPTION
Fixes #2223.