### PR TITLE
Made private/internal fields/properties readonly

### DIFF
--- a/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CSharpCompiler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal const string ResponseFileName = "csc.rsp";
 
-        private CommandLineDiagnosticFormatter _diagnosticFormatter;
+        private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
 
         protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories, IAnalyzerAssemblyLoader analyzerLoader)
             : base(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, additionalReferenceDirectories, analyzerLoader)

--- a/src/Compilers/CSharp/Desktop/CommandLine/CommandLineDiagnosticFormatter.cs
+++ b/src/Compilers/CSharp/Desktop/CommandLine/CommandLineDiagnosticFormatter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class CommandLineDiagnosticFormatter : CSharpDiagnosticFormatter
     {
         private readonly string _baseDirectory;
-        private Lazy<string> _lazyNormalizedBaseDirectory;
+        private readonly Lazy<string> _lazyNormalizedBaseDirectory;
         private readonly bool _displayFullPaths;
         private readonly bool _displayEndLocations;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal partial class Binder
     {
-        internal CSharpCompilation Compilation { get; private set; }
+        internal CSharpCompilation Compilation { get; }
         private readonly Binder _next;
 
         internal readonly BinderFlags Flags;

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // In a typing scenario, GetBinder is regularly called with a non-zero position.
         // This results in a lot of allocations of BinderFactoryVisitors. Pooling them
         // reduces this churn to almost nothing.
-        private ObjectPool<BinderFactoryVisitor> _binderFactoryVisitorPool;
+        private readonly ObjectPool<BinderFactoryVisitor> _binderFactoryVisitorPool;
 
         internal BinderFactory(CSharpCompilation compilation, SyntaxTree syntaxTree)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -920,8 +920,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static Func<Symbol, MethodSymbol> s_toMethodSymbolFunc = s => (MethodSymbol)s;
-        private static Func<Symbol, PropertySymbol> s_toPropertySymbolFunc = s => (PropertySymbol)s;
+        private static readonly Func<Symbol, MethodSymbol> s_toMethodSymbolFunc = s => (MethodSymbol)s;
+        private static readonly Func<Symbol, PropertySymbol> s_toPropertySymbolFunc = s => (PropertySymbol)s;
 
         private NamedTypeSymbol ConstructNamedType(
             NamedTypeSymbol type,
@@ -1133,7 +1133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private class ConsistentSymbolOrder : IComparer<Symbol>
         {
-            public static ConsistentSymbolOrder Instance = new ConsistentSymbolOrder();
+            public static readonly ConsistentSymbolOrder Instance = new ConsistentSymbolOrder();
             public int Compare(Symbol fst, Symbol snd)
             {
                 if (snd == fst) return 0;

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class LocalBinderFactory : CSharpSyntaxVisitor
     {
-        private SmallDictionary<CSharpSyntaxNode, Binder> _map;
+        private readonly SmallDictionary<CSharpSyntaxNode, Binder> _map;
         private bool _sawYield;
         private readonly MethodSymbol _method;
         private Binder _enclosing;

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1685,7 +1685,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     internal class StackOptimizerPass2 : BoundTreeRewriter
     {
         private int _nodeCounter;
-        private Dictionary<LocalSymbol, LocalDefUseInfo> _info;
+        private readonly Dictionary<LocalSymbol, LocalDefUseInfo> _info;
 
         private StackOptimizerPass2(Dictionary<LocalSymbol, LocalDefUseInfo> info)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Manages anonymous types declared in this compilation. Unifies types that are structurally equivalent.
         /// </summary>
-        private AnonymousTypeManager _anonymousTypeManager;
+        private readonly AnonymousTypeManager _anonymousTypeManager;
 
         private NamespaceSymbol _lazyGlobalNamespace;
 
@@ -176,8 +176,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Constructors and Factories
 
-        private static CSharpCompilationOptions s_defaultOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
-        private static CSharpCompilationOptions s_defaultSubmissionOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        private static readonly CSharpCompilationOptions s_defaultOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
+        private static readonly CSharpCompilationOptions s_defaultSubmissionOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
         /// <summary>
         /// Creates a new compilation from scratch. Methods such as AddSyntaxTrees or AddReferences
@@ -1890,7 +1890,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private DiagnosticBag _additionalCodegenWarnings = new DiagnosticBag();
+        private readonly DiagnosticBag _additionalCodegenWarnings = new DiagnosticBag();
 
         internal DeclarationTable Declarations
         {

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private static string[] s_newLineSequences = new[] { "\r\n", "\r", "\n" };
+        private static readonly string[] s_newLineSequences = new[] { "\r\n", "\r", "\n" };
 
         /// <summary>
         /// Given the full text of a documentation comment, strip off the comment punctuation (///, /**, etc)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal class AlwaysAssignedWalker : AbstractRegionDataFlowPass
     {
         private LocalState _endOfRegionState;
-        private HashSet<LabelSymbol> _labelsInside = new HashSet<LabelSymbol>();
+        private readonly HashSet<LabelSymbol> _labelsInside = new HashSet<LabelSymbol>();
 
         private AlwaysAssignedWalker(CSharpCompilation compilation, Symbol member, BoundNode node, BoundNode firstInRegion, BoundNode lastInRegion)
             : base(compilation, member, node, firstInRegion, lastInRegion)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -87,12 +87,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A cache for remember which structs are empty.
         /// </summary>
-        private EmptyStructTypeCache _emptyStructTypeCache;
+        private readonly EmptyStructTypeCache _emptyStructTypeCache;
 
         /// <summary>
         /// true if we should check to ensure that out parameters are assigned on every exit point.
         /// </summary>
-        private bool _requireOutParamsAssigned;
+        private readonly bool _requireOutParamsAssigned;
 
         /// <summary>
         /// The topmost method of this analysis.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If we are tracking exceptions, then by convention the first entry in the pending braches
         /// buffer contains a summary of the states that can arise from exceptions.
         /// </summary>
-        private bool _trackExceptions;
+        private readonly bool _trackExceptions;
 
         /// <summary>
         /// Pending escapes generated in the current scope (or more deeply nested scopes). When jump
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Where all diagnostics are deposited.
         /// </summary>
-        protected DiagnosticBag Diagnostics { get; private set; }
+        protected DiagnosticBag Diagnostics { get; }
 
         #region Region
         // For region analysis, we maintain some extra data.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // The "this" symbol for the current method.
         private ParameterSymbol _currentFrameThis;
 
-        private ArrayBuilder<LambdaDebugInfo> _lambdaDebugInfoBuilder;
+        private readonly ArrayBuilder<LambdaDebugInfo> _lambdaDebugInfoBuilder;
 
         // ID dispenser for field names of frame references
         private int _synthesizedFieldNameIdDispenser;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private const bool y = true;
         private const bool n = false;
 
-        private static bool[,] s_needsChecked =
+        private static readonly bool[,] s_needsChecked =
             {   //         chri08u08i16u16i32u32i64u64
                 /* chr */
                           { n, y, y, y, n, n, n, n, n },

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Used to enumerate the instance fields of a struct.
         /// </summary>
-        private EmptyStructTypeCache _emptyStructTypeCache = new NeverEmptyStructTypeCache();
+        private readonly EmptyStructTypeCache _emptyStructTypeCache = new NeverEmptyStructTypeCache();
 
         /// <summary>
         /// The set of local variables and parameters that were hoisted and need a proxy.

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private class InterpolatedStringScanner
         {
-            public Lexer lexer;
+            public readonly Lexer lexer;
             public bool isVerbatim;
             public bool allowNewlines;
             public SyntaxDiagnosticInfo error;

--- a/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
+++ b/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        private Func<SyntaxToken> _createQuickTokenFunction;
+        private readonly Func<SyntaxToken> _createQuickTokenFunction;
 
         private SyntaxToken CreateQuickToken()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<Location> _locations;  // NOTE: can be empty for the "global" alias.
 
         // lazy binding
-        private NameSyntax _aliasTargetName;
+        private readonly NameSyntax _aliasTargetName;
         private readonly bool _isExtern;
         private ImmutableArray<Diagnostic> _aliasTargetDiagnostics;
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Holds a collection of all the locations of anonymous types and delegates from source
         /// </summary>
-        private ConcurrentDictionary<Location, bool> _sourceLocationsSeen = new ConcurrentDictionary<Location, bool>();
+        private readonly ConcurrentDictionary<Location, bool> _sourceLocationsSeen = new ConcurrentDictionary<Location, bool>();
 #endif
 
         [Conditional("DEBUG")]

--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class ConversionSignatureComparer : IEqualityComparer<SourceUserDefinedConversionSymbol>
     {
-        private static ConversionSignatureComparer s_comparer = new ConversionSignatureComparer();
+        private static readonly ConversionSignatureComparer s_comparer = new ConversionSignatureComparer();
         public static ConversionSignatureComparer Comparer
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -84,12 +84,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         ///  (a) Key: Unassigned field symbol.
         ///  (b) Value: True if the unassigned field is effectively internal, false otherwise.
         /// </summary>
-        private ConcurrentDictionary<FieldSymbol, bool> _unassignedFieldsMap = new ConcurrentDictionary<FieldSymbol, bool>();
+        private readonly ConcurrentDictionary<FieldSymbol, bool> _unassignedFieldsMap = new ConcurrentDictionary<FieldSymbol, bool>();
 
         /// <summary>
         /// private fields declared in this assembly but never read
         /// </summary>
-        private ConcurrentSet<FieldSymbol> _unreadFields = new ConcurrentSet<FieldSymbol>();
+        private readonly ConcurrentSet<FieldSymbol> _unreadFields = new ConcurrentSet<FieldSymbol>();
 
         /// <summary>
         /// We imitate the native compiler's policy of not warning about unused fields

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Set in constructor, might be changed while decoding <see cref="IndexerNameAttribute"/>.
         /// </summary>
-        private string _sourceName;
+        private readonly string _sourceName;
 
         private string _lazyDocComment;
         private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembers;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -184,6 +184,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _map.SubstituteType(_substitutedFrom.GetDeducedBaseType(inProgress));
         }
 
-        private static Func<TypeSymbol, bool> s_isNotObjectFunc = type => type.SpecialType != SpecialType.System_Object;
+        private static readonly Func<TypeSymbol, bool> s_isNotObjectFunc = type => type.SpecialType != SpecialType.System_Object;
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             private struct NodeIteration
             {
-                internal GreenNode Node;
+                internal readonly GreenNode Node;
                 internal int DiagnosticIndex;
                 internal int SlotIndex;
 

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal partial struct SyntaxList<TNode> : IEquatable<SyntaxList<TNode>> where TNode : CSharpSyntaxNode
     {
-        private CSharpSyntaxNode _node;
+        private readonly CSharpSyntaxNode _node;
 
         internal SyntaxList(CSharpSyntaxNode node)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             private readonly HashSet<SyntaxNode> _nodesToRemove;
             private readonly SyntaxRemoveOptions _options;
             private readonly TextSpan _searchSpan;
-            private SyntaxTriviaListBuilder _residualTrivia;
+            private readonly SyntaxTriviaListBuilder _residualTrivia;
             private HashSet<SyntaxNode> _directivesToKeep;
 
             public SyntaxRemover(

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private struct NodeIteration
         {
-            internal GreenNode Node;
+            internal readonly GreenNode Node;
             internal int DiagnosticIndex;
             internal int SlotIndex;
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -831,7 +831,7 @@ public class C {}
 
         #region Helpers
 
-        private static string s_defaultNetModuleSourceHeader =
+        private static readonly string s_defaultNetModuleSourceHeader =
             @"using System;
                 using System.Reflection;
                 using System.Security.Permissions;
@@ -842,7 +842,7 @@ public class C {}
                 [assembly: UserDefinedAssemblyAttrAllowMultiple(""UserDefinedAssemblyAttrAllowMultiple"")]
             ";
 
-        private static string s_defaultNetModuleSourceBody =
+        private static readonly string s_defaultNetModuleSourceBody =
                 @"
                 public class NetModuleClass { }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class AttributeTests_Dynamic : WellKnownAttributesTestBase
     {
-        private static string s_dynamicTestSource = @"
+        private static readonly string s_dynamicTestSource = @"
 public class Base0 { }
 public class Base1<T> { }
 public class Base2<T, U> { }
@@ -815,7 +815,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute"));
         }
 
-        private static string s_noCS1980String = @"
+        private static readonly string s_noCS1980String = @"
 [Attr(typeof(%TYPENAME%))]            // No CS1980
 public class Gen<T>
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
@@ -314,9 +314,9 @@ class C
 
         private class ExpectedInitializer
         {
-            public string FieldName { get; set; }
-            public string InitialValue { get; set; }
-            public int LineNumber { get; set; } //0-indexed
+            public string FieldName { get; }
+            public string InitialValue { get; }
+            public int LineNumber { get; } //0-indexed
 
             public ExpectedInitializer(string fieldName, string initialValue, int lineNumber)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public partial class SyntaxBinderTests : CompilingTestBase
     {
         #region "Source"
-        private string _userDefinedConversionTestTemplate = @"
+        private readonly string _userDefinedConversionTestTemplate = @"
 class C1 { }
 class C2 { }
 class D 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -16,14 +16,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     /// </summary>
     public class UsingStatementTests : CompilingTestBase
     {
-        private string _managedClass = @"
+        private readonly string _managedClass = @"
 class MyManagedType : System.IDisposable
 {
     public void Dispose()
     { }
 }";
 
-        private string _managedStruct = @"
+        private readonly string _managedStruct = @"
 struct MyManagedType : System.IDisposable
 {
     public void Dispose()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
@@ -1739,7 +1739,7 @@ class Program
             Assert.True(statement2.Span.Contains(typeA4.Locations[0].SourceSpan));
         }
 
-        private static SyntaxTree s_equalityComparerSourceTree = Parse(@"
+        private static readonly SyntaxTree s_equalityComparerSourceTree = Parse(@"
 namespace System.Collections
 {
   public interface IEqualityComparer

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/LookupSymbolsInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/LookupSymbolsInfoTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private class TemplateArgEnumerable : IEnumerable<string>
         {
-            public static IEnumerable<string> Instance = new TemplateArgEnumerable();
+            public static readonly IEnumerable<string> Instance = new TemplateArgEnumerable();
 
             public IEnumerator<string> GetEnumerator()
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         private NamedTypeSymbol _outer2Class, _inner2Class, _innerInner2Class;
         private NamedTypeSymbol _outer3Class, _inner3Class;
         private NamedTypeSymbol _objectType, _intType;
-        private static DynamicTypeSymbol s_dynamicType = DynamicTypeSymbol.Instance;
+        private static readonly DynamicTypeSymbol s_dynamicType = DynamicTypeSymbol.Instance;
 
         private void CommonTestInitialization()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Retargeting
         /// Translation of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\Pia1.vb
         /// Disassembly of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\Pia1.dll
         /// </summary>
-        private static string s_sourcePia1 =
+        private static readonly string s_sourcePia1 =
 @"
 using System;
 using System.Reflection;
@@ -58,7 +58,7 @@ namespace NS1
         /// <summary>
         /// Disassembly of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes1.dll
         /// </summary>
-        private static string s_sourceLocalTypes1_IL =
+        private static readonly string s_sourceLocalTypes1_IL =
 @"
 using System;
 using System.Runtime.CompilerServices;
@@ -91,7 +91,7 @@ namespace NS1
         /// <summary>
         /// Translation of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes1.vb
         /// </summary>
-        private static string s_sourceLocalTypes1 =
+        private static readonly string s_sourceLocalTypes1 =
 @"
 using NS1;
 
@@ -106,7 +106,7 @@ public class LocalTypes1
         /// <summary>
         /// Disassembly of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes2.dll
         /// </summary>
-        private static string s_sourceLocalTypes2_IL =
+        private static readonly string s_sourceLocalTypes2_IL =
 @"
 using NS1;
 using System;
@@ -139,7 +139,7 @@ namespace NS1
         /// <summary>
         /// Translation of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes2.vb
         /// </summary>
-        private static string s_sourceLocalTypes2 =
+        private static readonly string s_sourceLocalTypes2 =
 @"
 using NS1;
 
@@ -154,7 +154,7 @@ public class LocalTypes2
         /// <summary>
         /// Disassembly of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes3.dll
         /// </summary>
-        private static string s_sourceLocalTypes3_IL =
+        private static readonly string s_sourceLocalTypes3_IL =
 @"
 using System;
 using System.Reflection;
@@ -219,7 +219,7 @@ public class LocalTypes3
         /// <summary>
         /// Translation of Roslyn\Main\Open\Compilers\Test\Resources\Core\SymbolsTests\NoPia\LocalTypes3.vb
         /// </summary>
-        private static string s_sourceLocalTypes3 =
+        private static readonly string s_sourceLocalTypes3 =
 @"
 using System;
 using System.Collections.Generic;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -2463,7 +2463,7 @@ End Class";
             return CreateCompilationWithMscorlib(source, new[] { s_propertiesDll }, options ?? TestOptions.ReleaseDll);
         }
 
-        private static MetadataReference s_propertiesDll = TestReferences.SymbolsTests.Properties;
+        private static readonly MetadataReference s_propertiesDll = TestReferences.SymbolsTests.Properties;
 
         #endregion
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -7674,7 +7674,7 @@ public class cly : clx
                 new ErrorDescription { Code = (int)ErrorCode.ERR_CantOverrideNonVirtual, Line = 13, Column = 29 });
         }
 
-        private static string s_typeWithMixedProperty = @"
+        private static readonly string s_typeWithMixedProperty = @"
 .class public auto ansi beforefieldinit Base_VirtGet_Set
        extends [mscorlib]System.Object
 {

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -2988,8 +2988,8 @@ public class Program
         /// </summary>
         private class TestError
         {
-            public bool IsWarning { get; set; }
-            public int ErrorCode { get; set; }
+            public bool IsWarning { get; }
+            public int ErrorCode { get; }
 
             public TestError(int code, bool warning)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class AnalyzerFileReferenceTests : TestBase
     {
-        private static SimpleAnalyzerAssemblyLoader _analyzerLoader = new SimpleAnalyzerAssemblyLoader();
+        private static readonly SimpleAnalyzerAssemblyLoader _analyzerLoader = new SimpleAnalyzerAssemblyLoader();
 
         public static AnalyzerFileReference CreateAnalyzerFileReference(string fullPath)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeTests.DiagnosticAnalyzers.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeTests.DiagnosticAnalyzers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnCompilationEndedAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "CompilationEnded";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             {
@@ -44,9 +44,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnNamePrefixDeclarationAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "Declaration";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
 
-            private string _errorSymbolPrefix;
+            private readonly string _errorSymbolPrefix;
 
             public WarningOnNamePrefixDeclarationAnalyzer(string errorSymbolPrefix)
             {
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnTypeDeclarationAnalyzer : DiagnosticAnalyzer
         {
             public const string TypeId = "TypeDeclaration";
-            private static DiagnosticDescriptor s_rule = GetRule(TypeId);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(TypeId);
 
             public override void Initialize(AnalysisContext analysisContext)
             {
@@ -109,9 +109,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnCodeBodyAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "CodeBody";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
 
-            private string _language;
+            private readonly string _language;
 
             public WarningOnCodeBodyAnalyzer(string language)
             {
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnCommentAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "Comment";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             {
@@ -214,8 +214,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class WarningOnTokenAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "Token";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
-            private IList<TextSpan> _spans;
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
+            private readonly IList<TextSpan> _spans;
 
             public WarningOnTokenAnalyzer(IList<TextSpan> spans)
             {
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         protected class ThrowExceptionForEachNamedTypeAnalyzer : DiagnosticAnalyzer
         {
             public const string Id = "ThrowException";
-            private static DiagnosticDescriptor s_rule = GetRule(Id);
+            private static readonly DiagnosticDescriptor s_rule = GetRule(Id);
 
             public ThrowExceptionForEachNamedTypeAnalyzer()
             {

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
     {
         private class C
         {
-            private string _value;
+            private readonly string _value;
 
             public C(string value)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityComparer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityComparer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             NonEquivalentPartialVersion = 11
         }
 
-        private static object s_assemblyIdentityGate = new object();
+        private static readonly object s_assemblyIdentityGate = new object();
 
         internal static AssemblyIdentityComparer.ComparisonResult CompareAssemblyIdentity(string fullName1, string fullName2, bool ignoreVersion, FusionAssemblyPortabilityPolicy policy, out bool unificationApplied)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class ModuleMetadataTests : TestBase
     {
-        private char _systemDrive = Environment.GetFolderPath(Environment.SpecialFolder.Windows)[0];
+        private readonly char _systemDrive = Environment.GetFolderPath(Environment.SpecialFolder.Windows)[0];
 
         [Fact]
         public unsafe void CreateFromMetadata_Errors()

--- a/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Desktop/AnalyzerFileReference.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableArray<DiagnosticAnalyzer> _lazyAllAnalyzers;
         private ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> _lazyAnalyzersPerLanguage;
         private Assembly _lazyAssembly;
-        private static string s_diagnosticNamespaceName = string.Format("{0}.{1}.{2}", nameof(Microsoft), nameof(CodeAnalysis), nameof(Diagnostics));
+        private static readonly string s_diagnosticNamespaceName = string.Format("{0}.{1}.{2}", nameof(Microsoft), nameof(CodeAnalysis), nameof(Diagnostics));
         private ImmutableDictionary<string, ImmutableHashSet<string>> _lazyAnalyzerTypeNameMap;
 
         public event EventHandler<AnalyzerLoadFailureEventArgs> AnalyzerLoadFailed;

--- a/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Desktop/CommandLine/CommonCompiler.cs
@@ -28,8 +28,8 @@ namespace Microsoft.CodeAnalysis
 
         private readonly string _clientDirectory;
 
-        public CommonMessageProvider MessageProvider { get; private set; }
-        public CommandLineArguments Arguments { get; private set; }
+        public CommonMessageProvider MessageProvider { get; }
+        public CommandLineArguments Arguments { get; }
         public IAnalyzerAssemblyLoader AnalyzerLoader { get; private set; }
         public abstract DiagnosticFormatter DiagnosticFormatter { get; }
         private readonly HashSet<Diagnostic> _reportedDiagnostics = new HashSet<Diagnostic>();

--- a/src/Compilers/Core/MSBuildTask/CanonicalError.cs
+++ b/src/Compilers/Core/MSBuildTask/CanonicalError.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     internal static class CanonicalError
     {
         // Defines the main pattern for matching messages.
-        private static Regex s_originCategoryCodeTextExpression = new Regex
+        private static readonly Regex s_originCategoryCodeTextExpression = new Regex
              (
                 // Beginning of line and any amount of whitespace.
                 @"^\s*"
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
              );
 
         // Matches and extracts filename and location from an 'origin' element.
-        private static Regex s_filenameLocationFromOrigin = new Regex
+        private static readonly Regex s_filenameLocationFromOrigin = new Regex
              (
                  "^"                                             // Beginning of line
                  + @"(\d+>)?"                                     // Optional ddd> project number prefix
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
              );
 
         // Matches location that is a simple number.
-        private static Regex s_lineFromLocation = new Regex        // Example: line
+        private static readonly Regex s_lineFromLocation = new Regex        // Example: line
             (
                 "^"                                              // Beginning of line
                 + "(?<LINE>[0-9]*)"                               // Match any number.
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             );
 
         // Matches location that is a range of lines.
-        private static Regex s_lineLineFromLocation = new Regex    // Example: line-line
+        private static readonly Regex s_lineLineFromLocation = new Regex    // Example: line-line
             (
                 "^"                                              // Beginning of line
                 + "(?<LINE>[0-9]*)"                               // Match any number.
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             );
 
         // Matches location that is a line and column
-        private static Regex s_lineColFromLocation = new Regex     // Example: line,col
+        private static readonly Regex s_lineColFromLocation = new Regex     // Example: line,col
             (
                 "^"                                              // Beginning of line
                 + "(?<LINE>[0-9]*)"                               // Match any number.
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             );
 
         // Matches location that is a line and column-range
-        private static Regex s_lineColColFromLocation = new Regex  // Example: line,col-col
+        private static readonly Regex s_lineColColFromLocation = new Regex  // Example: line,col-col
             (
                 "^"                                              // Beginning of line
                 + "(?<LINE>[0-9]*)"                               // Match any number.
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             );
 
         // Matches location that is line,col,line,col
-        private static Regex s_lineColLineColFromLocation = new Regex      // Example: line,col,line,col
+        private static readonly Regex s_lineColLineColFromLocation = new Regex      // Example: line,col,line,col
             (
                 "^"                                              // Beginning of line
                 + "(?<LINE>[0-9]*)"                               // Match any number.

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         internal override BuildProtocolConstants.RequestLanguage Language
             => BuildProtocolConstants.RequestLanguage.CSharpCompile;
 
-        private static string[] s_separators = { "\r\n" };
+        private static readonly string[] s_separators = { "\r\n" };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)
         {

--- a/src/Compilers/Core/MSBuildTask/RCWForCurrentContext.cs
+++ b/src/Compilers/Core/MSBuildTask/RCWForCurrentContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Indicates if we created the RCW and therefore need to release it's com reference.
         /// </summary>
-        private bool _shouldReleaseRCW;
+        private readonly bool _shouldReleaseRCW;
 
         /// <summary>
         /// Constructor creates the new RCW in the current context.

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// This stores the origional lines and error priority together in the order in which they were recieved.
         /// </summary>
-        private Queue<VBError> _vbErrorLines = new Queue<VBError>();
+        private readonly Queue<VBError> _vbErrorLines = new Queue<VBError>();
 
         // Used when parsing vbc output to determine the column number of an error
         private bool _isDoneOutputtingErrorMessage;
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         internal override BuildProtocolConstants.RequestLanguage Language
             => BuildProtocolConstants.RequestLanguage.VisualBasicCompile;
 
-        private static string[] s_separator = { "\r\n" };
+        private static readonly string[] s_separator = { "\r\n" };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)
         {
@@ -1104,8 +1104,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         private class VBError
         {
-            public string Message { get; set; }
-            public MessageImportance MessageImportance { get; set; }
+            public string Message { get; }
+            public MessageImportance MessageImportance { get; }
 
             public VBError(string message, MessageImportance importance)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// A set of additional non-code text files that can be used by analyzers.
         /// </summary>
-        public ImmutableArray<AdditionalText> AdditionalFiles { get; internal set; }
+        public ImmutableArray<AdditionalText> AdditionalFiles { get; }
 
         /// <summary>
         /// Creates analyzer options to be passed to <see cref="DiagnosticAnalyzer"/>.

--- a/src/Compilers/Core/Portable/NativePdbWriter/ComMemoryStream.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ComMemoryStream.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Utilities
     internal class ComMemoryStream : IUnsafeComStream
     {
         private const int ChunkSize = 32768;
-        private List<byte[]> _chunks = new List<byte[]>();
+        private readonly List<byte[]> _chunks = new List<byte[]>();
         private int _position;
         private int _length;
 

--- a/src/Compilers/Core/VBCSCompiler/CompilerServerLogger.cs
+++ b/src/Compilers/Core/VBCSCompiler/CompilerServerLogger.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         // Environment variable, if set, to enable logging and set the file to log to.
         private const string environmentVariable = "RoslynCommandLineLogFile";
 
-        private static Stream s_loggingStream;
+        private static readonly Stream s_loggingStream;
         private static string s_prefix = "---";
 
         /// <summary>

--- a/src/Compilers/Core/VBCSCompiler/MetadataCache.cs
+++ b/src/Compilers/Core/VBCSCompiler/MetadataCache.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
     internal class CachingMetadataReference : PortableExecutableReference
     {
-        private static MetadataAndSymbolCache s_mdCache = new MetadataAndSymbolCache();
+        private static readonly MetadataAndSymbolCache s_mdCache = new MetadataAndSymbolCache();
 
         internal CachingMetadataReference(string fullPath, MetadataReferenceProperties properties)
             : base(properties, fullPath)

--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private class ConnectionData
         {
-            public Task<CompletionReason> ConnectionTask;
+            public readonly Task<CompletionReason> ConnectionTask;
             public Task<TimeSpan?> ChangeKeepAliveTask;
 
             internal ConnectionData(Task<CompletionReason> connectionTask, Task<TimeSpan?> changeKeepAliveTask)

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     {
         private sealed class TestableClientConnection : IClientConnection
         {
-            internal string LoggingIdentifier = string.Empty;
+            internal readonly string LoggingIdentifier = string.Empty;
             internal Task<BuildRequest> ReadBuildRequestTask = TaskFromException<BuildRequest>(new Exception());
             internal Task WriteBuildResponseTask = TaskFromException(new Exception());
             internal Task MonitorTask = TaskFromException(new Exception());

--- a/src/Compilers/Core/VBCSCompilerTests/MockEngine.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/MockEngine.cs
@@ -44,9 +44,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             throw new NotImplementedException();
         }
 
-        private StringBuilder _messages = new StringBuilder();
-        private StringBuilder _errors = new StringBuilder();
-        private StringBuilder _warnings = new StringBuilder();
+        private readonly StringBuilder _messages = new StringBuilder();
+        private readonly StringBuilder _errors = new StringBuilder();
+        private readonly StringBuilder _warnings = new StringBuilder();
 
         public void LogCustomEvent(CustomBuildEventArgs e)
         {

--- a/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/FusionAssemblyIdentity.cs
+++ b/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/FusionAssemblyIdentity.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis
 
         // NOTE: The CLR caches assembly identities, but doesn't do so in a threadsafe manner.
         // Wrap all calls to this with a lock.
-        private static object s_assemblyIdentityGate = new object();
+        private static readonly object s_assemblyIdentityGate = new object();
         private static int CreateAssemblyNameObject(out IAssemblyName ppEnum, string szAssemblyName, uint dwFlags, IntPtr pvReserved)
         {
             lock (s_assemblyIdentityGate)

--- a/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
+++ b/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis
         private unsafe struct ASSEMBLY_INFO
         {
             public uint cbAssemblyInfo;
-            public uint dwAssemblyFlags;
-            public ulong uliAssemblySizeInKB;
+            public readonly uint dwAssemblyFlags;
+            public readonly ulong uliAssemblySizeInKB;
             public char* pszCurrentAssemblyPathBuf;
             public uint cchBuf;
         }

--- a/src/Compilers/Test/Utilities/Core2/Diagnostics/OptionsDiagnosticAnalyzer.cs
+++ b/src/Compilers/Test/Utilities/Core2/Diagnostics/OptionsDiagnosticAnalyzer.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 {
     public class OptionsDiagnosticAnalyzer<TLanguageKindEnum> : TestDiagnosticAnalyzer<TLanguageKindEnum> where TLanguageKindEnum : struct
     {
-        private AnalyzerOptions _expectedOptions;
-        private Dictionary<string, AnalyzerOptions> _mismatchedOptions = new Dictionary<string, AnalyzerOptions>();
+        private readonly AnalyzerOptions _expectedOptions;
+        private readonly Dictionary<string, AnalyzerOptions> _mismatchedOptions = new Dictionary<string, AnalyzerOptions>();
 
         public OptionsDiagnosticAnalyzer(AnalyzerOptions expectedOptions)
         {

--- a/src/Compilers/Test/Utilities/Core2/Diagnostics/TestDiagnosticAnalyzer.cs
+++ b/src/Compilers/Test/Utilities/Core2/Diagnostics/TestDiagnosticAnalyzer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private class NestedCodeBlockAnalyzer
         {
-            private TestDiagnosticAnalyzer<TLanguageKindEnum> _container;
+            private readonly TestDiagnosticAnalyzer<TLanguageKindEnum> _container;
 
             public NestedCodeBlockAnalyzer(TestDiagnosticAnalyzer<TLanguageKindEnum> container)
             {

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -752,7 +752,7 @@ Public MustInherit Class BasicTestBaseBase
             MyBase.DefaultVisit(node)
         End Sub
 
-        Private _names As New List(Of NameSyntax)
+        Private ReadOnly _names As New List(Of NameSyntax)
 
         Public Shared Function FindNames(node As SyntaxNode) As List(Of NameSyntax)
             Dim finder As New NameSyntaxFinder()
@@ -777,7 +777,7 @@ Public MustInherit Class BasicTestBaseBase
             MyBase.DefaultVisit(node)
         End Sub
 
-        Private _expressions As New List(Of ExpressionSyntax)
+        Private ReadOnly _expressions As New List(Of ExpressionSyntax)
 
         Public Shared Function FindExpression(node As SyntaxNode) As List(Of ExpressionSyntax)
             Dim finder As New ExpressionSyntaxFinder()
@@ -801,8 +801,8 @@ Public MustInherit Class BasicTestBaseBase
             MyBase.DefaultVisit(node)
         End Sub
 
-        Private _nodes As New List(Of SyntaxNode)
-        Private _kinds As New HashSet(Of SyntaxKind)(SyntaxFacts.EqualityComparer)
+        Private ReadOnly _nodes As New List(Of SyntaxNode)
+        Private ReadOnly _kinds As New HashSet(Of SyntaxKind)(SyntaxFacts.EqualityComparer)
 
         Public Shared Function FindNodes(Of T As SyntaxNode)(node As SyntaxNode, ParamArray kinds() As SyntaxKind) As List(Of T)
             Return New List(Of T)(From s In FindNodes(node, kinds) Select DirectCast(s, T))

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -15,7 +15,7 @@ Friend Class MockNamespaceSymbol
     Private _container As NamespaceSymbol
     Private _extent As NamespaceExtent
     Private _children As ImmutableArray(Of Symbol)
-    Private _name As String
+    Private ReadOnly _name As String
 
     Public Sub New(name As String, extent As NamespaceExtent, children As IEnumerable(Of Symbol))
         Me._name = name
@@ -117,8 +117,8 @@ Friend Class MockNamedTypeSymbol
     Inherits InstanceTypeSymbol
     Implements IMockSymbol
 
-    Private _name As String
-    Private _kind As TypeKind
+    Private ReadOnly _name As String
+    Private ReadOnly _kind As TypeKind
     Private _children As ImmutableArray(Of Symbol)
     Private _container As NamespaceOrTypeSymbol
 
@@ -616,8 +616,8 @@ End Class
 Friend Class MockModuleSymbol
     Inherits NonMissingModuleSymbol
 
-    Private _name As String
-    Private _assembly As AssemblySymbol
+    Private ReadOnly _name As String
+    Private ReadOnly _assembly As AssemblySymbol
 
     Public Sub New(name As String, assembly As AssemblySymbol)
         _name = name
@@ -710,8 +710,8 @@ End Class
 Friend Class MockAssemblySymbol
     Inherits NonMissingAssemblySymbol
 
-    Private _name As String
-    Private _module As ModuleSymbol
+    Private ReadOnly _name As String
+    Private ReadOnly _module As ModuleSymbol
 
     Public Sub New(name As String)
         _name = name

--- a/src/Compilers/Test/Utilities/VisualBasic/VBParser.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/VBParser.vb
@@ -4,7 +4,7 @@ Imports System.Text
 Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Public Class VBParser : Implements IParser
-    Private _options As VisualBasicParseOptions
+    Private ReadOnly _options As VisualBasicParseOptions
 
     Public Sub New(Optional options As VisualBasicParseOptions = Nothing)
         _options = options

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' performance in unlikely but possible code such as this: "int x; if (cond) goto l1; x =
         ''' 3; l5: print x; l4: goto l5; l3: goto l4; l2: goto l3; l1: goto l2;"
         ''' </summary>
-        Private _labels As New Dictionary(Of LabelSymbol, LabelStateAndNesting)
+        Private ReadOnly _labels As New Dictionary(Of LabelSymbol, LabelStateAndNesting)
 
         ''' <summary> All of the labels seen so far in this forward scan of the body </summary>
         Private _labelsSeen As New HashSet(Of LabelSymbol)

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Defines whether or not fields of intrinsic type should be tracked. Such fields should 
         ''' not be tracked for error reporting purposes, but should be tracked for region flow analysis
         ''' </summary>
-        Private _trackStructsWithIntrinsicTypedFields As Boolean
+        Private ReadOnly _trackStructsWithIntrinsicTypedFields As Boolean
 
         ''' <summary>
         ''' Variables that were used anywhere, in the sense required to suppress warnings about unused variables.
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' WARNING: if variable identifier maps into SlotKind.NotTracked, it may mean that VariableIdentifier 
         '''          is a structure without traceable fields. This mapping is created in MakeSlotImpl(...)
         ''' </summary>
-        Private _variableSlot As Dictionary(Of VariableIdentifier, Integer) = New Dictionary(Of VariableIdentifier, Integer)()
+        Private ReadOnly _variableSlot As Dictionary(Of VariableIdentifier, Integer) = New Dictionary(Of VariableIdentifier, Integer)()
 
         ''' <summary>
         ''' A mapping from the local variable slot to the symbol for the local variable itself.  This is used in the
@@ -484,7 +484,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' struct, and we'd need two different caches depending on _trackStructsWithIntrinsicTypedFields.
         ' So this optimization is not done for now in VB.
 
-        Private _isEmptyStructType As New Dictionary(Of NamedTypeSymbol, Boolean)()
+        Private ReadOnly _isEmptyStructType As New Dictionary(Of NamedTypeSymbol, Boolean)()
 
         Protected Overridable Function IsEmptyStructType(type As TypeSymbol) As Boolean
             Dim namedType = TryCast(type, NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsInWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsInWalker.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
-        Private _dataFlowsIn As HashSet(Of Symbol) = New HashSet(Of Symbol)()
+        Private ReadOnly _dataFlowsIn As HashSet(Of Symbol) = New HashSet(Of Symbol)()
 
         Private Function ResetState(state As LocalState) As LocalState
             Dim unreachable As Boolean = Not state.Reachable

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/EntryPointsWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/EntryPointsWalker.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
-        Private _entryPoints As HashSet(Of LabelStatementSyntax) = New HashSet(Of LabelStatementSyntax)()
+        Private ReadOnly _entryPoints As HashSet(Of LabelStatementSyntax) = New HashSet(Of LabelStatementSyntax)()
 
         Private Overloads Function Analyze() As Boolean
             '  We only need to scan in a single pass.

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/UnassignedVariablesWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/UnassignedVariablesWalker.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
-        Private _result As HashSet(Of Symbol) = New HashSet(Of Symbol)()
+        Private ReadOnly _result As HashSet(Of Symbol) = New HashSet(Of Symbol)()
 
         Protected Overrides Sub ReportUnassigned(local As Symbol,
                                                  node As VisualBasicSyntaxNode,

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/VariablesDeclaredWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/VariablesDeclaredWalker.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
-        Private _variablesDeclared As New HashSet(Of Symbol)
+        Private ReadOnly _variablesDeclared As New HashSet(Of Symbol)
 
         Private Overloads Function Analyze() As Boolean
             ' only one pass needed.

--- a/src/Compilers/VisualBasic/Portable/Analysis/ForLoopVerification.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/ForLoopVerification.vb
@@ -28,8 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Class ForLoopVerificationWalker
             Inherits BoundTreeWalker
 
-            Private _diagnostics As DiagnosticBag
-            Private _controlVariables As Stack(Of BoundExpression)
+            Private ReadOnly _diagnostics As DiagnosticBag
+            Private ReadOnly _controlVariables As Stack(Of BoundExpression)
 
             Public Sub New(diagnostics As DiagnosticBag)
                 _diagnostics = diagnostics

--- a/src/Compilers/VisualBasic/Portable/Analysis/IteratorAndAsyncAnalysis/IteratorAndAsyncCaptureWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/IteratorAndAsyncAnalysis/IteratorAndAsyncCaptureWalker.vb
@@ -19,8 +19,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ' In Release builds we hoist only variables (locals And parameters) that are captured. 
         ' This set will contain such variables after the bound tree is visited.
-        Private _variablesToHoist As OrderedSet(Of Symbol)
-        Private _byRefLocalsInitializers As Dictionary(Of LocalSymbol, BoundExpression)
+        Private ReadOnly _variablesToHoist As OrderedSet(Of Symbol)
+        Private ReadOnly _byRefLocalsInitializers As Dictionary(Of LocalSymbol, BoundExpression)
 
         ' Contains variables that are captured but can't be hoisted since their type can't be allocated on heap.
         ' The value is a list of all usage of each such variable.

--- a/src/Compilers/VisualBasic/Portable/Binding/AttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/AttributeBinder.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Inherits Binder
 
         ''' <summary> Root syntax node </summary>
-        Private _root As VisualBasicSyntaxNode
+        Private ReadOnly _root As VisualBasicSyntaxNode
 
         Public Sub New(containingBinder As Binder, tree As SyntaxTree, Optional node As VisualBasicSyntaxNode = Nothing)
             MyBase.New(containingBinder, tree)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -922,7 +922,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class ObjectInitializerBinder
         Inherits Binder
 
-        Private _receiver As BoundExpression
+        Private ReadOnly _receiver As BoundExpression
 
         Public Sub New(containingBinder As Binder, receiver As BoundExpression)
             MyBase.New(containingBinder)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -4143,7 +4143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Checks if a given symbol is a function that takes no parameters.
         ''' </summary>
-        Private Shared s_isFunctionWithoutArguments As Func(Of Symbol, Boolean) = Function(sym)
+        Private Shared ReadOnly s_isFunctionWithoutArguments As Func(Of Symbol, Boolean) = Function(sym)
                                                                                       If sym.Kind = SymbolKind.Method Then
                                                                                           Dim method = DirectCast(sym, MethodSymbol)
                                                                                           Return Not method.IsSub() AndAlso
@@ -4156,7 +4156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Checks if a given symbol is a property that is readable.
         ''' </summary>
-        Private Shared s_isReadablePropertyWithoutArguments As Func(Of Symbol, Boolean) = Function(sym)
+        Private Shared ReadOnly s_isReadablePropertyWithoutArguments As Func(Of Symbol, Boolean) = Function(sym)
                                                                                               If sym.Kind = SymbolKind.Property Then
                                                                                                   Dim prop = DirectCast(sym, PropertySymbol)
                                                                                                   Return prop.IsReadable AndAlso

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         ' An array consisting of just the Friend keyword.
-        Private Shared s_friendKeyword As SyntaxKind() = {SyntaxKind.FriendKeyword}
+        Private Shared ReadOnly s_friendKeyword As SyntaxKind() = {SyntaxKind.FriendKeyword}
 
         ' Report an error on the first keyword to match one of the given kinds.
         Public Sub ReportModifierError(modifiers As SyntaxTokenList,
@@ -1104,7 +1104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         ' An array consisting of just the NotInheritable keyword.
-        Private Shared s_notInheritableKeyword As SyntaxKind() = {SyntaxKind.NotInheritableKeyword}
+        Private Shared ReadOnly s_notInheritableKeyword As SyntaxKind() = {SyntaxKind.NotInheritableKeyword}
 
         ''' <summary>
         ''' Modifier validation code shared between properties and methods.
@@ -1710,12 +1710,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' These are the flags that are found in the syntax.  They must correspond to the modifiers list.
         ''' </summary>
         ''' <remarks></remarks>
-        Private _foundFlags As SourceMemberFlags
+        Private ReadOnly _foundFlags As SourceMemberFlags
         ''' <summary>
         ''' These are flags that are implied or computed
         ''' </summary>
         ''' <remarks></remarks>
-        Private _computedFlags As SourceMemberFlags
+        Private ReadOnly _computedFlags As SourceMemberFlags
 
         Public Sub New(foundFlags As SourceMemberFlags, computedFlags As SourceMemberFlags)
             _foundFlags = foundFlags

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -582,7 +582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private NotInheritable Class XmlNameComparer
             Implements IEqualityComparer(Of XmlName)
 
-            Public Shared Instance As New XmlNameComparer()
+            Public Shared ReadOnly Instance As New XmlNameComparer()
 
             Private Function IEqualityComparer_Equals(x As XmlName, y As XmlName) As Boolean Implements IEqualityComparer(Of XmlName).Equals
                 Return String.Equals(x.LocalName, y.LocalName, StringComparison.Ordinal) AndAlso String.Equals(x.XmlNamespace, y.XmlNamespace, StringComparison.Ordinal)

--- a/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _symbol As Symbol
 
         ''' <summary> Root syntax node </summary>
-        Private _root As VisualBasicSyntaxNode
+        Private ReadOnly _root As VisualBasicSyntaxNode
 
         ''' <summary>
         ''' Initializes a new instance of the <see cref="DeclarationInitializerBinder"/> class.

--- a/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend NotInheritable Class EarlyWellKnownAttributeBinder
         Inherits Binder
 
-        Private _owner As Symbol
+        Private ReadOnly _owner As Symbol
         Friend Sub New(owner As Symbol, containingBinder As Binder)
             MyBase.New(containingBinder, isEarlyAttributeBinder:=True)
             Me._owner = owner

--- a/src/Compilers/VisualBasic/Portable/Binding/ExecutableCodeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ExecutableCodeBinder.vb
@@ -79,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private Shared s_emptyLabelMap As MultiDictionary(Of String, SourceLabelSymbol) = New MultiDictionary(Of String, SourceLabelSymbol)(0, IdentifierComparison.Comparer)
+        Private Shared ReadOnly s_emptyLabelMap As MultiDictionary(Of String, SourceLabelSymbol) = New MultiDictionary(Of String, SourceLabelSymbol)(0, IdentifierComparison.Comparer)
 
         Private Shared Function BuildLabelsMap(labels As ImmutableArray(Of SourceLabelSymbol)) As MultiDictionary(Of String, SourceLabelSymbol)
             If Not labels.IsEmpty Then

--- a/src/Compilers/VisualBasic/Portable/Binding/LocalBinderBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LocalBinderBuilder.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private _nodeMap As ImmutableDictionary(Of VisualBasicSyntaxNode, BlockBaseBinder)
         Private _listMap As ImmutableDictionary(Of SyntaxList(Of StatementSyntax), BlockBaseBinder)
-        Private _enclosingMethod As MethodSymbol
+        Private ReadOnly _enclosingMethod As MethodSymbol
         Private _containingBinder As Binder
 
         Public Sub New(enclosingMethod As MethodSymbol)

--- a/src/Compilers/VisualBasic/Portable/Binding/LocalInProgressBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LocalInProgressBinder.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' forward local. However, just to make sure, we also keep track of every
         ' local whose type we are attempting to infer. (This might be necessary for
         ' "script class" scenarios where local vars are actually fields.)
-        Private _symbols As ConsList(Of LocalSymbol)
+        Private ReadOnly _symbols As ConsList(Of LocalSymbol)
 
         Public Sub New(containingBinder As Binder, symbol As LocalSymbol)
             MyBase.New(containingBinder)

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -237,14 +237,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private _kind As LookupResultKind
 
         ' The symbol, unless the kind is empty.
-        Private _symList As ArrayBuilder(Of Symbol)
+        Private ReadOnly _symList As ArrayBuilder(Of Symbol)
 
         ' The diagnostic. This is always set for NonAccessible and NonViable results. It may be
         ' set for viable results.
         Private _diagInfo As DiagnosticInfo
 
         ' The pool used to get instances from.
-        Private _pool As ObjectPool(Of LookupResult)
+        Private ReadOnly _pool As ObjectPool(Of LookupResult)
 
         ''''''''''''''''''''''''''''''
         ' Access routines
@@ -327,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''''''''''''''''''''''''''''''
         ' Creation routines
 
-        Private Shared s_poolInstance As ObjectPool(Of LookupResult) = CreatePool()
+        Private Shared ReadOnly s_poolInstance As ObjectPool(Of LookupResult) = CreatePool()
 
         Private Shared Function CreatePool() As ObjectPool(Of LookupResult)
             Dim pool As ObjectPool(Of LookupResult) = Nothing
@@ -974,7 +974,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         ' Create a diagnostic for ambiguous names in a namespace
-        Private Shared s_ambiguousInNSError As Func(Of ImmutableArray(Of Symbol), AmbiguousSymbolDiagnostic) =
+        Private Shared ReadOnly s_ambiguousInNSError As Func(Of ImmutableArray(Of Symbol), AmbiguousSymbolDiagnostic) =
             Function(syms As ImmutableArray(Of Symbol)) As AmbiguousSymbolDiagnostic
                 Dim container As Symbol = syms(0).ContainingSymbol
                 If container.Name.Length > 0 Then

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -2007,7 +2007,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private ReadOnly _semanticModel As MemberSemanticModel
             Private ReadOnly _thisSyntaxNodeOnly As VisualBasicSyntaxNode ' If not Nothing, record nodes for this syntax node only.
             Private _placeholderReplacementMap As Dictionary(Of BoundValuePlaceholderBase, BoundExpression)
-            Private _nodeCache As OrderPreservingMultiDictionary(Of VisualBasicSyntaxNode, BoundNode)
+            Private ReadOnly _nodeCache As OrderPreservingMultiDictionary(Of VisualBasicSyntaxNode, BoundNode)
 
             Private Sub New(semanticModel As MemberSemanticModel, thisSyntaxNodeOnly As VisualBasicSyntaxNode, nodeCache As OrderPreservingMultiDictionary(Of VisualBasicSyntaxNode, BoundNode))
                 _semanticModel = semanticModel

--- a/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class SourceModuleBinder
         Inherits Binder
 
-        Private _sourceModule As SourceModuleSymbol
+        Private ReadOnly _sourceModule As SourceModuleSymbol
 
         Public Sub New(containingBinder As Binder, sourceModule As SourceModuleSymbol)
             MyBase.New(containingBinder, sourceModule, sourceModule.ContainingSourceAssembly.DeclaringCompilation)

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundAnonymousTypePropertyAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundAnonymousTypePropertyAccess.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Friend Partial Class BoundAnonymousTypePropertyAccess
 
-        Private _lazyPropertySymbol As New Lazy(Of PropertySymbol)(AddressOf LazyGetProperty)
+        Private ReadOnly _lazyPropertySymbol As New Lazy(Of PropertySymbol)(AddressOf LazyGetProperty)
 
         Public Overrides ReadOnly Property ExpressionSymbol As Symbol
             Get

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Box
             End Enum
 
-            Private _container As Symbol
+            Private ReadOnly _container As Symbol
 
             Private _counter As Integer = 0
             Private _evalStack As Integer = 0

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '
         ' Stack is used so that the wait would observe the most recently added task and have 
         ' more chances to do inlined execution.
-        Private _compilerTasks As ConcurrentStack(Of Task)
+        Private ReadOnly _compilerTasks As ConcurrentStack(Of Task)
 
         ' Tracks whether any method body has hasErrors set, and used to avoid
         ' emitting if there are errors without corresponding diagnostics.

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' The common language version among the trees of the compilation.
         ''' </summary>
-        Private _languageVersion As LanguageVersion
+        Private ReadOnly _languageVersion As LanguageVersion
 
         Public Overrides ReadOnly Property Language As String
             Get

--- a/src/Compilers/VisualBasic/Portable/Declarations/RootSingleNamespaceDeclaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/RootSingleNamespaceDeclaration.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private _referenceDirectiveDiagnostics As ImmutableArray(Of Diagnostic)
         Private _referenceDirectives As ImmutableArray(Of ReferenceDirective)
-        Private _hasAssemblyAttributes As Boolean
+        Private ReadOnly _hasAssemblyAttributes As Boolean
 
         Public ReadOnly Property ReferenceDirectiveDiagnostics As ImmutableArray(Of Diagnostic)
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -581,7 +581,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Private Class SymbolComparer
                 Implements IEqualityComparer(Of Symbol)
 
-                Private _matcher As MatchSymbols
+                Private ReadOnly _matcher As MatchSymbols
 
                 Public Sub New(matcher As MatchSymbols)
                     Me._matcher = matcher

--- a/src/Compilers/VisualBasic/Portable/Emit/SpecializedGenericMethodInstanceReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SpecializedGenericMethodInstanceReference.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Inherits SpecializedMethodReference
         Implements Cci.IGenericMethodInstanceReference
 
-        Private _genericMethod As SpecializedMethodReference
+        Private ReadOnly _genericMethod As SpecializedMethodReference
 
         Public Sub New(underlyingMethod As MethodSymbol)
             MyBase.New(underlyingMethod)

--- a/src/Compilers/VisualBasic/Portable/Errors/CustomDiagnostics.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/CustomDiagnostics.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Implements IDiagnosticInfoWithSymbols
 
         ' not serialized
-        Private _badSymbol As Symbol
+        Private ReadOnly _badSymbol As Symbol
 
         ' Create a new bad symbol diagnostic with the given error id. This error message
         ' should have a single fill-in string, which is filled in with the symbol.

--- a/src/Compilers/VisualBasic/Portable/GlobalImport.ImportDiagnosticInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/GlobalImport.ImportDiagnosticInfo.vb
@@ -11,9 +11,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Class ImportDiagnosticInfo
             Inherits DiagnosticInfo
 
-            Private _importText As String
-            Private _startIndex, _length As Integer
-            Private _wrappedDiagnostic As DiagnosticInfo
+            Private ReadOnly _importText As String
+            Private ReadOnly _startIndex As Integer
+            Private ReadOnly _length As Integer
+            Private ReadOnly _wrappedDiagnostic As DiagnosticInfo
 
             Private Sub New(reader As ObjectReader)
                 MyBase.New(reader)

--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class DiagnosticsPass
         Inherits BoundTreeWalker
 
-        Private _expressionTreePlaceholders As New HashSet(Of BoundNode)(ReferenceEqualityComparer.Instance)
+        Private ReadOnly _expressionTreePlaceholders As New HashSet(Of BoundNode)(ReferenceEqualityComparer.Instance)
 
         Public Overrides Function VisitObjectCreationExpression(node As BoundObjectCreationExpression) As BoundNode
             If Me.IsInExpressionLambda Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
@@ -40,9 +40,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' A map from SyntaxNode to corresponding visited BoundStatement.
         ''' Used to ensure correct generation of resumable code for Unstructured Exception Handling.
         ''' </summary>
-        Private _unstructuredExceptionHandlingResumableStatements As New Dictionary(Of VisualBasicSyntaxNode, BoundStatement)(ReferenceEqualityComparer.Instance)
+        Private ReadOnly _unstructuredExceptionHandlingResumableStatements As New Dictionary(Of VisualBasicSyntaxNode, BoundStatement)(ReferenceEqualityComparer.Instance)
 
-        Private _leaveRestoreUnstructuredExceptionHandlingContextTracker As New Stack(Of BoundNode)()
+        Private ReadOnly _leaveRestoreUnstructuredExceptionHandlingContextTracker As New Stack(Of BoundNode)()
 #End If
 
 #If DEBUG Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ForEach.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ForEach.vb
@@ -782,8 +782,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Class LocalVariableSubstitutor
             Inherits BoundTreeRewriter
 
-            Private _original As LocalSymbol
-            Private _replacement As LocalSymbol
+            Private ReadOnly _original As LocalSymbol
+            Private ReadOnly _replacement As LocalSymbol
             Private _replacedNode As Boolean = False
 
             Public Shared Function Replace(

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_With.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_With.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Cache of value types which were already calculated by LocalOrFieldNeedsToBeCleanedUp 
         ''' in this lowering, serves as an optimization 
         ''' </summary>
-        Private _valueTypesCleanUpCache As New Dictionary(Of TypeSymbol, Boolean)
+        Private ReadOnly _valueTypesCleanUpCache As New Dictionary(Of TypeSymbol, Boolean)
 
         Private Function LocalOrFieldNeedsToBeCleanedUp(currentType As TypeSymbol) As Boolean
             Debug.Assert(currentType IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/ForBlockContext.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/ForBlockContext.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend NotInheritable Class ForBlockContext
         Inherits ExecutableStatementContext
 
-        Private Shared s_emptyNextStatement As NextStatementSyntax
+        Private Shared ReadOnly s_emptyNextStatement As NextStatementSyntax
 
         Shared Sub New()
             s_emptyNextStatement = InternalSyntaxFactory.NextStatement(InternalSyntaxFactory.MissingKeyword(SyntaxKind.NextKeyword), Nothing)

--- a/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/PropertyBlockContext.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/PropertyBlockContext.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend NotInheritable Class PropertyBlockContext
         Inherits DeclarationContext
 
-        Private _isPropertyBlock As Boolean
+        Private ReadOnly _isPropertyBlock As Boolean
 
         Friend Sub New(statement As StatementSyntax, prevContext As BlockContext, isPropertyBlock As Boolean)
             MyBase.New(SyntaxKind.PropertyBlock, statement, prevContext)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
@@ -2427,9 +2427,9 @@ TryResync:
     End Class
 
     Friend Structure XmlContext
-        Private _start As XmlElementStartTagSyntax
+        Private ReadOnly _start As XmlElementStartTagSyntax
         Private _content As SyntaxListBuilder(Of XmlNodeSyntax)
-        Private _pool As SyntaxListPool
+        Private ReadOnly _pool As SyntaxListPool
 
         Public Sub New(pool As SyntaxListPool, start As XmlElementStartTagSyntax)
             _pool = pool

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     (IsFullWidth(c) AndAlso (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_O))
         End Function
 
-        Private Shared s_isIDChar As Boolean() =
+        Private Shared ReadOnly s_isIDChar As Boolean() =
         {
             False, False, False, False, False, False, False, False, False, False,
             False, False, False, False, False, False, False, False, False, False,

--- a/src/Compilers/VisualBasic/Portable/Scanner/KeywordTable.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/KeywordTable.vb
@@ -287,8 +287,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Sub
         End Structure
 
-        Private Shared s_keywords As New Dictionary(Of String, SyntaxKind)(IdentifierComparison.Comparer)
-        Private Shared s_keywordProperties As New Dictionary(Of UShort, KeywordDescription)
+        Private Shared ReadOnly s_keywords As New Dictionary(Of String, SyntaxKind)(IdentifierComparison.Comparer)
+        Private Shared ReadOnly s_keywordProperties As New Dictionary(Of UShort, KeywordDescription)
 
         Friend Shared Function TokenOfString(tokenName As String) As SyntaxKind
             Debug.Assert(tokenName IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Scanner/QuickTokenAccumulator.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/QuickTokenAccumulator.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' # is marked complex as it may start directives.
         ' PERF: Use UShort instead of CharFlags so the compiler can use array literal initialization.
         '       The most natural type choice, Enum arrays, are not blittable due to a CLR limitation.
-        Private Shared s_charProperties As UShort() = {
+        Private Shared ReadOnly s_charProperties As UShort() = {
             CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex,
             CharFlags.Complex, CharFlags.White, CharFlags.LF, CharFlags.Complex, CharFlags.Complex, CharFlags.CR, CharFlags.Complex, CharFlags.Complex,
             CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex, CharFlags.Complex,

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         End Function
 
-        Private Shared s_docCommentCrLfToken As XmlTextTokenSyntax = SyntaxFactory.DocumentationCommentLineBreakToken(vbCrLf, vbLf, Nothing, Nothing)
+        Private Shared ReadOnly s_docCommentCrLfToken As XmlTextTokenSyntax = SyntaxFactory.DocumentationCommentLineBreakToken(vbCrLf, vbLf, Nothing, Nothing)
 
         Private Function MakeDocCommentLineBreakToken(
                 precedingTrivia As SyntaxList(Of VisualBasicSyntaxNode),

--- a/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
@@ -728,7 +728,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
 
-        Private Shared s_mapAccessToAccessOutsideAssembly() As Accessibility
+        Private Shared ReadOnly s_mapAccessToAccessOutsideAssembly() As Accessibility
 
         Shared Sub New()
             s_mapAccessToAccessOutsideAssembly = New Accessibility(Accessibility.Public) {}

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -445,7 +445,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' PERF: Use Integer instead of ConversionKind so the compiler can use array literal initialization.
             '       The most natural type choice, Enum arrays, are not blittable due to a CLR limitation.
-            Private Shared s_convkind As Integer(,)
+            Private Shared ReadOnly s_convkind As Integer(,)
 
             Shared Sub New()
                 Const NOC As Integer = Nothing 'ConversionKind.NoConversion

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Holds a collection of all the locations of anonymous types and delegates from source
         ''' </summary>
-        Private _sourceLocationsSeen As New ConcurrentDictionary(Of Location, Boolean)
+        Private ReadOnly _sourceLocationsSeen As New ConcurrentDictionary(Of Location, Boolean)
 #End If
 
         <Conditional("DEBUG")>

--- a/src/Compilers/VisualBasic/Portable/Symbols/LabelSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/LabelSymbol.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._name = name
         End Sub
 
-        Private _name As String
+        Private ReadOnly _name As String
 
         Public Overrides ReadOnly Property Name As String
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/MemberSignatureComparer.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MemberSignatureComparer.vb
@@ -27,9 +27,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         PropertySignatureComparer.WinRTConflictComparer,
                                         EventSignatureComparer.WinRTConflictComparer)
 
-        Private _methodComparer As MethodSignatureComparer
-        Private _propertyComparer As PropertySignatureComparer
-        Private _eventComparer As EventSignatureComparer
+        Private ReadOnly _methodComparer As MethodSignatureComparer
+        Private ReadOnly _propertyComparer As PropertySignatureComparer
+        Private ReadOnly _eventComparer As EventSignatureComparer
 
         Private Sub New(methodComparer As MethodSignatureComparer,
                         propertyComparer As PropertySignatureComparer,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -18,12 +18,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' <summary>
         ''' Type context for resolving generic type arguments.
         ''' </summary>
-        Private _typeContextOpt As PENamedTypeSymbol
+        Private ReadOnly _typeContextOpt As PENamedTypeSymbol
 
         ''' <summary>
         ''' Method context for resolving generic method type arguments.
         ''' </summary>
-        Private _methodContextOpt As PEMethodSymbol
+        Private ReadOnly _methodContextOpt As PEMethodSymbol
 
         Public Sub New(
             moduleSymbol As PEModuleSymbol,

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamespaceExtent.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamespaceExtent.vb
@@ -13,8 +13,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' assembly, or merged across all modules (source and metadata) in a particular compilation.
     ''' </summary>
     Partial Friend Structure NamespaceExtent
-        Private _kind As NamespaceKind
-        Private _symbolOrCompilation As Object
+        Private ReadOnly _kind As NamespaceKind
+        Private ReadOnly _symbolOrCompilation As Object
 
         ''' <summary>
         ''' Returns what kind of extent: Module, Assembly, or Compilation.

--- a/src/Compilers/VisualBasic/Portable/Symbols/NonMissingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NonMissingAssemblySymbol.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Gives about 8% win on subsequent lookups in some scenarios.     
         ''' </summary>
         ''' <remarks></remarks>
-        Private _emittedNameToTypeMap As New ConcurrentDictionary(Of MetadataTypeName.Key, NamedTypeSymbol)()
+        Private ReadOnly _emittedNameToTypeMap As New ConcurrentDictionary(Of MetadataTypeName.Key, NamedTypeSymbol)()
 
         ''' <summary>
         ''' The global namespace symbol. Lazily populated on first access.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2037,8 +2037,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ''' <summary> Queue element structure </summary>
             Public Structure QueueElement
-                Public Type As NamedTypeSymbol
-                Public Path As ConsList(Of FieldSymbol)
+                Public ReadOnly Type As NamedTypeSymbol
+                Public ReadOnly Path As ConsList(Of FieldSymbol)
 
                 Public Sub New(type As NamedTypeSymbol, path As ConsList(Of FieldSymbol))
                     Debug.Assert(type IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         ' holds diagnostics not related to source code 
         ' in any particular source file, for each stage.
-        Private _diagnosticBagDeclare As New DiagnosticBag()
+        Private ReadOnly _diagnosticBagDeclare As New DiagnosticBag()
         'Private m_diagnosticBagCompile As New DiagnosticBag()
         'Private m_diagnosticBagEmit As New DiagnosticBag()
 
@@ -146,7 +146,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private _nameAndExtension As String
+        Private ReadOnly _nameAndExtension As String
 
         Public Overrides ReadOnly Property Name As String
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -1112,12 +1112,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return syntaxTree.GetLocation(block.BlockStatement.Span)
         End Function
 
-        Private Shared s_overridableModifierKinds() As SyntaxKind =
+        Private Shared ReadOnly s_overridableModifierKinds() As SyntaxKind =
             {
                 SyntaxKind.OverridableKeyword
             }
 
-        Private Shared s_accessibilityModifierKinds() As SyntaxKind =
+        Private Shared ReadOnly s_accessibilityModifierKinds() As SyntaxKind =
             {
                 SyntaxKind.PrivateKeyword,
                 SyntaxKind.ProtectedKeyword,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceWithEventsBackingFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceWithEventsBackingFieldSymbol.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend NotInheritable Class SourceWithEventsBackingFieldSymbol
         Inherits SourceMemberFieldSymbol
 
-        Private _property As SourcePropertySymbol
+        Private ReadOnly _property As SourcePropertySymbol
 
         Public Sub New([property] As SourcePropertySymbol,
                        syntaxRef As SyntaxReference,

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -632,7 +632,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Class WellKnownMembersSignatureComparer
             Inherits SpecialMembersSignatureComparer
 
-            Private _compilation As VisualBasicCompilation
+            Private ReadOnly _compilation As VisualBasicCompilation
 
             Public Sub New(compilation As VisualBasicCompilation)
                 _compilation = compilation

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Implements IEnumerator(Of DiagnosticInfo), IDisposable, IEnumerator
 
             Private Structure NodeIteration
-                Friend node As GreenNode
+                Friend ReadOnly node As GreenNode
                 Friend diagnosticIndex As Integer
                 Friend slotIndex As Integer
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
@@ -127,8 +127,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Friend NotInheritable Class WithTwoChildren
             Inherits SyntaxList
 
-            Private _child0 As VisualBasicSyntaxNode
-            Private _child1 As VisualBasicSyntaxNode
+            Private ReadOnly _child0 As VisualBasicSyntaxNode
+            Private ReadOnly _child1 As VisualBasicSyntaxNode
 
             Private Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode)
                 MyBase.New(errors, annotations)
@@ -206,9 +206,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Friend NotInheritable Class WithThreeChildren
             Inherits SyntaxList
 
-            Private _child0 As VisualBasicSyntaxNode
-            Private _child1 As VisualBasicSyntaxNode
-            Private _child2 As VisualBasicSyntaxNode
+            Private ReadOnly _child0 As VisualBasicSyntaxNode
+            Private ReadOnly _child1 As VisualBasicSyntaxNode
+            Private ReadOnly _child2 As VisualBasicSyntaxNode
 
             Private Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode, child2 As VisualBasicSyntaxNode)
                 MyBase.New(errors, annotations)
@@ -632,7 +632,7 @@ enter:
     End Class
 
     Friend Structure SyntaxListBuilder(Of TNode As VisualBasicSyntaxNode)
-        Private _builder As SyntaxListBuilder
+        Private ReadOnly _builder As SyntaxListBuilder
 
         Public Shared Function Create() As SyntaxListBuilder(Of TNode)
             Return New SyntaxListBuilder(Of TNode)(8)
@@ -711,7 +711,7 @@ enter:
     End Structure
 
     Friend Structure SeparatedSyntaxListBuilder(Of TNode As VisualBasicSyntaxNode)
-        Private _builder As SyntaxListBuilder
+        Private ReadOnly _builder As SyntaxListBuilder
         Public Sub New(size As Integer)
             Me.New(New SyntaxListBuilder(size))
         End Sub
@@ -782,7 +782,7 @@ enter:
     Friend Structure SyntaxList(Of TNode As VisualBasicSyntaxNode)
         Implements IEquatable(Of SyntaxList(Of TNode))
 
-        Private _node As GreenNode
+        Private ReadOnly _node As GreenNode
 
         Friend Sub New(node As GreenNode)
             Me._node = node

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -447,7 +447,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' Maintain a list of tokens we're accumulating to put into a SkippedNodes trivia.
             Private _skippedTokensBuilder As SyntaxListBuilder(Of SyntaxToken) = SyntaxListBuilder(Of SyntaxToken).Create()
 
-            Private _preserveExistingDiagnostics As Boolean
+            Private ReadOnly _preserveExistingDiagnostics As Boolean
             Private _addDiagnosticsToFirstTokenOnly As Boolean
             Private _diagnosticsToAdd As IEnumerable(Of DiagnosticInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeFactories.vb
@@ -507,7 +507,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End Get
         End Property
 
-        Private Shared s_missingExpr As ExpressionSyntax = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("", Nothing, Nothing))
+        Private Shared ReadOnly s_missingExpr As ExpressionSyntax = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("", Nothing, Nothing))
         Friend Shared Function MissingExpression() As ExpressionSyntax
             Return s_missingExpr
         End Function

--- a/src/Compilers/VisualBasic/Portable/Syntax/SeparatedSyntaxListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SeparatedSyntaxListBuilder.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Friend Structure SeparatedSyntaxListBuilder(Of TNode As SyntaxNode)
-        Private _builder As SyntaxListBuilder
+        Private ReadOnly _builder As SyntaxListBuilder
         Private _expectSeparator As Boolean
 
         Public Shared Function Create() As SeparatedSyntaxListBuilder(Of TNode)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SimpleSyntaxReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SimpleSyntaxReference.vb
@@ -10,8 +10,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class SimpleSyntaxReference
         Inherits SyntaxReference
 
-        Private _tree As SyntaxTree
-        Private _node As SyntaxNode
+        Private ReadOnly _tree As SyntaxTree
+        Private ReadOnly _node As SyntaxNode
 
         Friend Sub New(tree As SyntaxTree, node As SyntaxNode)
             _tree = tree

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxKindFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxKindFacts.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Shared s_reservedKeywords As SyntaxKind() = New SyntaxKind() {
+        Private Shared ReadOnly s_reservedKeywords As SyntaxKind() = New SyntaxKind() {
             SyntaxKind.AddressOfKeyword,
             SyntaxKind.AddHandlerKeyword,
             SyntaxKind.AliasKeyword,
@@ -239,7 +239,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return s_reservedKeywords
         End Function
 
-        Private Shared s_contextualKeywords As SyntaxKind() = New SyntaxKind() {
+        Private Shared ReadOnly s_contextualKeywords As SyntaxKind() = New SyntaxKind() {
             SyntaxKind.AggregateKeyword,
             SyntaxKind.AllKeyword,
             SyntaxKind.AnsiKeyword,
@@ -294,7 +294,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return s_contextualKeywords
         End Function
 
-        Private Shared s_punctuationKinds As SyntaxKind() = New SyntaxKind() {
+        Private Shared ReadOnly s_punctuationKinds As SyntaxKind() = New SyntaxKind() {
             SyntaxKind.ExclamationToken,
             SyntaxKind.AtToken,
             SyntaxKind.CommaToken,
@@ -345,7 +345,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return s_punctuationKinds
         End Function
 
-        Private Shared s_preprocessorKeywords As SyntaxKind() = New SyntaxKind() {
+        Private Shared ReadOnly s_preprocessorKeywords As SyntaxKind() = New SyntaxKind() {
                                                             SyntaxKind.IfKeyword,
                                                             SyntaxKind.ThenKeyword,
                                                             SyntaxKind.ElseIfKeyword,

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxListBuilder.vb
@@ -13,7 +13,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Friend Structure SyntaxListBuilder(Of TNode As SyntaxNode)
-        Private _builder As SyntaxListBuilder
+        Private ReadOnly _builder As SyntaxListBuilder
 
         Public Shared Function Create() As SyntaxListBuilder(Of TNode)
             Return New SyntaxListBuilder(Of TNode)(8)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Private ReadOnly _nodesToRemove As HashSet(Of SyntaxNode)
             Private ReadOnly _options As SyntaxRemoveOptions
             Private ReadOnly _searchSpan As TextSpan
-            Private _residualTrivia As SyntaxTriviaListBuilder
+            Private ReadOnly _residualTrivia As SyntaxTriviaListBuilder
             Private _directivesToKeep As HashSet(Of SyntaxNode)
 
             Public Sub New(nodes As SyntaxNode(), options As SyntaxRemoveOptions)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNormalizer.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNormalizer.vb
@@ -22,8 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private _afterLineBreak As Boolean
         Private _afterIndentation As Boolean
 
-        Private _lineBreaksAfterToken As Dictionary(Of SyntaxToken, Integer) = New Dictionary(Of SyntaxToken, Integer)()
-        Private _lastStatementsInBlocks As HashSet(Of SyntaxNode) = New HashSet(Of SyntaxNode)()
+        Private ReadOnly _lineBreaksAfterToken As Dictionary(Of SyntaxToken, Integer) = New Dictionary(Of SyntaxToken, Integer)()
+        Private ReadOnly _lastStatementsInBlocks As HashSet(Of SyntaxNode) = New HashSet(Of SyntaxNode)()
 
         Private _indentationDepth As Integer
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.vb
@@ -10,10 +10,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Structure SyntaxTreeDiagnosticEnumerator
 
         Private Structure NodeIteration
-            Friend node As GreenNode
+            Friend ReadOnly node As GreenNode
             Friend diagnosticIndex As Integer
             Friend slotIndex As Integer
-            Friend inDocumentationComment As Boolean
+            Friend ReadOnly inDocumentationComment As Boolean
 
             Friend Sub New(node As GreenNode, inDocumentationComment As Boolean)
                 Me.node = node
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Sub
         End Structure
 
-        Private _tree As SyntaxTree
+        Private ReadOnly _tree As SyntaxTree
         Private _stack As NodeIteration()
         Private _count As Integer
         Private _current As Diagnostic

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -165,7 +165,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "Serialization"
 
-        Private Shared s_binder As RecordingObjectBinder = New ConcurrentRecordingObjectBinder()
+        Private Shared ReadOnly s_binder As RecordingObjectBinder = New ConcurrentRecordingObjectBinder()
         ''' <summary>
         ''' Serialize this node to a byte stream.
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Utilities/SyntaxListPool.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/SyntaxListPool.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Class SyntaxListPool
-        Private _freeList As New Stack(Of SyntaxListBuilder)
+        Private ReadOnly _freeList As New Stack(Of SyntaxListBuilder)
 
         Friend Function Allocate() As SyntaxListBuilder
             If _freeList.Count > 0 Then

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -1024,7 +1024,7 @@ Imports System.Reflection
 
 #Region "Helpers"
 
-    Private Shared s_defaultNetModuleSourceHeader As String = <![CDATA[
+    Private Shared ReadOnly s_defaultNetModuleSourceHeader As String = <![CDATA[
 Imports System
 Imports System.Reflection
 Imports System.Security.Permissions
@@ -1035,7 +1035,7 @@ Imports System.Security.Permissions
 <Assembly: UserDefinedAssemblyAttrAllowMultiple("UserDefinedAssemblyAttrAllowMultiple")>
 ]]>.Value
 
-    Private Shared s_defaultNetModuleSourceBody As String = <![CDATA[
+    Private Shared ReadOnly s_defaultNetModuleSourceBody As String = <![CDATA[
 Public Class NetModuleClass
 End Class
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
@@ -145,7 +145,7 @@ Public Class Test
     End Sub
 End Class
 ]]>.Value
-        Private _commonValidatorForCondAttrType As Func(Of Boolean, Action(Of ModuleSymbol)) =
+        Private ReadOnly _commonValidatorForCondAttrType As Func(Of Boolean, Action(Of ModuleSymbol)) =
             Function(isFromSource As Boolean) _
                 Sub(m As ModuleSymbol)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenVBCore.vb
@@ -3148,7 +3148,7 @@ End Module
 
 #Region "Symbols Validator"
 
-        Private Shared s_normalizeRegex As New Regex("^(\s*)", RegexOptions.Multiline)
+        Private Shared ReadOnly s_normalizeRegex As New Regex("^(\s*)", RegexOptions.Multiline)
 
         Private Sub ValidateSourceSymbols([module] As ModuleSymbol)
             ValidateSourceSymbol([module].GlobalNamespace)

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
     Public Class OptionalArgumentsTests
         Inherits BasicTestBase
 
-        Private _librarySource As XElement =
+        Private ReadOnly _librarySource As XElement =
             <compilation>
                 <file name="library.vb">
                     <![CDATA[
@@ -154,7 +154,7 @@ End Module
 ]]></file>
             </compilation>
 
-        Private _classLibrary As MetadataReference = CreateHelperLibrary(_librarySource.Value)
+        Private ReadOnly _classLibrary As MetadataReference = CreateHelperLibrary(_librarySource.Value)
 
         Public Function CreateHelperLibrary(source As String) As MetadataReference
             Dim libraryCompilation = VisualBasicCompilation.Create("library",

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -7737,9 +7737,9 @@ BC35000: Requested operation is not available because the runtime library functi
 
 #Region "Expression Tree Test Helpers"
 
-        Private _exprTesting As XElement = <file name="exprlambdatest.vb"><%= ExpTreeTestResources.ExprLambdaUtils %></file>
+        Private ReadOnly _exprTesting As XElement = <file name="exprlambdatest.vb"><%= ExpTreeTestResources.ExprLambdaUtils %></file>
 
-        Private _queryTesting As XElement = <file name="QueryHelper.vb"><%= ExpTreeTestResources.QueryHelper %></file>
+        Private ReadOnly _queryTesting As XElement = <file name="QueryHelper.vb"><%= ExpTreeTestResources.QueryHelper %></file>
 
 #End Region
 

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -49,10 +49,10 @@ Namespace Global
     Friend Class ExpressionPrinter
         Inherits System.Linq.Expressions.ExpressionVisitor
 
-        Private _s As StringBuilder = New StringBuilder()
+        Private ReadOnly _s As StringBuilder = New StringBuilder()
 
         Private _indent As String = ""
-        Private _indentStep As String = "  "
+        Private ReadOnly _indentStep As String = "  "
 
         Public Shared Function GetCultureInvariantString(val As Object) As String
             If val Is Nothing Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.vb
@@ -61,8 +61,8 @@ End Enum
         Private NotInheritable Class TestAdditionalText
             Inherits AdditionalText
 
-            Private _path As String
-            Private _text As SourceText
+            Private ReadOnly _path As String
+            Private ReadOnly _text As SourceText
 
             Public Sub New(path As String, text As SourceText)
                 _path = path

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -522,7 +522,7 @@ End Namespace
         Private Class CodeBlockAnalyzer
             Inherits DiagnosticAnalyzer
 
-            Private Shared s_descriptor As DiagnosticDescriptor = DescriptorFactory.CreateSimpleDescriptor("CodeBlockDiagnostic")
+            Private Shared ReadOnly s_descriptor As DiagnosticDescriptor = DescriptorFactory.CreateSimpleDescriptor("CodeBlockDiagnostic")
 
             Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
                 Get

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
@@ -3781,7 +3781,7 @@ End Class
             Assert.Equal("Me, t, t1", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside))
         End Sub
 
-        Private Shared s_customIL As XCData = <![CDATA[
+        Private Shared ReadOnly s_customIL As XCData = <![CDATA[
 .class public auto ansi beforefieldinit External
        extends [mscorlib]System.Object
 {

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ArrayLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ArrayLiteralTests.vb
@@ -19,9 +19,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Public Class ArrayLiteralTests
         Inherits BasicTestBase
 
-        Private _strictOff As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.Off)
-        Private _strictOn As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.On)
-        Private _strictCustom As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.Custom)
+        Private ReadOnly _strictOff As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.Off)
+        Private ReadOnly _strictOn As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.On)
+        Private ReadOnly _strictCustom As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(OptionStrict.Custom)
 
         <Fact()>
         Public Sub TestArrayLiteralInferredType()

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/ConstructorDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/ConstructorDocumentationCommentTests.vb
@@ -6,9 +6,9 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class ConstructorDocumentationCommentTests
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
@@ -10015,9 +10015,9 @@ AssemblyName
         End Sub
 
         Private Structure NameSyntaxInfo
-            Public Syntax As String
-            Public Symbols As String()
-            Public Types As String()
+            Public ReadOnly Syntax As String
+            Public ReadOnly Symbols As String()
+            Public ReadOnly Types As String()
 
             Public Sub New(syntax As String, symbols As String(), types As String())
                 Me.Syntax = syntax
@@ -11839,8 +11839,8 @@ xmlDoc)
 #Region "Helpers"
 
         Private Structure AliasInfo
-            Public Name As String
-            Public Target As String
+            Public ReadOnly Name As String
+            Public ReadOnly Target As String
 
             Public Sub New(name As String, target As String)
                 Me.Name = name

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/EventDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/EventDocumentationCommentTests.vb
@@ -8,9 +8,9 @@ Imports Roslyn.Test.Utilities
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class EventDocumentationCommentTests
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/FieldDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/FieldDocumentationCommentTests.vb
@@ -6,11 +6,11 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class FieldDocumentationCommentTests
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
-        Private _enumSymbol As NamedTypeSymbol
-        Private _valueType As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
+        Private ReadOnly _enumSymbol As NamedTypeSymbol
+        Private ReadOnly _valueType As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.vb
@@ -10,9 +10,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class MethodDocumentationCommentTests
         Inherits BasicTestBase
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/PropertyDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/PropertyDocumentationCommentTests.vb
@@ -6,9 +6,9 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class PropertyDocumentationCommentTests
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/TypeDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/TypeDocumentationCommentTests.vb
@@ -6,9 +6,9 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class TypeDocumentationCommentTests
 
-        Private _compilation As VisualBasicCompilation
-        Private _acmeNamespace As NamespaceSymbol
-        Private _widgetClass As NamedTypeSymbol
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _acmeNamespace As NamespaceSymbol
+        Private ReadOnly _widgetClass As NamedTypeSymbol
 
         Public Sub New()
             _compilation = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataMemberTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataMemberTests.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
     Public Class MetadataMemberTests
         Inherits BasicTestBase
 
-        Private _VTableGapClassIL As String = <![CDATA[
+        Private ReadOnly _VTableGapClassIL As String = <![CDATA[
 .class public auto ansi beforefieldinit Class
        extends [mscorlib]System.Object
 {
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
 } // end of class Class
 ]]>.Value
 
-        Private _VTableGapInterfaceIL As String = <![CDATA[
+        Private ReadOnly _VTableGapInterfaceIL As String = <![CDATA[
 .class interface public abstract auto ansi Interface
 {
   .method public hidebysig newslot specialname rtspecialname abstract virtual 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
     Public Class WinMdEventTest
         Inherits BasicTestBase
 
-        Private _eventInterfaceILTemplate As String = <![CDATA[
+        Private ReadOnly _eventInterfaceILTemplate As String = <![CDATA[
 .class interface public abstract auto ansi {0}
 {{
   .method public hidebysig newslot specialname abstract virtual 
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
 ]]>.Value
         Private ReadOnly _eventLibRef As MetadataReference
 
-        Private _dynamicCommonSrc As XElement =
+        Private ReadOnly _dynamicCommonSrc As XElement =
             <compilation>
                 <file name="dynamic_common.vb">
                     <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
@@ -4294,7 +4294,7 @@ End Class
         End Sub
 #End Region
 #Region "Properties calls"
-        Private _propertiesCallBaseSource As XElement =
+        Private ReadOnly _propertiesCallBaseSource As XElement =
             <compilation>
                 <file name="a.vb">
 Module Program

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -10404,7 +10404,7 @@ BC31086: 'Public Overrides Sub F1()' cannot override 'Public Sub F1()' because i
             CompilationUtils.AssertTheseDeclarationDiagnostics(compilation1, expectedErrors1)
         End Sub
 
-        Private Shared s_typeWithMixedProperty As String = <![CDATA[
+        Private Shared ReadOnly s_typeWithMixedProperty As String = <![CDATA[
 .class public auto ansi beforefieldinit Base_VirtGet_Set
        extends [mscorlib]System.Object
 {

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -14,7 +14,7 @@ Imports Roslyn.Test.Utilities
 
 Public Class IncrementalParser
 
-    Private _s As String = <![CDATA[
+    Private ReadOnly _s As String = <![CDATA[
 '-----------------------
 '
 '  Copyright (c)

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/StatementSyntaxWalkerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/StatementSyntaxWalkerTests.vb
@@ -104,7 +104,7 @@ End Namespace
     Friend Class TestWalker
         Inherits StatementSyntaxWalker
 
-        Private _arg As TextWriter
+        Private ReadOnly _arg As TextWriter
 
         Public Sub New(arg As TextWriter)
             Me._arg = arg

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxAnnotationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxAnnotationTests.vb
@@ -780,7 +780,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             End Function
         End Class
 
-        Private _allInOneVisualBasicCode As String = TestResource.AllInOneVisualBasicCode
-        Private _helloWorldCode As String = TestResource.HelloWorldVisualBasicCode
+        Private ReadOnly _allInOneVisualBasicCode As String = TestResource.AllInOneVisualBasicCode
+        Private ReadOnly _helloWorldCode As String = TestResource.HelloWorldVisualBasicCode
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -979,7 +979,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                            {New TextSpan(26, 5), New TextSpan(26, 5), New TextSpan(71, 22), New TextSpan(94, 1), New TextSpan(96, 5)})
         End Sub
 
-        Private Shared s_messageProvider As New MockMessageProvider()
+        Private Shared ReadOnly s_messageProvider As New MockMessageProvider()
 
         Private Function CreateDiagnosticInfo(code As Integer) As DiagnosticInfo
             Return New DiagnosticInfo(s_messageProvider, code)

--- a/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
+++ b/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DiagnosticAnalyzerAttributeAnalyzer : DiagnosticAnalyzerCorrectnessAnalyzer
     {
-        private static LocalizableString s_localizableTitleMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingDiagnosticAnalyzerAttributeTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessageMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingAttributeMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources), DiagnosticAnalyzerAttributeFullName);
-        private static LocalizableString s_localizableDescriptionMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingDiagnosticAnalyzerAttributeDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingDiagnosticAnalyzerAttributeTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingAttributeMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources), DiagnosticAnalyzerAttributeFullName);
+        private static readonly LocalizableString s_localizableDescriptionMissingAttribute = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingDiagnosticAnalyzerAttributeDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor MissingDiagnosticAnalyzerAttributeRule = new DiagnosticDescriptor(
             DiagnosticIds.MissingDiagnosticAnalyzerAttributeRuleId,
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             description: s_localizableDescriptionMissingAttribute,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableTitleAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessageAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableDescriptionAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescriptionAddLanguageSupportToAnalyzer = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AddLanguageSupportToAnalyzerDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor AddLanguageSupportToAnalyzerRule = new DiagnosticDescriptor(
             DiagnosticIds.AddLanguageSupportToAnalyzerRuleId,

--- a/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         where TObjectCreationExpressionSyntax : SyntaxNode
         where TLanguageKindEnum : struct
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseLocalizableStringsInDescriptorDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor UseLocalizableStringsInDescriptorRule = new DiagnosticDescriptor(
             DiagnosticIds.UseLocalizableStringsInDescriptorRuleId,

--- a/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         where TInvocationExpressionSyntax : SyntaxNode
         where TLanguageKindEnum : struct
     {
-        private static LocalizableString s_localizableTitleMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessageMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableDescriptionMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescriptionMissingKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.MissingKindArgumentToRegisterActionDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor MissingKindArgumentRule = new DiagnosticDescriptor(
             DiagnosticIds.MissingKindArgumentToRegisterActionRuleId,
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             description: s_localizableDescriptionMissingKindArgument,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableTitleUnsupportedSymbolKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UnsupportedSymbolKindArgumentToRegisterActionTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessageUnsupportedSymbolKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UnsupportedSymbolKindArgumentToRegisterActionMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleUnsupportedSymbolKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UnsupportedSymbolKindArgumentToRegisterActionTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageUnsupportedSymbolKindArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UnsupportedSymbolKindArgumentToRegisterActionMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor UnsupportedSymbolKindArgumentRule = new DiagnosticDescriptor(
             DiagnosticIds.UnsupportedSymbolKindArgumentRuleId,
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableTitleInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessageInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableDescriptionInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources), nameof(TLanguageKindEnumName));
+        private static readonly LocalizableString s_localizableTitleInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescriptionInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources), nameof(TLanguageKindEnumName));
 
         public static DiagnosticDescriptor InvalidSyntaxKindTypeArgumentRule = new DiagnosticDescriptor(
             DiagnosticIds.InvalidSyntaxKindTypeArgumentRuleId,

--- a/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/CodeAnalysis/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
@@ -17,9 +17,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         where TIdentifierNameSyntax : SyntaxNode
         where TVariableDeclaratorSyntax : SyntaxNode
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidReportDiagnosticDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         public static DiagnosticDescriptor InvalidReportDiagnosticRule = new DiagnosticDescriptor(
             DiagnosticIds.InvalidReportDiagnosticRuleId,

--- a/src/Diagnostics/FxCop/CSharp/Usage/CSharpCA2214DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/CSharp/Usage/CSharpCA2214DiagnosticAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.Usage
 
         private sealed class SyntaxNodeAnalyzer
         {
-            private INamedTypeSymbol _containingType;
+            private readonly INamedTypeSymbol _containingType;
 
             public SyntaxNodeAnalyzer(IMethodSymbol constructorSymbol)
             {

--- a/src/Diagnostics/FxCop/Core/Design/CA1008DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Design/CA1008DiagnosticAnalyzer.cs
@@ -40,10 +40,10 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
         internal const string RuleMultipleZeroCustomTag = "RuleMultipleZero";
         internal const string RuleNoZeroCustomTag = "RuleNoZero";
 
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldHaveZeroValue), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldHaveZeroValueDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldHaveZeroValue), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldHaveZeroValueDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
-        private static LocalizableString s_localizableMessageRuleRename = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueFlagsRename), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageRuleRename = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueFlagsRename), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static DiagnosticDescriptor RuleRename = new DiagnosticDescriptor(RuleId,
                                                                        s_localizableTitle,
                                                                        s_localizableMessageRuleRename,
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
                                                                        helpLinkUri: "http://msdn.microsoft.com/library/ms182149.aspx",
                                                                        customTags: DiagnosticCustomTags.Microsoft.Concat(RuleRenameCustomTag).ToArray());
 
-        private static LocalizableString s_localizableMessageRuleMultipleZero = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueFlagsMultipleZero), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageRuleMultipleZero = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueFlagsMultipleZero), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static DiagnosticDescriptor RuleMultipleZero = new DiagnosticDescriptor(RuleId,
                                                                s_localizableTitle,
                                                                s_localizableMessageRuleMultipleZero,
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
                                                                helpLinkUri: "http://msdn.microsoft.com/library/ms182149.aspx",
                                                                customTags: DiagnosticCustomTags.Microsoft.Concat(RuleMultipleZeroCustomTag).ToArray());
 
-        private static LocalizableString s_localizableMessageRuleNoZero = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueNotFlagsNoZeroValue), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageRuleNoZero = new LocalizableResourceString(nameof(FxCopRulesResources.EnumsShouldZeroValueNotFlagsNoZeroValue), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static DiagnosticDescriptor RuleNoZero = new DiagnosticDescriptor(RuleId,
                                                                s_localizableTitle,
                                                                s_localizableMessageRuleNoZero,

--- a/src/Diagnostics/FxCop/Core/Design/CA1012DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Design/CA1012DiagnosticAnalyzer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
     public sealed class CA1012DiagnosticAnalyzer : AbstractNamedTypeAnalyzer
     {
         internal const string RuleId = "CA1012";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.AbstractTypesShouldNotHavePublicConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.TypeIsAbstractButHasPublicConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.AbstractTypesShouldNotHavePublicConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.TypeIsAbstractButHasPublicConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,

--- a/src/Diagnostics/FxCop/Core/Design/CA1024DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Design/CA1024DiagnosticAnalyzer.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
     public abstract class CA1024DiagnosticAnalyzer<TLanguageKindEnum> : DiagnosticAnalyzer where TLanguageKindEnum : struct
     {
         internal const string RuleId = "CA1024";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.UsePropertiesWhereAppropriate), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.ChangeToAPropertyIfAppropriate), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.UsePropertiesWhereAppropriateDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.UsePropertiesWhereAppropriate), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.ChangeToAPropertyIfAppropriate), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.UsePropertiesWhereAppropriateDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,

--- a/src/Diagnostics/FxCop/Core/Design/StaticTypeRulesDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Design/StaticTypeRulesDiagnosticAnalyzer.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
         internal const string CA1052RuleId = "CA1052";
         internal const string CA1053RuleId = "CA1053";
 
-        private static LocalizableString s_localizableTitleCA1052 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldBeStaticOrNotInheritable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessageCA1052 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypeIsNotStatic), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitleCA1052 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldBeStaticOrNotInheritable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageCA1052 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypeIsNotStatic), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static readonly DiagnosticDescriptor CA1052Rule = new DiagnosticDescriptor(CA1052RuleId,
                                                                           s_localizableTitleCA1052,
                                                                           s_localizableMessageCA1052,
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
                                                                           helpLinkUri: "http://msdn.microsoft.com/library/ms182168.aspx",
                                                                           customTags: DiagnosticCustomTags.Microsoft);
 
-        private static LocalizableString s_localizableTitleCA1053 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldNotHaveConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessageCA1053 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldNotHaveConstructorsMessage), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitleCA1053 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldNotHaveConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageCA1053 = new LocalizableResourceString(nameof(FxCopRulesResources.StaticHolderTypesShouldNotHaveConstructorsMessage), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static readonly DiagnosticDescriptor CA1053Rule = new DiagnosticDescriptor(CA1053RuleId,
                                                                           s_localizableTitleCA1053,
                                                                           s_localizableMessageCA1053,

--- a/src/Diagnostics/FxCop/Core/Naming/CA1715DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Naming/CA1715DiagnosticAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Naming
     {
         internal const string RuleId = "CA1715";
 
-        private static LocalizableString s_localizableMessageAndTitleInterfaceRule = new LocalizableResourceString(nameof(FxCopRulesResources.InterfaceNamesShouldStartWithI), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageAndTitleInterfaceRule = new LocalizableResourceString(nameof(FxCopRulesResources.InterfaceNamesShouldStartWithI), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static readonly DiagnosticDescriptor InterfaceRule = new DiagnosticDescriptor(RuleId,
                                                                                       s_localizableMessageAndTitleInterfaceRule,
                                                                                       s_localizableMessageAndTitleInterfaceRule,
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Naming
                                                                                       helpLinkUri: "http://msdn.microsoft.com/library/ms182243.aspx",
                                                                                       customTags: DiagnosticCustomTags.Microsoft);
 
-        private static LocalizableString s_localizableMessageAndTitleTypeParameterRule = new LocalizableResourceString(nameof(FxCopRulesResources.TypeParameterNamesShouldStartWithT), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageAndTitleTypeParameterRule = new LocalizableResourceString(nameof(FxCopRulesResources.TypeParameterNamesShouldStartWithT), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
         internal static readonly DiagnosticDescriptor TypeParameterRule = new DiagnosticDescriptor(RuleId,
                                                                                       s_localizableMessageAndTitleTypeParameterRule,
                                                                                       s_localizableMessageAndTitleTypeParameterRule,

--- a/src/Diagnostics/FxCop/Core/Performance/RemoveEmptyFinalizers.cs
+++ b/src/Diagnostics/FxCop/Core/Performance/RemoveEmptyFinalizers.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Performance
     public abstract class RemoveEmptyFinalizers<TLanguageKindEnum> : DiagnosticAnalyzer where TLanguageKindEnum : struct
     {
         public const string RuleId = "CA1821";
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(FxCopRulesResources.RemoveEmptyFinalizers), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.RemoveEmptyFinalizersDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(FxCopRulesResources.RemoveEmptyFinalizers), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.RemoveEmptyFinalizersDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableMessageAndTitle,

--- a/src/Diagnostics/FxCop/Core/Usage/CA2200DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/CA2200DiagnosticAnalyzer.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     public abstract class CA2200DiagnosticAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2200";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.RethrowToPreserveStackDetails), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.RethrowException), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FxCopRulesResources.RethrowToPreserveStackDetails), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(FxCopRulesResources.RethrowException), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,

--- a/src/Diagnostics/FxCop/Core/Usage/CA2214DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/CA2214DiagnosticAnalyzer.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     public abstract class CA2214DiagnosticAnalyzer<TLanguageKindEnum> : DiagnosticAnalyzer where TLanguageKindEnum : struct
     {
         public const string RuleId = "CA2214";
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(FxCopRulesResources.DoNotCallOverridableMethodsInConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.DoNotCallOverridableMethodsInConstructorsDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(FxCopRulesResources.DoNotCallOverridableMethodsInConstructors), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(FxCopRulesResources.DoNotCallOverridableMethodsInConstructorsDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         public static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableMessageAndTitle,

--- a/src/Diagnostics/FxCop/Core/Usage/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Usage/SerializationRulesDiagnosticAnalyzer.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
     {
         // Implement serialization constructors
         internal const string RuleCA2229Id = "CA2229";
-        private static LocalizableString s_localizableTitleCA2229 = new LocalizableResourceString(nameof(FxCopRulesResources.ImplementSerializationConstructor), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescriptionCA2229 = new LocalizableResourceString(nameof(FxCopRulesResources.ImplementSerializationConstructorDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitleCA2229 = new LocalizableResourceString(nameof(FxCopRulesResources.ImplementSerializationConstructor), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescriptionCA2229 = new LocalizableResourceString(nameof(FxCopRulesResources.ImplementSerializationConstructorDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor RuleCA2229 = new DiagnosticDescriptor(RuleCA2229Id,
                                                                          s_localizableTitleCA2229,
@@ -27,9 +27,9 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
 
         // Mark ISerializable types with SerializableAttribute
         internal const string RuleCA2237Id = "CA2237";
-        private static LocalizableString s_localizableTitleCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkISerializableTypesWithAttribute), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessageCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.AddSerializableAttributeToType), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescriptionCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkISerializableTypesWithAttributeDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitleCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkISerializableTypesWithAttribute), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.AddSerializableAttributeToType), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescriptionCA2237 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkISerializableTypesWithAttributeDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor RuleCA2237 = new DiagnosticDescriptor(RuleCA2237Id,
                                                                          s_localizableTitleCA2237,
@@ -43,9 +43,9 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
 
         // Mark all non-serializable fields
         internal const string RuleCA2235Id = "CA2235";
-        private static LocalizableString s_localizableTitleCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkAllNonSerializableFields), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableMessageCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.FieldIsOfNonSerializableType), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
-        private static LocalizableString s_localizableDescriptionCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkAllNonSerializableFieldsDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableTitleCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkAllNonSerializableFields), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableMessageCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.FieldIsOfNonSerializableType), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
+        private static readonly LocalizableString s_localizableDescriptionCA2235 = new LocalizableResourceString(nameof(FxCopRulesResources.MarkAllNonSerializableFieldsDescription), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources));
 
         internal static DiagnosticDescriptor RuleCA2235 = new DiagnosticDescriptor(RuleCA2235Id,
                                                                          s_localizableTitleCA2235,
@@ -102,10 +102,10 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Usage
 
         private sealed class Analyzer
         {
-            private INamedTypeSymbol _iserializableTypeSymbol;
-            private INamedTypeSymbol _serializationInfoTypeSymbol;
-            private INamedTypeSymbol _streamingContextTypeSymbol;
-            private INamedTypeSymbol _serializableAttributeTypeSymbol;
+            private readonly INamedTypeSymbol _iserializableTypeSymbol;
+            private readonly INamedTypeSymbol _serializationInfoTypeSymbol;
+            private readonly INamedTypeSymbol _streamingContextTypeSymbol;
+            private readonly INamedTypeSymbol _serializableAttributeTypeSymbol;
 
             public Analyzer(
                 INamedTypeSymbol iserializableTypeSymbol,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/AssemblyAttributesDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/AssemblyAttributesDiagnosticAnalyzer.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.Analyzers
         internal const string CA1016RuleId = "CA1016";
         internal const string CA1014RuleId = "CA1014";
 
-        private static LocalizableString s_localizableMessageCA1016 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.AssembliesShouldBeMarkedWithAssemblyVersionAttribute), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageCA1016 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.AssembliesShouldBeMarkedWithAssemblyVersionAttribute), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor CA1016Rule = new DiagnosticDescriptor(CA1016RuleId,
                                                                          s_localizableMessageCA1016,
                                                                          s_localizableMessageCA1016,
@@ -22,8 +22,8 @@ namespace System.Runtime.Analyzers
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182155.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableMessageCA1014 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAssembliesWithCLSCompliantAttribute), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescriptionCA1014 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAssembliesWithCLSCompliantDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageCA1014 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAssembliesWithCLSCompliantAttribute), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionCA1014 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAssembliesWithCLSCompliantDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor CA1014Rule = new DiagnosticDescriptor(CA1014RuleId,
                                                                          s_localizableMessageCA1014,
                                                                          s_localizableMessageCA1014,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/DefineAccessorsForAttributeArguments.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/DefineAccessorsForAttributeArguments.cs
@@ -22,7 +22,7 @@ namespace System.Runtime.Analyzers
         internal const string AddAccessorCase = "AddAccessor";
         internal const string MakePublicCase = "MakePublic";
         internal const string RemoveSetterCase = "RemoveSetter";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DefineAccessorsForAttributeArguments), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DefineAccessorsForAttributeArguments), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/EnumWithFlagsAttribute.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/EnumWithFlagsAttribute.cs
@@ -35,9 +35,9 @@ namespace System.Runtime.Analyzers
         internal const string RuleIdDoNotMarkEnumsWithFlags = "CA2217";
         internal const string RuleNameForExportAttribute = "EnumWithFlagsAttributeRules";
 
-        private static LocalizableString s_localizableTitleCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlags), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessageCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlagsMessage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescriptionCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlagsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitleCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlags), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlagsMessage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionCA1027 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkEnumsWithFlagsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor Rule1027 = new DiagnosticDescriptor(RuleIdMarkEnumsWithFlags,
                                                                              s_localizableTitleCA1027,
                                                                              s_localizableMessageCA1027,
@@ -48,9 +48,9 @@ namespace System.Runtime.Analyzers
                                                                              helpLinkUri: "http://msdn.microsoft.com/library/ms182159.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableTitleCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlags), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessageCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlagsMessage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescriptionCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlagsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitleCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlags), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlagsMessage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionCA2217 = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotMarkEnumsWithFlagsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor Rule2217 = new DiagnosticDescriptor(RuleIdDoNotMarkEnumsWithFlags,
                                                                              s_localizableTitleCA2217,
                                                                              s_localizableMessageCA2217,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/MarkAllAssembliesWithComVisible.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/MarkAllAssembliesWithComVisible.cs
@@ -11,8 +11,8 @@ namespace System.Runtime.Analyzers
     public sealed class MarkAllAssembliesWithComVisibleAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1017";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAllAssembliesWithComVisible), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAllAssembliesWithComVisibleDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAllAssembliesWithComVisible), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAllAssembliesWithComVisibleDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                                       s_localizableTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/MarkAttributesWithAttributeUsage.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/MarkAttributesWithAttributeUsage.cs
@@ -16,8 +16,8 @@ namespace System.Runtime.Analyzers
     public sealed class MarkAttributesWithAttributeUsageAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1018";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.CustomAttrShouldHaveAttributeUsage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAttributesWithAttributeUsage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.CustomAttrShouldHaveAttributeUsage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.MarkAttributesWithAttributeUsage), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                     s_localizableTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/OverrideMethodsOnComparableTypes.cs
@@ -17,9 +17,9 @@ namespace System.Runtime.Analyzers
     public sealed class OverrideMethodsOnComparableTypesAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1036";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterface), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterface), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterfaceDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterface), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterface), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnIComparableInterfaceDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                                   s_localizableTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/UseGenericEventHandler.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Design/UseGenericEventHandler.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.Analyzers
     public abstract class UseGenericEventHandler : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1003";
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.UseGenericEventHandlerInstances), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.UseGenericEventHandlerInstances), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RuleId,
@@ -71,11 +71,11 @@ namespace System.Runtime.Analyzers
 
         protected abstract class AnalyzerBase
         {
-            private Compilation _compilation;
-            private INamedTypeSymbol _eventHandler;
-            private INamedTypeSymbol _genericEventHandler;
-            private INamedTypeSymbol _eventArgs;
-            private INamedTypeSymbol _comSourceInterfacesAttribute;
+            private readonly Compilation _compilation;
+            private readonly INamedTypeSymbol _eventHandler;
+            private readonly INamedTypeSymbol _genericEventHandler;
+            private readonly INamedTypeSymbol _eventArgs;
+            private readonly INamedTypeSymbol _comSourceInterfacesAttribute;
 
             public AnalyzerBase(
                 Compilation compilation,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Globalization/UseOrdinalStringComparison.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Globalization/UseOrdinalStringComparison.cs
@@ -10,8 +10,8 @@ namespace System.Runtime.Analyzers
     {
         internal const string RuleId = "CA1309";
 
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.StringComparisonShouldBeOrdinalOrOrdinalIgnoreCase), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.StringComparisonShouldBeOrdinalDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.StringComparisonShouldBeOrdinalOrOrdinalIgnoreCase), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.StringComparisonShouldBeOrdinalDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableMessageAndTitle,
                                                                              s_localizableMessageAndTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Performance/AvoidUnsealedAttributes.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Performance/AvoidUnsealedAttributes.cs
@@ -16,8 +16,8 @@ namespace System.Runtime.Analyzers
     public sealed class AvoidUnsealedAttributesAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1813";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.AvoidUnsealedAttributes), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.SealAttributeTypesForImprovedPerf), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.AvoidUnsealedAttributes), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.SealAttributeTypesForImprovedPerf), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Reliability/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Reliability/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -21,8 +21,8 @@ namespace System.Runtime.Analyzers
     public abstract class DoNotLockOnObjectsWithWeakIdentity : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2002";
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotLockOnObjectsWithWeakIdentity), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotLockOnWeakIdentity), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotLockOnObjectsWithWeakIdentity), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DoNotLockOnWeakIdentity), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableTitle,
                                                                          s_localizableMessage,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.Analyzers
     {
         internal const string RuleId = "CA2213";
         internal const string Dispose = "Dispose";
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DisposableFieldsShouldBeDisposed), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.DisposableFieldsShouldBeDisposed), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableMessageAndTitle,
@@ -58,7 +58,7 @@ namespace System.Runtime.Analyzers
         protected abstract class AbstractAnalyzer
         {
             protected INamedTypeSymbol _disposableType;
-            private ConcurrentDictionary<IFieldSymbol, bool> _fieldDisposedMap = new ConcurrentDictionary<IFieldSymbol, bool>();
+            private readonly ConcurrentDictionary<IFieldSymbol, bool> _fieldDisposedMap = new ConcurrentDictionary<IFieldSymbol, bool>();
 
             public AbstractAnalyzer(INamedTypeSymbol disposableType)
             {

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Usage/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Core/Usage/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -15,8 +15,8 @@ namespace System.Runtime.Analyzers
     public sealed class OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2231";
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEquals), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEquals), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(SystemRuntimeAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsDescription), SystemRuntimeAnalyzersResources.ResourceManager, typeof(SystemRuntimeAnalyzersResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                          s_localizableMessageAndTitle,

--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/MarkAssembliesWithAssemblyVersionAttributeTests.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/MarkAssembliesWithAssemblyVersionAttributeTests.cs
@@ -151,8 +151,8 @@ using System.Reflection;
 ");
         }
 
-        private static string s_number = "CA1016";
-        private static string s_message = "Assemblies should be marked with AssemblyVersionAttribute";
+        private static readonly string s_number = "CA1016";
+        private static readonly string s_message = "Assemblies should be marked with AssemblyVersionAttribute";
 
         private static DiagnosticResult s_diagnostic = new DiagnosticResult
         {

--- a/src/Diagnostics/FxCop/VisualBasic/Usage/BasicCA2214DiagnosticAnalyzer.vb
+++ b/src/Diagnostics/FxCop/VisualBasic/Usage/BasicCA2214DiagnosticAnalyzer.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FxCopAnalyzers.Usage
 
         Private NotInheritable Class SyntaxNodeAnalyzer
 
-            Private _containingType As INamedTypeSymbol
+            Private ReadOnly _containingType As INamedTypeSymbol
 
             Public Sub New(constructorSymbol As IMethodSymbol)
                 _containingType = constructorSymbol.ContainingType

--- a/src/Diagnostics/Roslyn/CSharp/Performance/LinqAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/CSharp/Performance/LinqAnalyzer.cs
@@ -20,8 +20,8 @@ namespace Roslyn.Diagnostics.Analyzers.CSharp.Performance
         private const string IListMetadataName = "System.Collections.Generic.IList`1";
         private const string EnumerableMetadataName = "System.Linq.Enumerable";
 
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotUseLinqOnIndexableCollectionMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotUseLinqOnIndexableCollectionDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotUseLinqOnIndexableCollectionMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotUseLinqOnIndexableCollectionDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         public static readonly DiagnosticDescriptor DoNotCallLastOnIndexableDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DoNotCallLinqOnIndexable,

--- a/src/Diagnostics/Roslyn/CSharp/Reliability/CSharpSymbolDeclaredEventAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/CSharp/Reliability/CSharpSymbolDeclaredEventAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Roslyn.Diagnostics.Analyzers.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpSymbolDeclaredEventAnalyzer : SymbolDeclaredEventAnalyzer<SyntaxKind>
     {
-        private static HashSet<string> s_symbolTypesWithExpectedSymbolDeclaredEvent = new HashSet<string>(
+        private static readonly HashSet<string> s_symbolTypesWithExpectedSymbolDeclaredEvent = new HashSet<string>(
             new[] { "SourceNamespaceSymbol", "SourceNamedTypeSymbol", "SourceEventSymbol", "SourceFieldSymbol", "SourceMethodSymbol", "SourcePropertySymbol" });
 
         protected override CompilationAnalyzer GetCompilationAnalyzer(Compilation compilation, INamedTypeSymbol symbolType)

--- a/src/Diagnostics/Roslyn/CSharp/Reliability/ImmutableCollectionAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/CSharp/Reliability/ImmutableCollectionAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Roslyn.Diagnostics.Analyzers.CSharp.Reliability
     {
         private const string ImmutableArrayMetadataName = "System.Collections.Immutable.ImmutableArray`1";
 
-        private static LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCallToImmutableArrayMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageAndTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCallToImmutableArrayMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         public static readonly DiagnosticDescriptor DoNotCallToImmutableArrayDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DoNotCallToImmutableArrayRuleId,

--- a/src/Diagnostics/Roslyn/Core/ApiDesign/CancellationTokenMustBeLastAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/CancellationTokenMustBeLastAnalyzer.cs
@@ -11,8 +11,8 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class CancellationTokenMustBeLastAnalyzer : DiagnosticAnalyzer
     {
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.CancellationTokenMustBeLastMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.CancellationTokenMustBeLastDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.CancellationTokenMustBeLastMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.CancellationTokenMustBeLastDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.CancellationTokenMustBeLastRuleId,

--- a/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -73,7 +73,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
                 miscellaneousOptions:
                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        private static HashSet<MethodKind> s_ignorableMethodKinds = new HashSet<MethodKind>
+        private static readonly HashSet<MethodKind> s_ignorableMethodKinds = new HashSet<MethodKind>
         {
             MethodKind.EventAdd,
             MethodKind.EventRemove

--- a/src/Diagnostics/Roslyn/Core/Documentation/DoNotUseVerbatimCrefsAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Documentation/DoNotUseVerbatimCrefsAnalyzer.cs
@@ -13,9 +13,9 @@ namespace Roslyn.Diagnostics.Analyzers.Documentation
 {
     public abstract class DoNotUseVerbatimCrefsAnalyzer : DiagnosticAnalyzer
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseProperCrefTagsDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DoNotUseVerbatimCrefsRuleId,

--- a/src/Diagnostics/Roslyn/Core/Performance/CodeActionCreateAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Performance/CodeActionCreateAnalyzer.cs
@@ -14,8 +14,8 @@ namespace Roslyn.Diagnostics.Analyzers
         internal const string CodeActionMetadataName = "Microsoft.CodeAnalysis.CodeActions.CodeAction";
         internal const string CreateMethodName = "Create";
 
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DontUseCodeActionCreateDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DontUseCodeActionCreateMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DontUseCodeActionCreateDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DontUseCodeActionCreateMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor DontUseCodeActionCreateRule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DontUseCodeActionCreateRuleId,

--- a/src/Diagnostics/Roslyn/Core/Performance/DiagnosticDescriptorAccessAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Performance/DiagnosticDescriptorAccessAnalyzer.cs
@@ -11,9 +11,9 @@ namespace Roslyn.Diagnostics.Analyzers
     {
         private static readonly string s_diagnosticTypeFullName = typeof(Diagnostic).FullName;
 
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DiagnosticDescriptorAccessDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor DoNotRealizeDiagnosticDescriptorRule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DoNotAccessDiagnosticDescriptorRuleId,

--- a/src/Diagnostics/Roslyn/Core/Performance/EmptyArrayDiagnosticAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Performance/EmptyArrayDiagnosticAnalyzer.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Performance
         /// <summary>The name of the Empty method on System.Array.</summary>
         internal const string ArrayEmptyMethodName = "Empty";
 
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseArrayEmptyDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseArrayEmptyMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseArrayEmptyDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseArrayEmptyMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         /// <summary>The diagnostic descriptor used when Array.Empty should be used instead of a new array allocation.</summary>
         internal static readonly DiagnosticDescriptor UseArrayEmptyDescriptor = new DiagnosticDescriptor(

--- a/src/Diagnostics/Roslyn/Core/Performance/EquatableAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Performance/EquatableAnalyzer.cs
@@ -14,8 +14,8 @@ namespace Roslyn.Diagnostics.Analyzers
     {
         private const string IEquatableMetadataName = "System.IEquatable`1";
 
-        private static LocalizableString s_localizableTitleImplementIEquatable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ImplementIEquatableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessageImplementIEquatable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ImplementIEquatableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleImplementIEquatable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ImplementIEquatableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageImplementIEquatable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ImplementIEquatableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         private static readonly DiagnosticDescriptor s_implementIEquatableDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.ImplementIEquatableRuleId,
@@ -25,8 +25,8 @@ namespace Roslyn.Diagnostics.Analyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        private static LocalizableString s_localizableTitleOverridesObjectEquals = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.OverrideObjectEqualsDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessageOverridesObjectEquals = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.OverrideObjectEqualsMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleOverridesObjectEquals = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.OverrideObjectEqualsDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageOverridesObjectEquals = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.OverrideObjectEqualsMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         private static readonly DiagnosticDescriptor s_overridesObjectEqualsDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.OverrideObjectEqualsRuleId,

--- a/src/Diagnostics/Roslyn/Core/Performance/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Performance/SpecializedEnumerableCreationAnalyzer.cs
@@ -19,8 +19,8 @@ namespace Roslyn.Diagnostics.Analyzers
         internal const string LinqEnumerableMetadataName = "System.Linq.Enumerable";
         internal const string EmptyMethodName = "Empty";
 
-        private static LocalizableString s_localizableTitleUseEmptyEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseEmptyEnumerableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessageUseEmptyEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseEmptyEnumerableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleUseEmptyEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseEmptyEnumerableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageUseEmptyEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseEmptyEnumerableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor UseEmptyEnumerableRule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.UseEmptyEnumerableRuleId,
@@ -31,8 +31,8 @@ namespace Roslyn.Diagnostics.Analyzers
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        private static LocalizableString s_localizableTitleUseSingletonEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseSingletonEnumerableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessageUseSingletonEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseSingletonEnumerableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitleUseSingletonEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseSingletonEnumerableDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessageUseSingletonEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.UseSingletonEnumerableMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor UseSingletonEnumerableRule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.UseSingletonEnumerableRuleId,
@@ -91,8 +91,8 @@ namespace Roslyn.Diagnostics.Analyzers
 
         protected abstract class AbstractCodeBlockStartedAnalyzer<TLanguageKindEnum> where TLanguageKindEnum : struct
         {
-            private INamedTypeSymbol _genericEnumerableSymbol;
-            private IMethodSymbol _genericEmptyEnumerableSymbol;
+            private readonly INamedTypeSymbol _genericEnumerableSymbol;
+            private readonly IMethodSymbol _genericEmptyEnumerableSymbol;
 
             public AbstractCodeBlockStartedAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
             {
@@ -116,7 +116,7 @@ namespace Roslyn.Diagnostics.Analyzers
         protected abstract class AbstractSyntaxAnalyzer
         {
             protected INamedTypeSymbol genericEnumerableSymbol;
-            private IMethodSymbol _genericEmptyEnumerableSymbol;
+            private readonly IMethodSymbol _genericEmptyEnumerableSymbol;
 
             public AbstractSyntaxAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
             {

--- a/src/Diagnostics/Roslyn/Core/Reliability/ConsumePreserveSigAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/ConsumePreserveSigAnalyzer.cs
@@ -9,9 +9,9 @@ namespace Roslyn.Diagnostics.Analyzers
     public abstract class ConsumePreserveSigAnalyzer<TSyntaxKind> : DiagnosticAnalyzer
         where TSyntaxKind : struct
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.ConsumePreserveSigDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor ConsumePreserveSigAnalyzerDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.ConsumePreserveSigRuleId,

--- a/src/Diagnostics/Roslyn/Core/Reliability/DirectlyAwaitingTaskAnalyzerRule.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/DirectlyAwaitingTaskAnalyzerRule.cs
@@ -6,8 +6,8 @@ namespace Roslyn.Diagnostics.Analyzers
 {
     internal static class DirectlyAwaitingTaskAnalyzerRule
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DirectlyAwaitingTaskDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DirectlyAwaitingTaskMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DirectlyAwaitingTaskDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DirectlyAwaitingTaskMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         public static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DirectlyAwaitingTaskAnalyzerRuleId,

--- a/src/Diagnostics/Roslyn/Core/Reliability/DoNotCreateTasksWithoutTaskSchedulerAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/DoNotCreateTasksWithoutTaskSchedulerAnalyzer.cs
@@ -11,9 +11,9 @@ namespace Roslyn.Diagnostics.Analyzers
     public abstract class DoNotCreateTasksWithoutTaskSchedulerAnalyzer<TSyntaxKind> : DiagnosticAnalyzer
         where TSyntaxKind : struct
     {
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.DoNotCreateTasksWithoutTaskSchedulerDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         internal static readonly DiagnosticDescriptor DoNotCreateTasksWithoutTaskSchedulerAnalyzerDescriptor = new DiagnosticDescriptor(
             RoslynDiagnosticIds.DoNotCreateTasksWithoutTaskSchedulerRuleId,

--- a/src/Diagnostics/Roslyn/Core/Reliability/MissingSharedAttributeAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/MissingSharedAttributeAnalyzer.cs
@@ -10,8 +10,8 @@ namespace Roslyn.Diagnostics.Analyzers.Reliability
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class MissingSharedAttributeAnalyzer : DiagnosticAnalyzer
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MissingSharedAttributeDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MissingSharedAttributeMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MissingSharedAttributeDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MissingSharedAttributeMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         public static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.MissingSharedAttributeRuleId,

--- a/src/Diagnostics/Roslyn/Core/Reliability/MixedVersionsOfMefAttributesAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/MixedVersionsOfMefAttributesAnalyzer.cs
@@ -16,8 +16,8 @@ namespace Roslyn.Diagnostics.Analyzers.Reliability
     {
         private static readonly string[] s_mefNamespaces = new[] { "System.ComponentModel.Composition", "System.Composition" };
 
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MixedVersionsOfMefAttributesDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MixedVersionsOfMefAttributesMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MixedVersionsOfMefAttributesDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.MixedVersionsOfMefAttributesMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
 
         public static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId,

--- a/src/Diagnostics/Roslyn/Core/Reliability/SymbolDeclaredEventAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/Reliability/SymbolDeclaredEventAnalyzer.cs
@@ -15,9 +15,9 @@ namespace Roslyn.Diagnostics.Analyzers
     public abstract class SymbolDeclaredEventAnalyzer<TSyntaxKind> : DiagnosticAnalyzer
         where TSyntaxKind : struct
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
-        private static LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleTitle), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleMessage), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsResources.SymbolDeclaredEventRuleDescription), RoslynDiagnosticsResources.ResourceManager, typeof(RoslynDiagnosticsResources));
         private static readonly string s_fullNameOfSymbol = typeof(ISymbol).FullName;
 
         internal static readonly DiagnosticDescriptor SymbolDeclaredEventRule = new DiagnosticDescriptor(

--- a/src/Diagnostics/Roslyn/VisualBasic/Usage/BasicUseSiteDiagnosticsCheckEnforcerAnalyzer.vb
+++ b/src/Diagnostics/Roslyn/VisualBasic/Usage/BasicUseSiteDiagnosticsCheckEnforcerAnalyzer.vb
@@ -13,10 +13,10 @@ Namespace Roslyn.Diagnostics.Analyzers.VisualBasic
     Public Class BasicUseSiteDiagnosticsCheckEnforcerAnalyzer
         Inherits AbstractSyntaxNodeAnalyzer(Of SyntaxKind)
 
-        Private Shared s_localizableTitle As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsResources.UseSiteDiagnosticsCheckerDescription), RoslynDiagnosticsResources.ResourceManager, GetType(RoslynDiagnosticsResources))
-        Private Shared s_localizableMessage As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsResources.UseSiteDiagnosticsCheckerMessage), RoslynDiagnosticsResources.ResourceManager, GetType(RoslynDiagnosticsResources))
+        Private Shared ReadOnly s_localizableTitle As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsResources.UseSiteDiagnosticsCheckerDescription), RoslynDiagnosticsResources.ResourceManager, GetType(RoslynDiagnosticsResources))
+        Private Shared ReadOnly s_localizableMessage As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsResources.UseSiteDiagnosticsCheckerMessage), RoslynDiagnosticsResources.ResourceManager, GetType(RoslynDiagnosticsResources))
 
-        Private Shared s_descriptor As DiagnosticDescriptor = New DiagnosticDescriptor(RoslynDiagnosticIds.UseSiteDiagnosticsCheckerRuleId,
+        Private Shared ReadOnly s_descriptor As DiagnosticDescriptor = New DiagnosticDescriptor(RoslynDiagnosticIds.UseSiteDiagnosticsCheckerRuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
                                                                              "Usage",
@@ -24,7 +24,7 @@ Namespace Roslyn.Diagnostics.Analyzers.VisualBasic
                                                                              False,
                                                                              WellKnownDiagnosticTags.Telemetry)
 
-        Private Shared s_propertiesToValidateMap As Dictionary(Of String, String) = New Dictionary(Of String, String)(StringComparer.OrdinalIgnoreCase) From
+        Private Shared ReadOnly s_propertiesToValidateMap As Dictionary(Of String, String) = New Dictionary(Of String, String)(StringComparer.OrdinalIgnoreCase) From
                 {
                     {s_baseTypeString, s_typeSymbolFullyQualifiedName},
                     {s_interfacesString, s_typeSymbolFullyQualifiedName},

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ArrayBuilder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ArrayBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly ObjectPool<ArrayBuilder<T>> s_poolInstance = new ObjectPool<ArrayBuilder<T>>(() => new ArrayBuilder<T>(), 16);
         private static readonly ReadOnlyCollection<T> s_empty = new ReadOnlyCollection<T>(new T[0]);
 
-        private List<T> _items;
+        private readonly List<T> _items;
 
         public static ArrayBuilder<T> GetInstance(int size = 0)
         {

--- a/src/Features/CSharp/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InvertIf
     // [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InvertIf)]
     internal partial class InvertIfCodeRefactoringProvider : CodeRefactoringProvider
     {
-        private static Dictionary<SyntaxKind, Tuple<SyntaxKind, SyntaxKind>> s_binaryMap =
+        private static readonly Dictionary<SyntaxKind, Tuple<SyntaxKind, SyntaxKind>> s_binaryMap =
             new Dictionary<SyntaxKind, Tuple<SyntaxKind, SyntaxKind>>(SyntaxFacts.EqualityComparer)
                 {
                     { SyntaxKind.EqualsExpression, Tuple.Create(SyntaxKind.NotEqualsExpression, SyntaxKind.ExclamationEqualsToken) },

--- a/src/Features/CSharp/CodeStyle/CSharpCodeStyleOptionsProvider.cs
+++ b/src/Features/CSharp/CodeStyle/CSharpCodeStyleOptionsProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
     [ExportOptionProvider, Shared]
     internal class CSharpCodeStyleOptionsProvider : IOptionProvider
     {
-        private IEnumerable<IOption> _options = new List<IOption>
+        private readonly IEnumerable<IOption> _options = new List<IOption>
             {
                 CSharpCodeStyleOptions.UseVarWhenDeclaringLocals
             }.ToImmutableArray();

--- a/src/Features/CSharp/Completion/CSharpCompletionOptionsProvider.cs
+++ b/src/Features/CSharp/Completion/CSharpCompletionOptionsProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
     [ExportOptionProvider, Shared]
     internal class CSharpCompletionOptionsProvider : IOptionProvider
     {
-        private IEnumerable<IOption> _options = new List<IOption>
+        private readonly IEnumerable<IOption> _options = new List<IOption>
             {
                 CSharpCompletionOptions.AddNewLineOnEnterAfterFullyTypedWord,
                 CSharpCompletionOptions.IncludeSnippets,

--- a/src/Features/CSharp/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     internal sealed class SnippetCompletionProvider : AbstractCompletionProvider
     {
         // If null, the document's language service will be used.
-        private ISnippetInfoService _snippetInfoService;
+        private readonly ISnippetInfoService _snippetInfoService;
 
         public SnippetCompletionProvider(ISnippetInfoService snippetInfoService = null)
         {

--- a/src/Features/Core/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 {
     internal class ChangeSignatureCodeAction : CodeActionWithOptions
     {
-        private AbstractChangeSignatureService _changeSignatureService;
-        private ChangeSignatureAnalyzedContext _context;
+        private readonly AbstractChangeSignatureService _changeSignatureService;
+        private readonly ChangeSignatureAnalyzedContext _context;
 
         public ChangeSignatureCodeAction(AbstractChangeSignatureService changeSignatureService, ChangeSignatureAnalyzedContext context)
         {

--- a/src/Features/Core/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
+++ b/src/Features/Core/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
     internal abstract partial class AbstractSuppressionCodeFixProvider : ISuppressionFixProvider
     {
         public static string SuppressMessageAttributeName = "System.Diagnostics.CodeAnalysis.SuppressMessageAttribute";
-        private static string s_globalSuppressionsFileName = "GlobalSuppressions";
-        private static string s_suppressionsFileCommentTemplate =
+        private static readonly string s_globalSuppressionsFileName = "GlobalSuppressions";
+        private static readonly string s_suppressionsFileCommentTemplate =
 @"
 {0} This file is used by Code Analysis to maintain SuppressMessage 
 {0} attributes that are applied to this project.

--- a/src/Features/Core/Completion/AbstractCompletionService.cs
+++ b/src/Features/Core/Completion/AbstractCompletionService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Completion
         private const int MruSize = 10;
 
         private readonly List<string> _committedItems = new List<string>(MruSize);
-        private object _mruGate = new object();
+        private readonly object _mruGate = new object();
 
         private void CompletionItemComitted(CompletionItem item)
         {

--- a/src/Features/Core/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
         }
 
-        private static Comparer s_comparer = new Comparer();
+        private static readonly Comparer s_comparer = new Comparer();
 
         protected override async Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(
             Document document, int position, CompletionTriggerInfo triggerInfo,

--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         // PERF: Many CompletionProviders derive AbstractSymbolCompletionProvider and therefore
         // compute identical contexts. This actually shows up on the 2-core typing test.
         // Cache the most recent document/position/computed SyntaxContext to reduce repeat computation.
-        private static Dictionary<Document, Task<AbstractSyntaxContext>> s_cachedDocuments = new Dictionary<Document, Task<AbstractSyntaxContext>>();
+        private static readonly Dictionary<Document, Task<AbstractSyntaxContext>> s_cachedDocuments = new Dictionary<Document, Task<AbstractSyntaxContext>>();
         private static int s_cachedPosition;
         private static readonly object s_cacheGate = new object();
 

--- a/src/Features/Core/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.RemoveUnnecessaryCast
 {
     internal abstract class RemoveUnnecessaryCastDiagnosticAnalyzerBase<TLanguageKindEnum> : DiagnosticAnalyzer, IBuiltInAnalyzer where TLanguageKindEnum : struct
     {
-        private static LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FeaturesResources.RemoveUnnecessaryCast), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.CastIsRedundant), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FeaturesResources.RemoveUnnecessaryCast), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.CastIsRedundant), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
 
         private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId,
                                                                     s_localizableTitle,

--- a/src/Features/Core/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -11,9 +11,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
 {
     internal abstract class SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum> : DiagnosticAnalyzer, IBuiltInAnalyzer where TLanguageKindEnum : struct
     {
-        private static LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.NameCanBeSimplified), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.NameCanBeSimplified), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
 
-        private static LocalizableString s_localizableTitleSimplifyNames = new LocalizableResourceString(nameof(FeaturesResources.SimplifyNames), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_localizableTitleSimplifyNames = new LocalizableResourceString(nameof(FeaturesResources.SimplifyNames), FeaturesResources.ResourceManager, typeof(FeaturesResources));
         private static readonly DiagnosticDescriptor s_descriptorSimplifyNames = new DiagnosticDescriptor(IDEDiagnosticIds.SimplifyNamesDiagnosticId,
                                                                     s_localizableTitleSimplifyNames,
                                                                     s_localizableMessage,
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                                                                     isEnabledByDefault: true,
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
 
-        private static LocalizableString s_localizableTitleSimplifyMemberAccess = new LocalizableResourceString(nameof(FeaturesResources.SimplifyMemberAccess), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_localizableTitleSimplifyMemberAccess = new LocalizableResourceString(nameof(FeaturesResources.SimplifyMemberAccess), FeaturesResources.ResourceManager, typeof(FeaturesResources));
         private static readonly DiagnosticDescriptor s_descriptorSimplifyMemberAccess = new DiagnosticDescriptor(IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId,
                                                                     s_localizableTitleSimplifyMemberAccess,
                                                                     s_localizableMessage,
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                                                                     isEnabledByDefault: true,
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
 
-        private static LocalizableString s_localizableTitleSimplifyThisOrMe = new LocalizableResourceString(nameof(FeaturesResources.SimplifyThisOrMe), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_localizableTitleSimplifyThisOrMe = new LocalizableResourceString(nameof(FeaturesResources.SimplifyThisOrMe), FeaturesResources.ResourceManager, typeof(FeaturesResources));
         private static readonly DiagnosticDescriptor s_descriptorSimplifyThisOrMe = new DiagnosticDescriptor(IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId,
                                                                     s_localizableTitleSimplifyThisOrMe,
                                                                     s_localizableMessage,

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private ImmutableArray<ISymbol> _lazySymbols;
         private ImmutableArray<SyntaxNode> _lazyAllSyntaxNodesToAnalyze;
 
-        private AnalyzerOptions _analyzerOptions;
+        private readonly AnalyzerOptions _analyzerOptions;
 
         public DiagnosticAnalyzerDriver(
             Document document, 

--- a/src/Features/Core/EncapsulateField/EncapsulateFieldCodeAction.cs
+++ b/src/Features/Core/EncapsulateField/EncapsulateFieldCodeAction.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
 {
     internal class EncapsulateFieldCodeAction : CodeAction
     {
-        private EncapsulateFieldResult _result;
-        private string _title;
+        private readonly EncapsulateFieldResult _result;
+        private readonly string _title;
 
         public EncapsulateFieldCodeAction(EncapsulateFieldResult result, string title)
         {

--- a/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
         private partial class Editor
         {
-            private TService _service;
+            private readonly TService _service;
             private TargetProjectChangeInLanguage _targetProjectChangeInLanguage = TargetProjectChangeInLanguage.NoChange;
             private IGenerateTypeService _targetLanguageService;
 

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             private readonly TService _service;
             private readonly string _title;
 
-            private static Regex s_newlinePattern = new Regex(@"[\r\n]+", RegexOptions.Compiled);
+            private static readonly Regex s_newlinePattern = new Regex(@"[\r\n]+", RegexOptions.Compiled);
 
             internal AbstractIntroduceVariableCodeAction(
                 TService service,

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
     {
         private partial class State
         {
-            public SemanticDocument Document { get; private set; }
+            public SemanticDocument Document { get; }
             public TExpressionSyntax Expression { get; private set; }
 
             public bool InAttributeContext { get; private set; }

--- a/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.DocCommentFormatter.cs
+++ b/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.DocCommentFormatter.cs
@@ -13,16 +13,16 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     {
         internal class DocCommentFormatter
         {
-            private static int s_indentSize = 2;
-            private static int s_wrapLength = 80;
+            private static readonly int s_indentSize = 2;
+            private static readonly int s_wrapLength = 80;
 
-            private static string s_summaryHeader = FeaturesResources.Summary;
-            private static string s_paramHeader = FeaturesResources.Parameters;
-            private static string s_labelFormat = "{0}:";
-            private static string s_typeParameterHeader = FeaturesResources.TypeParameters;
-            private static string s_returnsHeader = FeaturesResources.Returns;
-            private static string s_exceptionsHeader = FeaturesResources.Exceptions;
-            private static string s_remarksHeader = FeaturesResources.Remarks;
+            private static readonly string s_summaryHeader = FeaturesResources.Summary;
+            private static readonly string s_paramHeader = FeaturesResources.Parameters;
+            private static readonly string s_labelFormat = "{0}:";
+            private static readonly string s_typeParameterHeader = FeaturesResources.TypeParameters;
+            private static readonly string s_returnsHeader = FeaturesResources.Returns;
+            private static readonly string s_exceptionsHeader = FeaturesResources.Exceptions;
+            private static readonly string s_remarksHeader = FeaturesResources.Remarks;
 
             internal static ImmutableArray<string> Format(IDocumentationCommentFormattingService docCommentFormattingService, DocumentationComment docComment)
             {

--- a/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     {
         private class WrappedMethodSymbol : AbstractWrappedSymbol, IMethodSymbol
         {
-            private IMethodSymbol _symbol;
+            private readonly IMethodSymbol _symbol;
 
             public WrappedMethodSymbol(IMethodSymbol methodSymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)
                 : base(methodSymbol, canImplementImplicitly, docCommentFormattingService)

--- a/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
+++ b/src/Features/Core/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     {
         private class WrappedPropertySymbol : AbstractWrappedSymbol, IPropertySymbol
         {
-            private IPropertySymbol _symbol;
+            private readonly IPropertySymbol _symbol;
 
             public WrappedPropertySymbol(IPropertySymbol propertySymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)
                 : base(propertySymbol, canImplementImplicitly, docCommentFormattingService)

--- a/src/Features/Core/Shared/Utilities/PatternMatch.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatch.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// </summary>
         public PatternMatchKind Kind { get; }
 
-        private bool _punctuationStripped;
+        private readonly bool _punctuationStripped;
 
         internal PatternMatch(PatternMatchKind resultType, bool punctuationStripped, bool isCaseSensitive, int? camelCaseWeight = null)
             : this()

--- a/src/Features/Core/SolutionCrawler/InvocationReasons.cs
+++ b/src/Features/Core/SolutionCrawler/InvocationReasons.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     {
         public static readonly InvocationReasons Empty = new InvocationReasons(ImmutableHashSet.Create<string>());
 
-        private ImmutableHashSet<string> _reasons;
+        private readonly ImmutableHashSet<string> _reasons;
 
         public InvocationReasons(string reason)
             : this(ImmutableHashSet.Create<string>(reason))

--- a/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// </summary>
         private class SolutionCrawlerProgressReporter : ISolutionCrawlerProgressReporter
         {
-            private IAsynchronousOperationListener _listener;
+            private readonly IAsynchronousOperationListener _listener;
 
             // use event map and event queue so that we can guarantee snapshot and sequencial ordering of events from
             // multiple consumer from possibly multiple threads

--- a/src/Features/Core/Workspace/FileTracker.cs
+++ b/src/Features/Core/Workspace/FileTracker.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Host
 
         private class FileActions
         {
-            private FileTracker _tracker;
+            private readonly FileTracker _tracker;
             private readonly string _path;
             private ImmutableArray<Action> _actions;
             private Task _invokeTask;

--- a/src/Features/VisualBasic/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.CodeAction.vb
+++ b/src/Features/VisualBasic/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.CodeAction.vb
@@ -9,12 +9,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
         Private Class GenerateEventCodeAction
             Inherits CodeAction
 
-            Private _solution As Solution
-            Private _targetSymbol As INamedTypeSymbol
-            Private _generatedEvent As IEventSymbol
-            Private _codeGenerationOptions As CodeGenerationOptions
-            Private _codeGenService As ICodeGenerationService
-            Private _generatedType As INamedTypeSymbol
+            Private ReadOnly _solution As Solution
+            Private ReadOnly _targetSymbol As INamedTypeSymbol
+            Private ReadOnly _generatedEvent As IEventSymbol
+            Private ReadOnly _codeGenerationOptions As CodeGenerationOptions
+            Private ReadOnly _codeGenService As ICodeGenerationService
+            Private ReadOnly _generatedType As INamedTypeSymbol
 
             Public Sub New(solution As Solution,
                     targetSymbol As INamedTypeSymbol,

--- a/src/Features/VisualBasic/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.ReplaceTokenKeywordCodeAction.vb
+++ b/src/Features/VisualBasic/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.ReplaceTokenKeywordCodeAction.vb
@@ -10,9 +10,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectExitContinue
         Private Class ReplaceTokenKeywordCodeAction
             Inherits CodeAction
 
-            Private _blockKind As SyntaxKind
+            Private ReadOnly _blockKind As SyntaxKind
             Private _invalidToken As SyntaxToken
-            Private _document As Document
+            Private ReadOnly _document As Document
 
             Public Sub New(blockKind As SyntaxKind,
                     invalidToken As SyntaxToken,

--- a/src/Features/VisualBasic/CodeFixes/MoveToTopOfFile/MoveToTopOfFileCodeFixProvider.MoveToLineCodeAction.vb
+++ b/src/Features/VisualBasic/CodeFixes/MoveToTopOfFile/MoveToTopOfFileCodeFixProvider.MoveToLineCodeAction.vb
@@ -9,10 +9,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.MoveToTopOfFile
         Private Class MoveToLineCodeAction
             Inherits CodeAction
 
-            Private _destinationLine As Integer
-            Private _document As Document
+            Private ReadOnly _destinationLine As Integer
+            Private ReadOnly _document As Document
             Private _token As SyntaxToken
-            Private _title As String
+            Private ReadOnly _title As String
 
             Public Sub New(document As Document, token As SyntaxToken, destinationLine As Integer, title As String)
                 _document = document

--- a/src/Features/VisualBasic/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.vb
+++ b/src/Features/VisualBasic/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         Private Class SimplifyTypeNamesFixAllProvider
             Inherits BatchSimplificationFixAllProvider
 
-            Friend Shared Shadows Instance As SimplifyTypeNamesFixAllProvider = New SimplifyTypeNamesFixAllProvider
+            Friend Shared Shadows ReadOnly Instance As SimplifyTypeNamesFixAllProvider = New SimplifyTypeNamesFixAllProvider
 
             Protected Overrides Function GetNodeToSimplify(root As SyntaxNode, model As SemanticModel, diagnostic As Diagnostic, workspace As Workspace, ByRef codeActionId As String, cancellationToken As CancellationToken) As SyntaxNode
                 codeActionId = Nothing

--- a/src/Features/VisualBasic/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Friend Class CrefCompletionProvider
         Inherits AbstractCompletionProvider
 
-        Private _crefFormat2 As SymbolDisplayFormat =
+        Private ReadOnly _crefFormat2 As SymbolDisplayFormat =
             New SymbolDisplayFormat(
                 globalNamespaceStyle:=SymbolDisplayGlobalNamespaceStyle.Omitted,
                 typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameOnly,

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -2577,9 +2577,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         private struct SpanRangeEdit
         {
-            public int Start;
-            public int Count;
-            public ReplSpan[] Replacement;
+            public readonly int Start;
+            public readonly int Count;
+            public readonly ReplSpan[] Replacement;
 
             public SpanRangeEdit(int start, int count, ReplSpan[] replacement)
             {

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2751,7 +2751,7 @@ new System.Data.DataSet()
 
         private class MetadataReferenceProvider : Microsoft.CodeAnalysis.MetadataFileReferenceProvider
         {
-            private Dictionary<string, PortableExecutableReference> _metadata;
+            private readonly Dictionary<string, PortableExecutableReference> _metadata;
 
             public MetadataReferenceProvider(Dictionary<string, PortableExecutableReference> metadata)
             {

--- a/src/Scripting/Core/Emit/ReflectionEmitter.Refs.cs
+++ b/src/Scripting/Core/Emit/ReflectionEmitter.Refs.cs
@@ -613,7 +613,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
         private sealed class MethodGenericParameter : UnimplementedType
         {
             private readonly int _position;
-            private MethodInfo _containingMethod;
+            private readonly MethodInfo _containingMethod;
 
             public MethodGenericParameter(MethodInfo containingMethod, int position)
             {
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
             private readonly string _name;
             private readonly CallingConventions _callingConvention;
             private readonly Module _moduleProxy;
-            private Type[] _extraParameterTypes;
+            private readonly Type[] _extraParameterTypes;
             private ParameterInfo[] _parameters;
             private ParameterInfo _returnParameter;
             private Type[] _genericParameters;

--- a/src/Scripting/Core/Emit/ReflectionEmitter.cs
+++ b/src/Scripting/Core/Emit/ReflectionEmitter.cs
@@ -2785,7 +2785,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
         }
 
         private static Func<char[], Type, int, Type> s_lazyArrayTypeFactory;
-        private static char[] s_arrayFormat = new[] { '[', ']' };
+        private static readonly char[] s_arrayFormat = new[] { '[', ']' };
 
         // Creates and instance of a BCL internal SymbolType that represents a SzArray of given element type.
         // We can't implement this ourselves since Type.IsSzArray called by signature builder is internal.

--- a/src/Scripting/Test/ScriptEngine.cs
+++ b/src/Scripting/Test/ScriptEngine.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
         // state captured by session at creation time:
         private ScriptOptions _options = ScriptOptions.Default;
-        private ScriptBuilder _builder;
+        private readonly ScriptBuilder _builder;
 
         static ScriptEngine()
         {

--- a/src/Scripting/Test/Session.cs
+++ b/src/Scripting/Test/Session.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Scripting
     {
         private readonly ScriptEngine _engine;
         private ScriptOptions _options;
-        private Type _globalsType;
+        private readonly Type _globalsType;
         private object _globals;
         private Script _previousScript;
         private Lazy<object> _nextInputState;

--- a/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
+++ b/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Test.PdbUtilities
 
         private class PdbSource
         {
-            internal string name;
+            internal readonly string name;
             internal Guid doctype;
             internal Guid language;
             internal Guid vendor;
@@ -34,12 +34,12 @@ namespace Roslyn.Test.PdbUtilities
 
         private class PdbTokenLine
         {
-            internal uint token;
-            internal uint file_id;
-            internal uint line;
-            internal uint column;
-            internal uint endLine;
-            internal uint endColumn;
+            internal readonly uint token;
+            internal readonly uint file_id;
+            internal readonly uint line;
+            internal readonly uint column;
+            internal readonly uint endLine;
+            internal readonly uint endColumn;
             internal PdbSource sourceFile;
             internal PdbTokenLine/*?*/ nextLine;
 
@@ -348,8 +348,8 @@ namespace Roslyn.Test.PdbUtilities
                 get { return _size == 0; }
             }
 
-            private int _size;
-            private uint[] _words;
+            private readonly int _size;
+            private readonly uint[] _words;
         }
 
         private class IntHashTable
@@ -398,7 +398,7 @@ namespace Roslyn.Test.PdbUtilities
             private int _occupancy;
 
             private int _loadsize;
-            private int _loadFactorPerc;    // 100 = 1.0
+            private readonly int _loadFactorPerc;    // 100 = 1.0
 
             private int _version;
 
@@ -681,15 +681,15 @@ namespace Roslyn.Test.PdbUtilities
                 bits.ReadUInt32(out relocCrc);
             }
 
-            internal short section;                    // 0..1
-            internal short pad1;                       // 2..3
-            internal int offset;                     // 4..7
-            internal int size;                       // 8..11
-            internal uint flags;                      // 12..15
-            internal short module;                     // 16..17
-            internal short pad2;                       // 18..19
-            internal uint dataCrc;                    // 20..23
-            internal uint relocCrc;                   // 24..27
+            internal readonly short section;                    // 0..1
+            internal readonly short pad1;                       // 2..3
+            internal readonly int offset;                     // 4..7
+            internal readonly int size;                       // 8..11
+            internal readonly uint flags;                      // 12..15
+            internal readonly short module;                     // 16..17
+            internal readonly short pad2;                       // 18..19
+            internal readonly uint dataCrc;                    // 20..23
+            internal readonly uint relocCrc;                   // 24..27
         }
 
         private class DbiModuleInfo
@@ -721,19 +721,19 @@ namespace Roslyn.Test.PdbUtilities
                 bits.Align(4);
             }
 
-            internal int opened;                 //  0..3
-            internal ushort flags;                  // 32..33
-            internal short stream;                 // 34..35
-            internal int cbSyms;                 // 36..39
-            internal int cbOldLines;             // 40..43
-            internal int cbLines;                // 44..57
-            internal short files;                  // 48..49
-            internal short pad1;                   // 50..51
-            internal uint offsets;
-            internal int niSource;
-            internal int niCompiler;
-            internal string moduleName;
-            internal string objectName;
+            internal readonly int opened;                 //  0..3
+            internal readonly ushort flags;                  // 32..33
+            internal readonly short stream;                 // 34..35
+            internal readonly int cbSyms;                 // 36..39
+            internal readonly int cbOldLines;             // 40..43
+            internal readonly int cbLines;                // 44..57
+            internal readonly short files;                  // 48..49
+            internal readonly short pad1;                   // 50..51
+            internal readonly uint offsets;
+            internal readonly int niSource;
+            internal readonly int niCompiler;
+            internal readonly string moduleName;
+            internal readonly string objectName;
         }
 
         private struct DbiHeader
@@ -762,26 +762,26 @@ namespace Roslyn.Test.PdbUtilities
                 bits.ReadInt32(out reserved);
             }
 
-            internal int sig;                        // 0..3
-            internal int ver;                        // 4..7
-            internal int age;                        // 8..11
-            internal short gssymStream;                // 12..13
-            internal ushort vers;                       // 14..15
-            internal short pssymStream;                // 16..17
-            internal ushort pdbver;                     // 18..19
-            internal short symrecStream;               // 20..21
-            internal ushort pdbver2;                    // 22..23
-            internal int gpmodiSize;                 // 24..27
-            internal int secconSize;                 // 28..31
-            internal int secmapSize;                 // 32..35
-            internal int filinfSize;                 // 36..39
-            internal int tsmapSize;                  // 40..43
-            internal int mfcIndex;                   // 44..47
-            internal int dbghdrSize;                 // 48..51
-            internal int ecinfoSize;                 // 52..55
-            internal ushort flags;                      // 56..57
-            internal ushort machine;                    // 58..59
-            internal int reserved;                   // 60..63
+            internal readonly int sig;                        // 0..3
+            internal readonly int ver;                        // 4..7
+            internal readonly int age;                        // 8..11
+            internal readonly short gssymStream;                // 12..13
+            internal readonly ushort vers;                       // 14..15
+            internal readonly short pssymStream;                // 16..17
+            internal readonly ushort pdbver;                     // 18..19
+            internal readonly short symrecStream;               // 20..21
+            internal readonly ushort pdbver2;                    // 22..23
+            internal readonly int gpmodiSize;                 // 24..27
+            internal readonly int secconSize;                 // 28..31
+            internal readonly int secmapSize;                 // 32..35
+            internal readonly int filinfSize;                 // 36..39
+            internal readonly int tsmapSize;                  // 40..43
+            internal readonly int mfcIndex;                   // 44..47
+            internal readonly int dbghdrSize;                 // 48..51
+            internal readonly int ecinfoSize;                 // 52..55
+            internal readonly ushort flags;                      // 56..57
+            internal readonly ushort machine;                    // 58..59
+            internal readonly int reserved;                   // 60..63
         }
 
         private struct DbiDbgHdr
@@ -801,17 +801,17 @@ namespace Roslyn.Test.PdbUtilities
                 bits.ReadUInt16(out snSectionHdrOrig);
             }
 
-            internal ushort snFPO;                 // 0..1
-            internal ushort snException;           // 2..3 (deprecated)
-            internal ushort snFixup;               // 4..5
-            internal ushort snOmapToSrc;           // 6..7
-            internal ushort snOmapFromSrc;         // 8..9
-            internal ushort snSectionHdr;          // 10..11
-            internal ushort snTokenRidMap;         // 12..13
-            internal ushort snXdata;               // 14..15
-            internal ushort snPdata;               // 16..17
-            internal ushort snNewFPO;              // 18..19
-            internal ushort snSectionHdrOrig;      // 20..21
+            internal readonly ushort snFPO;                 // 0..1
+            internal readonly ushort snException;           // 2..3 (deprecated)
+            internal readonly ushort snFixup;               // 4..5
+            internal readonly ushort snOmapToSrc;           // 6..7
+            internal readonly ushort snOmapFromSrc;         // 8..9
+            internal readonly ushort snSectionHdr;          // 10..11
+            internal readonly ushort snTokenRidMap;         // 12..13
+            internal readonly ushort snXdata;               // 14..15
+            internal readonly ushort snPdata;               // 16..17
+            internal readonly ushort snNewFPO;              // 18..19
+            internal readonly ushort snSectionHdrOrig;      // 20..21
         }
 
         private class PdbFileHeader
@@ -838,11 +838,11 @@ namespace Roslyn.Test.PdbUtilities
 
             internal readonly byte[] magic;
             internal readonly int pageSize;
-            internal int freePageMap;
-            internal int pagesUsed;
-            internal int directorySize;
+            internal readonly int freePageMap;
+            internal readonly int pagesUsed;
+            internal readonly int directorySize;
             internal readonly int zero;
-            internal int[] directoryRoot;
+            internal readonly int[] directoryRoot;
         }
 
         private class PdbReader
@@ -953,8 +953,8 @@ namespace Roslyn.Test.PdbUtilities
                 get { return contentSize; }
             }
 
-            internal int contentSize;
-            internal int[] pages;
+            internal readonly int contentSize;
+            internal readonly int[] pages;
         }
 
         private class MsfDirectory
@@ -1005,7 +1005,7 @@ namespace Roslyn.Test.PdbUtilities
                 }
             }
 
-            internal DataStream[] streams;
+            internal readonly DataStream[] streams;
         }
 
         private struct CV_FileCheckSum

--- a/src/Test/Utilities/AssertEx.cs
+++ b/src/Test/Utilities/AssertEx.cs
@@ -514,7 +514,7 @@ namespace Roslyn.Test.Utilities
             return false;
         }
 
-        private static Lazy<List<Tuple<string, int, string>>> s_diffLinks = new Lazy<List<Tuple<string, int, string>>>(() =>
+        private static readonly Lazy<List<Tuple<string, int, string>>> s_diffLinks = new Lazy<List<Tuple<string, int, string>>>(() =>
         {
             AppDomain.CurrentDomain.DomainUnload += (_, __) =>
             {

--- a/src/Test/Utilities/EventWaiter.cs
+++ b/src/Test/Utilities/EventWaiter.cs
@@ -14,7 +14,7 @@ namespace Roslyn.Test.Utilities
     /// </summary>
     public sealed class EventWaiter : IDisposable
     {
-        private ManualResetEvent _eventSignal = new ManualResetEvent(false);
+        private readonly ManualResetEvent _eventSignal = new ManualResetEvent(false);
         private Exception _capturedException;
 
         /// <summary>

--- a/src/Test/Utilities/ImmutableArrayInterop.cs
+++ b/src/Test/Utilities/ImmutableArrayInterop.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Test.Utilities
         private struct ByteArrayUnion
         {
             [FieldOffset(0)]
-            internal byte[] MutableArray;
+            internal readonly byte[] MutableArray;
 
             [FieldOffset(0)]
             internal ImmutableArray<byte> ImmutableArray;

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/GreenNodes/GreenNodeWriter.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/GreenNodes/GreenNodeWriter.vb
@@ -13,8 +13,8 @@ Friend Class GreenNodeWriter
     Inherits WriteUtils
 
     Private _writer As TextWriter    'output is sent here.
-    Private _nonterminalsWithOneChild As List(Of String) = New List(Of String)
-    Private _nonterminalsWithTwoChildren As List(Of String) = New List(Of String)
+    Private ReadOnly _nonterminalsWithOneChild As List(Of String) = New List(Of String)
+    Private ReadOnly _nonterminalsWithTwoChildren As List(Of String) = New List(Of String)
 
     ' Initialize the class with the parse tree to write.
     Public Sub New(parseTree As ParseTree)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/WriteUtils.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/WriteUtils.vb
@@ -704,7 +704,7 @@ Public MustInherit Class WriteUtils
         GenerateXmlComment(writer, descriptionText, remarksText, indent)
     End Sub
 
-    Private _VBKeywords As String() = {
+    Private ReadOnly _VBKeywords As String() = {
         "ADDHANDLER",
         "ADDRESSOF",
         "ALIAS",

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/XmlRenamer.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Util/XmlRenamer.vb
@@ -4,7 +4,7 @@ Imports System.IO
 Imports <xmlns="http://schemas.microsoft.com/VisualStudio/Roslyn/Compiler">
 
 Public Class XmlRenamer
-    Private _xDoc As XDocument
+    Private ReadOnly _xDoc As XDocument
 
     Public Sub New(xDoc As XDocument)
         _xDoc = xDoc

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
@@ -48,7 +48,7 @@ Public Class ParseTree
     Public RootToken, RootTrivia As ParseNodeStructure
 
     ' Remember nodes with errors so we only report one error per node.
-    Private _elementsWithErrors As New Dictionary(Of XNode, Boolean)
+    Private ReadOnly _elementsWithErrors As New Dictionary(Of XNode, Boolean)
 
     ' Report an error.
     Public Sub ReportError(referencingNode As XNode, message As String, ParamArray args As Object())
@@ -501,7 +501,7 @@ Public Class ParseNodeChild
 
     Public ReadOnly SeparatorsName As String
 
-    Private _childKindNames As New Dictionary(Of String, List(Of String))
+    Private ReadOnly _childKindNames As New Dictionary(Of String, List(Of String))
     Private _childKind As Object
 
     Public ReadOnly SeparatorsTypeId As String

--- a/src/Tools/Source/OpenSourceDebug/OpenSourceDebugPackage.cs
+++ b/src/Tools/Source/OpenSourceDebug/OpenSourceDebugPackage.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenSourceDebug
         private const string VisualStudioHive = "VisualStudio";
         private const string MSBuildDirectory = @"Microsoft\MSBuild\14.0";
 
-        private string _CSharpTargetsTemplate =
+        private readonly string _CSharpTargetsTemplate =
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup Condition=""'$(RoslynHive)'=='{0}'"">

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
@@ -37,7 +37,7 @@ namespace Roslyn.SyntaxVisualizer.Control
         private TreeViewItem _currentSelection;
         private bool _isNavigatingFromSourceToTree;
         private bool _isNavigatingFromTreeToSource;
-        private System.Windows.Forms.PropertyGrid _propertyGrid;
+        private readonly System.Windows.Forms.PropertyGrid _propertyGrid;
         private static readonly Thickness s_defaultBorderThickness = new Thickness(1);
         #endregion
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -787,7 +787,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private static ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>> s_declAttributes
+        private static readonly ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>> s_declAttributes
             = new ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>>();
 
         public override IReadOnlyList<SyntaxNode> GetAttributes(SyntaxNode declaration)
@@ -802,7 +802,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return attrs;
         }
 
-        private static ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>> s_declReturnAttributes
+        private static readonly ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>> s_declReturnAttributes
             = new ConditionalWeakTable<SyntaxNode, IReadOnlyList<SyntaxNode>>();
 
         public override IReadOnlyList<SyntaxNode> GetReturnAttributes(SyntaxNode declaration)

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptionsProvider.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptionsProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     [ExportOptionProvider, Shared]
     internal class CSharpFormattingOptionsProvider : IOptionProvider
     {
-        private IEnumerable<IOption> _options = new List<IOption>
+        private readonly IEnumerable<IOption> _options = new List<IOption>
             {
                 CSharpFormattingOptions.SpacingAfterMethodDeclarationName,
                 CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis,

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.DocumentationCommentExteriorCommentRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.DocumentationCommentExteriorCommentRewriter.cs
@@ -10,10 +10,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         private class DocumentationCommentExteriorCommentRewriter : CSharpSyntaxRewriter
         {
-            private bool _forceIndentation;
-            private int _indentation;
-            private int _indentationDelta;
-            private OptionSet _optionSet;
+            private readonly bool _forceIndentation;
+            private readonly int _indentation;
+            private readonly int _indentationDelta;
+            private readonly OptionSet _optionSet;
 
             public DocumentationCommentExteriorCommentRewriter(
                 bool forceIndentation,

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             private readonly Func<SyntaxNode, bool> _expandInsideNode;
             private readonly CancellationToken _cancellationToken;
             private readonly SyntaxAnnotation _annotationForReplacedAliasIdentifier;
-            private bool _expandParameter;
+            private readonly bool _expandParameter;
 
             public Expander(
                 SemanticModel semanticModel,

--- a/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
+++ b/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
@@ -29,7 +29,7 @@ namespace Roslyn.Utilities
             return fullPath;
         }
 
-        private static char[] s_pathChars = new char[] { Path.VolumeSeparatorChar, Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        private static readonly char[] s_pathChars = new char[] { Path.VolumeSeparatorChar, Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         public static string GetRelativePath(string baseDirectory, string fullPath)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/Host/SimpleAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/SimpleAnalyzerAssemblyLoaderService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Host
     [ExportWorkspaceService(typeof(IAnalyzerService), ServiceLayer.Default), Shared]
     internal sealed class SimpleAnalyzerAssemblyLoaderService : IAnalyzerService
     {
-        private SimpleAnalyzerAssemblyLoader _loader = new SimpleAnalyzerAssemblyLoader();
+        private readonly SimpleAnalyzerAssemblyLoader _loader = new SimpleAnalyzerAssemblyLoader();
 
         public IAnalyzerAssemblyLoader GetLoader()
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildTargets.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildTargets.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// </summary>
     internal class BuildTargets
     {
-        private MSB.Evaluation.Project _project;
-        private List<string> _buildTargets;
+        private readonly MSB.Evaluation.Project _project;
+        private readonly List<string> _buildTargets;
 
         public BuildTargets(MSB.Evaluation.Project project, params string[] targets)
         {

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
         private class ReplaceChange : Change
         {
-            private Func<SyntaxNode, SyntaxGenerator, SyntaxNode> _modifier;
+            private readonly Func<SyntaxNode, SyntaxGenerator, SyntaxNode> _modifier;
 
             public ReplaceChange(SyntaxNode node, Func<SyntaxNode, SyntaxGenerator, SyntaxNode> modifier)
                 : base(node)
@@ -222,8 +222,8 @@ namespace Microsoft.CodeAnalysis.Editing
 
         private class InsertChange : Change
         {
-            private List<SyntaxNode> _newNodes;
-            private bool _isBefore;
+            private readonly List<SyntaxNode> _newNodes;
+            private readonly bool _isBefore;
 
             public InsertChange(SyntaxNode node, IEnumerable<SyntaxNode> newNodes, bool isBefore)
                 : base(node)

--- a/src/Workspaces/Core/Portable/Formatting/FormattingExtensions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingExtensions.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             spaceOrIndentation = text.ConvertTabToSpace(tabSize, baseToken.ToString().GetTextColumn(tabSize, initialColumn), text.Length);
         }
 
-        private static char[] s_trimChars = new char[] { '\r', '\n' };
+        private static readonly char[] s_trimChars = new char[] { '\r', '\n' };
 
         public static string AdjustIndentForXmlDocExteriorTrivia(
             this string triviaText,

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptionsProvider.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptionsProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     [ExportOptionProvider, Shared]
     internal class FormattingOptionsProvider : IOptionProvider
     {
-        private IEnumerable<IOption> _options = new List<IOption>
+        private readonly IEnumerable<IOption> _options = new List<IOption>
         {
             FormattingOptions.UseTabs,
             FormattingOptions.TabSize,

--- a/src/Workspaces/Core/Portable/Formatting/Rules/NextOperation`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/NextOperation`1.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     /// </summary>
     internal struct NextOperation<TResult>
     {
-        private int _index;
+        private readonly int _index;
         private SyntaxToken _token1;
         private SyntaxToken _token2;
-        private IOperationHolder<TResult> _operationCache;
+        private readonly IOperationHolder<TResult> _operationCache;
 
         public NextOperation(int index, SyntaxToken token1, SyntaxToken token2, IOperationHolder<TResult> operationCache)
         {

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly bool _logSessionInfo;
 
-        private Solution _oldSolution;
-        private Solution _newSolution;
+        private readonly Solution _oldSolution;
+        private readonly Solution _newSolution;
         private SolutionChanges _solutionChanges;
 
         public LinkedFileDiffMergingSession(Solution oldSolution, Solution newSolution, SolutionChanges solutionChanges, bool logSessionInfo)

--- a/src/Workspaces/Core/Portable/Options/OptionsServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionsServiceFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Options
     [ExportWorkspaceServiceFactory(typeof(IOptionService), ServiceLayer.Default), Shared]
     internal class OptionsServiceFactory : IWorkspaceServiceFactory
     {
-        private IOptionService _optionService;
+        private readonly IOptionService _optionService;
 
         [ImportingConstructor]
         public OptionsServiceFactory(IOptionService optionService)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 {
     internal static partial class ConflictResolver
     {
-        private static SymbolDisplayFormat s_metadataSymbolDisplayFormat = new SymbolDisplayFormat(
+        private static readonly SymbolDisplayFormat s_metadataSymbolDisplayFormat = new SymbolDisplayFormat(
             globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeConstraints | SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeVariance,

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Simplification
     [ExportOptionProvider, Shared]
     internal class SimplificationOptionsProvider : IOptionProvider
     {
-        private IEnumerable<IOption> _options = new List<IOption>
+        private readonly IEnumerable<IOption> _options = new List<IOption>
             {
                 SimplificationOptions.PreferAliasToQualification,
                 SimplificationOptions.PreferOmittingModuleNamesInQualification,

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal abstract class XmlDocumentationProvider : DocumentationProvider
     {
-        private NonReentrantLock _gate = new NonReentrantLock();
+        private readonly NonReentrantLock _gate = new NonReentrantLock();
         private Dictionary<string, string> _docComments;
 
         protected abstract Stream GetSourceStream(CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/PrimaryWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/PrimaryWorkspace.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
 
         private static Workspace s_primaryWorkspace;
 
-        private static List<TaskCompletionSource<Workspace>> s_primaryWorkspaceTaskSourceList =
+        private static readonly List<TaskCompletionSource<Workspace>> s_primaryWorkspaceTaskSourceList =
             new List<TaskCompletionSource<Workspace>>();
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
         public ProjectId ProjectId { get; }
         public Guid Id { get; }
 
-        private string _debugName;
+        private readonly string _debugName;
 
         private DocumentId(ProjectId projectId, string debugName)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public sealed class ProjectId : IEquatable<ProjectId>
     {
-        private string _debugName;
+        private readonly string _debugName;
 
         /// <summary>
         /// The system generated unique id.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Guid Id { get; }
 
-        private string _debugName;
+        private readonly string _debugName;
 
         private SolutionId(string debugName)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.TextTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.TextTracker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis
             private readonly Workspace _workspace;
             private readonly DocumentId _documentId;
             internal readonly SourceTextContainer TextContainer;
-            private EventHandler<TextChangeEventArgs> _weakOnTextChanged;
+            private readonly EventHandler<TextChangeEventArgs> _weakOnTextChanged;
             private readonly Action<Workspace, DocumentId, SourceText, PreservationMode> _onChangedHandler;
 
             internal TextTracker(

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
             return new WorkspaceRegistration();
         }
 
-        private static ConditionalWeakTable<SourceTextContainer, WorkspaceRegistration>.CreateValueCallback s_createRegistration = CreateRegistration;
+        private static readonly ConditionalWeakTable<SourceTextContainer, WorkspaceRegistration>.CreateValueCallback s_createRegistration = CreateRegistration;
 
         /// <summary>
         /// Returns a <see cref="WorkspaceRegistration" /> for a given text container.

--- a/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
+++ b/src/Workspaces/VisualBasic/Desktop/MSBuild/VisualBasicProjectFileLoader.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class VisualBasicProjectFileLoader
         Inherits ProjectFileLoader
 
-        Private _workspaceServices As HostWorkspaceServices
+        Private ReadOnly _workspaceServices As HostWorkspaceServices
 
         Friend Sub New(workspaceServices As HostWorkspaceServices)
             Me._workspaceServices = workspaceServices
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #If Not MSBUILD12 Then
                 Implements MSB.Tasks.Hosting.IAnalyzerHostObject
 #End If
-                Private _projectFile As VisualBasicProjectFile
+                Private ReadOnly _projectFile As VisualBasicProjectFile
                 Private _initialized As Boolean
                 Private _parseOptions As VisualBasicParseOptions
                 Private _compilationOptions As VisualBasicCompilationOptions
@@ -276,7 +276,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Private _references As IEnumerable(Of MSB.Framework.ITaskItem)
                 Private _analyzerReferences As IEnumerable(Of MSB.Framework.ITaskItem)
                 Private _noStandardLib As Boolean
-                Private _warnings As Dictionary(Of String, ReportDiagnostic)
+                Private ReadOnly _warnings As Dictionary(Of String, ReportDiagnostic)
                 Private _sdkPath As String
                 Private _targetCompactFramework As Boolean
                 Private _vbRuntime As String

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.DocumentationCommentClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.DocumentationCommentClassifier.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
     Partial Friend Class Worker
         Private Class DocumentationCommentClassifier
-            Private _worker As Worker
+            Private ReadOnly _worker As Worker
 
             Public Sub New(worker As Worker)
                 _worker = worker

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.XmlClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.XmlClassifier.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
     Partial Friend Class Worker
         Private Class XmlClassifier
-            Private _worker As Worker
+            Private ReadOnly _worker As Worker
 
             Public Sub New(worker As Worker)
                 _worker = worker

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -731,13 +731,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         ''' <summary>
         ''' Look inside a trivia list for a skipped token that contains the given position.
         ''' </summary>
-        Private s_findSkippedTokenForward As Func(Of SyntaxTriviaList, Integer, SyntaxToken) =
+        Private ReadOnly s_findSkippedTokenForward As Func(Of SyntaxTriviaList, Integer, SyntaxToken) =
             Function(l, p) FindTokenHelper.FindSkippedTokenForward(GetSkippedTokens(l), p)
 
         ''' <summary>
         ''' Look inside a trivia list for a skipped token that contains the given position.
         ''' </summary>
-        Private s_findSkippedTokenBackward As Func(Of SyntaxTriviaList, Integer, SyntaxToken) =
+        Private ReadOnly s_findSkippedTokenBackward As Func(Of SyntaxTriviaList, Integer, SyntaxToken) =
             Function(l, p) FindTokenHelper.FindSkippedTokenBackward(GetSkippedTokens(l), p)
 
         ''' <summary>

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Private Const s_indentationLevelCacheSize = 20
         Private Const s_lineContinuationCacheSize = 80
 
-        Private _lineContinuations(s_lineContinuationCacheSize) As LineContinuationTrivia
+        Private ReadOnly _lineContinuations(s_lineContinuationCacheSize) As LineContinuationTrivia
 
         Public Sub New(treeInfo As TreeData, optionSet As OptionSet)
             MyBase.New(treeInfo, optionSet)

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -71,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
             Private _modifiedSubSpans As List(Of ValueTuple(Of TextSpan, TextSpan)) = Nothing
             Private _speculativeModel As SemanticModel
             Private _isProcessingStructuredTrivia As Integer
-            Private _complexifiedSpans As HashSet(Of TextSpan) = New HashSet(Of TextSpan)
+            Private ReadOnly _complexifiedSpans As HashSet(Of TextSpan) = New HashSet(Of TextSpan)
 
             Private Sub AddModifiedSpan(oldSpan As TextSpan, newSpan As TextSpan)
                 newSpan = New TextSpan(oldSpan.Start, newSpan.Length)

--- a/src/Workspaces/VisualBasic/Portable/Simplification/AbstractVisualBasicSimplifier.AbstractExpressionRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/AbstractVisualBasicSimplifier.AbstractExpressionRewriter.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             Private ReadOnly _processedParentNodes As HashSet(Of SyntaxNode)
             Private _hasMoreWork As Boolean
             Protected _alwaysSimplify As Boolean
-            Private _simplificationOptions As OptionSet
+            Private ReadOnly _simplificationOptions As OptionSet
             Private _semanticModel As SemanticModel
 
             Protected Sub New(optionSet As OptionSet, cancellationToken As CancellationToken)

--- a/src/Workspaces/VisualBasic/Portable/Utilities/ImportsClauseComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/ImportsClauseComparer.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
 
         Public Shared ReadOnly Instance As IComparer(Of ImportsClauseSyntax) = New ImportsClauseComparer()
 
-        Private _nameComparer As IComparer(Of NameSyntax)
+        Private ReadOnly _nameComparer As IComparer(Of NameSyntax)
 
         Private Sub New()
             _nameComparer = NameSyntaxComparer.Create(TokenComparer.NormalInstance)


### PR DESCRIPTION
Updated member signatures throughout the codebase to use `readonly` where possible. RoslynLight.sln builds in VS2015 CTP6 and BuildAndTest.proj runs all tests without errors.