### PR TITLE
Clean up the FxCop serialization rules' fixers

### DIFF
--- a/src/Diagnostics/FxCop/CSharp/CSharpFxCopRulesDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/CSharp/CSharpFxCopRulesDiagnosticAnalyzers.csproj
@@ -78,7 +78,7 @@
     <Compile Include="Design\CodeFixes\CA1052CSharpCodeFixProvider.cs" />
     <Compile Include="Design\CSharpCA1024DiagnosticAnalyzer.cs" />
     <Compile Include="Performance\RemoveEmptyFinalizers.cs" />
-    <Compile Include="Usage\CodeFixes\CA2235CSharpCodeFixProvider.cs" />
+    <Compile Include="Usage\MarkAllNonSerializableFields.Fixer.cs" />
     <Compile Include="Usage\CSharpCA2200DiagnosticAnalyzer.cs" />
     <Compile Include="Usage\CSharpCA2214DiagnosticAnalyzer.cs" />
   </ItemGroup>

--- a/src/Diagnostics/FxCop/CSharp/Usage/MarkAllNonSerializableFields.Fixer.cs
+++ b/src/Diagnostics/FxCop/CSharp/Usage/MarkAllNonSerializableFields.Fixer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.FxCopAnalyzers.Usage;
 namespace Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.Usage
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "CA2237 CodeFix provider"), Shared]
-    public class CA2235CSharpCodeFixProvider : CA2235CodeFixProviderBase
+    public class CSharpMarkAllNonSerializableFieldsFixer : MarkAllNonSerializableFieldsFixer
     {
         protected override SyntaxNode GetFieldDeclarationNode(SyntaxNode node)
         {
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.Usage
                 fieldNode = fieldNode.Parent;
             }
 
-            return fieldNode.Kind() == SyntaxKind.FieldDeclaration ? fieldNode : null;
+            return fieldNode?.Kind() == SyntaxKind.FieldDeclaration ? fieldNode : null;
         }
     }
 }

--- a/src/Diagnostics/FxCop/Core/FxCopRulesDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/FxCop/Core/FxCopRulesDiagnosticAnalyzers.csproj
@@ -142,9 +142,9 @@
     <Compile Include="SolutionChangeAction.cs" />
     <Compile Include="Usage\CA2200DiagnosticAnalyzer.cs" />
     <Compile Include="Usage\CA2214DiagnosticAnalyzer.cs" />
-    <Compile Include="Usage\CodeFixes\CA2229CodeFixProvider.cs" />
-    <Compile Include="Usage\CodeFixes\CA2235CodeFixProviderBase.cs" />
-    <Compile Include="Usage\CodeFixes\CA2237CodeFixProvider.cs" />
+    <Compile Include="Usage\ImplementSerializationConstructors.Fixer.cs" />
+    <Compile Include="Usage\MarkAllNonSerializableFields.Fixer.cs" />
+    <Compile Include="Usage\MarkTypesWithSerializable.Fixer.cs" />
     <Compile Include="Usage\SerializationRulesDiagnosticAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Diagnostics/FxCop/Core/Usage/CodeFixes/CA2235CodeFixProviderBase.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/CodeFixes/CA2235CodeFixProviderBase.cs
