### PR TITLE
Use XDocument in RuleSetProcessor

### DIFF
--- a/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
+++ b/src/Compilers/Core/Desktop/CodeAnalysis.Desktop.csproj
@@ -105,6 +105,7 @@
       <HintPath>..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.Desktop" />


### PR DESCRIPTION
The XmlDocument type is not a part of the 4.5 portable subset and was
preventing the rule processing from being used in all portable
scenarios.