### PR TITLE
Check analyzer consistency

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -11801,6 +11801,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The analyzer assembly {0} does not match the loaded assembly &apos;{1}&apos;.  Analyzers may not work as expected..
+        /// </summary>
+        internal static string WRN_LoadedAnalyzerDiffers {
+            get {
+                return ResourceManager.GetString("WRN_LoadedAnalyzerDiffers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specified analyzer does not match the loaded assembly.
+        /// </summary>
+        internal static string WRN_LoadedAnalyzerDiffers_Title {
+            get {
+                return ResourceManager.GetString("WRN_LoadedAnalyzerDiffers_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;l&apos; suffix is easily confused with the digit &apos;1&apos; -- use &apos;L&apos; for clarity.
         /// </summary>
         internal static string WRN_LowercaseEllSuffix {
@@ -11851,6 +11869,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string WRN_MainIgnored_Title {
             get {
                 return ResourceManager.GetString("WRN_MainIgnored_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The assembly &apos;{0}&apos; is required by analyzer {1} but was not found.  Analyzers may not work as expected..
+        /// </summary>
+        internal static string WRN_MissingAnalyzerDependency {
+            get {
+                return ResourceManager.GetString("WRN_MissingAnalyzerDependency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An assembly required by an analyzer was not found.
+        /// </summary>
+        internal static string WRN_MissingAnalyzerDependency_Title {
+            get {
+                return ResourceManager.GetString("WRN_MissingAnalyzerDependency_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4633,4 +4633,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ContantStringTooLong" xml:space="preserve">
     <value>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</value>
   </data>
+  <data name="WRN_LoadedAnalyzerDiffers" xml:space="preserve">
+    <value>The analyzer assembly {0} does not match the loaded assembly '{1}'.  Analyzers may not work as expected.</value>
+  </data>
+  <data name="WRN_LoadedAnalyzerDiffers_Title" xml:space="preserve">
+    <value>Specified analyzer does not match the loaded assembly</value>
+  </data>
+  <data name="WRN_MissingAnalyzerDependency" xml:space="preserve">
+    <value>The assembly '{0}' is required by analyzer {1} but was not found.  Analyzers may not work as expected.</value>
+  </data>
+  <data name="WRN_MissingAnalyzerDependency_Title" xml:space="preserve">
+    <value>An assembly required by an analyzer was not found</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1273,7 +1273,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadPdbData = 8036,
         // available 8037-8039
         INF_UnableToLoadSomeTypesInAnalyzer = 8040,
-        // available 8041-8049
+        WRN_LoadedAnalyzerDiffers = 8041,
+        WRN_MissingAnalyzerDependency = 8042,
+        // available 8043-8049
         ERR_InitializerOnNonAutoProperty = 8050,
         ERR_AutoPropertyMustHaveGetAccessor = 8051,
         ERR_AutoPropertyInitializerInInterface = 8052,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -274,6 +274,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AnalyzerCannotBeCreated:
                 case ErrorCode.WRN_NoAnalyzerInAssembly:
                 case ErrorCode.WRN_UnableToLoadAnalyzer:
+                case ErrorCode.WRN_MissingAnalyzerDependency:
+                case ErrorCode.WRN_LoadedAnalyzerDiffers:
                 case ErrorCode.WRN_DefineIdentifierRequired:
                 case ErrorCode.WRN_CLS_NoVarArgs:
                 case ErrorCode.WRN_CLS_BadArgType:

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -199,6 +199,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override int ERR_MetadataNameTooLong { get { return (int)ErrorCode.ERR_MetadataNameTooLong; } }
         public override int ERR_EncReferenceToAddedMember { get { return (int)ErrorCode.ERR_EncReferenceToAddedMember; } }
 
+        public override int WRN_LoadedAnalyzerDiffers { get { return (int)ErrorCode.WRN_LoadedAnalyzerDiffers; } }
+        public override int WRN_MissingAnalyzerDependency { get { return (int)ErrorCode.WRN_MissingAnalyzerDependency; } }
+
         public override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -28,6 +28,7 @@
     <Compile Include="AnalyzerFileReferenceTests.cs" />
     <Compile Include="AsyncQueueTests.cs" />
     <Compile Include="Collections\BoxesTest.cs" />
+    <Compile Include="ConsistencyCheckerTests.cs" />
     <Compile Include="Diagnostics\DiagnosticLocalizationTests.cs" />
     <Compile Include="Emit\EmitOptionsTests.cs" />
     <Compile Include="Emit\CustomDebugInfoTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/ConsistencyCheckerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ConsistencyCheckerTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class ConsistencyCheckerTests : TestBase
+    {
+        [Fact]
+        public void BadFileOnDisk()
+        {
+            var directory = Temp.CreateDirectory();
+
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            var alphaAssembly = Assembly.Load(File.ReadAllBytes(alphaDll.Path));
+            var badFile = directory.CreateFile("Alpha.dll.bad").WriteAllText("This is not an assembly");
+
+            var consistencyChecker = new ConsistencyChecker(Enumerable.Empty<string>());
+            var analyzerAssemblies = new Dictionary<string, Assembly>
+            {
+                { badFile.Path, alphaAssembly }
+            };
+
+            var errors = consistencyChecker.CheckAssemblies(analyzerAssemblies);
+
+            Assert.Equal(expected: 1, actual: errors.Length);
+            Assert.Equal(expected: ConsistencyErrorKind.UnableToReadFile, actual: errors[0].Kind);
+        }
+
+        [Fact]
+        public void MissingReference()
+        {
+            var directory = Temp.CreateDirectory();
+
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            var alphaAssembly = Assembly.Load(File.ReadAllBytes(alphaDll.Path));
+
+            var consistencyChecker = new ConsistencyChecker(Enumerable.Empty<string>());
+            var analyzerAssemblies = new Dictionary<string, Assembly>
+            {
+                { alphaDll.Path, alphaAssembly }
+            };
+
+            var errors = consistencyChecker.CheckAssemblies(analyzerAssemblies);
+
+            Assert.Equal(expected: 2, actual: errors.Length);
+            Assert.Equal(expected: ConsistencyErrorKind.MissingReference, actual: errors[0].Kind);
+            Assert.Equal(expected: ConsistencyErrorKind.MissingReference, actual: errors[1].Kind);
+        }
+
+        [Fact]
+        public void WhiteListPreventsMissingReferenceErrors()
+        {
+            var directory = Temp.CreateDirectory();
+
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            var alphaAssembly = Assembly.Load(File.ReadAllBytes(alphaDll.Path));
+
+            var consistencyChecker = new ConsistencyChecker(new[] { "mscorlib", "Gamma" });
+            var analyzerAssemblies = new Dictionary<string, Assembly>
+            {
+                { alphaDll.Path, alphaAssembly }
+            };
+
+            var errors = consistencyChecker.CheckAssemblies(analyzerAssemblies);
+
+            Assert.Equal(expected: 0, actual: errors.Length);
+        }
+
+        [Fact]
+        public void LoadedAssemblyIsDifferent()
+        {
+            var directory = Temp.CreateDirectory();
+
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            var betaDll = directory.CreateFile("Beta.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Beta);
+            var betaAssembly = Assembly.Load(File.ReadAllBytes(betaDll.Path));
+
+            var consistencyChecker = new ConsistencyChecker(new[] { "mscorlib", "Gamma" });
+            var analyzerAssemblies = new Dictionary<string, Assembly>
+            {
+                { alphaDll.Path, betaAssembly }
+            };
+
+            var errors = consistencyChecker.CheckAssemblies(analyzerAssemblies);
+
+            Assert.Equal(expected: 1, actual: errors.Length);
+            Assert.Equal(expected: ConsistencyErrorKind.LoadedAssemblyDiffers, actual: errors[0].Kind);
+        }
+
+        [Fact]
+        public void MultipleAssemblies()
+        {
+            var directory = Temp.CreateDirectory();
+
+            var alphaDll = Temp.CreateDirectory().CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            var betaDll = Temp.CreateDirectory().CreateFile("Beta.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Beta);
+            var gammaDll = Temp.CreateDirectory().CreateFile("Gamma.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Gamma);
+            var deltaDll = Temp.CreateDirectory().CreateFile("Delta.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Delta);
+
+            var analyzerAssemblies = new Dictionary<string, Assembly>
+            {
+                { alphaDll.Path, Assembly.Load(File.ReadAllBytes(alphaDll.Path)) },
+                { betaDll.Path, Assembly.Load(File.ReadAllBytes(betaDll.Path)) },
+                { gammaDll.Path, Assembly.Load(File.ReadAllBytes(gammaDll.Path)) },
+                { deltaDll.Path, Assembly.Load(File.ReadAllBytes(deltaDll.Path)) }
+            };
+
+            var consistencyChecker = new ConsistencyChecker(new[] { "mscorlib" });
+
+            var errors = consistencyChecker.CheckAssemblies(analyzerAssemblies);
+
+            Assert.Equal(expected: 0, actual: errors.Length);
+        }
+    }
+}

--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -77,6 +77,7 @@
     <Compile Include="CommandLine\ErrorLogger.cs" />
     <Compile Include="CommandLine\TouchedFileLogger.cs" />
     <Compile Include="CompilerPathUtilities.cs" />
+    <Compile Include="ConsistencyChecker.cs" />
     <Compile Include="FileSystemExtensions.cs" />
     <Compile Include="DesktopStrongNameProvider.cs" />
     <Compile Include="CommandLineAnalyzerReference.cs" />

--- a/src/Compilers/Core/Desktop/ConsistencyChecker.cs
+++ b/src/Compilers/Core/Desktop/ConsistencyChecker.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal enum ConsistencyErrorKind
+    {
+        UnableToReadFile,
+        MissingReference,
+        LoadedAssemblyDiffers,
+    }
+
+    internal sealed class ConsistencyError
+    {
+        public ConsistencyErrorKind Kind { get; }
+        public string FilePath { get; }
+        public string RelatedAssemblyName { get; }
+        public Exception Exception { get; }
+
+        public ConsistencyError(ConsistencyErrorKind kind, string filePath, string relatedAssemblyName = null, Exception exception = null)
+        {
+            Kind = kind;
+            FilePath = filePath;
+            RelatedAssemblyName = relatedAssemblyName;
+            Exception = exception;
+        }
+    }
+
+    /// <summary>
+    /// Validates that a set of analyzer assemblies on disk and their loaded
+    /// equivalents are complete and consistent.
+    /// 
+    /// This type performs two checks:
+    /// 1.) It checks that the assembly file on disk and the corresponding loaded
+    /// assembly are the same. This is done by comparing the MVIDs values.
+    /// 
+    /// 2.) It checks that all of an assemblies dependencies are satisified by
+    /// other assemblies in the set. E.g., if assembly A depends on assembly B,
+    /// B must also be specified. A whitelist can be provided to skip checks for
+    /// assemblies that are expected to be provided and loaded by the host, for
+    /// example, mscorlib, System.*, and Microsoft.CodeAnalysis.*.
+    /// 
+    /// Together these rules catch cases where an analyzer may not have all the
+    /// dependencies it needs to run correctly, or where it is going to run with
+    /// different dependencies than expected.
+    /// </summary>
+    internal sealed class ConsistencyChecker
+    {
+        private readonly ImmutableArray<string> _prefixWhiteList;
+
+        public ConsistencyChecker(IEnumerable<string> prefixWhiteList)
+        {
+            _prefixWhiteList = ImmutableArray.CreateRange(prefixWhiteList);
+        }
+
+        public ImmutableArray<ConsistencyError> CheckAssemblies(Dictionary<string, Assembly> pathsToAssemblies, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ArrayBuilder<ConsistencyError> errors = new ArrayBuilder<ConsistencyError>();
+
+            Dictionary<string, Guid> pathsToMvids = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+            HashSet<AssemblyIdentity> identitiesOfAssembliesOnDisk = new HashSet<AssemblyIdentity>();
+            Dictionary<string, ImmutableArray<AssemblyIdentity>> pathsToReferences = new Dictionary<string, ImmutableArray<AssemblyIdentity>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var path in pathsToAssemblies.Keys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    using (var reader = new PEReader(FileUtilities.OpenRead(path)))
+                    {
+                        var metadataReader = reader.GetMetadataReader();
+
+                        pathsToMvids[path] = metadataReader.GetModuleVersionIdOrThrow();
+                        identitiesOfAssembliesOnDisk.Add(metadataReader.ReadAssemblyIdentityOrThrow());
+                        pathsToReferences[path] = metadataReader.GetReferencedAssembliesOrThrow();
+                    }
+                }
+                catch (Exception e)
+                {
+                    errors.Add(new ConsistencyError(ConsistencyErrorKind.UnableToReadFile, path, exception: e));
+                }
+            }
+
+            if (errors.Count > 0)
+            {
+                return errors.ToImmutable();
+            }
+
+            foreach (var path in pathsToAssemblies.Keys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Guid fileMvid = pathsToMvids[path];
+                Guid loadedMvid = pathsToAssemblies[path].ManifestModule.ModuleVersionId;
+
+                if (fileMvid != loadedMvid)
+                {
+                    errors.Add(
+                        new ConsistencyError(
+                            ConsistencyErrorKind.LoadedAssemblyDiffers,
+                            path,
+                            pathsToAssemblies[path].FullName));
+                }
+
+                ImmutableArray<AssemblyIdentity> references = pathsToReferences[path];
+                foreach (var reference in references)
+                {
+                    if (!identitiesOfAssembliesOnDisk.Contains(reference) &&
+                        !_prefixWhiteList.Any(prefix => reference.Name.StartsWith(prefix)))
+                    {
+
+                        errors.Add(
+                            new ConsistencyError(
+                                ConsistencyErrorKind.MissingReference,
+                                path,
+                                reference.ToString()));
+                    }
+                }
+            }
+
+            return errors.ToImmutable();
+        }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -202,6 +202,10 @@ namespace Microsoft.CodeAnalysis
         public abstract int ERR_MetadataNameTooLong { get; }
         public abstract int ERR_EncReferenceToAddedMember { get; }
 
+        // Analyzers:
+        public abstract int WRN_MissingAnalyzerDependency { get; }
+        public abstract int WRN_LoadedAnalyzerDiffers { get; }
+
         public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
         public abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);
         public abstract void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex);

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1897,9 +1897,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         WRN_AnalyzerCannotBeCreated = 42376
         WRN_NoAnalyzerInAssembly = 42377
         WRN_UnableToLoadAnalyzer = 42378
+        WRN_LoadedAnalyzerDiffers = 42379
+        WRN_MissingAnalyzerDependency = 42380
 
-        ' // AVAILABLE                             42379 - 49998
-        ERRWRN_Last = WRN_UnableToLoadAnalyzer + 1
+        ' // AVAILABLE                             42381 - 49998
+        ERRWRN_Last = WRN_MissingAnalyzerDependency + 1
 
         '// HIDDENS AND INFOS BEGIN HERE
         HDN_UnusedImportClause = 50000

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -327,6 +327,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property WRN_LoadedAnalyzerDiffers As Integer
+            Get
+                Return ERRID.WRN_LoadedAnalyzerDiffers
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property WRN_MissingAnalyzerDependency As Integer
+            Get
+                Return ERRID.WRN_MissingAnalyzerDependency
+            End Get
+        End Property
+
         Public Overrides Sub ReportDuplicateMetadataReferenceStrong(diagnostics As DiagnosticBag, location As Location, reference As MetadataReference, identity As AssemblyIdentity, equivalentReference As MetadataReference, equivalentIdentity As AssemblyIdentity)
             diagnostics.Add(ERRID.ERR_DuplicateReferenceStrong,
                             DirectCast(location, Location),

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -13306,6 +13306,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to The analyzer assembly {0} does not match the loaded assembly &apos;{1}&apos;.  Analyzers may not work as expected..
+        '''</summary>
+        Friend ReadOnly Property WRN_LoadedAnalyzerDiffers() As String
+            Get
+                Return ResourceManager.GetString("WRN_LoadedAnalyzerDiffers", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Specified analyzer does not match the loaded assembly.
+        '''</summary>
+        Friend ReadOnly Property WRN_LoadedAnalyzerDiffers_Title() As String
+            Get
+                Return ResourceManager.GetString("WRN_LoadedAnalyzerDiffers_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to The entry point of the program is global script code; ignoring &apos;{0}&apos; entry point..
         '''</summary>
         Friend ReadOnly Property WRN_MainIgnored() As String
@@ -13338,6 +13356,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property WRN_MemberShadowsSynthMember6_Title() As String
             Get
                 Return ResourceManager.GetString("WRN_MemberShadowsSynthMember6_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to The assembly &apos;{0}&apos; is required by analyzer {1} but was not found.  Analyzers may not work as expected..
+        '''</summary>
+        Friend ReadOnly Property WRN_MissingAnalyzerDependency() As String
+            Get
+                Return ResourceManager.GetString("WRN_MissingAnalyzerDependency", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to An assembly required by an analyzer was not found.
+        '''</summary>
+        Friend ReadOnly Property WRN_MissingAnalyzerDependency_Title() As String
+            Get
+                Return ResourceManager.GetString("WRN_MissingAnalyzerDependency_Title", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5294,4 +5294,16 @@
   <data name="FEATURE_NameOfExpressions" xml:space="preserve">
     <value>'nameof' expressions</value>
   </data>
+  <data name="WRN_LoadedAnalyzerDiffers" xml:space="preserve">
+    <value>The analyzer assembly {0} does not match the loaded assembly '{1}'.  Analyzers may not work as expected.</value>
+  </data>
+  <data name="WRN_LoadedAnalyzerDiffers_Title" xml:space="preserve">
+    <value>Specified analyzer does not match the loaded assembly</value>
+  </data>
+  <data name="WRN_MissingAnalyzerDependency" xml:space="preserve">
+    <value>The assembly '{0}' is required by analyzer {1} but was not found.  Analyzers may not work as expected.</value>
+  </data>
+  <data name="WRN_MissingAnalyzerDependency_Title" xml:space="preserve">
+    <value>An assembly required by an analyzer was not found</value>
+  </data>
 </root>

--- a/src/Test/Utilities/TestMessageProvider.cs
+++ b/src/Test/Utilities/TestMessageProvider.cs
@@ -229,6 +229,16 @@ namespace Roslyn.Test.Utilities
             get { throw new NotImplementedException(); }
         }
 
+        public override int WRN_LoadedAnalyzerDiffers
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override int WRN_MissingAnalyzerDependency
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public override void ReportDuplicateMetadataReferenceStrong(DiagnosticBag diagnostics, Location location, MetadataReference reference, AssemblyIdentity identity, MetadataReference equivalentReference, AssemblyIdentity equivalentIdentity)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
*Note that this change is incomplete. This work is not yet wired into VS or vbcscompiler.exe. However, I want to get the core parts out for review as quickly as possible.*

The change adds the `ConsistencyChecker` type and wires it into csc.exe
and vbc.exe. This type validates that a set of analyzer assemblies on
disk and their loaded equivalents are complete and consistent.

This type performs two checks:

1. It checks that the assembly file on disk and the corresponding loaded
   assembly are the same. This is done by comparing the MVIDs values.
2. It checks that all of an assemblies dependencies are satisified by
   other assemblies in the set. E.g., if assembly A depends on assembly B,
   B must also be specified. A whitelist can be provided to skip checks for
   assemblies that are expected to be provided and loaded by the host, for
   example, mscorlib, System.*, and Microsoft.CodeAnalysis.*.

Together these rules catch cases where an analyzer may not have all the
dependencies it needs to run correctly, or where it is going to run with
different dependencies than expected.