### PR TITLE
Replace d4a181 fix for FixedBufferAttribute with proper fix

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -168,10 +168,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         protected override int GetIndexOfReferencedAssembly(AssemblyIdentity identity)
         {
-            var assemblies = this.moduleSymbol.GetReferencedAssemblySymbols();
+            // Go through all assemblies referenced by the current module and
+            // find the one which *exactly* matches the given identity.
+            // No unification will be performed
+            var assemblies = this.moduleSymbol.GetReferencedAssemblies();
             for (int i = 0; i < assemblies.Length; i++)
             {
-                if (identity.Equals(assemblies[i].Identity))
+                if (identity.Equals(assemblies[i]))
                 {
                     return i;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -239,13 +239,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             if (containingPEModule.Module.HasFixedBufferAttribute(_handle, out elementTypeName, out bufferSize))
             {
                 var decoder = new MetadataDecoder(containingPEModule);
-                var specialTypeName = MetadataHelpers.DecodeTypeName(elementTypeName).TopLevelType;
-                var specialType = SpecialTypes.GetTypeFromMetadataName(specialTypeName);
-                if (specialType != SpecialType.None &&
-                    specialType.FixedBufferElementSizeInBytes() != 0)
+                var elementType = decoder.GetTypeSymbolForSerializedType(elementTypeName);
+                if (elementType.FixedBufferElementSizeInBytes() != 0)
                 {
                     fixedSize = bufferSize;
-                    fixedElementType = decoder.GetSpecialType(specialType);
+                    fixedElementType = elementType;
                     return true;
                 }
             }

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -31,6 +31,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected abstract TypeSymbol LookupTopLevelTypeDefSymbol(int referencedAssemblyIndex, ref MetadataTypeName emittedName);
         protected abstract TypeSymbol LookupNestedTypeDefSymbol(TypeSymbol container, ref MetadataTypeName emittedName);
+
+        /// <summary>
+        /// Given the identity of an assembly referenced by this module, finds
+        /// the index of that assembly in the list of assemblies referenced by
+        /// the current module.
+        /// </summary>
         protected abstract int GetIndexOfReferencedAssembly(AssemblyIdentity identity);
 
         internal TypeSymbol GetTypeSymbolForSerializedType(string s)
@@ -70,7 +76,7 @@ namespace Microsoft.CodeAnalysis
             return _factory.MakePointerTypeSymbol(this.moduleSymbol, type, customModifiers);
         }
 
-        internal TypeSymbol GetSpecialType(SpecialType specialType)
+        protected TypeSymbol GetSpecialType(SpecialType specialType)
         {
             return _factory.GetSpecialType(this.moduleSymbol, specialType);
         }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -160,9 +160,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Protected Overrides Function GetIndexOfReferencedAssembly(identity As AssemblyIdentity) As Integer
-            Dim assemblies = moduleSymbol.GetReferencedAssemblySymbols()
+            ' Go through all assemblies referenced by the current module And
+            ' find the one which *exactly* matches the given identity.
+            ' No unification will be performed
+            Dim assemblies = ModuleSymbol.GetReferencedAssemblies()
             For i = 0 To assemblies.Length - 1
-                If identity.Equals(assemblies(i).Identity) Then
+                If identity.Equals(assemblies(i)) Then
                     Return i
                 End If
             Next


### PR DESCRIPTION
The old fix used SpecialType decoding to fetch the unified special type
for the encoded type of a FixedBufferAttribute. While this works, the
underlying issue behind the missing type inside the FixedBufferAttribute
is that decoded types are loaded by checking the referenced assembly symbols
rather than the referenced assemblies.

This reverts the change from d4a181 and changes type decoding in
attribute loading to use the referenced assemblies.