### PR TITLE
Handle cancellation tokens correctly in 'fix all occurences'

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesCodeAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesCodeAction.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var previewDialogService = _workspace.Services.GetService<IPreviewDialogService>();
             if (previewDialogService == null)
             {
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 return null;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             return await _originalCodeAction.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Features/Core/CodeFixes/FixAllOccurrences/FixAllCodeAction.cs
+++ b/src/Features/Core/CodeFixes/FixAllOccurrences/FixAllCodeAction.cs
@@ -43,10 +43,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             FixAllLogger.LogContext(_fixAllContext, IsInternalCodeFixProvider(_fixAllContext.CodeFixProvider));
 
             var service = _fixAllContext.Project.Solution.Workspace.Services.GetService<IFixAllGetFixesService>();
-            return await service.GetFixAllOperationsAsync(_fixAllProvider, _fixAllContext).ConfigureAwait(false);
+            // Use the new cancellation token instead of the stale one present inside _fixAllContext.
+            return await service.GetFixAllOperationsAsync(_fixAllProvider, _fixAllContext.WithCancellationToken(cancellationToken)).ConfigureAwait(false);
         }
 
         private static bool IsInternalCodeFixProvider(CodeFixProvider fixer)


### PR DESCRIPTION
Use the correct cancellation token in 'fix all occurences' and also bail on cancellation in more places in the 'fix all occurences' code path.