### PR TITLE
Setting next statement inside a scope with a lambda cause NRE

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -694,21 +694,48 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var newStatements = ArrayBuilder<BoundStatement>.GetInstance();
 
-            if (prologue.Count > 0)
-            {
-                newStatements.Add(new BoundSequencePoint(null, null) { WasCompilerGenerated = true });
-            }
-
-            InsertAndFreePrologue(newStatements, prologue);
-
             foreach (var statement in node.Statements)
             {
                 var replacement = (BoundStatement)this.Visit(statement);
                 if (replacement != null)
                 {
+                    if (newStatements.Count == 0 && prologue.Count > 0)
+                    {
+                        for (int i = 0; i < prologue.Count; i++)
+                        {
+                            BoundStatement prologueStatement = new BoundExpressionStatement(prologue[i].Syntax, prologue[i]);
+
+                            // transfer the bound sequence point from the first rewritten statement to the first prologue expression statement:
+                            if (i == 0)
+                            {
+                                BoundSequencePoint sequencePoint;
+                                BoundSequencePointWithSpan sequencePointWithSpan;
+                                if ((sequencePointWithSpan = replacement as BoundSequencePointWithSpan) != null)
+                                {
+                                    prologueStatement = new BoundSequencePointWithSpan(sequencePointWithSpan.Syntax, prologueStatement, sequencePointWithSpan.Span);
+                                    replacement = sequencePointWithSpan.StatementOpt;
+                                }
+                                else if ((sequencePoint = replacement as BoundSequencePoint) != null)
+                                {
+                                    prologueStatement = new BoundSequencePoint(sequencePoint.Syntax, prologueStatement);
+                                    replacement = sequencePoint.StatementOpt;
+                                }
+                            }
+
+                            newStatements.Add(prologueStatement);
+                        }
+
+                        if (replacement == null)
+                        {
+                            continue;
+                        }
+                    }
+
                     newStatements.Add(replacement);
                 }
             }
+
+            prologue.Free();
 
             // TODO: we may not need to update if there was nothing to rewrite.
             return node.Update(newLocals.ToImmutableAndFree(), newStatements.ToImmutableAndFree());

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -624,7 +624,7 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" hidden=""true"" document=""0"" />
-        <entry offset=""0xa"" hidden=""true"" document=""0"" />
+        <entry offset=""0xa"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
         <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
         <entry offset=""0x17"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
         <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
@@ -712,7 +712,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0xe0"" />
+          <slot startOffset=""0x11"" endOffset=""0xdf"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -724,21 +724,20 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" hidden=""true"" document=""0"" />
-        <entry offset=""0x11"" hidden=""true"" document=""0"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""0"" />
-        <entry offset=""0x86"" hidden=""true"" document=""0"" />
-        <entry offset=""0xe1"" hidden=""true"" document=""0"" />
-        <entry offset=""0xf9"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x101"" hidden=""true"" document=""0"" />
+        <entry offset=""0x11"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x28"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x34"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x40"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x57"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x85"" hidden=""true"" document=""0"" />
+        <entry offset=""0xe0"" hidden=""true"" document=""0"" />
+        <entry offset=""0xf8"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x100"" hidden=""true"" document=""0"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
-        <await yield=""0x98"" resume=""0xb3"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x97"" resume=""0xb2"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -815,7 +814,7 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" hidden=""true"" document=""0"" />
-        <entry offset=""0xa"" hidden=""true"" document=""0"" />
+        <entry offset=""0xa"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
         <entry offset=""0x15"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
         <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
         <entry offset=""0x2d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
