### PR TITLE
Introduce variable in Conditional Access Expressions.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2434,5 +2434,113 @@ class Test
 }
 ");
         }
+
+        [WorkItem(1130990)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void InParentConditionalAccessExpressions()
+        {
+            var code =
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var y = [|F(new C())|]?.F(new C())?.F(new C());
+        return x;
+    }
+}";
+
+            var expected =
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var {|Rename:c|} = F(new C());
+        var y = c?.F(new C())?.F(new C());
+        return x;
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(1130990)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void InParentConditionalAccessExpression2()
+        {
+            var code =
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var y = [|F(new C()).F(new C())|]?.F(new C());
+        return x;
+    }
+}";
+
+            var expected =
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var {|Rename:c|} = F(new C()).F(new C());
+        var y = c?.F(new C());
+        return x;
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(1130990)]
+        [WorkItem(3110, "https://github.com/dotnet/roslyn/issues/3110")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void MissingAcrossMultipleParentConditionalAccessExpressions()
+        {
+            TestMissing(
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var y = [|F(new C())?.F(new C())|]?.F(new C());
+        return x;
+    }
+}");
+        }
+
+        [WorkItem(1130990)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void MissingOnInvocationExpressionInParentConditionalAccessExpressions()
+        {
+            TestMissing(
+    @"using System;
+class C
+{
+    public T F<T>(T x)
+    {
+        var y = F(new C())?.[|F(new C())|]?.F(new C());
+        return x;
+    }
+}");
+        }
+
+        [WorkItem(1130990)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void MissingOnMemberBindingExpressionInParentConditionalAccessExpressions()
+        {
+            TestMissing(
+    @"using System;
+class C
+{
+    static void Test(string s)
+    {
+        var l = s?.[|Length|] ?? 0;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1416,6 +1416,79 @@ End Module
 </File>)
         End Sub
 
+        <WorkItem(1130990)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub InParentConditionalAccessExpressions()
+            Dim code =
+<File>
+Imports System
+Class C
+    Function F(Of T)(x As T) As T
+        Dim y = [|F(New C)|]?.F(New C)?.F(New C)
+        Return x
+    End Function
+End Class
+</File>
+            Dim expected =
+<File>
+Imports System
+Class C
+    Function F(Of T)(x As T) As T
+        Dim {|Rename:c1|} As C = F(New C)
+        Dim y = c1?.F(New C)?.F(New C)
+        Return x
+    End Function
+End Class
+</File>
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(1130990)>
+        <WorkItem(3110, "https://github.com/dotnet/roslyn/issues/3110")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub MissingAcrossMultipleParentConditionalAccessExpressions()
+            TestMissing(
+<File>
+Imports System
+Class C
+    Function F(Of T)(x As T) As T
+        Dim y = [|F(New C)?.F(New C)|]?.F(New C)
+        Return x
+    End Function
+End Class
+</File>)
+        End Sub
+
+        <WorkItem(1130990)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub MissingOnInvocationExpressionInParentConditionalAccessExpressions()
+            TestMissing(
+<File>
+Imports System
+Class C
+    Function F(Of T)(x As T) As T
+        Dim y = F(New C)?.[|F(New C)|]?.F(New C)
+        Return x
+    End Function
+End Class
+</File>)
+        End Sub
+
+        <WorkItem(1130990)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub MissingOnMemberBindingExpressionInParentConditionalAccessExpressions()
+            TestMissing(
+<File>
+Imports System
+Class C
+    Sub F()
+        Dim s as String = "Text"
+        Dim l = s?.[|Length|]
+    End Sub
+End Class
+</File>)
+        End Sub
+
         <WorkItem(2026, "https://github.com/dotnet/roslyn/issues/2026")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceAllFromInsideIfBlock()


### PR DESCRIPTION
Introduce variable for an expression whose parent is a conditional access expression. Fixes internal bug 1130990. 