### PR TITLE
made error list to report Project ID Guid to error list

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IVsHierarchyEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IVsHierarchyEvents.cs
@@ -69,6 +69,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 UpdateProjectDisplayNameAndFilePath();
             }
 
+            if ((propid == (int)__VSHPROPID.VSHPROPID_ProjectIDGuid) &&
+                 itemid == (uint)VSConstants.VSITEMID.Root)
+            {
+                // this should happen whle project loading if it ever happens
+                _guid = GetProjectIDGuid(_hierarchy);
+            }
+
             return VSConstants.S_OK;
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -44,11 +44,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             public SourceCodeKind SourceCodeKind { get; }
             public DocumentKey Key { get; }
 
-            /// <summary>
-            /// <see cref="IVsHierarchy"/> of shared or project k project.
-            /// </summary>
-            public IVsHierarchy SharedHierarchy { get; }
-
             public event EventHandler UpdatedOnDisk;
             public event EventHandler<bool> Opened;
             public event EventHandler<bool> Closing;
@@ -72,11 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
                 this.Folders = project.GetFolderNames(itemId);
 
-                // TODO: 
-                // this one doesn't work for asynchronous project load situation where shared projects is loaded after one uses shared file. 
-                // we need to figure out what to do on those case. but this works for project k case.
-                // opened an issue to track this issue - https://github.com/dotnet/roslyn/issues/1859
-                this.SharedHierarchy = project.Hierarchy == null ? null : LinkedFileUtilities.GetSharedHierarchyForItem(project.Hierarchy, itemId);
                 _documentProvider = documentProvider;
 
                 this.Key = documentKey;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
@@ -97,12 +97,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         uint GetItemId();
 
         /// <summary>
-        /// Returns <see cref="IVsHierarchy"/> of the shared (or project k) project this <see cref="IVisualStudioHostDocument"/> belongs to.
-        /// it will return null if it belongs to a normal project.
-        /// </summary>
-        IVsHierarchy SharedHierarchy { get; }
-
-        /// <summary>
         /// Gets the text container associated with the document when it is in an opened state.
         /// </summary>
         /// <returns></returns>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -14,7 +15,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     {
         ProjectId Id { get; }
         string Language { get; }
+
         IVsHierarchy Hierarchy { get; }
+        Guid Guid { get; }
+
         Workspace Workspace { get; }
         string ProjectSystemName { get; }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.HostProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.HostProject.cs
@@ -61,20 +61,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     hostObjectType: null);
             }
 
-            public Microsoft.VisualStudio.Shell.Interop.IVsHierarchy Hierarchy
-            {
-                get { return null; }
-            }
+            public Microsoft.VisualStudio.Shell.Interop.IVsHierarchy Hierarchy => null;
 
-            public Workspace Workspace
-            {
-                get { return _workspace; }
-            }
+            public Guid Guid => Guid.Empty;
 