@@ -898,7 +897,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0xcf"" />
+          <slot startOffset=""0xe"" endOffset=""0xcb"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -910,22 +909,21 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" hidden=""true"" document=""0"" />
-        <entry offset=""0x11"" hidden=""true"" document=""0"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""0"" />
-        <entry offset=""0x64"" hidden=""true"" document=""0"" />
-        <entry offset=""0xbd"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""0"" />
-        <entry offset=""0xd0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xe8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
-        <entry offset=""0xf0"" hidden=""true"" document=""0"" />
+        <entry offset=""0xe"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x19"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x25"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x31"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x3d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x54"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x60"" hidden=""true"" document=""0"" />
+        <entry offset=""0xb9"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""0"" />
+        <entry offset=""0xcc"" hidden=""true"" document=""0"" />
+        <entry offset=""0xe4"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xec"" hidden=""true"" document=""0"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
-        <await yield=""0x76"" resume=""0x91"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x72"" resume=""0x8d"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -1029,7 +1029,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x32"" endOffset=""0xfb"" />
+          <slot startOffset=""0x32"" endOffset=""0xfa"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1038,17 +1038,16 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x32"" hidden=""true"" document=""0"" />
-        <entry offset=""0x3d"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x3e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x4a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x56"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x62"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x79"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""0"" />
-        <entry offset=""0xb0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xb7"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""0"" />
-        <entry offset=""0xee"" hidden=""true"" document=""0"" />
-        <entry offset=""0xf5"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x3d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x49"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x55"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x61"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x78"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""0"" />
+        <entry offset=""0xaf"" hidden=""true"" document=""0"" />
+        <entry offset=""0xb6"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""0"" />
+        <entry offset=""0xed"" hidden=""true"" document=""0"" />
+        <entry offset=""0xf4"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1150,7 +1149,7 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x17"" hidden=""true"" document=""0"" />
+        <entry offset=""0x17"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
         <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
         <entry offset=""0x23"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
         <entry offset=""0x2a"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
@@ -1222,7 +1221,7 @@ class C
 
             v.VerifyIL("C.<M>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      133 (0x85)
+  // Code size      132 (0x84)
   .maxstack  2
   .locals init (int V_0,
                 bool V_1)
@@ -1237,7 +1236,7 @@ class C
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
   IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_007a
+  IL_0014:  br.s       IL_0079
   IL_0016:  ldc.i4.0
   IL_0017:  stloc.1
   IL_0018:  ldloc.1
@@ -1248,40 +1247,39 @@ class C
   IL_0021:  ldarg.0
   IL_0022:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
   IL_0027:  stfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_002c:  nop
-  IL_002d:  ldarg.0
-  IL_002e:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0033:  ldc.i4.1
-  IL_0034:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
-  IL_0039:  ldarg.0
-  IL_003a:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_003f:  ldc.i4.1
-  IL_0040:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
-  IL_0045:  ldarg.0
-  IL_0046:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_004b:  ldc.i4.1
-  IL_004c:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
-  IL_0051:  ldarg.0
-  IL_0052:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0057:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
-  IL_005d:  newobj     ""System.Action..ctor(object, System.IntPtr)""
-  IL_0062:  callvirt   ""void System.Action.Invoke()""
-  IL_0067:  nop
-  IL_0068:  ldarg.0
-  IL_0069:  ldc.i4.1
-  IL_006a:  stfld      ""int C.<M>d__0.<>2__current""
-  IL_006f:  ldarg.0
-  IL_0070:  ldc.i4.1
-  IL_0071:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0076:  ldc.i4.1
-  IL_0077:  stloc.1
-  IL_0078:  br.s       IL_0018
-  IL_007a:  ldarg.0
-  IL_007b:  ldc.i4.m1
-  IL_007c:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0081:  ldc.i4.0
-  IL_0082:  stloc.1
-  IL_0083:  br.s       IL_0018
+  IL_002c:  ldarg.0
+  IL_002d:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0032:  ldc.i4.1
+  IL_0033:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
+  IL_0038:  ldarg.0
+  IL_0039:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_003e:  ldc.i4.1
+  IL_003f:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
+  IL_0044:  ldarg.0
+  IL_0045:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_004a:  ldc.i4.1
+  IL_004b:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
+  IL_0050:  ldarg.0
+  IL_0051:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0056:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
+  IL_005c:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0061:  callvirt   ""void System.Action.Invoke()""
+  IL_0066:  nop
+  IL_0067:  ldarg.0
+  IL_0068:  ldc.i4.1
+  IL_0069:  stfld      ""int C.<M>d__0.<>2__current""
+  IL_006e:  ldarg.0
+  IL_006f:  ldc.i4.1
+  IL_0070:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0075:  ldc.i4.1
+  IL_0076:  stloc.1
+  IL_0077:  br.s       IL_0018
+  IL_0079:  ldarg.0
+  IL_007a:  ldc.i4.m1
+  IL_007b:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0080:  ldc.i4.0
+  IL_0081:  stloc.1
+  IL_0082:  br.s       IL_0018
 }
 ");
 
