### PR TITLE
Update keyword strings for C# Advanced page

### DIFF
--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -142,7 +142,7 @@
     <comment>"C#" node help text in profile Import/Export.</comment>
   </data>
   <data name="306" xml:space="preserve">
-    <value>Enter outlining mode when files open;Underline errors in the editor;Turn live semantic errors on or off;Turn highlight references on or off;Change refactoring settings;Generate XML documentation comments;Surround generated code with #region;Change the settings for Organize Usings</value>
+    <value>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs</value>
     <comment>C# Advanced options page keywords</comment>
   </data>
   <data name="307" xml:space="preserve">


### PR DESCRIPTION
Make the keyword strings for the C# Advanced page match the option text, to increase the chances of people finding the page with Quick Launch.

Fixes internal TFS bug 1163900.