### PR TITLE
check a symbol for null before descending into its base type

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
                 // if generating quick info for an attribute, bind to the class instead of the constructor
                 if (syntaxFactsService.IsAttributeName(token.Parent) &&
-                    symbol.ContainingType.IsAttribute())
+                    symbol.ContainingType?.IsAttribute() == true)
                 {
                     symbol = symbol.ContainingType;
                 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 ////
                 if (originalSimpleName.GetAncestor<AttributeSyntax>() != null)
                 {
-                    if (symbol.IsConstructor() && symbol.ContainingType.IsAttribute())
+                    if (symbol.IsConstructor() && symbol.ContainingType?.IsAttribute() == true)
                     {
                         symbol = symbol.ContainingType;
                         var name = symbol.Name;

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -481,7 +481,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 ' 2. If it's an attribute, make sure the identifier matches the attribute's class name without the attribute suffix.
                 '
                 If originalSimpleName.GetAncestor(Of AttributeSyntax)() IsNot Nothing Then
-                    If symbol.IsConstructor() AndAlso symbol.ContainingType.IsAttribute() Then
+                    If symbol.IsConstructor() AndAlso symbol.ContainingType?.IsAttribute() Then
                         symbol = symbol.ContainingType
                         Dim name = symbol.Name
                         Debug.Assert(name.StartsWith(originalSimpleName.Identifier.ValueText, StringComparison.Ordinal))


### PR DESCRIPTION
When preparing quick info for attributes, there are corner cases where the symbol's containing type could be null (e.g., the type or one of its subtypes comes from an unreferenced assembly.)  The ultimate entry into this case was really in [AbstractSemanticQuickInfoProvider.cs](https://github.com/dotnet/roslyn/blob/8053b00c08ac33c44917d9f6eb20f6467ae7b55d/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs#L238) but in reviewing calls to `ITypeSymbolExtensions.IsAttribute()` there were at least two other locations that could potentially hit the same null ref, [here](https://github.com/dotnet/roslyn/blob/8053b00c08ac33c44917d9f6eb20f6467ae7b55d/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb#L484) and [here](https://github.com/dotnet/roslyn/blob/8053b00c08ac33c44917d9f6eb20f6467ae7b55d/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs#L429), so I though it would be better to fix it at the root rather than patch all of the call sites and hope no more were created, though I'm certainly open to discussion here.

I was unable to repro this manually and I couldn't construct a failing test without a lot of hackery, hence no added/updated unit test.

Fixes #2440.