### PR TITLE
Correct Property for ExplicitlyImplementedCodeElement

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
         private static readonly SymbolDisplayFormat s_fullNameFormat =
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
-                memberOptions: SymbolDisplayMemberOptions.IncludeContainingType,
+                memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeExplicitInterface,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
 
@@ -794,17 +794,21 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 case SyntaxKind.DelegateDeclaration:
                     return ((DelegateDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.MethodDeclaration:
-                    return ((MethodDeclarationSyntax)node).Identifier.ToString();
+                    return ((MethodDeclarationSyntax)node).ExplicitInterfaceSpecifier?.ToString() +
+                        ((MethodDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.ConstructorDeclaration:
                     return ((ConstructorDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.DestructorDeclaration:
                     return "~" + ((DestructorDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.PropertyDeclaration:
-                    return ((PropertyDeclarationSyntax)node).Identifier.ToString();
+                    return ((PropertyDeclarationSyntax)node).ExplicitInterfaceSpecifier?.ToString() +
+                        ((PropertyDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.IndexerDeclaration:
-                    return ((IndexerDeclarationSyntax)node).ThisKeyword.ToString();
+                    return ((IndexerDeclarationSyntax)node).ExplicitInterfaceSpecifier?.ToString() +
+                        ((IndexerDeclarationSyntax)node).ThisKeyword.ToString();
                 case SyntaxKind.EventDeclaration:
-                    return ((EventDeclarationSyntax)node).Identifier.ToString();
+                    return ((EventDeclarationSyntax)node).ExplicitInterfaceSpecifier?.ToString() +
+                        ((EventDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.Parameter:
                     return ((ParameterSyntax)node).Identifier.ToString();
                 case SyntaxKind.NamespaceDeclaration:

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
@@ -114,6 +114,38 @@ class C
                      TextPoint(line:=3, lineOffset:=5, absoluteOffset:=15, lineLength:=38)))
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetStartPointExplicitlyImplementedEvent()
+            Dim code =
+<Code>
+delegate void SampleEventHandler(object sender);
+
+interface I1
+{
+    event SampleEventHandler SampleEvent;
+}
+
+class C1 : I1
+{
+    event SampleEventHandler $$I1.SampleEvent
+    {
+        add
+        {
+        }
+
+        remove
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetStartPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=10, lineOffset:=5, absoluteOffset:=131, lineLength:=43)))
+        End Sub
+
 #End Region
 
 #Region "GetEndPoint tests"
@@ -219,6 +251,38 @@ class C
                      ThrowsNotImplementedException),
                 Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
                      TextPoint(line:=7, lineOffset:=6, absoluteOffset:=96, lineLength:=5)))
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetEndPointExplicitlyImplementedEvent()
+            Dim code =
+<Code>
+delegate void SampleEventHandler(object sender);
+
+interface I1
+{
+    event SampleEventHandler SampleEvent;
+}
+
+class C1 : I1
+{
+    event SampleEventHandler $$I1.SampleEvent
+    {
+        add
+        {
+        }
+
+        remove
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetEndPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=19, lineOffset:=6, absoluteOffset:=250, lineLength:=5)))
         End Sub
 
 #End Region
@@ -333,6 +397,36 @@ class C
             TestFullName(code, "C.F")
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ExplicitlyImplementedEvent()
+            Dim code =
+<Code>
+delegate void SampleEventHandler(object sender);
+
+interface I1
+{
+    event SampleEventHandler SampleEvent;
+}
+
+class C1 : I1
+{
+    event SampleEventHandler $$I1.SampleEvent
+    {
+        add
+        {
+        }
+
+        remove
+        {
+        }
+    }
+}
+</Code>
+
+            TestFullName(code, "C1.I1.SampleEvent")
+        End Sub
+
 #End Region
 
 #Region "IsPropertyStyleEvent tests"
@@ -425,6 +519,36 @@ class C
 </Code>
 
             TestName(code, "F")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ExplicitlyImplementedEvent()
+            Dim code =
+<Code>
+delegate void SampleEventHandler(object sender);
+
+interface I1
+{
+    event SampleEventHandler SampleEvent;
+}
+
+class C1 : I1
+{
+    event SampleEventHandler $$I1.SampleEvent
+    {
+        add
+        {
+        }
+
+        remove
+        {
+        }
+    }
+}
+</Code>
+
+            TestName(code, "I1.SampleEvent")
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -28,6 +28,30 @@ class D
                 Part(EnvDTE.vsCMPart.vsCMPartBody,
                      TextPoint(line:=5, lineOffset:=1, absoluteOffset:=65, lineLength:=23)))
         End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetStartPointExplicitlyImplementedMethod()
+            Dim code =
+<Code>
+public interface I1
+{
+    int f1();
+}
+
+public class C1 : I1
+{
+    int I1.f1$$()
+    {
+        return 0;
+    }
+}
+</Code>
+
+            TestGetStartPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=8, lineOffset:=5, absoluteOffset:=67, lineLength:=15)))
+        End Sub
 #End Region
 
 #Region "Get End Point"
@@ -48,6 +72,30 @@ class D
             TestGetEndPoint(code,
                 Part(EnvDTE.vsCMPart.vsCMPartBody,
                      TextPoint(line:=6, lineOffset:=1, absoluteOffset:=89, lineLength:=5)))
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetEndPointExplicitlyImplementedMethod()
+            Dim code =
+<Code>
+public interface I1
+{
+    int f1();
+}
+
+public class C1 : I1
+{
+    int I1.f1$$()
+    {
+        return 0;
+    }
+}
+</Code>
+
+            TestGetEndPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=11, lineOffset:=6, absoluteOffset:=108, lineLength:=5)))
         End Sub
 #End Region
 
