### PR TITLE
[EnC] VS Crash when updating a method with async lambda

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 var generator = synthesizedDef.Method;
                 var synthesizedSymbol = (ISymbol)synthesizedDef;
 
-                switch (GetChange(generator))
+                switch (GetChange((IDefinition)generator))
                 {
                     case SymbolChange.Updated:
                         // The generator has been updated. Some synthesized members should be reused, others updated or added.

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -888,12 +888,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim stateMachineTypeOpt As StateMachineTypeSymbol = Nothing
+            Dim variableSlotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method)
 
             ' In case of async/iterator lambdas, the method has already been uniquely named, so there is no need to
             ' produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) method name.
             Const methodOrdinal As Integer = -1
 
-            Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, SlotAllocatorOpt, stateMachineTypeOpt)
+            Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, slotAllocatorOpt:=variableSlotAllocatorOpt, stateMachineTypeOpt:=stateMachineTypeOpt) ' /* SlotAllocatorOpt:=Nothing*/
         End Function
 
         Public Overrides Function VisitTryCast(node As BoundTryCast) As BoundNode


### PR DESCRIPTION
The symbol change around async lambda is not properly covered, resulting into unreachable exception.