### PR TITLE
Make option string values match their names

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
@@ -155,7 +155,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to _Highlight references to symbol under cursor.
+        '''  Looks up a localized string similar to Highlight related _keywords under cursor.
         '''</summary>
         Friend Shared ReadOnly Property Option_EnableHighlightKeywords() As String
             Get
@@ -164,7 +164,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Highlight related _keywords under cursor.
+        '''  Looks up a localized string similar to _Highlight references to symbol under cursor.
         '''</summary>
         Friend Shared ReadOnly Property Option_EnableHighlightReferences() As String
             Get

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -157,10 +157,10 @@
     <value>A_utomatic insertion of end constructs</value>
   </data>
   <data name="Option_EnableHighlightKeywords" xml:space="preserve">
-    <value>_Highlight references to symbol under cursor</value>
+    <value>Highlight related _keywords under cursor</value>
   </data>
   <data name="Option_EnableHighlightReferences" xml:space="preserve">
-    <value>Highlight related _keywords under cursor</value>
+    <value>_Highlight references to symbol under cursor</value>
   </data>
   <data name="Option_EnableLineCommit" xml:space="preserve">
     <value>_Pretty listing (reformatting) of code</value>


### PR DESCRIPTION
These two strings seem to have had their values reversed.

Fixes internal TFS bug 1108650.