### PR TITLE
Fix FindSymbolAtPosition when invoked on user-defined operators

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
@@ -21,7 +21,49 @@ End Module
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub CSharpFindReferencesOnOperatorOverload()
+        Public Sub CSharpFindReferencesOnUnaryOperatorOverload()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class A
+{
+    void Foo()
+    {
+        A a;
+        var x = $$[|-|]a;
+    }
+    public static A operator {|Definition:-|}(A a) { return a; }}
+}
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub CSharpFindReferencesOnUnaryOperatorOverloadFromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class A
+{
+    void Foo()
+    {
+        A a;
+        var x = [|-|]a;
+    }
+    public static A operator {|Definition:$$-|}(A a) { return a; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub CSharpFindReferencesOnBinaryOperatorOverload()
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -39,8 +81,73 @@ class A
 </Workspace>
             Test(input)
         End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub VisualBasicFindReferencesOnOperatorOverload()
+        Public Sub CSharpFindReferencesOnBinaryOperatorOverloadFromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class A
+{
+    void Foo()
+    {
+        var x = new A() [|+|] new A();
+    }
+    public static A operator {|Definition:$$+|}(A a, A b) { return a; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub VisualBasicFindReferencesOnUnaryOperatorOverload()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class A
+    Public Shared Operator {|Definition:-|}(x As A) As A
+        Return x
+    End Operator
+
+    Sub Foo()
+        Dim a As A
+        Dim b = $$[|-|]a
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub VisualBasicFindReferencesOnUnaryOperatorOverloadFromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class A
+    Public Shared Operator {|Definition:$$-|}(x As A) As A
+        Return x
+    End Operator
+
+    Sub Foo()
+        Dim a As A
+        Dim b = [|-|]a
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub VisualBasicFindReferencesOnBinaryOperatorOverload()
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -52,6 +159,27 @@ Class A
 
     Sub Foo()
         Dim a = New A [|^$$|] New A
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub VisualBasicFindReferencesOnBinaryOperatorOverloadFromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class A
+    Public Shared Operator {|Definition:$$^|}(x As A, y As A) As A
+        Return y
+    End Operator
+
+    Sub Foo()
+        Dim a = New A [|^|] New A
     End Sub
 End Class
         </Document>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
@@ -1365,126 +1365,8 @@ End Class]]>
             Test(input)
         End Sub
 
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref1()
-            Dim input =
-<Workspace>
-    <Project Language="C#" CommonReferences="true">
-        <Document><![CDATA[
-                using System;
-                class Test
-                {
-                    /// <summary>
-                    /// <see cref="[|operator|] !"/>
-                    /// <see cref="[|operator|] +"/>
-                    /// <see cref="[|$$operator|]"/>
-                    /// </summary>
-                    /// <param name="t"></param>
-                    /// <returns></returns>
-                    public static Test {|Definition:operator|} !(Test t)
-                    {
-                        return new Test();
-                    }
-                    public static int {|Definition:operator|} +(Test t1, Test t2)
-                    {
-                        return 1;
-                    }
-                }]]>
-        </Document>
-    </Project>
-</Workspace>
-            Test(input)
-        End Sub
-
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref1_VisualBasic()
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document><![CDATA[
-                Imports System
-                Class Test
-                    ''' <summary>
-                    ''' <see cref="[|Operator|] Not"/>
-                    ''' <see cref="[|Operator|] +"/>
-                    ''' <see cref="[|$$Operator|]"/>
-                    ''' </summary>
-                    ''' <param name="t"></param>
-                    ''' <returns></returns>
-                    Public Shared {|Definition:Operator|} Not(t As Test) As Test
-                        Return New Test()
-                    End Operator
-                    Public Shared {|Definition:Operator|} +(t1 As Test, t2 As Test) As Integer
-                        Return 1
-                    End Operator
-                End Class]]>
-        </Document>
-    </Project>
-</Workspace>
-            Test(input)
-        End Sub
-
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref2()
-            Dim input =
-<Workspace>
-    <Project Language="C#" CommonReferences="true">
-        <Document><![CDATA[
-                using System;
-                class Test
-                {
-                    /// <summary>
-                    /// <see cref="[|$$operator|] !"/>
-                    /// <see cref="operator +"/>
-                    /// <see cref="[|operator|]"/>
-                    /// </summary>
-                    /// <param name="t"></param>
-                    /// <returns></returns>
-                    public static Test {|Definition:operator|} !(Test t)
-                    {
-                        return new Test();
-                    }
-                    public static int operator +(Test t1, Test t2)
-                    {
-                        return 1;
-                    }
-                }]]>
-        </Document>
-    </Project>
-</Workspace>
-            Test(input)
-        End Sub
-
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref2_VisualBasic()
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document><![CDATA[
-                Imports System
-                Class Test
-                    ''' <summary>
-                    ''' <see cref="[|$$Operator|] Not"/>
-                    ''' <see cref="Operator +"/>
-                    ''' <see cref="[|Operator|]"/>
-                    ''' </summary>
-                    ''' <param name="t"></param>
-                    ''' <returns></returns>
-                    Public Shared {|Definition:Operator|} Not(t As Test) As Test
-                        Return New Test()
-                    End Operator
-                    Public Shared Operator +(t1 As Test, t2 As Test) As Integer
-                        Return 1
-                    End Operator
-                End Class]]>
-        </Document>
-    </Project>
-</Workspace>
-            Test(input)
-        End Sub
-
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref3()
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestOperatorInCref()
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1494,9 +1376,7 @@ End Class]]>
                 {
                     /// <summary>
                     /// <see cref="operator !"/>
-                    /// <see cref="[|$$operator|] +"/>
-                    /// <see cref="[|operator|](Test,Test)"/>
-                    /// <see cref="[|operator|]"/>
+                    /// <see cref="operator [|+|]"/>
                     /// </summary>
                     /// <param name="t"></param>
                     /// <returns></returns>
@@ -1504,7 +1384,7 @@ End Class]]>
                     {
                         return new Test();
                     }
