### PR TITLE
Offer to generate static class in Imports statement

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -747,6 +747,23 @@ NewLines("Public Interface I \n  Sub Foo(a As X.Y.Z) \n End Interface \n Public 
 index:=0)
         End Sub
 
+        <WorkItem(1130905)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeInImports()
+            Test(
+NewLines("Imports [|Fizz|]"),
+NewLines("Friend Class Fizz\nEnd Class\n"), isAddedDocument:=True)
+        End Sub
+
+        <WorkItem(1130905)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeInImports2()
+            Test(
+NewLines("Imports [|Fizz|]"),
+NewLines("Imports Fizz \n Friend Class Fizz \n End Class"),
+index:=1)
+        End Sub
+
         Public Class AddImportTestsWithAddImportDiagnosticProvider
             Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 

--- a/src/Features/VisualBasic/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
@@ -23,10 +23,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateType
         Friend Const BC32042 As String = "BC32042" ' error BC32042: Too few type arguments to 'AA(Of T)'.
         Friend Const BC32043 As String = "BC32043" ' error BC32043: Too many type arguments to 'AA(Of T)'.
         Friend Const BC32045 As String = "BC32045" ' error BC32045: 'Foo' has no type parameters and so cannot have type arguments.
+        Friend Const BC40056 As String = "BC40056" ' error BC40056: Namespace or type specified in the Imports 'A' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30182, BC30451, BC30456, BC32042, BC32043, BC32045)
+                Return ImmutableArray.Create(BC30002, BC30182, BC30451, BC30456, BC32042, BC32043, BC32045, BC40056)
             End Get
         End Property
 

--- a/src/Features/VisualBasic/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/GenerateType/VisualBasicGenerateTypeService.vb
@@ -90,10 +90,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
                 document As SemanticDocument, simpleName As SimpleNameSyntax, cancellationToken As CancellationToken, ByRef generateTypeServiceStateOptions As GenerateTypeServiceStateOptions) As Boolean
             generateTypeServiceStateOptions = New GenerateTypeServiceStateOptions()
 
-            If simpleName.GetAncestorOrThis(Of ImportsStatementSyntax)() IsNot Nothing Then
-                Return False
-            End If
-
             If simpleName.IsParentKind(SyntaxKind.DictionaryAccessExpression) Then
                 Return False
             End If


### PR DESCRIPTION
We now offer to generate types in imports statements, matching the
behavior of using static in C#

Fixes internal bug 1130905