-            public string ProjectSystemName
-            {
-                get { return "MiscellaneousFiles"; }
-            }
+            public Workspace Workspace => _workspace;
+
+            public string ProjectSystemName => "MiscellaneousFiles";
 
             public IVisualStudioHostDocument GetDocumentOrAdditionalDocument(DocumentId id)
             {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
@@ -2,14 +2,12 @@
 
 using System;
 using System.Collections.Immutable;
-using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TableControl;
 using Microsoft.VisualStudio.TableManager;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -18,15 +16,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
     internal abstract class AbstractTableEntriesSnapshot<TData> : ITableEntriesSnapshot
     {
+        // TODO: remove this once we have new drop
+        protected const string ProjectGuidKey = "projectguid";
+
         private readonly int _version;
         private readonly ImmutableArray<TData> _items;
         private ImmutableArray<ITrackingPoint> _trackingPoints;
 
-        protected AbstractTableEntriesSnapshot(int version, ImmutableArray<TData> items, ImmutableArray<ITrackingPoint> trackingPoints)
+        protected readonly Guid ProjectGuid;
+
+        protected AbstractTableEntriesSnapshot(int version, Guid projectGuid, ImmutableArray<TData> items, ImmutableArray<ITrackingPoint> trackingPoints)
         {
             _version = version;
             _items = items;
             _trackingPoints = trackingPoints;
+
+            ProjectGuid = projectGuid;
         }
 
         public abstract object SnapshotIdentity { get; }
@@ -212,6 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             return project.Name;
         }
 
+        // TODO: remove this once we moved to new drop
         protected IVsHierarchy GetHierarchy(Workspace workspace, ProjectId projectId)
         {
             if (projectId == null)
@@ -226,6 +232,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             }
 
             return vsWorkspace.GetHierarchy(projectId);
+        }
+
+        protected static Guid GetProjectGuid(Workspace workspace, ProjectId projectId)
+        {
+            if (projectId == null)
+            {
+                return Guid.Empty;
+            }
+
+            var vsWorkspace = workspace as VisualStudioWorkspaceImpl;
+            var project = vsWorkspace?.GetHostProject(projectId);
+            if (project == null)
+            {
+                return Guid.Empty;
+            }
+
+            return project.Guid;
         }
 
         // we don't use these

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             return project.Name;
         }
 