@@ -1,87 +1,81 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FxCopAnalyzers.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
 {
-    public abstract class CA2235CodeFixProviderBase : MultipleCodeFixProviderBase
+    /// <summary>
+    /// CA2235: Mark all non-serializable fields
+    /// </summary>
+    public abstract class CA2235CodeFixProviderBase : CodeFixProvider
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds
-        {
-            get { return ImmutableArray.Create(SerializationRulesDiagnosticAnalyzer.RuleCA2235Id); }
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SerializationRulesDiagnosticAnalyzer.RuleCA2235Id);
 
         protected abstract SyntaxNode GetFieldDeclarationNode(SyntaxNode node);
 
-        internal override Task<IEnumerable<CodeAction>> GetFixesAsync(Document document, SemanticModel model, SyntaxNode root, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var actions = ImmutableArray.CreateBuilder<CodeAction>();
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var node = root.FindNode(context.Span);
+            var fieldNode = GetFieldDeclarationNode(node);
+            if(fieldNode == null)
+            {
+                return;
+            }
+
+            var diagnostic = context.Diagnostics.Single();
 
             // Fix 1: Add a NonSerialized attribute to the field
-            var fieldNode = GetFieldDeclarationNode(nodeToFix);
-            if (fieldNode != null)
+            context.RegisterCodeFix(new MyCodeAction(FxCopFixersResources.AddNonSerializedAttribute,
+                                        async ct => await AddNonSerializedAttribute(context.Document, fieldNode, ct).ConfigureAwait(false)),
+                                    diagnostic);
+
+
+            // Fix 2: If the type of the field is defined in source, then add the serializable attribute to the type.
+            var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            var fieldSymbol = model.GetDeclaredSymbol(node, context.CancellationToken) as IFieldSymbol;
+            var type = fieldSymbol?.Type;
+            if (type != null && type.Locations.Any(l => l.IsInSource))
             {
-                var generator = SyntaxGenerator.GetGenerator(document);
-                var codeAction = new MyDocumentCodeAction(FxCopFixersResources.AddNonSerializedAttribute,
-                                                          async ct => await AddNonSerializedAttribute(document, model, root, fieldNode, generator).ConfigureAwait(false));
-                actions.Add(codeAction);
-
-                // Fix 2: If the type of the field is defined in source, then add the serializable attribute to the type.
-                var fieldSymbol = model.GetDeclaredSymbol(nodeToFix, cancellationToken) as IFieldSymbol;
-                var type = fieldSymbol.Type;
-                if (type.Locations.Any(l => l.IsInSource))
-                {
-                    var typeCodeAction = new MySolutionCodeAction(FxCopFixersResources.AddSerializableAttribute,
-                                                                  async ct => await AddSerializableAttributeToType(document, model, generator, type, cancellationToken).ConfigureAwait(false));
-
-                    actions.Add(typeCodeAction);
-                }
+                context.RegisterCodeFix(new MyCodeAction(FxCopFixersResources.AddSerializableAttribute,
+                            async ct => await AddSerializableAttributeToType(context.Document, type, ct).ConfigureAwait(false)),
+                        diagnostic);
             }
-
-            return Task.FromResult<IEnumerable<CodeAction>>(actions.ToImmutable());
         }
 
-        private static async Task<Solution> AddSerializableAttributeToType(Document document, SemanticModel model, SyntaxGenerator generator, ITypeSymbol type, CancellationToken cancellationToken)
+        private async Task<Document> AddNonSerializedAttribute(Document document, SyntaxNode fieldNode, CancellationToken cancellationToken)
         {
-            var typeDeclNode = type.DeclaringSyntaxReferences.First().GetSyntax(cancellationToken);
-
-            var serializableAttr = generator.Attribute(generator.TypeExpression(WellKnownTypes.SerializableAttribute(model.Compilation)));
-            var newTypeDeclNode = generator.AddAttributes(typeDeclNode, serializableAttr);
-            var documentContainingNode = document.Project.Solution.GetDocument(typeDeclNode.SyntaxTree);
-            var docRoot = await documentContainingNode.GetSyntaxRootAsync(cancellationToken);
-            var newDocumentContainingNode = documentContainingNode.WithSyntaxRoot(docRoot.ReplaceNode(typeDeclNode, newTypeDeclNode));
-            return newDocumentContainingNode.Project.Solution;
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var attr = editor.Generator.Attribute(editor.Generator.TypeExpression(WellKnownTypes.NonSerializedAttribute(editor.SemanticModel.Compilation)));
+            editor.AddAttribute(fieldNode, attr);
+            return editor.GetChangedDocument();
         }
 
-        private Task<Document> AddNonSerializedAttribute(Document document, SemanticModel model, SyntaxNode root, SyntaxNode fieldNode, SyntaxGenerator generator)
+        private static async Task<Document> AddSerializableAttributeToType(Document document, ITypeSymbol type, CancellationToken cancellationToken)
         {
-            var attr = generator.Attribute(generator.TypeExpression(WellKnownTypes.NonSerializedAttribute(model.Compilation)));
-            var newNode = generator.AddAttributes(fieldNode, attr);
-            var newDocument = document.WithSyntaxRoot(root.ReplaceNode(fieldNode, newNode));
-            return Task.FromResult(newDocument);
-        }
+            var editor = SymbolEditor.Create(document);
+            await editor.EditOneDeclarationAsync(type, (docEditor, declaration) => 
+            {
+                var serializableAttr = docEditor.Generator.Attribute(docEditor.Generator.TypeExpression(WellKnownTypes.SerializableAttribute(docEditor.SemanticModel.Compilation)));
+                docEditor.AddAttribute(declaration, serializableAttr);
+            }, cancellationToken);
 
-        private class MyDocumentCodeAction : DocumentChangeAction
+            return editor.GetChangedDocuments().First();
+        }
+        
+        private class MyCodeAction : DocumentChangeAction
         {
-            public MyDocumentCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
                 base(title, createChangedDocument)
-            {
-            }
-        }
-
-        private class MySolutionCodeAction : SolutionChangeAction
-        {
-            public MySolutionCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution) :
-                base(title, createChangedSolution)
             {
             }
         }

