### PR TITLE
Bug1735

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -118,9 +118,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                         {
                             return GetIndentationFromCommaSeparatedList(previousToken);
                         }
-
-                        // okay, beginning of the line is not trivia, use the last token on the line as base token
-                        return GetIndentationBasedOnToken(token);
+                        else if (!previousToken.IsKind(SyntaxKind.None))
+                        {
+                            // okay, beginning of the line is not trivia, use the last token on the line as base token
+                            return GetIndentationBasedOnToken(token);
+                        }
                     }
 
                     // this case we will keep the indentation of this trivia line

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -97,6 +97,20 @@ using System.Linq;
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void AfterTopOfFileComment()
+        {
+            var code = @"// comment
+
+class
+";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 2,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void DottedName()
         {
             var code = @"using System.


### PR DESCRIPTION
Fix for #1735 

@basoundr @Pilchie  please review.

The smart indenter is not very smart when it comes to the first token in the file. The logic is hard to follow in the GetDesiredIndentation function, (I'm not entirely sure what it all is trying to do), but it definitely should not have been attempting to determine the indentation based on the token in this case, because that function assumes that minimum indentation must occur.