@@ -1292,7 +1290,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x21"" endOffset=""0x84"" />
+          <slot startOffset=""0x21"" endOffset=""0x83"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1301,15 +1299,14 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x39"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x45"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x51"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x68"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x7a"" hidden=""true"" document=""0"" />
-        <entry offset=""0x81"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x21"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x38"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x44"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x50"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x67"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x79"" hidden=""true"" document=""0"" />
+        <entry offset=""0x80"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -139,15 +139,14 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""22"" endColumn=""11"" document=""0"" />
-        <entry offset=""0x1b"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""22"" document=""0"" />
-        <entry offset=""0x25"" startLine=""24"" startColumn=""5"" endLine=""24"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xd"" startLine=""14"" startColumn=""9"" endLine=""22"" endColumn=""11"" document=""0"" />
+        <entry offset=""0x1a"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""22"" document=""0"" />
+        <entry offset=""0x24"" startLine=""24"" startColumn=""5"" endLine=""24"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x27"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x26"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x26"" attributes=""0"" />
+        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x26"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_0"" name=""&lt;M&gt;b__0"" parameterNames=""x"">
@@ -160,16 +159,15 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""20"" endColumn=""15"" document=""0"" />
-        <entry offset=""0x29"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""26"" document=""0"" />
-        <entry offset=""0x33"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x0"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x14"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x1b"" startLine=""17"" startColumn=""13"" endLine=""20"" endColumn=""15"" document=""0"" />
+        <entry offset=""0x28"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""26"" document=""0"" />
+        <entry offset=""0x32"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x35"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x34"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x34"" attributes=""0"" />
+        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x34"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_1"" name=""&lt;M&gt;b__1"" parameterNames=""y"">
@@ -220,15 +218,14 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xd"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
-        <entry offset=""0xe"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""39"" document=""0"" />
-        <entry offset=""0x1b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""14"" document=""0"" />
-        <entry offset=""0x22"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xd"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""39"" document=""0"" />
+        <entry offset=""0x1a"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""14"" document=""0"" />
+        <entry offset=""0x21"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x23"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x22"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
+        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c__DisplayClass0_0"" name=""&lt;Foo&gt;b__0"">
@@ -313,15 +310,14 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""19"" endColumn=""11"" document=""0"" />
-        <entry offset=""0x1b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""22"" document=""0"" />
-        <entry offset=""0x25"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xd"" startLine=""14"" startColumn=""9"" endLine=""19"" endColumn=""11"" document=""0"" />
+        <entry offset=""0x1a"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""22"" document=""0"" />
+        <entry offset=""0x24"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x27"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
-        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x26"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x26"" attributes=""0"" />
+        <local name=""f1"" il_index=""1"" il_start=""0x0"" il_end=""0x26"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_0"" name=""&lt;M&gt;b__0"" parameterNames=""x"">
@@ -334,16 +330,15 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""66"" document=""0"" />
-        <entry offset=""0x29"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""26"" document=""0"" />
-        <entry offset=""0x33"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x0"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x14"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x1b"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""66"" document=""0"" />
+        <entry offset=""0x28"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""26"" document=""0"" />
+        <entry offset=""0x32"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x35"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
-        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x34"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x34"" attributes=""0"" />
+        <local name=""f2"" il_index=""1"" il_start=""0x0"" il_end=""0x34"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_1"" name=""&lt;M&gt;b__1"" parameterNames=""y"">
@@ -536,19 +531,18 @@ class C : B
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x27"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x2e"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""0"" />
-        <entry offset=""0x35"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x47"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x59"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x6b"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""43"" document=""0"" />
+        <entry offset=""0x27"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2d"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""0"" />
+        <entry offset=""0x34"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x46"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x58"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x6a"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x6c"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x6c"" attributes=""0"" />
-        <scope startOffset=""0x27"" endOffset=""0x6b"">
-          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x27"" il_end=""0x6b"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x6b"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x6b"" attributes=""0"" />
+        <scope startOffset=""0x27"" endOffset=""0x6a"">
+          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x27"" il_end=""0x6a"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -631,16 +625,15 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""0"" />
-        <entry offset=""0xe"" startLine=""9"" startColumn=""9"" endLine=""12"" endColumn=""31"" document=""0"" />
-        <entry offset=""0x79"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x6"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""0"" />
+        <entry offset=""0xd"" startLine=""9"" startColumn=""9"" endLine=""12"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x78"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x7a"">
+      <scope startOffset=""0x0"" endOffset=""0x79"">
         <namespace name=""System.Linq"" />
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
-        <local name=""x"" il_index=""1"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x79"" attributes=""0"" />
+        <local name=""x"" il_index=""1"" il_start=""0x0"" il_end=""0x79"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass0_0"" name=""&lt;M&gt;b__0"" parameterNames=""a"">
@@ -825,23 +818,21 @@ class C
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" document=""0"" />
         <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""39"" document=""0"" />
         <entry offset=""0xf"" hidden=""true"" document=""0"" />