@@ -240,6 +288,28 @@ class C
             TestFullName(code, "C.~C")
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ExplicitlyImplementedMethod()
+            Dim code =
+<Code>
+public interface I1
+{
+    int f1();
+}
+
+public class C1 : I1
+{
+    int I1.f1$$()
+    {
+        return 0;
+    }
+}
+</Code>
+
+            TestFullName(code, "C1.I1.f1")
+        End Sub
+
 #End Region
 
 #Region "FunctionKind tests"
@@ -404,6 +474,28 @@ class C : B
 #End Region
 
 #Region "Name tests"
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ExplicitlyImplementedMethod()
+            Dim code =
+<Code>
+public interface I1
+{
+    int f1();
+}
+
+public class C1 : I1
+{
+    int I1.f1$$()
+    {
+        return 0;
+    }
+}
+</Code>
+
+            TestName(code, "I1.f1")
+        End Sub
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub Name_Destructor()

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -248,6 +248,69 @@ class C
                      TextPoint(line:=3, lineOffset:=5, absoluteOffset:=15, lineLength:=31)))
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetStartPoint_ExplicitlyImplementedIndexer()
+            Dim code =
+<Code>
+interface I1
+{
+    int this[int i]
+    { get;set; }
+}
+
+class C1 : I1
+{
+    int $$I1.this[int i]
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetStartPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=9, lineOffset:=5, absoluteOffset:=76, lineLength:=22)))
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetStartPoint_ExplicitlyImplementedProperty()
+            Dim code =
+<Code>
+interface I1
+{
+    int Prop1 { get; set; }
+}
+
+class C1 : I1
+{
+    int $$I1.Prop1
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetStartPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=8, lineOffset:=5, absoluteOffset:=67, lineLength:=16)))
+        End Sub
+
 #End Region
 
 #Region "GetEndPoint() tests"
@@ -489,6 +552,69 @@ class C
                      TextPoint(line:=13, lineOffset:=6, absoluteOffset:=182, lineLength:=5)))
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetEndPoint_ExplicitlyImplementedProperty()
+            Dim code =
+<Code>
+interface I1
+{
+    int Prop1 { get; set; }
+}
+
+class C1 : I1
+{
+    int $$I1.Prop1
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetEndPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=18, lineOffset:=6, absoluteOffset:=178, lineLength:=5)))
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetEndPoint_ExplicitlyImplementedIndexer()
+            Dim code =
+<Code>
+interface I1
+{
+    int this[int i]
+    { get;set; }
+}
+
+class C1 : I1
+{
+    int $$I1.this[int i]
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestGetEndPoint(code,
+                Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes,
+                     TextPoint(line:=19, lineOffset:=6, absoluteOffset:=193, lineLength:=5)))
+        End Sub
+
 #End Region
 
 #Region "FullName tests"
@@ -539,6 +665,65 @@ class C
 </Code>
 
             TestFullName(code, "C.this")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ExplicitlyImplementedProperty()
+            Dim code =
+<Code>
+interface I1
+{
+    int Prop1 { get; set; }
+}
+
+class C1 : I1
+{
+    int $$I1.Prop1
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestFullName(code, "C1.I1.Prop1")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ExplicitlyImplementedIndexer()
+            Dim code =
+<Code>
+interface I1
+{
+    int this[int i]
+    { get;set; }
+}
+
+class C1 : I1
+{
+    int $$I1.this[int i]
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestFullName(code, "C1.I1.this")
         End Sub
 
 #End Region
@@ -648,6 +833,65 @@ class C
 </Code>
 
             TestName(code, "this")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ExplicitlyImplementedProperty()
+            Dim code =
+<Code>
+interface I1
+{
+    int Prop1 { get; set; }
+}
+
+class C1 : I1
+{
+    int $$I1.Prop1
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestName(code, "I1.Prop1")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ExplicitlyImplementedIndexer()
+            Dim code =
+<Code>
+interface I1
+{
+    int this[int i]
+    { get;set; }
+}
+
+class C1 : I1
+{
+    int $$I1.this[int i]
+    {
+        get
+        {
+            return 0;
+        }
+
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            TestName(code, "I1.this")
         End Sub
 
 #End Region


### PR DESCRIPTION
Fix #2437: Make sure the Code Element for explicitly implemented
interface member carry the appropriate properties