### PR TITLE
Fix some aggressive Intellisense issues in debugger windows...

### DIFF
--- a/src/Features/CSharp/Completion/CompletionProviders/SuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Completion/CompletionProviders/SuggestionModeCompletionProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             {
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-                if (triggerInfo.IsDebugger && triggerInfo.IsImmediateWindow)
+                if (triggerInfo.IsDebugger)
                 {
                     // Aggressive Intellisense in the debugger: always show the builder 
                     return new CompletionItem(this, "", CompletionUtilities.GetTextChangeSpan(text, position), isBuilder: true);


### PR DESCRIPTION
- Use suggestion mode by default in all debugger windows (not just in Immediate).
- Tweak completion to not send "Enter" through to single-line debugger windows (Watch, etc).  They don't support displaying more that one line of expression text.