-        <entry offset=""0x11"" hidden=""true"" document=""0"" />
-        <entry offset=""0x17"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x20"" hidden=""true"" document=""0"" />
-        <entry offset=""0x26"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x27"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x2e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x41"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x54"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x55"" hidden=""true"" document=""0"" />
-        <entry offset=""0x59"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x5f"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x11"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x20"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x26"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x2d"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x40"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x53"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x54"" hidden=""true"" document=""0"" />
+        <entry offset=""0x58"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x5e"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x60"">
-        <scope startOffset=""0x11"" endOffset=""0x55"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0x11"" il_end=""0x55"" attributes=""0"" />
-          <scope startOffset=""0x20"" endOffset=""0x55"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x20"" il_end=""0x55"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x5f"">
+        <scope startOffset=""0x11"" endOffset=""0x54"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0x11"" il_end=""0x54"" attributes=""0"" />
+          <scope startOffset=""0x20"" endOffset=""0x54"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x20"" il_end=""0x54"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -905,25 +896,23 @@ class C
         <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""44"" document=""0"" />
         <entry offset=""0x2b"" hidden=""true"" document=""0"" />
         <entry offset=""0x36"" hidden=""true"" document=""0"" />
-        <entry offset=""0x38"" hidden=""true"" document=""0"" />
-        <entry offset=""0x3f"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x4f"" hidden=""true"" document=""0"" />
-        <entry offset=""0x56"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x57"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x5f"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x73"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x88"" hidden=""true"" document=""0"" />
-        <entry offset=""0x8e"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x93"" hidden=""true"" document=""0"" />
-        <entry offset=""0x97"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x9b"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x38"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x4f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x56"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x5e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x72"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x86"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x87"" hidden=""true"" document=""0"" />
+        <entry offset=""0x8d"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x92"" hidden=""true"" document=""0"" />
+        <entry offset=""0x96"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x9a"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x9c"">
-        <scope startOffset=""0x38"" endOffset=""0x88"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""5"" il_start=""0x38"" il_end=""0x88"" attributes=""0"" />
-          <scope startOffset=""0x4f"" endOffset=""0x88"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""6"" il_start=""0x4f"" il_end=""0x88"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x9b"">
+        <scope startOffset=""0x38"" endOffset=""0x87"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""5"" il_start=""0x38"" il_end=""0x87"" attributes=""0"" />
+          <scope startOffset=""0x4f"" endOffset=""0x87"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""6"" il_start=""0x4f"" il_end=""0x87"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -983,23 +972,21 @@ class C
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" document=""0"" />
         <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""31"" document=""0"" />
         <entry offset=""0xa"" hidden=""true"" document=""0"" />
