### PR TITLE
Adding tests for internal bug #854662

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -1414,6 +1414,37 @@ compareTokens: false,
 options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals), false } });
         }
 
+        [WorkItem(854662)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void TestInNestedCollectionInitializers()
+        {
+            Test(
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    public Dictionary<int, int> A { get; private set; }
+    static int Main(string[] args)
+    {
+        int a = 0;
+        return new Program { A = { { [|a + 2|], 0 } } }.A.Count;
+    }
+}",
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    public Dictionary<int, int> A { get; private set; }
+    static int Main(string[] args)
+    {
+        int a = 0;
+        var {|Rename:v|} = a + 2;
+        return new Program { A = { { v, 0 } } }.A.Count;
+    }
+}",
+compareTokens: false);
+        }
+
         [WorkItem(884961)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInArrayInitializer()

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -9647,6 +9647,42 @@ class C
             TestExtractMethod(code, expected);
         }
 
+        [WorkItem(854662)]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public void TestExtractCollectionInitializer2()
+        {
+            var code =
+@"using System;
+using System.Collections.Generic;
+class Program
+{
+    public Dictionary<int, int> A { get; private set; }
+    static int Main(string[] args)
+    {
+        int a = 0;
+        return new Program { A = { { [|a + 2|], 0 } } }.A.Count;
+    }
+}";
+            var expected = @"using System;
+using System.Collections.Generic;
+class Program
+{
+    public Dictionary<int, int> A { get; private set; }
+    static int Main(string[] args)
+    {
+        int a = 0;
+        return new Program { A = { { NewMethod(a), 0 } } }.A.Count;
+    }
+
+    private static int NewMethod(int a)
+    {
+        return a + 2;
+    }
+}";
+
+            TestExtractMethod(code, expected);
+        }
+
         [WorkItem(530267)]
         [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void TestCoClassImplicitConversion()


### PR DESCRIPTION
Adding unit tests for Introduce variable and Extract Method in Nested
Collection Initializer cases.

The bug no longer reproes. This change is test only.