### PR TITLE
Make constructor for Location internal

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public abstract class Location
     {
-        protected Location()
+        internal Location()
         {
         }
 

--- a/src/Compilers/Core/Portable/PublicAPI.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.txt
@@ -602,7 +602,6 @@ Microsoft.CodeAnalysis.LocalizableString.ToString(System.IFormatProvider formatP
 Microsoft.CodeAnalysis.Location
 Microsoft.CodeAnalysis.Location.IsInMetadata.get -> bool
 Microsoft.CodeAnalysis.Location.IsInSource.get -> bool
-Microsoft.CodeAnalysis.Location.Location() -> void
 Microsoft.CodeAnalysis.LocationKind
 Microsoft.CodeAnalysis.LocationKind.ExternalFile = 4 -> Microsoft.CodeAnalysis.LocationKind
 Microsoft.CodeAnalysis.LocationKind.MetadataFile = 2 -> Microsoft.CodeAnalysis.LocationKind


### PR DESCRIPTION
Fixes #1587

Location is currently a public abstract class. However, since Location is something that can be provided to a Roslyn Diagnostic (via Diagnostic.Create()) supporting arbitrary derived Location types means that Roslyn's analyzer and fixer engines would need to be resilient against arbitrary implemntations that can throw exceptions.

This change makes it impossible to inherit Location externally so that we don't have to do complicated work to guard against such implementations.

There are no known external inheritors of Location at the moment (as far as we are aware). Plus we always have the option to ease this restriction and allow inheritance in the future if we find that there are legitimate use cases for it.