-        <entry offset=""0xc"" hidden=""true"" document=""0"" />
-        <entry offset=""0x12"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x1f"" hidden=""true"" document=""0"" />
-        <entry offset=""0x25"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x26"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x40"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x53"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x54"" hidden=""true"" document=""0"" />
-        <entry offset=""0x58"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x61"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xc"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x25"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x2c"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x3f"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x52"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x53"" hidden=""true"" document=""0"" />
+        <entry offset=""0x57"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x60"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x62"">
-        <scope startOffset=""0xc"" endOffset=""0x54"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0xc"" il_end=""0x54"" attributes=""0"" />
-          <scope startOffset=""0x1f"" endOffset=""0x54"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x1f"" il_end=""0x54"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x61"">
+        <scope startOffset=""0xc"" endOffset=""0x53"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""2"" il_start=""0xc"" il_end=""0x53"" attributes=""0"" />
+          <scope startOffset=""0x1f"" endOffset=""0x53"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""3"" il_start=""0x1f"" il_end=""0x53"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -1059,23 +1046,21 @@ class C
         <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" document=""0"" />
         <entry offset=""0x2"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""43"" document=""0"" />
         <entry offset=""0xd"" hidden=""true"" document=""0"" />
-        <entry offset=""0xf"" hidden=""true"" document=""0"" />
-        <entry offset=""0x15"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x22"" hidden=""true"" document=""0"" />
-        <entry offset=""0x28"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x29"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x30"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x43"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x56"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x57"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x62"" hidden=""true"" document=""0"" />
-        <entry offset=""0x71"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
+        <entry offset=""0xf"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x22"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x28"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x2f"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x42"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x55"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x56"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x61"" hidden=""true"" document=""0"" />
+        <entry offset=""0x70"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x72"">
-        <scope startOffset=""0xf"" endOffset=""0x57"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xf"" il_end=""0x57"" attributes=""0"" />
-          <scope startOffset=""0x22"" endOffset=""0x57"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""2"" il_start=""0x22"" il_end=""0x57"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x71"">
+        <scope startOffset=""0xf"" endOffset=""0x56"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xf"" il_end=""0x56"" attributes=""0"" />
+          <scope startOffset=""0x22"" endOffset=""0x56"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""2"" il_start=""0x22"" il_end=""0x56"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -1132,25 +1117,23 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" startLine=""10"" startColumn=""14"" endLine=""10"" endColumn=""24"" document=""0"" />
         <entry offset=""0xe"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""32"" document=""0"" />
         <entry offset=""0x15"" hidden=""true"" document=""0"" />
-        <entry offset=""0x17"" hidden=""true"" document=""0"" />
-        <entry offset=""0x1d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x1e"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x25"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x38"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x39"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""58"" document=""0"" />
-        <entry offset=""0x63"" hidden=""true"" document=""0"" />
-        <entry offset=""0x66"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x1d"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x24"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x37"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x38"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""58"" document=""0"" />
+        <entry offset=""0x62"" hidden=""true"" document=""0"" />
+        <entry offset=""0x65"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x67"">
+      <scope startOffset=""0x0"" endOffset=""0x66"">
         <namespace name=""System"" />
