### PR TITLE
IntroduceLocal: Get Outermost Block

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1416,6 +1416,73 @@ End Module
 </File>)
         End Sub
 
+        <WorkItem(2026, "https://github.com/dotnet/roslyn/issues/2026")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub TestReplaceAllFromInsideIfBlock()
+            Dim code =
+<File>
+Imports System
+Module DataTipInfoGetterModule
+    Friend Function GetInfoAsync() As DebugDataTipInfo
+        Dim expression As ExpressionSyntax = Nothing
+
+        Dim curr = DirectCast(expression.Parent, ExpressionSyntax)
+        If curr Is expression.Parent Then
+            Return New DebugDataTipInfo([|expression.Parent|].Span)
+        End If
+
+        Return Nothing
+    End Function
+End Module
+
+Friend Class TextSpan
+End Class
+
+Friend Class ExpressionSyntax
+    Public Property Parent As ExpressionSyntax
+    Public Property Span As TextSpan
+End Class
+
+Friend Class DebugDataTipInfo
+    Public Sub New(span As Object)
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Imports System
+Module DataTipInfoGetterModule
+    Friend Function GetInfoAsync() As DebugDataTipInfo
+        Dim expression As ExpressionSyntax = Nothing
+        Dim {|Rename:parent|} As ExpressionSyntax = expression.Parent
+
+        Dim curr = DirectCast(parent, ExpressionSyntax)
+        If curr Is parent Then
+            Return New DebugDataTipInfo(parent.Span)
+        End If
+
+        Return Nothing
+    End Function
+End Module
+
+Friend Class TextSpan
+End Class
+
+Friend Class ExpressionSyntax
+    Public Property Parent As ExpressionSyntax
+    Public Property Span As TextSpan
+End Class
+
+Friend Class DebugDataTipInfo
+    Public Sub New(span As Object)
+    End Sub
+End Class
+</File>
+
+            Test(code, expected, index:=1, compareTokens:=False)
+        End Sub
+
         <WorkItem(1065661)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceVariableTextDoesntSpanLines()

--- a/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
+++ b/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
@@ -127,7 +127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
             Dim localAnnotation = New SyntaxAnnotation()
             localDeclaration = localDeclaration.WithAdditionalAnnotations(Formatter.Annotation, localAnnotation)
 
-            Dim oldOutermostBlock = expression.GetContainingExecutableBlocks().FirstOrDefault()
+            Dim oldOutermostBlock = expression.GetContainingExecutableBlocks().LastOrDefault()
             If oldOutermostBlock.IsSingleLineExecutableBlock() Then
                 oldOutermostBlock = oldOutermostBlock.Parent
             End If


### PR DESCRIPTION
Fixes #2026

We are trying to find the outermost containing executable block but
were actually getting the Innermost containing executable block. Seems
like a typo to me, getting First() instead of Last(). Also, the
corresponding C# implementation correctly uses Last(). Making VB do the
same thing.