### PR TITLE
Update C# IsNameOfContext Extension

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -2953,6 +2953,7 @@ class C
         End Sub
 
         <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+        <WorkItem(1439, "https://github.com/dotnet/roslyn/issues/1439")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
             Using result = RenameEngineResult.Create(
@@ -2963,7 +2964,7 @@ class C
 {
     void F(int [|$$z|])
     {
-        string x = nameof({|ref:zoo|});
+        nameof({|ref:zoo|}).ToString();
     }
 
     int zoo;
@@ -2973,7 +2974,7 @@ class C
                     </Project>
                 </Workspace>, renameTo:="zoo")
 
-                result.AssertLabeledSpansAre("ref", "string x = nameof(C.zoo);", RelatedLocationType.ResolvedNonReferenceConflict)
+                result.AssertLabeledSpansAre("ref", "nameof(C.zoo).ToString();", RelatedLocationType.ResolvedNonReferenceConflict)
             End Using
         End Sub
 

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2851,6 +2851,7 @@ End Class
             End Sub
 
             <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
+            <WorkItem(1439, "https://github.com/dotnet/roslyn/issues/1439")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
                 Using result = RenameEngineResult.Create(
@@ -2858,8 +2859,8 @@ End Class
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
 Class C
-    Sub F([|$$z|] As Integer)
-        Dim x = NameOf({|ref:zoo|})
+    Sub F([|$$z|] As String)
+        F(NameOf({|ref:zoo|}).ToString())
     End Sub
 
     Dim zoo As Integer
@@ -2868,7 +2869,7 @@ End Class
                         </Project>
                     </Workspace>, renameTo:="zoo")
 
-                    result.AssertLabeledSpansAre("ref", "Dim x = NameOf(C.zoo)", RelatedLocationType.ResolvedNonReferenceConflict)
+                    result.AssertLabeledSpansAre("ref", "F(NameOf(C.zoo).ToString())", RelatedLocationType.ResolvedNonReferenceConflict)
                 End Using
             End Sub
         End Class


### PR DESCRIPTION
Fixes #1439

C#'s version of IsNameOfContext was written against a previous compiler
implementation of nameof in which the expression. Now, we only need to
check whether the nearest containing invocation expression is an
unqualified invocation of "nameof" that doesn't bind to anything.