### PR TITLE
Fix for internal bug 1132014: Implement interface generates innacessible...

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -2641,5 +2641,50 @@ partial class C
     }}
     #endregion";
         }
+
+        [WorkItem(1132014)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public void TestInaccesibleAttributes()
+        {
+            Test(
+@"using System;
+
+public class Foo : [|Holder.SomeInterface|]
+{
+}
+
+public class Holder
+{
+    public interface SomeInterface
+    {
+        void Something([SomeAttribute] string helloWorld);
+    }
+
+    private class SomeAttribute : Attribute
+    {
+    }
+}",
+@"using System;
+
+public class Foo : Holder.SomeInterface
+{
+    public void Something(string helloWorld)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class Holder
+{
+    public interface SomeInterface
+    {
+        void Something([SomeAttribute] string helloWorld);
+    }
+
+    private class SomeAttribute : Attribute
+    {
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -2127,5 +2127,45 @@ End Interface", index:=1, compareTokens:=False)
 
             Return code
         End Function
+
+        <WorkItem(1132014)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        Public Sub TestInaccesibleAttributes()
+            Test(
+"Imports System
+
+Public Class Foo
+    Implements [|Holder.SomeInterface|]
+End Class
+
+Public Class Holder
+	Public Interface SomeInterface
+		Sub Something(<SomeAttribute> helloWorld As String)
+	End Interface
+
+	Private Class SomeAttribute
+		Inherits Attribute
+	End Class
+End Class",
+"Imports System
+
+Public Class Foo
+    Implements Holder.SomeInterface
+
+    Public Sub Something(helloWorld As String) Implements Holder.SomeInterface.Something
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Public Class Holder
+	Public Interface SomeInterface
+		Sub Something(<SomeAttribute> helloWorld As String)
+	End Interface
+
+	Private Class SomeAttribute
+		Inherits Attribute
+	End Class
+End Class", compareTokens:=False)
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -28,7 +28,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var updatedMethod = method.EnsureNonConflictingNames(
                     this.State.ClassOrStructType, syntaxFacts, cancellationToken);
 
-                updatedMethod = updatedMethod.RemoveAttributeFromParametersAndReturnType(compilation.ComAliasNameAttributeType());
+                updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                    accessibleWithin: this.State.ClassOrStructType,
+                    removeAttributeType: compilation.ComAliasNameAttributeType());
 
                 return CodeGenerationSymbolFactory.CreateMethodSymbol(
                     updatedMethod,

--- a/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
+++ b/src/Features/Core/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
@@ -32,7 +32,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var getAccessor = property.GetMethod == null
                     ? null
                     : CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                        property.GetMethod.RemoveAttributeFromParametersAndReturnType(comAliasNameAttribute),
+                        property.GetMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                            accessibleWithin: this.State.ClassOrStructType,
+                            removeAttributeType: comAliasNameAttribute),
                         attributes: null,
                         accessibility: accessibility,
                         explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.GetMethod : null,
@@ -41,7 +43,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var setAccessor = property.SetMethod == null
                     ? null
                     : CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                        property.SetMethod.RemoveAttributeFromParametersAndReturnType(comAliasNameAttribute),
+                        property.SetMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                            accessibleWithin: this.State.ClassOrStructType,
+                            removeAttributeType: comAliasNameAttribute),
                         attributes: null,
                         accessibility: accessibility,
                         explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.SetMethod : null,


### PR DESCRIPTION
... attributes on implemented members

Fix is to remove inaccessible attributes from the generated members and its parameters.