### PR TITLE
Allow public key token in InternalsVisibleTo attribute due to compatibility reasons.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1969,7 +1969,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            const AssemblyIdentityParts allowedParts = AssemblyIdentityParts.Name | AssemblyIdentityParts.PublicKey;
+            // Allow public key token due to compatibility reasons, but we are not going to use its value.
+            const AssemblyIdentityParts allowedParts = AssemblyIdentityParts.Name | AssemblyIdentityParts.PublicKey | AssemblyIdentityParts.PublicKeyToken; 
 
             if ((parts & ~allowedParts) != 0)
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -14808,7 +14808,7 @@ class C
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(1116455, "DevDiv")]
         public void CS1725ERR_FriendAssemblyBadArgs()
         {
             var text = @"
@@ -14828,6 +14828,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""Test, Version=1.1.1.*"")]              // error
 [assembly: InternalsVisibleTo(""Test, ProcessorArchitecture=MSIL"")]   // error
 [assembly: InternalsVisibleTo(""Test, CuLTure=EN"")]                   // error
+[assembly: InternalsVisibleTo(""Test, PublicKeyToken=null"")]          // ok
 ";
             // Tested against Dev12
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -929,7 +929,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return False
             End If
 
-            Const allowedParts = AssemblyIdentityParts.Name Or AssemblyIdentityParts.PublicKey
+            ' Allow public key token due to compatibility reasons, but we are not going to use its value.
+            Const allowedParts = AssemblyIdentityParts.Name Or AssemblyIdentityParts.PublicKey Or AssemblyIdentityParts.PublicKeyToken
 
             If (parts And Not allowedParts) <> 0 Then
                 diagnostics.Add(ERRID.ERR_FriendAssemblyBadArguments, If(nodeOpt IsNot Nothing, nodeOpt.GetLocation(), NoLocation.Singleton), displayName)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -13240,7 +13240,7 @@ BC31527: 'Microsoft.VisualBasic.ComClassAttribute' cannot be applied to a class 
         ' BC31531ERR_DllImportNotLegalOnEventMethod
         ' see AttributeTests
 
-        <Fact>
+        <Fact, WorkItem(1116455, "DevDiv")>
         Public Sub BC31534ERR_FriendAssemblyBadArguments()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndReferences(
     <compilation name="FriendAssemblyBadArguments">
@@ -13261,6 +13261,7 @@ Imports System.Runtime.CompilerServices
 <Assembly: InternalsVisibleTo("Test, Version=1.1.1.*")>              ' error
 <Assembly: InternalsVisibleTo("Test, ProcessorArchitecture=MSIL")>   ' error
 <Assembly: InternalsVisibleTo("Test, CuLTure=EN")>                   ' error
+<Assembly: InternalsVisibleTo("Test, PublicKeyToken=null")>          ' ok
         ]]></file>
     </compilation>, {SystemCoreRef})
 


### PR DESCRIPTION
@VSadov, @gafter, @agocke, @jaredpar Please review.  