-        protected IVsHierarchy GetHierarchy(Workspace workspace, ProjectId projectId, DocumentId documentId)
+        protected IVsHierarchy GetHierarchy(Workspace workspace, ProjectId projectId)
         {
             if (projectId == null)
             {
@@ -223,18 +223,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             if (vsWorkspace == null)
             {
                 return null;
-            }
-
-            if (documentId != null)
-            {
-                // document doesn't actually exist in the workspace
-                var document = vsWorkspace.GetHostDocument(documentId);
-                if (document == null)
-                {
-                    return null;
-                }
-
-                return document.SharedHierarchy ?? document.Project.Hierarchy;
             }
 
             return vsWorkspace.GetHierarchy(projectId);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -238,6 +238,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 private class TableEntriesSnapshot : AbstractTableEntriesSnapshot<DiagnosticData>, IWpfTableEntriesSnapshot
                 {
                     private readonly TableEntriesFactory _factory;
+
+                    // TODO: remove this once we get new drop
                     private readonly int _projectRank;
 
                     private FrameworkElement[] _descriptions;
@@ -245,7 +247,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     public TableEntriesSnapshot(
                         TableEntriesFactory factory, int version,
                         int projectRank, ImmutableArray<DiagnosticData> items, ImmutableArray<ITrackingPoint> trackingPoints) :
-                        base(version, items, trackingPoints)
+                        base(version, GetProjectGuid(factory._workspace, factory._projectId), items, trackingPoints)
                     {
                         _projectRank = projectRank;
                         _factory = factory;
@@ -311,7 +313,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             case StandardTableKeyNames.ProjectName:
                                 content = GetProjectName(_factory._workspace, _factory._projectId);
                                 return content != null;
+                            case ProjectGuidKey:
+                                content = ProjectGuid;
+                                return ProjectGuid != Guid.Empty;
                             case StandardTableKeyNames.Project:
+                                // TODO: remove this once we move to new drop
                                 content = GetHierarchy(_factory._workspace, _factory._projectId);
                                 return content != null;
                             default:

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetProjectName(_factory._workspace, _factory._projectId);
                                 return content != null;
                             case StandardTableKeyNames.Project:
-                                content = GetHierarchy(_factory._workspace, _factory._projectId, _factory._documentId);
+                                content = GetHierarchy(_factory._workspace, _factory._projectId);
                                 return content != null;
                             default:
                                 content = null;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetProjectName(_factory._workspace, _factory._documentId.ProjectId);
                                 return content != null;
                             case StandardTableKeyNames.Project:
-                                content = GetHierarchy(_factory._workspace, _factory._documentId.ProjectId, _factory._documentId);
+                                content = GetHierarchy(_factory._workspace, _factory._documentId.ProjectId);
                                 return content != null;
                             case StandardTableKeyNames.TaskCategory:
                                 content = VSTASKCATEGORY.CAT_COMMENTS;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
                     public TableEntriesSnapshot(
                         TableEntriesFactory factory, int version, ImmutableArray<TodoTaskItem> items, ImmutableArray<ITrackingPoint> trackingPoints) :
-                        base(version, items, trackingPoints)
+                        base(version, GetProjectGuid(factory._workspace, factory._documentId.ProjectId), items, trackingPoints)
                     {
                         _factory = factory;
                     }
@@ -187,7 +187,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             case StandardTableKeyNames.ProjectName:
                                 content = GetProjectName(_factory._workspace, _factory._documentId.ProjectId);
                                 return content != null;
+                            case ProjectGuidKey:
+                                content = ProjectGuid;
+                                return ProjectGuid != Guid.Empty;
                             case StandardTableKeyNames.Project:
+                                // TODO: remove this once moved to new drop
                                 content = GetHierarchy(_factory._workspace, _factory._documentId.ProjectId);
                                 return content != null;
                             case StandardTableKeyNames.TaskCategory:

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -70,7 +70,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly ReiteratedVersionSnapshotTracker _snapshotTracker;
         private readonly IFormattingRule _vbHelperFormattingRule;
         private readonly string _itemMoniker;
-        private readonly IVsHierarchy _sharedHierarchy;
 
         public AbstractProject Project { get { return _containedLanguage.Project; } }
         public bool SupportsRename { get { return _hostType == HostType.Razor; } }
@@ -79,14 +78,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         public IReadOnlyList<string> Folders { get; }
         public TextLoader Loader { get; }
         public DocumentKey Key { get; }
-
-        public IVsHierarchy SharedHierarchy
-        {
-            get
-            {
-                return _sharedHierarchy;
-            }
-        }
 
         public ContainedDocument(
             AbstractContainedLanguage containedLanguage,
@@ -108,11 +99,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             var rdt = (IVsRunningDocumentTable)componentModel.GetService<SVsServiceProvider>().GetService(typeof(SVsRunningDocumentTable));
 
+            IVsHierarchy sharedHierarchy;
             uint itemIdInSharedHierarchy;
-            var isSharedHierarchy = LinkedFileUtilities.TryGetSharedHierarchyAndItemId(hierarchy, itemId, out _sharedHierarchy, out itemIdInSharedHierarchy);
+            var isSharedHierarchy = LinkedFileUtilities.TryGetSharedHierarchyAndItemId(hierarchy, itemId, out sharedHierarchy, out itemIdInSharedHierarchy);
 
             var filePath = isSharedHierarchy
-                ? rdt.GetMonikerForHierarchyAndItemId(_sharedHierarchy, itemIdInSharedHierarchy)
+                ? rdt.GetMonikerForHierarchyAndItemId(sharedHierarchy, itemIdInSharedHierarchy)
                 : rdt.GetMonikerForHierarchyAndItemId(hierarchy, itemId);
 
             // we couldn't look up the document moniker in RDT for a hierarchy/item pair

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/Framework/MockHierarchy.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/Framework/MockHierarchy.vb
@@ -61,6 +61,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         End Function
 
         Public Function GetGuidProperty(itemid As UInteger, propid As Integer, ByRef pguid As Guid) As Integer Implements IVsHierarchy.GetGuidProperty
+            If itemid = VSConstants.VSITEMID_ROOT And propid = CType(__VSHPROPID.VSHPROPID_ProjectIDGuid, Integer) Then
+                pguid = Guid.NewGuid()
+
+                Return VSConstants.S_OK
+            End If
+
             Throw New NotImplementedException()
         End Function
 


### PR DESCRIPTION
we decide to move away from IVsHierarchy and instead use Project Id Guid. we just need some kind of ID to distinguish between different projects. IVsHierarchy is just not right one to use for that purpose.