-        <scope startOffset=""0x1"" endOffset=""0x66"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x66"" attributes=""0"" />
-          <scope startOffset=""0x17"" endOffset=""0x39"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x17"" il_end=""0x39"" attributes=""0"" />
+        <scope startOffset=""0x1"" endOffset=""0x65"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x65"" attributes=""0"" />
+          <scope startOffset=""0x17"" endOffset=""0x38"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x17"" il_end=""0x38"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -1218,25 +1201,24 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x6"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""20"" document=""0"" />
-        <entry offset=""0xe"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x21"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""0"" />
-        <entry offset=""0x2e"" hidden=""true"" document=""0"" />
-        <entry offset=""0x3a"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""28"" document=""0"" />
-        <entry offset=""0x41"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""29"" document=""0"" />
-        <entry offset=""0x54"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x56"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""28"" document=""0"" />
-        <entry offset=""0x5d"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""29"" document=""0"" />
-        <entry offset=""0x70"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x72"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x6"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""20"" document=""0"" />
+        <entry offset=""0xd"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x20"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""0"" />
+        <entry offset=""0x2d"" hidden=""true"" document=""0"" />
+        <entry offset=""0x39"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""28"" document=""0"" />
+        <entry offset=""0x40"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x53"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x55"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""28"" document=""0"" />
+        <entry offset=""0x5c"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""29"" document=""0"" />
+        <entry offset=""0x6f"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x71"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x73"">
+      <scope startOffset=""0x0"" endOffset=""0x72"">
         <namespace name=""System"" />
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
-        <scope startOffset=""0x21"" endOffset=""0x72"">
-          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x21"" il_end=""0x72"" attributes=""0"" />
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x72"" attributes=""0"" />
+        <scope startOffset=""0x20"" endOffset=""0x71"">
+          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x20"" il_end=""0x71"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -1301,27 +1283,25 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1"" hidden=""true"" document=""0"" />
         <entry offset=""0x7"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""36"" document=""0"" />
         <entry offset=""0x12"" startLine=""12"" startColumn=""38"" endLine=""12"" endColumn=""46"" document=""0"" />
-        <entry offset=""0x1d"" hidden=""true"" document=""0"" />
-        <entry offset=""0x23"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x24"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x2b"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""25"" document=""0"" />
-        <entry offset=""0x3d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""25"" document=""0"" />
-        <entry offset=""0x4f"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""0"" />
-        <entry offset=""0x61"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x64"" hidden=""true"" document=""0"" />
-        <entry offset=""0x79"" hidden=""true"" document=""0"" />
-        <entry offset=""0x7b"" hidden=""true"" document=""0"" />
-        <entry offset=""0x90"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x23"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""25"" document=""0"" />
+        <entry offset=""0x3c"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""25"" document=""0"" />
+        <entry offset=""0x4e"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""0"" />
+        <entry offset=""0x60"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x63"" hidden=""true"" document=""0"" />
+        <entry offset=""0x78"" hidden=""true"" document=""0"" />
+        <entry offset=""0x7a"" hidden=""true"" document=""0"" />
+        <entry offset=""0x8f"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x91"">
+      <scope startOffset=""0x0"" endOffset=""0x90"">
         <namespace name=""System"" />
-        <scope startOffset=""0x1"" endOffset=""0x90"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x90"" attributes=""0"" />
-          <scope startOffset=""0x1d"" endOffset=""0x62"">
-            <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x1d"" il_end=""0x62"" attributes=""0"" />
+        <scope startOffset=""0x1"" endOffset=""0x8f"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x8f"" attributes=""0"" />
+          <scope startOffset=""0x1d"" endOffset=""0x61"">
+            <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x1d"" il_end=""0x61"" attributes=""0"" />
           </scope>
         </scope>
       </scope>
@@ -1329,6 +1309,294 @@ class C
   </methods>
 </symbols>
 ");
