### PR TITLE
Add missing On keyword to Option statements

### DIFF
--- a/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
@@ -2789,6 +2789,39 @@ End Module";
             Verify(code, expected);
         }
 
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        public void OptionExplicitOn()
+        {
+            var code = @"[|Option Explicit|]";
+            var expected = @"Option Explicit On
+";
+
+            Verify(code, expected);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        public void OptionInferOn()
+        {
+            var code = @"[|Option Infer|]";
+            var expected = @"Option Infer On
+";
+
+            Verify(code, expected);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        public void OptionStrictOn()
+        {
+            var code = @"[|Option Strict|]";
+            var expected = @"Option Strict On
+";
+
+            Verify(code, expected);
+        }
+
         private string CreateMethod(string body)
         {
             return @"Imports System


### PR DESCRIPTION
Add logic to AddMissingTokensCleanupProvider to add omitted On keyword from end of Option Explicit, Option Strict and Option Infer statements

Fixes tfs 1151995

@Pilchie @basoundr  please review