### PR TITLE
Tweak the location of "Add Analyzer"

### DIFF
--- a/src/VisualStudio/Setup/Commands.vsct
+++ b/src/VisualStudio/Setup/Commands.vsct
@@ -142,7 +142,7 @@
         </Strings>
       </Button>
       <!-- <project context menu> | Add | Analyzer... -->
-      <Button guid="guidRoslynGrpId" id="cmdidProjectContextAddAnalyzer" priority="0x0280" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidProjectContextAddAnalyzer" priority="0x0400" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_ADD_REFERENCES" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -153,7 +153,7 @@
         </Strings>
       </Button>
       <!-- Project | Add Analyzer... -->
-      <Button guid="guidRoslynGrpId" id="cmdidProjectAddAnalyzer" priority="0x0180" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidProjectAddAnalyzer" priority="0x0296" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_PROJ_OPTIONS" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -164,7 +164,7 @@
         </Strings>
       </Button>
       <!-- <References node context menu> | Add Analyzer -->
-      <Button guid="guidRoslynGrpId" id="cmdidReferencesContextAddAnalyzer" priority="0x0180" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidReferencesContextAddAnalyzer" priority="0x1100" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_REFROOT_ADD" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>


### PR DESCRIPTION
Tweak the location of the "Add Analyzer" menu items.

Right now the "Add Analyzer" menu items are located immediately below
the "Add Reference" menu item in the top-level Project menu, the project
context menu, and the References node context menu. This places "Add
Analyzer" above "Add Service Reference" and "Add Connected Service".

Logically, references, service references, and connected services are
more closely associated than analyzers. This change moves the "Add
Analyzer" menu item below the others in all of these menus.

Fixes #1289.