--- a/src/Diagnostics/FxCop/Core/Usage/ImplementSerializationConstructors.Fixer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/ImplementSerializationConstructors.Fixer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     /// CA2229: Implement serialization constructors.
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = "CA2229 CodeFix provider"), Shared]
-    public sealed class CA2229CodeFixProvider : CodeFixProvider
+    public sealed class ImplementSerializationConstructorsFixer : CodeFixProvider
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SerializationRulesDiagnosticAnalyzer.RuleCA2229Id); 
 

--- a/src/Diagnostics/FxCop/Core/Usage/MarkAllNonSerializableFields.Fixer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/MarkAllNonSerializableFields.Fixer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     /// <summary>
     /// CA2235: Mark all non-serializable fields
     /// </summary>
-    public abstract class CA2235CodeFixProviderBase : CodeFixProvider
+    public abstract class MarkAllNonSerializableFieldsFixer : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SerializationRulesDiagnosticAnalyzer.RuleCA2235Id);
 

--- a/src/Diagnostics/FxCop/Core/Usage/MarkTypesWithSerializable.Fixer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/MarkTypesWithSerializable.Fixer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     /// CA2237: Mark ISerializable types with SerializableAttribute
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = "CA2237 CodeFix provider"), Shared]
-    public sealed class CA2237CodeFixProvider : CodeFixProvider
+    public sealed class MarkTypesWithSerializableFixer : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SerializationRulesDiagnosticAnalyzer.RuleCA2237Id);
 

--- a/src/Diagnostics/FxCop/Core/Usage/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/SerializationRulesDiagnosticAnalyzer.cs
@@ -168,10 +168,17 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
                 // If this is type is marked Serializable check it's fields types' as well
                 if (IsSerializable(namedTypeSymbol))
                 {
-                    var nonSerialableFields = namedTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => !IsSerializable(m.Type));
-                    foreach (var field in nonSerialableFields)
+                    var nonSerializableFields = namedTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => !IsSerializable(m.Type));
+                    foreach (var field in nonSerializableFields)
                     {
-                        context.ReportDiagnostic(field.CreateDiagnostic(RuleCA2235, field.Name, namedTypeSymbol.Name, field.Type));
+                        if (field.IsImplicitlyDeclared && field.AssociatedSymbol != null)
+                        {
+                            context.ReportDiagnostic(field.AssociatedSymbol.CreateDiagnostic(RuleCA2235, field.AssociatedSymbol.Name, namedTypeSymbol.Name, field.Type));
+                        }
+                        else
+                        {
+                            context.ReportDiagnostic(field.CreateDiagnostic(RuleCA2235, field.Name, namedTypeSymbol.Name, field.Type));
+                        }
                     }
                 }
             }

--- a/src/Diagnostics/FxCop/Test/FxCopRulesDiagnosticAnalyzersTest.csproj
+++ b/src/Diagnostics/FxCop/Test/FxCopRulesDiagnosticAnalyzersTest.csproj
@@ -98,9 +98,9 @@
     <Compile Include="Usage\CA2229Tests.cs" />
     <Compile Include="Usage\CA2235Tests.cs" />
     <Compile Include="Usage\CA2237Tests.cs" />
-    <Compile Include="Usage\CodeFixes\CA2229FixerTests.cs" />
-    <Compile Include="Usage\CodeFixes\CA2235FixerTests.cs" />
-    <Compile Include="Usage\CodeFixes\CA2237FixerTests.cs" />
+    <Compile Include="Usage\ImplementSerializationConstructorsTests.Fixer.cs" />
+    <Compile Include="Usage\MarkAllNonSerializableFieldsTests.Fixer.cs" />
+    <Compile Include="Usage\MarkTypesWithSerializableTests.Fixer.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Diagnostics/FxCop/Test/Usage/CA2235Tests.cs
+++ b/src/Diagnostics/FxCop/Test/Usage/CA2235Tests.cs
@@ -184,6 +184,40 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 GetCA2235BasicResultAt(13, 29, "s3", "CA2235InternalWithNonPublicNonSerializableFields", "NonSerializableType"));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void CA2235AutoProperties()
+        {
+            VerifyCSharp(@"
+                using System;
+                public class NonSerializableType { }
+
+                [Serializable]
+                public class SerializableType { }
+    
+                [Serializable]
+                internal class CA2235WithAutoProperties
+                {
+                    public SerializableType s1;
+                    internal NonSerializableType s2 {get; set; }
+                }",
+                GetCA2235CSharpResultAt(12, 50, "s2", "CA2235WithAutoProperties", "NonSerializableType"));
+
+            VerifyBasic(@"
+                Imports System
+                Public Class NonSerializableType
+                End Class
+                <Serializable>
+                Public Class SerializableType
+                End Class
+
+                <Serializable>
+                Friend Class CA2235WithAutoProperties 
+                    Public s1 As SerializableType
+                    Friend Property s2 As NonSerializableType
+                End Class",
+                GetCA2235BasicResultAt(12, 37, "s2", "CA2235WithAutoProperties", "NonSerializableType"));
+        }
+
         internal static string CA2235Name = "CA2235";
         internal static string CA2235Message = FxCopRulesResources.FieldIsOfNonSerializableType;
 