-                    public static int {|Definition:operator|} +(Test t1, Test t2)
+                    public static int operator {|Definition:$$+|}(Test t1, Test t2)
                     {
                         return 1;
                     }
@@ -1515,8 +1395,8 @@ End Class]]>
             Test(input)
         End Sub
 
-        <Fact(Skip:="641100"), Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestOperatorInCref3_VisualBasic()
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestOperatorInCrefVisualBasic()
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -1524,17 +1404,15 @@ End Class]]>
                 Imports System
                 Class Test
                     ''' <summary>
-                    ''' <see cref="Operator Not"/>
-                    ''' <see cref="[|$$Operator|] +"/>
-                    ''' <see cref="[|Operator|](Test,Test)"/>
-                    ''' <see cref="[|Operator|]"/>
+                    ''' <see cref="Operator Not(Test)"/>
+                    ''' <see cref="Operator [|+|](Test, Test)"/>
                     ''' </summary>
                     ''' <param name="t"></param>
                     ''' <returns></returns>
                     Public Shared Operator Not(t As Test) As Test
                         Return New Test()
                     End Operator
-                    Public Shared {|Definition:Operator|} +(t1 As Test, t2 As Test) As Integer
+                    Public Shared Operator {|Definition:$$+|}(t1 As Test, t2 As Test) As Integer
                         Return 1
                     End Operator
                 End Class]]>

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -47,8 +47,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return
                 (SyntaxFacts.IsAnyUnaryExpression(kind) &&
-                    (token.Parent is PrefixUnaryExpressionSyntax || token.Parent is PostfixUnaryExpressionSyntax)) ||
-                (SyntaxFacts.IsBinaryExpression(kind) && token.Parent is BinaryExpressionSyntax) ||
+                    (token.Parent is PrefixUnaryExpressionSyntax || token.Parent is PostfixUnaryExpressionSyntax || token.Parent is OperatorDeclarationSyntax)) ||
+                (SyntaxFacts.IsBinaryExpression(kind) && (token.Parent is BinaryExpressionSyntax || token.Parent is OperatorDeclarationSyntax)) ||
                 (SyntaxFacts.IsAssignmentExpressionOperatorToken(kind) && token.Parent is AssignmentExpressionSyntax);
         }
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -33,8 +33,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function IsOperator(token As SyntaxToken) As Boolean Implements ISyntaxFactsService.IsOperator
-            Return (IsUnaryExpressionOperatorToken(CType(token.Kind, SyntaxKind)) AndAlso TypeOf token.Parent Is UnaryExpressionSyntax) OrElse
-                   (IsBinaryExpressionOperatorToken(CType(token.Kind, SyntaxKind)) AndAlso TypeOf token.Parent Is BinaryExpressionSyntax)
+            Return (IsUnaryExpressionOperatorToken(CType(token.Kind, SyntaxKind)) AndAlso (TypeOf token.Parent Is UnaryExpressionSyntax OrElse TypeOf token.Parent Is OperatorStatementSyntax)) OrElse
+                   (IsBinaryExpressionOperatorToken(CType(token.Kind, SyntaxKind)) AndAlso (TypeOf token.Parent Is BinaryExpressionSyntax OrElse TypeOf token.Parent Is OperatorStatementSyntax))
         End Function
 
         Public Function IsContextualKeyword(token As SyntaxToken) As Boolean Implements ISyntaxFactsService.IsContextualKeyword


### PR DESCRIPTION
SymbolFinder.FindSymbolAtPosition was rejecting user-defined operators
if it was invoked on the declaration of a user-defined operator. Uses
worked just fine.

Fixes issue #1773.