### PR TITLE
Enable BinaryOperators Test1

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Public Class BinaryOperators
         Inherits BasicTestBase
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/856")>
+        <Fact>
         Public Sub Test1()
 
             Dim compilationDef =


### PR DESCRIPTION
This test was disabled due to an issue running the test on CTP6.  This issue no longer reproduces on
newer builds including the RC.  Enabling and closing the bug.

closes #856