### PR TITLE
Removed redundant default value assignment in field initializers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryTranslationState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryTranslationState.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            private int _nextTransparentIdentifierNumber = 0;
+            private int _nextTransparentIdentifierNumber;
 
             internal string TransparentRangeVariableName()
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // lazily compute if the compiler is in "strict" mode (rather than duplicating bugs for compatibility)
-        private bool? _strict = null;
+        private bool? _strict;
         private bool Strict
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
@@ -89,9 +89,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private class OpenTypeVisitor : CSharpSyntaxVisitor
         {
-            private Dictionary<GenericNameSyntax, bool> _allowedMap = null;
-            private bool _seenConstructed = false;
-            private bool _seenGeneric = false;
+            private Dictionary<GenericNameSyntax, bool> _allowedMap;
+            private bool _seenConstructed;
+            private bool _seenGeneric;
 
             /// <param name="typeSyntax">The argument to typeof.</param>
             /// <param name="allowedMap">

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private readonly HashSet<LocalSymbol> _stackLocals;
 
         // not 0 when in a protected region with a handler. 
-        private int _tryNestingLevel = 0;
+        private int _tryNestingLevel;
 
         private readonly SynthesizedLocalOrdinalsDispenser _synthesizedLocalOrdinals = new SynthesizedLocalOrdinalsDispenser();
         private int _uniqueNameId;
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private static readonly object s_returnLabel = new object();
 
         private int _asyncCatchHandlerOffset = -1;
-        private ArrayBuilder<int> _asyncYieldPoints = null;
-        private ArrayBuilder<int> _asyncResumePoints = null;
+        private ArrayBuilder<int> _asyncYieldPoints;
+        private ArrayBuilder<int> _asyncResumePoints;
 
         /// <summary>
         /// In some cases returns are handled as gotos to return epilogue.

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -292,8 +292,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     //
     internal class StackOptimizerPass1 : BoundTreeRewriter
     {
-        private int _counter = 0;
-        private int _evalStack = 0;
+        private int _counter;
+        private int _evalStack;
         private ExprContext _context;
         private BoundLocal _assignmentLocal;
 
@@ -1684,7 +1684,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     //
     internal class StackOptimizerPass2 : BoundTreeRewriter
     {
-        private int _nodeCounter = 0;
+        private int _nodeCounter;
         private Dictionary<LocalSymbol, LocalDefUseInfo> _info;
 
         private StackOptimizerPass2(Dictionary<LocalSymbol, LocalDefUseInfo> info)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1877,7 +1877,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private DiagnosticBag _lazyDeclarationDiagnostics;
-        private bool _declarationDiagnosticsFrozen = false;
+        private bool _declarationDiagnosticsFrozen;
 
         /// <summary>
         /// A bag in which diagnostics that should be reported after code gen can be deposited.

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private SyntaxNodeLocationComparer _lazyComparer;
         private DocumentationCommentIncludeCache _includedFileCache;
 
-        private int _indentDepth = 0;
+        private int _indentDepth;
 
         private Stack<TemporaryStringBuilder> _temporaryStringBuilders;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/CSharpDataFlowAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/CSharpDataFlowAnalysis.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<ISymbol> _captured;
         private ImmutableArray<ISymbol> _unsafeAddressTaken;
         private HashSet<PrefixUnaryExpressionSyntax> _unassignedVariableAddressOfSyntaxes;
-        private bool? _succeeded = null;
+        private bool? _succeeded;
 
         internal CSharpDataFlowAnalysis(RegionAnalysisContext context)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowAnalysis.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<SyntaxNode> _exitPoints;
         private object _regionStartPointIsReachable;
         private object _regionEndPointIsReachable;
-        private bool? _succeeded = null;
+        private bool? _succeeded;
 
         internal CSharpControlFlowAnalysis(RegionAnalysisContext context)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this is false). Since the analysis proceeds by monotonically changing the state computed
         /// at each label, this must terminate.
         /// </summary>
-        internal bool backwardBranchChanged = false;
+        internal bool backwardBranchChanged;
 
         /// <summary>
         /// See property PendingBranches

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly DiagnosticBag _diagnostics;
         private readonly AwaitInFinallyAnalysis _analysis;
 
-        private AwaitCatchFrame _currentAwaitCatchFrame = null;
+        private AwaitCatchFrame _currentAwaitCatchFrame;
         private AwaitFinallyFrame _currentAwaitFinallyFrame = new AwaitFinallyFrame();
 
         private AsyncExceptionHandlerRewriter(
@@ -845,12 +845,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // subsequent leaves to an already proxied label redirected to the proxy.
             // At the proxy lable we will execute finally and forward the control flow 
             // to the actual destination. (which could be proxied again in the parent)
-            public Dictionary<LabelSymbol, LabelSymbol> proxyLabels = null;
+            public Dictionary<LabelSymbol, LabelSymbol> proxyLabels;
 
-            public List<LabelSymbol> proxiedLabels = null;
+            public List<LabelSymbol> proxiedLabels;
 
-            public GeneratedLabelSymbol returnProxyLabel = null;
-            public SynthesizedLocal returnValue = null;
+            public GeneratedLabelSymbol returnProxyLabel;
+            public SynthesizedLocal returnValue;
 
             public AwaitFinallyFrame()
             {

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.IteratorFinallyFrame.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.IteratorFinallyFrame.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // This is enough information to restore Try/Finally tree structure in Dispose and dispatch any valid state
             // into a corresponding try.
             // NOTE: union of all values in this map gives all nested frames.
-            public Dictionary<int, IteratorFinallyFrame> knownStates = null;
+            public Dictionary<int, IteratorFinallyFrame> knownStates;
 
             // labels within this frame (branching to these labels does not go through finally).
             public readonly HashSet<LabelSymbol> labels;
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // subsequent leaves to an already proxied label redirected to the proxy.
             // At the proxy lable we will execute finally and forward the control flow 
             // to the actual destination. (which could be proxied again in the parent)
-            public Dictionary<LabelSymbol, LabelSymbol> proxyLabels = null;
+            public Dictionary<LabelSymbol, LabelSymbol> proxyLabels;
 
             public IteratorFinallyFrame(
                 IteratorFinallyFrame parent,

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// When this is more that 0, returns are emitted as "methodValue = value; goto exitLabel;"
         /// </summary>
-        private int _tryNestingLevel = 0;
+        private int _tryNestingLevel;
         private LabelSymbol _exitLabel;
         private LocalSymbol _methodValue;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // null when currently enclosing conditional access node
         // is not supposed to be lowered.
-        private BoundExpression _currentConditionalAccessTarget = null;
-        private int _currentConditionalAccessID = 0;
+        private BoundExpression _currentConditionalAccessTarget;
+        private int _currentConditionalAccessID;
 
         private enum ConditionalAccessLoweringKind
         {

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected readonly LocalSymbol cachedState;
 
-        private int _nextState = 0;
+        private int _nextState;
 
         /// <summary>
         /// For each distinct label, the set of states that need to be dispatched to that label.

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxListPool.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxListPool.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     internal class SyntaxListPool
     {
         private ArrayElement<SyntaxListBuilder>[] _freeList = new ArrayElement<SyntaxListBuilder>[10];
-        private int _freeIndex = 0;
+        private int _freeIndex;
 
 #if DEBUG
         private readonly List<SyntaxListBuilder> _allocated = new List<SyntaxListBuilder>();

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -926,8 +926,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     referencedAssemblies = assembly.AssemblyReferences;
                 }
 
-                private bool _internalsVisibleComputed = false;
-                private bool _internalsPotentiallyVisibleToCompilation = false;
+                private bool _internalsVisibleComputed;
+                private bool _internalsPotentiallyVisibleToCompilation;
 
                 internal override AssemblySymbol CreateAssemblySymbol()
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2203,8 +2203,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public readonly ArrayBuilder<ImmutableArray<FieldOrPropertyInitializer>> InstanceInitializers = ArrayBuilder<ImmutableArray<FieldOrPropertyInitializer>>.GetInstance();
             public readonly ArrayBuilder<SyntaxReference> IndexerDeclarations = ArrayBuilder<SyntaxReference>.GetInstance();
 
-            public int StaticSyntaxLength = 0;
-            public int InstanceSyntaxLength = 0;
+            public int StaticSyntaxLength;
+            public int InstanceSyntaxLength;
 
             public MembersAndInitializers ToReadOnlyAndFree()
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal partial class SourceNamedTypeSymbol
     {
-        private Tuple<NamedTypeSymbol, ImmutableArray<NamedTypeSymbol>> _lazyDeclaredBases = null;
+        private Tuple<NamedTypeSymbol, ImmutableArray<NamedTypeSymbol>> _lazyDeclaredBases;
 
         private NamedTypeSymbol _lazyBaseType = ErrorTypeSymbol.UnknownResultType;
         private ImmutableArray<NamedTypeSymbol> _lazyInterfaces;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private string _sourceName;
 
         private string _lazyDocComment;
-        private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembers = null;
-        private SynthesizedSealedPropertyAccessor _lazySynthesizedSealedAccessor = null;
+        private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembers;
+        private SynthesizedSealedPropertyAccessor _lazySynthesizedSealedAccessor;
         private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
 
         // CONSIDER: if the parameters were computed lazily, ParameterCount could be overridden to fall back on the syntax (as in SourceMemberMethodSymbol).

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private static readonly Func<Symbol, NamedTypeSymbol, Symbol> s_symbolAsMemberFunc = SymbolExtensions.SymbolAsMember;
 
-        private readonly bool _unbound = false;
+        private readonly bool _unbound;
         private readonly NamedTypeSymbol _originalDefinition;
         private readonly TypeMap _inputMap;
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // InterfaceInfo for a common case of a type not implementing anything directly or indirectly.
         private static readonly InterfaceInfo s_noInterfaces = new InterfaceInfo();
 
-        private ImmutableHashSet<Symbol> _lazyAbstractMembers = null;
-        private InterfaceInfo _lazyInterfaceInfo = null;
+        private ImmutableHashSet<Symbol> _lazyAbstractMembers;
+        private InterfaceInfo _lazyInterfaceInfo;
 
         private class InterfaceInfo
         {

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxLastTokenReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxLastTokenReplacer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private readonly SyntaxToken _oldToken;
         private readonly SyntaxToken _newToken;
         private int _count = 1;
-        private bool _found = false;
+        private bool _found;
 
         private SyntaxLastTokenReplacer(SyntaxToken oldToken, SyntaxToken newToken)
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 
         private class WriteOnlyStream : Stream
         {
-            private int _length = 0;
+            private int _length;
             public override bool CanRead { get { return false; } }
             public override bool CanSeek { get { return false; } }
             public override bool CanWrite { get { return true; } }

--- a/src/Compilers/CSharp/Test/Symbol/DeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DeclarationTests.cs
@@ -365,7 +365,7 @@ public class B
             private readonly SyntaxTree _underlyingTree;
             private readonly CompilationUnitSyntax _root;
 
-            public int AccessCount = 0;
+            public int AccessCount;
 
             public CountedSyntaxTree(SyntaxTree underlying)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/ConcurrentLruCacheTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/ConcurrentLruCacheTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
             : IEnumerable<KeyValuePair<K, V>>
         {
             private readonly KeyValuePair<K, V>[] _store;
-            private int _index = 0;
+            private int _index;
             public OrderedTestDictionary(int capacity)
             {
                 _store = new KeyValuePair<K, V>[capacity];

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public abstract class ManagedCompiler : ToolTask
     {
-        private CancellationTokenSource _sharedCompileCts = null;
+        private CancellationTokenSource _sharedCompileCts;
         internal readonly PropertyDictionary _store = new PropertyDictionary();
 
         public ManagedCompiler()
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// to create our own.
         /// </summary>
         [Output]
-        public new int ExitCode { get; private set; } = 0;
+        public new int ExitCode { get; private set; }
 
         /// <summary>
         /// Handle a response from the server, reporting messages and returning

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public class Vbc : ManagedCompiler
     {
-        private bool _useHostCompilerIfAvailable = false;
+        private bool _useHostCompilerIfAvailable;
 
         // The following 1 fields are used, set and re-set in LogEventsFromTextOutput()
         /// <summary>
@@ -33,8 +33,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         private Queue<VBError> _vbErrorLines = new Queue<VBError>();
 
         // Used when parsing vbc output to determine the column number of an error
-        private bool _isDoneOutputtingErrorMessage = false;
-        private int _numberOfLinesInErrorMessage = 0;
+        private bool _isDoneOutputtingErrorMessage;
+        private int _numberOfLinesInErrorMessage;
 
         #region Properties
 

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         // debug sequence points from all blocks, note that each 
         // sequence point references absolute IL offset via IL marker
-        public ArrayBuilder<RawSequencePoint> SeqPointsOpt = null;
+        public ArrayBuilder<RawSequencePoint> SeqPointsOpt;
 
         /// <summary> 
         /// In some cases we have to get a final IL offset during emit phase, for example for
@@ -52,12 +52,12 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// will be put into allocatedILMarkers array. Note that only markers from reachable blocks 
         /// are materialized, the rest will have offset -1.
         /// </summary>
-        private ArrayBuilder<ILMarker> _allocatedILMarkers = null;
+        private ArrayBuilder<ILMarker> _allocatedILMarkers;
 
         // Since blocks are created lazily in GetCurrentBlock,
         // pendingBlockCreate is set to true when a block must be
         // created, in particular for leader blocks in exception handlers.
-        private bool _pendingBlockCreate = false;
+        private bool _pendingBlockCreate;
 
         internal ILBuilder(ITokenDeferral module, LocalSlotManager localSlotManager, OptimizationLevel optimizations)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis
     internal class DiagnosticBag
     {
         // The lazyBag field is populated lazily -- the first time an error is added.
-        private ConcurrentQueue<Diagnostic> _lazyBag = null;
+        private ConcurrentQueue<Diagnostic> _lazyBag;
 
         /// <summary>
         /// Return true if the bag is completely empty - not even containing void diagnostics.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             this.CompilationUnit = compilationUnit;
         }
-        private WeakReference<SemanticModel> _weakModel = null;
+        private WeakReference<SemanticModel> _weakModel;
         public SemanticModel SemanticModel
         {
             get

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // At most one of these should be non-null.
         private Lazy<SemanticModel> _lazySemanticModel;
         private SemanticModel _semanticModel;
-        private WeakReference<SemanticModel> _weakModel = null;
+        private WeakReference<SemanticModel> _weakModel;
 
         /// <summary>
         /// Lockable object only instance is knowledgeable about.

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             private readonly SourceText _text;
             private readonly int[] _lineStarts;
-            private int _lastLineNumber = 0;
+            private int _lastLineNumber;
 
             public LineInfo(SourceText text, int[] lineStarts)
             {

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         private sealed class TestableDiagnosticListener : IDiagnosticListener
         {
-            public int ProcessedCount = 0;
+            public int ProcessedCount;
             public DateTime? LastProcessedTime;
             public TimeSpan? KeepAlive;
 

--- a/src/Compilers/Helpers/AbstractAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Helpers/AbstractAnalyzerAssemblyLoader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         private readonly List<string> _dependencyPaths = new List<string>();
         private readonly object _guard = new object();
 
-        private bool _hookedAssemblyResolve = false;
+        private bool _hookedAssemblyResolve;
 
         /// <summary>
         /// Implemented by derived types to handle the actual loading of an assembly from

--- a/src/Compilers/Helpers/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Helpers/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Used to generate unique names for per-assembly directories.
         /// </summary>
-        private int _assemblyDirectoryId = 0;
+        private int _assemblyDirectoryId;
 
         public ShadowCopyAnalyzerAssemblyLoader(string baseDirectory = null)
         {

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -149,10 +149,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             public ISymbol Symbol;
             public CandidateReason CandidateReason;
             public ImmutableArray<ISymbol> CandidateSymbols = ImmutableArray.Create<ISymbol>();
-            public ITypeSymbol Type = null;
-            public ITypeSymbol ConvertedType = null;
+            public ITypeSymbol Type;
+            public ITypeSymbol ConvertedType;
             public Conversion ImplicitConversion = default(Conversion);
-            public IAliasSymbol Alias = null;
+            public IAliasSymbol Alias;
             public Optional<object> ConstantValue = default(Optional<object>);
             public bool IsCompileTimeConstant { get { return ConstantValue.HasValue; } }
             public ImmutableArray<ISymbol> MemberGroup = ImmutableArray.Create<ISymbol>();

--- a/src/Compilers/Test/Utilities/Core2/CSReflectionBasedKindProvider.cs
+++ b/src/Compilers/Test/Utilities/Core2/CSReflectionBasedKindProvider.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         private const string CS_DLL = "Microsoft.CodeAnalysis.CSharp.dll";
         private const string CS_KIND_TYPE = "Roslyn.Compilers.CSharp.SyntaxKind";
-        private Type _CSKindType = null;
-        private readonly string _folder = null;
+        private Type _CSKindType;
+        private readonly string _folder;
 
         public CSReflectionBasedKindProvider(string folder)
         {

--- a/src/Compilers/Test/Utilities/Core2/DirectoryHelper.cs
+++ b/src/Compilers/Test/Utilities/Core2/DirectoryHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         public event Action<string> FileFound;
 
-        private readonly string _rootPath = null;
+        private readonly string _rootPath;
         public DirectoryHelper(string path)
         {
             if (!Directory.Exists(path))

--- a/src/Compilers/Test/Utilities/Core2/ParseHelpers.cs
+++ b/src/Compilers/Test/Utilities/Core2/ParseHelpers.cs
@@ -22,13 +22,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private Type m_CSParserType = null;
         private Type m_VBParserType = null;
 #endif
-        private Type _CSSyntaxTreeType = null;
-        private Type _visualBasicSyntaxTreeType = null;
-        private object _CSOptions = null;
-        private object _VBOptions = null;
+        private Type _CSSyntaxTreeType;
+        private Type _visualBasicSyntaxTreeType;
+        private object _CSOptions;
+        private object _VBOptions;
         private readonly string _CSFileName = "Default.cs";
         private readonly string _VBFileName = "Default.vb";
-        private object _codeKind = null;
+        private object _codeKind;
         public SyntaxTree ParseCSTree(string code, string folder)
         {
             if (_CSSyntaxTreeType == null)

--- a/src/Compilers/Test/Utilities/Core2/VBReflectionBasedKindProvider.cs
+++ b/src/Compilers/Test/Utilities/Core2/VBReflectionBasedKindProvider.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         private const string VB_DLL = "Microsoft.CodeAnalysis.VisualBasic.dll";
         private const string VB_KIND_TYPE = "Roslyn.Compilers.VisualBasic.SyntaxKind";
-        private Type _VBKindType = null;
-        private readonly string _folder = null;
+        private Type _VBKindType;
+        private readonly string _folder;
 
         public VBReflectionBasedKindProvider(string folder)
         {

--- a/src/Diagnostics/FxCop/Core/Design/CA1024DiagnosticAnalyzer.cs
+++ b/src/Diagnostics/FxCop/Core/Design/CA1024DiagnosticAnalyzer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.FxCopAnalyzers.Design
 
         protected abstract class CA1024CodeBlockEndedAnalyzer
         {
-            protected bool suppress = false;
+            protected bool suppress;
 
             protected abstract Location GetDiagnosticLocation(SyntaxNode node);
 

--- a/src/EditorFeatures/TestUtilities/Parallel/AsyncFactCommand.cs
+++ b/src/EditorFeatures/TestUtilities/Parallel/AsyncFactCommand.cs
@@ -9,7 +9,7 @@ namespace Roslyn.Test.Utilities.Parallel
 {
     internal class AsyncFactCommand : FactCommand
     {
-        private readonly IDictionary<IMethodInfo, Task<MethodResult>> _testMethodInvokeInfo = null;
+        private readonly IDictionary<IMethodInfo, Task<MethodResult>> _testMethodInvokeInfo;
 
         public AsyncFactCommand(IMethodInfo method, IDictionary<IMethodInfo, Task<MethodResult>> testMethodInvokeInfo)
             : base(method)

--- a/src/EditorFeatures/TestUtilities/Parallel/AsyncTestClassCommand.cs
+++ b/src/EditorFeatures/TestUtilities/Parallel/AsyncTestClassCommand.cs
@@ -10,7 +10,7 @@ namespace Roslyn.Test.Utilities.Parallel
 {
     internal class AsyncTestClassCommand : ITestClassCommand
     {
-        private readonly Dictionary<MethodInfo, object> _fixtures = null;
+        private readonly Dictionary<MethodInfo, object> _fixtures;
 
         public AsyncTestClassCommand(Dictionary<MethodInfo, object> fixtures)
         {

--- a/src/EditorFeatures/TestUtilities/Parallel/ParallelTestClassCommand.cs
+++ b/src/EditorFeatures/TestUtilities/Parallel/ParallelTestClassCommand.cs
@@ -16,9 +16,9 @@ namespace Roslyn.Test.Utilities.Parallel
         private readonly Dictionary<MethodInfo, object> _fixtures = new Dictionary<MethodInfo, object>();
         private readonly IDictionary<IMethodInfo, Task<MethodResult>> _testMethodTasks = new Dictionary<IMethodInfo, Task<MethodResult>>();
         private ITypeInfo _typeUnderTest;
-        private bool _classStarted = false;
+        private bool _classStarted;
         private bool _invokingSingleMethod = true;
-        private List<TraceListener> _oldListeners = null;
+        private List<TraceListener> _oldListeners;
 
         public ParallelTestClassCommand()
             : this((ITypeInfo)null)

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
     {
         internal readonly Assembly Assembly;
         private readonly DkmClrRuntimeInstance _runtimeInstance;
-        private int _resolveTypeNameFailures = 0;
+        private int _resolveTypeNameFailures;
 
         public DkmClrModuleInstance(DkmClrRuntimeInstance runtimeInstance, Assembly assembly, DkmModule module) :
             base(module)

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private ImmutableArray<ISymbol> _lazySymbols;
         private ImmutableArray<SyntaxNode> _lazyAllSyntaxNodesToAnalyze;
 
-        private AnalyzerOptions _analyzerOptions = null;
+        private AnalyzerOptions _analyzerOptions;
 
         public DiagnosticAnalyzerDriver(
             Document document, 

--- a/src/Features/Core/EditAndContinue/EncDebuggingSessionInfo.cs
+++ b/src/Features/Core/EditAndContinue/EncDebuggingSessionInfo.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     internal class EncDebuggingSessionInfo
     {
         public readonly List<EncEditSessionInfo> EditSessions = new List<EncEditSessionInfo>();
-        public int EmptyEditSessions = 0;
+        public int EmptyEditSessions;
 
         internal void EndEditSession(EncEditSessionInfo encEditSessionInfo)
         {

--- a/src/Features/Core/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Features/Core/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         private readonly HashSet<TaskCompletionSource<bool>> _pendingTasks = new HashSet<TaskCompletionSource<bool>>();
 
         private int _counter;
-        private bool _trackActiveTokens = false;
+        private bool _trackActiveTokens;
         private HashSet<DiagnosticAsyncToken> _activeDiagnosticTokens = new HashSet<DiagnosticAsyncToken>();
 
         public IAsyncToken BeginAsyncOperation(string name, object tag = null)

--- a/src/Interactive/Features/Interactive/Core/SynchronizedVersionedList.cs
+++ b/src/Interactive/Features/Interactive/Core/SynchronizedVersionedList.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         private int _lastSnapshotVersion = -1;
 
         // the current version, each modification increments it:
-        private int _version = 0;
+        private int _version;
 
         internal int Version
         {

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
     /// </summary>
     internal class InteractiveWindow : IInteractiveWindow
     {
-        private bool _adornmentToMinimize = false;
+        private bool _adornmentToMinimize;
 
         // true iff code is being executed:
         private bool _isRunning;

--- a/src/InteractiveWindow/Editor/Output/OutputClassifierProvider.cs
+++ b/src/InteractiveWindow/Editor/Output/OutputClassifierProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         private static readonly object s_textBufferPropertyKey = new object();
 
         [Import]
-        private IClassificationTypeRegistryService _classificationRegistry = null;
+        private IClassificationTypeRegistryService _classificationRegistry;
 
         public IClassifier GetClassifier(ITextBuffer textBuffer)
         {

--- a/src/InteractiveWindow/Editor/Output/OutputClassifierProvider.cs
+++ b/src/InteractiveWindow/Editor/Output/OutputClassifierProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         private static readonly object s_textBufferPropertyKey = new object();
 
         [Import]
-        private IClassificationTypeRegistryService _classificationRegistry;
+        private IClassificationTypeRegistryService _classificationRegistry = null;
 
         public IClassifier GetClassifier(ITextBuffer textBuffer)
         {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -93,7 +93,7 @@ namespace BoundTreeGenerator
             new BoundNodeClassWriter(writer, tree, targetLang).WriteFile();
         }
 
-        private int _indent = 0;
+        private int _indent;
         private bool _needsIndent = true;
 
         private void Write(string format, params object[] args)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -16,7 +16,7 @@ namespace CSharpSyntaxGenerator
         private readonly IDictionary<string, Node> _nodeMap;
 
         private const int INDENT_SIZE = 4;
-        private int _indentLevel = 0;
+        private int _indentLevel;
         private bool _needIndent = true;
 
         protected AbstractFileWriter(TextWriter writer, Tree tree)

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
@@ -34,9 +34,9 @@ namespace Roslyn.SyntaxVisualizer.Control
         }
 
         #region Private State
-        private TreeViewItem _currentSelection = null;
-        private bool _isNavigatingFromSourceToTree = false;
-        private bool _isNavigatingFromTreeToSource = false;
+        private TreeViewItem _currentSelection;
+        private bool _isNavigatingFromSourceToTree;
+        private bool _isNavigatingFromTreeToSource;
         private System.Windows.Forms.PropertyGrid _propertyGrid;
         private static readonly Thickness s_defaultBorderThickness = new Thickness(1);
         #endregion

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -76,9 +76,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 }
             }
 
-            private int _skipRenameForComplexification = 0;
+            private int _skipRenameForComplexification;
             private bool _isProcessingComplexifiedSpans;
-            private List<ValueTuple<TextSpan, TextSpan>> _modifiedSubSpans = null;
+            private List<ValueTuple<TextSpan, TextSpan>> _modifiedSubSpans;
             private SemanticModel _speculativeModel;
             private int _isProcessingTrivia;
 

--- a/src/Workspaces/CSharp/Portable/Simplification/AbstractCSharpReducer.AbstractExpressionRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/AbstractCSharpReducer.AbstractExpressionRewriter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
             // can be used to simplify whole subtrees while just annotating one syntax node.
             // This is e.g. useful in the name simplification, where a whole qualified name is annotated
-            protected bool alwaysSimplify = false;
+            protected bool alwaysSimplify;
 
             private static SyntaxNode GetParentNode(SyntaxNode node)
             {

--- a/src/Workspaces/Core/Desktop/Log/RoslynEventSource.cs
+++ b/src/Workspaces/Core/Desktop/Log/RoslynEventSource.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         // might not "enabled" but we always have this singleton alive
         public static readonly RoslynEventSource Instance = new RoslynEventSource();
 
-        private readonly bool _initialized = false;
+        private readonly bool _initialized;
         private RoslynEventSource()
         {
             _initialized = true;

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return !string.IsNullOrEmpty(documentItem.GetMetadata("Link"));
         }
 
-        private IDictionary<string, MSB.Evaluation.ProjectItem> _documents = null;
+        private IDictionary<string, MSB.Evaluation.ProjectItem> _documents;
 
         protected bool IsDocumentGenerated(MSB.Framework.ITaskItem documentItem)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/LineScanner.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/LineScanner.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
     internal class LineScanner
     {
         private readonly string _line;
-        private int _currentPosition = 0;
+        private int _currentPosition;
 
         public LineScanner(string line)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -252,9 +252,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private class Entry
         {
-            public int Count = 0;
-            public ImmutableHashSet<string> AliasNameSet = null;
-            public List<SyntaxToken> ConstructorInitializerCache = null;
+            public int Count;
+            public ImmutableHashSet<string> AliasNameSet;
+            public List<SyntaxToken> ConstructorInitializerCache;
 
             public readonly ConcurrentDictionary<string, IList<SyntaxToken>> IdentifierCache = new ConcurrentDictionary<string, IList<SyntaxToken>>();
             public readonly ConcurrentDictionary<SyntaxNode, SymbolInfo> SymbolInfoCache = new ConcurrentDictionary<SyntaxNode, SymbolInfo>();

--- a/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
+++ b/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             return logMessage;
         }
 
-        private Dictionary<string, object> _map = null;
-        private Action<Dictionary<string, object>> _propertySetter = null;
+        private Dictionary<string, object> _map;
+        private Action<Dictionary<string, object>> _propertySetter;
 
         private KeyValueLogMessage()
         {

--- a/src/Workspaces/Core/Portable/Log/LogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/LogAggregator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// </summary>
     internal class LogAggregator : IEnumerable<KeyValuePair<object, LogAggregator.Counter>>
     {
-        private static int s_globalId = 0;
+        private static int s_globalId;
 
         private readonly ConcurrentDictionary<object, Counter> _map = new ConcurrentDictionary<object, Counter>(concurrencyLevel: 2, capacity: 2);
 
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         internal class Counter
         {
-            private int _count = 0;
+            private int _count;
 
             public void SetCount(int count)
             {

--- a/src/Workspaces/Core/Portable/Log/Logger.cs
+++ b/src/Workspaces/Core/Portable/Log/Logger.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// </summary>
     internal static partial class Logger
     {
-        private static ILogger s_currentLogger = null;
+        private static ILogger s_currentLogger;
 
         /// <summary>
         /// next unique block id that will be given to each LogBlock
         /// </summary>
-        private static int s_lastUniqueBlockId = 0;
+        private static int s_lastUniqueBlockId;
 
         /// <summary>
         /// give a way to explicitly set/replace the logger

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         private Solution _intermediateSolutionContainingOnlyModifiedDocuments;
 
         // This is Lazy Initialized when it is first used
-        private ILookup<DocumentId, RelatedLocation> _relatedLocationsByDocumentId = null;
+        private ILookup<DocumentId, RelatedLocation> _relatedLocationsByDocumentId;
 
         public ConflictResolution(
             Solution oldSolution,

--- a/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
@@ -101,10 +101,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         private class CommentBuilder
         {
             private readonly DocumentationComment _comment;
-            private ImmutableArray<string>.Builder _parameterNamesBuilder = null;
-            private ImmutableArray<string>.Builder _typeParameterNamesBuilder = null;
-            private ImmutableArray<string>.Builder _exceptionTypesBuilder = null;
-            private Dictionary<string, ImmutableArray<string>.Builder> _exceptionTextBuilders = null;
+            private ImmutableArray<string>.Builder _parameterNamesBuilder;
+            private ImmutableArray<string>.Builder _typeParameterNamesBuilder;
+            private ImmutableArray<string>.Builder _exceptionTypesBuilder;
+            private Dictionary<string, ImmutableArray<string>.Builder> _exceptionTextBuilders;
 
             /// <summary>
             /// Parse and construct a <see cref="DocumentationComment" /> from the given fragment of XML.

--- a/src/Workspaces/Core/Portable/Shared/Utilities/ProgressTracker.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/ProgressTracker.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     /// </summary>
     internal class ProgressTracker
     {
-        private int _completedItems = 0;
-        private int _totalItems = 0;
+        private int _completedItems;
+        private int _totalItems;
 
         private readonly Action<int, int> _updateActionOpt;
 

--- a/src/Workspaces/Core/Portable/Utilities/AnnotationTable.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AnnotationTable.cs
@@ -25,7 +25,7 @@ namespace Roslyn.Utilities
     /// </summary>
     internal class AnnotationTable<TAnnotation> where TAnnotation : class
     {
-        private int _globalId = 0;
+        private int _globalId;
 
         private readonly Dictionary<TAnnotation, SyntaxAnnotation> _realAnnotationMap = new Dictionary<TAnnotation, SyntaxAnnotation>();
         private readonly Dictionary<string, TAnnotation> _annotationMap = new Dictionary<string, TAnnotation>();

--- a/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
@@ -58,19 +58,19 @@ namespace Roslyn.Utilities
         /// The hash set of all currently outstanding asynchronous requests. Null if there are no requests,
         /// and will never be empty.
         /// </summary>
-        private HashSet<Request> _requests = null;
+        private HashSet<Request> _requests;
 
         /// <summary>
         /// If an asynchronous request is active, the CancellationTokenSource that allows for
         /// cancelling the underlying computation.
         /// </summary>
-        private CancellationTokenSource _asynchronousComputationCancellationSource = null;
+        private CancellationTokenSource _asynchronousComputationCancellationSource;
 
         /// <summary>
         /// Whether a computation is active or queued on any thread, whether synchronous or
         /// asynchronous.
         /// </summary>
-        private bool _computationActive = false;
+        private bool _computationActive;
 
         /// <summary>
         /// Creates an AsyncLazy that always returns the value, analogous to <see cref="Task.FromResult{T}" />.

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Utilities
     {
         private readonly LinkedList<T> _list;
         private readonly Dictionary<T, LinkedListNode<T>> _map;
-        private int _insertionIndex = 0;
+        private int _insertionIndex;
 
         public LinkedHashQueue()
             : this(null)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal class BranchId
     {
-        private static int s_nextId = 0;
+        private static int s_nextId;
 
         private readonly int _id;
 


### PR DESCRIPTION
Removed redundant default value assignment in field initializers. RoslynLight.sln builds in VS2015 CTP6 and BuildAndTest.proj runs all tests without errors.