+        }
+
+        [WorkItem(749138, "DevDiv")]
+        [Fact]
+        public void SequencePoints_Delegate_Method()
+        {
+            var source = @"
+using System;
+class C
+{
+    public static void Main()
+    {
+        Action a = null;
+        a = (Action)delegate { a = null; };
+        a();
+    }
+}
+";
+
+            // Verify the sequence point on the display class construction
+            var c = CompileAndVerify(source, options: TestOptions.DebugDll);
+            c.VerifyIL("C.Main", @"
+{ 
+  // Code size       44 (0x2c)
+  .maxstack  3
+  .locals init (C.<>c__DisplayClass0_0 V_0) //CS$<>8__locals0
+ -IL_0000:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.0
+ -IL_0006:  ldloc.0
+  IL_0007:  ldnull
+  IL_0008:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_000d:  ldloc.0
+  IL_000e:  ldloc.0
+  IL_000f:  ldftn      ""void C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_0015:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_001a:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_001f:  ldloc.0
+  IL_0020:  ldfld      ""System.Action C.<>c__DisplayClass0_0.a""
+  IL_0025:  callvirt   ""void System.Action.Invoke()""
+  IL_002a:  nop
+ -IL_002b:  ret
+}
+", sequencePoints: "C.Main");
+        }
+
+        [WorkItem(749138, "DevDiv")]
+        [Fact]
+        public void SequencePoints_Delegate_IfClause()
+        {
+            var source = @"
+using System;
+class C
+{
+    public static void Main()
+    {
+        bool b = true;
+        if (b)
+        {
+            Action a = null;
+            a = (Action)delegate { a = null; };
+            a();
+        }
+    }
+}
+";
+
+            // Verify the sequence point on the display class construction
+            var c = CompileAndVerify(source, options: TestOptions.DebugDll);
+            c.VerifyIL("C.Main", @"
+{ 
+  // Code size       53 (0x35)
+  .maxstack  3
+  .locals init (bool V_0, //b
+                bool V_1,
+                C.<>c__DisplayClass0_0 V_2) //CS$<>8__locals0
+ -IL_0000:  nop
+ -IL_0001:  ldc.i4.1
+  IL_0002:  stloc.0
+ -IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+ ~IL_0005:  ldloc.1
+  IL_0006:  brfalse.s  IL_0034
+ -IL_0008:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_000d:  stloc.2
+ -IL_000e:  ldloc.2
+  IL_000f:  ldnull
+  IL_0010:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0015:  ldloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  ldftn      ""void C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_001d:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0022:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0027:  ldloc.2
+  IL_0028:  ldfld      ""System.Action C.<>c__DisplayClass0_0.a""
+  IL_002d:  callvirt   ""void System.Action.Invoke()""
+  IL_0032:  nop
+ -IL_0033:  nop
+ -IL_0034:  ret
+}
+", sequencePoints: "C.Main");
+        }
+
+        [WorkItem(749138, "DevDiv")]
+        [Fact]
+        public void SequencePoints_Delegate_Block()
+        {
+            var source = @"
+using System;
+class C
+{
+    public static void Main()
+    {
+        {
+            Action a = null;
+            a = (Action)delegate { a = null; };
+            a();
+        }
+    }
+}
+";
+
+            // Verify the sequence point on the display class construction
+            var c = CompileAndVerify(source, options: TestOptions.DebugDll);
+            c.VerifyIL("C.Main", @"
+{ 
+  // Code size       46 (0x2e)
+  .maxstack  3
+  .locals init (C.<>c__DisplayClass0_0 V_0) //CS$<>8__locals0
+ -IL_0000:  nop
+ -IL_0001:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_0006:  stloc.0
+ -IL_0007:  ldloc.0
+  IL_0008:  ldnull
+  IL_0009:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_000e:  ldloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldftn      ""void C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_0016:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_001b:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0020:  ldloc.0
+  IL_0021:  ldfld      ""System.Action C.<>c__DisplayClass0_0.a""
+  IL_0026:  callvirt   ""void System.Action.Invoke()""
+  IL_002b:  nop
+ -IL_002c:  nop
+ -IL_002d:  ret
+}
+", sequencePoints: "C.Main");
+        }
+
+        [WorkItem(749138, "DevDiv")]
+        [Fact]
+        public void SequencePoints_Delegate_For()
+        {
+            var source = @"
+using System;
+class C
+{
+    public static void Main()
+    {       
+        for (int x = 0; x < 10; x++)
+        {
+            Action a = null;
+            a = (Action)delegate { a = null; };
+            a();
+        }
+    }
+}
+";
+
+            // Verify the sequence point on the display class construction
+            var c = CompileAndVerify(source, options: TestOptions.DebugDll);
+            c.VerifyIL("C.Main", @"
+{ 
+  // Code size       65 (0x41)
+  .maxstack  3
+  .locals init (int V_0, //x
+                C.<>c__DisplayClass0_0 V_1, //CS$<>8__locals0
+                int V_2,
+                bool V_3)
+ -IL_0000:  nop
+ -IL_0001:  ldc.i4.0
+  IL_0002:  stloc.0
+ ~IL_0003:  br.s       IL_0037
+ -IL_0005:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_000a:  stloc.1
+ -IL_000b:  ldloc.1
+  IL_000c:  ldnull
+  IL_000d:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0012:  ldloc.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldftn      ""void C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_001a:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_001f:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0024:  ldloc.1
+  IL_0025:  ldfld      ""System.Action C.<>c__DisplayClass0_0.a""
+  IL_002a:  callvirt   ""void System.Action.Invoke()""
+  IL_002f:  nop
+ -IL_0030:  nop
+ -IL_0031:  ldloc.0
+  IL_0032:  stloc.2
+  IL_0033:  ldloc.2
+  IL_0034:  ldc.i4.1
+  IL_0035:  add
+  IL_0036:  stloc.0
+ -IL_0037:  ldloc.0
+  IL_0038:  ldc.i4.s   10
+  IL_003a:  clt
+  IL_003c:  stloc.3
+ ~IL_003d:  ldloc.3
+  IL_003e:  brtrue.s   IL_0005
+ -IL_0040:  ret
+}
+", sequencePoints: "C.Main");
+        }
+
+        [WorkItem(749138, "DevDiv")]
+        [Fact]
+        public void SequencePoints_Delegate_ForEach()
+        {
+            var source = @"
+using System;
+class C
+{
+    public static void Main()
+    {       
+        foreach (int x in new[] { 1 })
+        {
+            Action a = null;
+            a = (Action)delegate { a = null; };
+            a();
+        }
+    }
+}
+";
+
+            // Verify the sequence point on the display class construction
+            var c = CompileAndVerify(source, options: TestOptions.DebugDll);
+            c.VerifyIL("C.Main", @"
+{ 
+  // Code size       76 (0x4c)
+  .maxstack  4
+  .locals init (int[] V_0,
+                int V_1,
+                int V_2, //x
+                C.<>c__DisplayClass0_0 V_3) //CS$<>8__locals0
+ -IL_0000:  nop
+ -IL_0001:  nop
+ -IL_0002:  ldc.i4.1
+  IL_0003:  newarr     ""int""
+  IL_0008:  dup
+  IL_0009:  ldc.i4.0
+  IL_000a:  ldc.i4.1
+  IL_000b:  stelem.i4
+  IL_000c:  stloc.0
+  IL_000d:  ldc.i4.0
+  IL_000e:  stloc.1
+ ~IL_000f:  br.s       IL_0045
+ -IL_0011:  ldloc.0
+  IL_0012:  ldloc.1
+  IL_0013:  ldelem.i4
+  IL_0014:  stloc.2
+ -IL_0015:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_001a:  stloc.3
+ -IL_001b:  ldloc.3
+  IL_001c:  ldnull
+  IL_001d:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0022:  ldloc.3
+  IL_0023:  ldloc.3
+  IL_0024:  ldftn      ""void C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_002a:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_002f:  stfld      ""System.Action C.<>c__DisplayClass0_0.a""
+ -IL_0034:  ldloc.3
+  IL_0035:  ldfld      ""System.Action C.<>c__DisplayClass0_0.a""
+  IL_003a:  callvirt   ""void System.Action.Invoke()""
+  IL_003f:  nop
+ -IL_0040:  nop
+ ~IL_0041:  ldloc.1
+  IL_0042:  ldc.i4.1
+  IL_0043:  add
+  IL_0044:  stloc.1
+ -IL_0045:  ldloc.1
+  IL_0046:  ldloc.0
+  IL_0047:  ldlen
+  IL_0048:  conv.i4
+  IL_0049:  blt.s      IL_0011
+ -IL_004b:  ret
+}
+", sequencePoints: "C.Main");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -323,8 +323,7 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0xd"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" document=""0"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" document=""0"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1e"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />


### PR DESCRIPTION
This happens since setting next statement skips the closure initialization, which marks as hidden sequence point. 

In this PR, we emit a regular sequence point instead of a hidden sequence point to closure initialization when it is located inside of conditional blocks like 'if (b) { ... }', so IP move won't skip closure initialization.