### PR TITLE
Reset ExpressionCompiler error message on each retry

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
@@ -21,39 +21,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal static readonly AssemblyIdentity SystemXmlLinqIdentity = new AssemblyIdentity("System.Xml.Linq");
         internal static readonly AssemblyIdentity MicrosoftVisualBasicIdentity = new AssemblyIdentity("Microsoft.VisualBasic");
 
-        /// <summary>
-        /// Compile C# expression and emit assembly with evaluation method.
-        /// </summary>
-        /// <returns>
-        /// Result containing generated assembly, type and method names, and any format specifiers.
-        /// </returns>
-        internal CompileResult CompileExpression(
-            InspectionContext inspectionContext,
-            string expr,
-            DkmEvaluationFlags compilationFlags,
-            DiagnosticFormatter formatter,
-            out ResultProperties resultProperties,
-            out string error,
-            out ImmutableArray<AssemblyIdentity> missingAssemblyIdentities,
-            CultureInfo preferredUICulture,
-            CompilationTestData testData)
-        {
-            var diagnostics = DiagnosticBag.GetInstance();
-            var result = this.CompileExpression(inspectionContext, expr, compilationFlags, diagnostics, out resultProperties, testData);
-            if (diagnostics.HasAnyErrors())
-            {
-                bool useReferencedModulesOnly;
-                error = GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, out useReferencedModulesOnly, out missingAssemblyIdentities);
-            }
-            else
-            {
-                error = null;
-                missingAssemblyIdentities = ImmutableArray<AssemblyIdentity>.Empty;
-            }
-            diagnostics.Free();
-            return result;
-        }
-
         internal abstract CompileResult CompileExpression(
             InspectionContext inspectionContext,
             string expr,

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -292,13 +292,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             DkmUtilities.GetMetadataBytesPtrFunction getMetaDataBytesPtr,
             out string errorMessage)
         {
-            errorMessage = null;
             TResult compileResult;
 
             PooledHashSet<AssemblyIdentity> assembliesLoadedInRetryLoop = null;
             bool tryAgain;
             do
             {
+                errorMessage = null;
+
                 var context = createContext(metadataBlocks, useReferencedModulesOnly: false);
                 var diagnostics = DiagnosticBag.GetInstance();
                 compileResult = compile(context, diagnostics);

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -106,6 +106,40 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return result;
         }
 
+        /// <summary>
+        /// Compile C# expression and emit assembly with evaluation method.
+        /// </summary>
+        /// <returns>
+        /// Result containing generated assembly, type and method names, and any format specifiers.
+        /// </returns>
+        static internal CompileResult CompileExpression(
+            this EvaluationContextBase evaluationContext,
+            InspectionContext inspectionContext,
+            string expr,
+            DkmEvaluationFlags compilationFlags,
+            DiagnosticFormatter formatter,
+            out ResultProperties resultProperties,
+            out string error,
+            out ImmutableArray<AssemblyIdentity> missingAssemblyIdentities,
+            CultureInfo preferredUICulture,
+            CompilationTestData testData)
+        {
+            var diagnostics = DiagnosticBag.GetInstance();
+            var result = evaluationContext.CompileExpression(inspectionContext, expr, compilationFlags, diagnostics, out resultProperties, testData);
+            if (diagnostics.HasAnyErrors())
+            {
+                bool useReferencedModulesOnly;
+                error = evaluationContext.GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, out useReferencedModulesOnly, out missingAssemblyIdentities);
+            }
+            else
+            {
+                error = null;
+                missingAssemblyIdentities = ImmutableArray<AssemblyIdentity>.Empty;
+            }
+            diagnostics.Free();
+            return result;
+        }
+
         internal static CompileResult CompileExpressionWithRetry(
             ImmutableArray<MetadataBlock> metadataBlocks,
             EvaluationContextBase context,


### PR DESCRIPTION
The expression compiler was returning a non-null error string in cases
where it succeeded on retry.