### PR TITLE
Adjust the color for enums, interfaces, and type parameters

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private UserTypeEnumsFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.FontAndColors_UserTypes_Enums;
-                this.ForegroundColor = Color.FromRgb(0x2B, 0x91, 0xAF);
+                this.ForegroundColor = Color.FromRgb(0x66, 0x8C, 0x92);
             }
         }
         #endregion
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private UserTypeInterfacesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.FontAndColors_UserTypes_Interfaces;
-                this.ForegroundColor = Color.FromRgb(0x2B, 0x91, 0xAF);
+                this.ForegroundColor = Color.FromRgb(0x66, 0x8C, 0x92);
             }
         }
         #endregion
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private UserTypeTypeParametersFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.FontAndColors_UserTypes_TypeParameters;
-                this.ForegroundColor = Color.FromRgb(0x2B, 0x91, 0xAF);
+                this.ForegroundColor = Color.FromRgb(0x66, 0x8C, 0x92);
             }
         }
         #endregion


### PR DESCRIPTION
The topic of light theme colors came up in #1482. Currently, the light theme uses the same default color for all type kinds (classes, structures, enums, interfaces, etc.). The dark theme on the other hand uses a unique color for enums, interfaces, and type parameters.

This change updates the Light theme colors for enums, interfaces, and type parameters so they are distinguished from other type kinds. The value chosen for these kinds is a luminosity-adjusted color derived from the colors for classes along with the default Dark theme values for these colors. The goal is to provide the same overall experience as users of the dark theme.

I actually forget the original algorithm I used to derive this color, but I found [the tweet I made](https://twitter.com/samharwell/status/302136911848427521) regarding it. If it matters for the purpose of this pull request, I can look up the formula(s) I used.

#### The following shows the default colors:

![image](https://cloud.githubusercontent.com/assets/1408396/7427528/6e9f070a-ef92-11e4-81ce-3176befb6c68.png)

#### After this pull request, the default colors are modified to the following:

![image](https://cloud.githubusercontent.com/assets/1408396/7427546/be1e5a7e-ef92-11e4-8b3a-e9a31e64cc98.png)
