### PR TITLE
CommonFormattingOptions dont use LangSerializers

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpLanguageSettingsSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpLanguageSettingsSerializer.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
-    [ExportLanguageSpecificOptionSerializer(LanguageNames.CSharp, FormattingOptions.FormattingFeatureName, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), Shared]
+    [ExportLanguageSpecificOptionSerializer(LanguageNames.CSharp, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), Shared]
     internal class CSharpLanguageSettingsSerializer : AbstractLanguageSettingsSerializer
     {
         [ImportingConstructor]

--- a/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicLanguageSettingsSerializer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicLanguageSettingsSerializer.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.Options
 Imports System.Composition
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
-    <ExportLanguageSpecificOptionSerializer(LanguageNames.VisualBasic, FormattingOptions.FormattingFeatureName, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), [Shared]>
+    <ExportLanguageSpecificOptionSerializer(LanguageNames.VisualBasic, FormattingOptions.TabFeatureName, BraceCompletionOptions.FeatureName, CompletionOptions.FeatureName, SignatureHelpOptions.FeatureName, NavigationBarOptions.FeatureName), [Shared]>
     Friend NotInheritable Class VisualBasicLanguageSettingsSerializer
         Inherits AbstractLanguageSettingsSerializer
 

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public static readonly PerLanguageOption<int> IndentationSize = new PerLanguageOption<int>(TabFeatureName, "IndentationSize", defaultValue: 4);
 
-        public static readonly PerLanguageOption<IndentStyle> SmartIndent = new PerLanguageOption<IndentStyle>(FormattingFeatureName, "SmartIndent", defaultValue: IndentStyle.Smart);
+        public static readonly PerLanguageOption<IndentStyle> SmartIndent = new PerLanguageOption<IndentStyle>(TabFeatureName, "SmartIndent", defaultValue: IndentStyle.Smart);
 
         public static readonly PerLanguageOption<string> NewLine = new PerLanguageOption<string>(FormattingFeatureName, "NewLine", defaultValue: "\r\n");
 


### PR DESCRIPTION
Fix #2218 Language Settings Serializers should not be used to serialize
Non-PerLangaugeOptions. This change addresses this issue