--- a/src/Diagnostics/FxCop/Test/Usage/ImplementSerializationConstructorsTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/Test/Usage/ImplementSerializationConstructorsTests.Fixer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(858655)]
         protected override CodeFixProvider GetBasicCodeFixProvider()
         {
-            return new CA2229CodeFixProvider();
+            return new ImplementSerializationConstructorsFixer();
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new CA2229CodeFixProvider();
+            return new ImplementSerializationConstructorsFixer();
         }
 
         #region CA2229

--- a/src/Diagnostics/FxCop/Test/Usage/MarkAllNonSerializableFieldsTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/Test/Usage/MarkAllNonSerializableFieldsTests.Fixer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(858655)]
         protected override CodeFixProvider GetBasicCodeFixProvider()
         {
-            return new CA2235BasicCodeFixProvider();
+            return new BasicMarkAllNonSerializableFieldsFixer();
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(858655)]
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new CA2235CSharpCodeFixProvider();
+            return new CSharpMarkAllNonSerializableFieldsFixer();
         }
 
         #region CA2235

--- a/src/Diagnostics/FxCop/Test/Usage/MarkTypesWithSerializableTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/Test/Usage/MarkTypesWithSerializableTests.Fixer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(858655)]
         protected override CodeFixProvider GetBasicCodeFixProvider()
         {
-            return new CA2237CodeFixProvider();
+            return new MarkTypesWithSerializableFixer();
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(858655)]
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new CA2237CodeFixProvider();
+            return new MarkTypesWithSerializableFixer();
         }
 
         #region CA2237

--- a/src/Diagnostics/FxCop/VisualBasic/BasicFxCopRulesDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/FxCop/VisualBasic/BasicFxCopRulesDiagnosticAnalyzers.vbproj
@@ -102,7 +102,7 @@
     <Compile Include="Performance\RemoveEmptyFinalizers.vb" />
     <Compile Include="Usage\BasicCA2200DiagnosticAnalyzer.vb" />
     <Compile Include="Usage\BasicCA2214DiagnosticAnalyzer.vb" />
-    <Compile Include="Usage\CodeFixes\CA2235BasicCodeFixProvider.vb" />
+    <Compile Include="Usage\MarkAllNonSerializableFields.Fixer.vb" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.props">

--- a/src/Diagnostics/FxCop/VisualBasic/Usage/MarkAllNonSerializableFields.Fixer.vb
+++ b/src/Diagnostics/FxCop/VisualBasic/Usage/MarkAllNonSerializableFields.Fixer.vb
@@ -6,8 +6,8 @@ Imports Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.Usage
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:="CA2229 CodeFix provider"), [Shared]>
-    Public Class CA2235BasicCodeFixProvider
-        Inherits CA2235CodeFixProviderBase
+    Public Class BasicMarkAllNonSerializableFieldsFixer
+        Inherits MarkAllNonSerializableFieldsFixer
 
         Protected Overrides Function GetFieldDeclarationNode(node As SyntaxNode) As SyntaxNode
             Dim fieldNode = node
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.Usage
                 fieldNode = fieldNode.Parent
             End While
 
-            Return If(fieldNode.Kind() = VisualBasic.SyntaxKind.FieldDeclaration, fieldNode, Nothing)
+            Return If(fieldNode?.Kind() = VisualBasic.SyntaxKind.FieldDeclaration, fieldNode, Nothing)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fix a bug in CA2235 where it reporting when the backing field of a autoprop was not serializable. Instead, report the violation on the autoprop itself.
The fixers were cleaned up to user the syntaxeditor\generator apis cleanly.

All the file renames are in a single commit - so reviewing commit by commit would give a better diff.