### PR TITLE
update comment banner matchers to not require a trailing newline

### DIFF
--- a/src/EditorFeatures/CSharpTest/Organizing/OrganizeUsingsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/OrganizeUsingsTests.cs
@@ -435,6 +435,7 @@ namespace B { }";
             Check(initial, final, true);
         }
 
+        [WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")]
         [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
         public void DoTouchCommentsAtBeginningOfFile1()
         {
@@ -448,9 +449,9 @@ namespace A { }
 namespace B { }";
 
             var final =
-@"// I like namespace A
+@"// Copyright (c) Microsoft Corporation.  All rights reserved.
+// I like namespace A
 using A;
-// Copyright (c) Microsoft Corporation.  All rights reserved.
 using B;
 
 namespace A { }
@@ -459,6 +460,7 @@ namespace B { }";
             Check(initial, final, true);
         }
 
+        [WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")]
         [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
         public void DoTouchCommentsAtBeginningOfFile2()
         {
@@ -472,9 +474,9 @@ namespace A { }
 namespace B { }";
 
             var final =
-@"/* I like namespace A */
+@"/* Copyright (c) Microsoft Corporation.  All rights reserved. */
+/* I like namespace A */
 using A;
-/* Copyright (c) Microsoft Corporation.  All rights reserved. */
 using B;
 
 namespace A { }
@@ -483,6 +485,7 @@ namespace B { }";
             Check(initial, final, true);
         }
 
+        [WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")]
         [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
         public void DoTouchCommentsAtBeginningOfFile3()
         {
@@ -503,6 +506,58 @@ using B;
 
 namespace A { }
 namespace B { }";
+
+            Check(initial, final, true);
+        }
+
+        [WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
+        public void CommentsNotAtTheStartOfTheFile1()
+        {
+            var initial =
+@"namespace N
+{
+    // attached to System.Text
+    using System.Text;
+    // attached to System
+    using System;
+}";
+
+            var final =
+@"namespace N
+{
+    // attached to System
+    using System;
+    // attached to System.Text
+    using System.Text;
+}";
+
+            Check(initial, final, true);
+        }
+
+        [WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
+        public void CommentsNotAtTheStartOfTheFile2()
+        {
+            var initial =
+@"namespace N
+{
+    // not attached to System.Text
+
+    using System.Text;
+    // attached to System
+    using System;
+}";
+
+            var final =
+@"namespace N
+{
+    // not attached to System.Text
+
+    // attached to System
+    using System;
+    using System.Text;
+}";
 
             Check(initial, final, true);
         }

--- a/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeImportsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeImportsTests.vb
@@ -4,8 +4,6 @@ Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.OrganizeImports
-Imports Microsoft.CodeAnalysis.Text
-Imports Roslyn.Test.EditorUtilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Organizing
     Public Class OrganizeImportsTests
@@ -199,6 +197,7 @@ end namespace</content>
             Check(initial, final, True)
         End Sub
 
+        <WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")>
         <Fact, Trait(Traits.Feature, Traits.Features.Organizing)>
         Public Sub DoTouchCommentsAtBeginningOfFile1()
             Dim initial =
@@ -211,9 +210,9 @@ namespace A { }
 namespace B { }</content>
 
             Dim final =
-<content>' I like namespace A
+<content>' Copyright (c) Microsoft Corporation.  All rights reserved.
+' I like namespace A
 Imports A
-' Copyright (c) Microsoft Corporation.  All rights reserved.
 Imports B
 
 namespace A { }
@@ -222,6 +221,7 @@ namespace B { }</content>
             Check(initial, final, True)
         End Sub
 
+        <WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")>
         <Fact, Trait(Traits.Feature, Traits.Features.Organizing)>
         Public Sub DoTouchCommentsAtBeginningOfFile2()
             Dim initial =
@@ -234,9 +234,9 @@ namespace A { }
 namespace B { }</content>
 
             Dim final =
-<content>'' I like namespace A */
+<content>'' Copyright (c) Microsoft Corporation.  All rights reserved. */
+'' I like namespace A */
 Imports A
-'' Copyright (c) Microsoft Corporation.  All rights reserved. */
 Imports B
 
 namespace A { }
@@ -245,6 +245,7 @@ namespace B { }</content>
             Check(initial, final, True)
         End Sub
 
+        <WorkItem(2480, "https://github.com/dotnet/roslyn/issues/2480")>
         <Fact, Trait(Traits.Feature, Traits.Features.Organizing)>
         Public Sub DoTouchCommentsAtBeginningOfFile3()
             Dim initial =

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -1,16 +1,10 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Linq
 Imports System.Runtime.CompilerServices
-Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Shared.Collections
-Imports Microsoft.CodeAnalysis.Shared.Extensions
-Imports Microsoft.CodeAnalysis.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
@@ -192,6 +186,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         ' (whitespace* comment whitespace* newline)+ OneOrMoreBlankLines
         Private ReadOnly s_bannerMatcher As Matcher(Of SyntaxTrivia)
 
+        ' Used to match the following:
+        '
+        ' <start-of-file> (whitespace* comment whitespace* newline)+ blankLine*
+        Private ReadOnly s_fileBannerMatcher As Matcher(Of SyntaxTrivia)
+
         Sub New()
             Dim whitespace = Matcher.Repeat(Match(SyntaxKind.WhitespaceTrivia, "\\b"))
             Dim endOfLine = Match(SyntaxKind.EndOfLineTrivia, "\\n")
@@ -205,6 +204,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Matcher.Sequence(
                     Matcher.OneOrMore(commentLine),
                     s_oneOrMoreBlankLines)
+            s_fileBannerMatcher =
+                Matcher.Sequence(
+                    Matcher.OneOrMore(commentLine),
+                    Matcher.Repeat(singleBlankLine))
         End Sub
 
         Private Function Match(kind As SyntaxKind, description As String) As Matcher(Of SyntaxTrivia)
@@ -537,11 +540,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 leadingTriviaToStrip = New List(Of SyntaxTrivia)()
             End If
 
-            ' Now, consume as many banners as we can.
+            ' Now, consume as many banners as we can.  s_fileBannerMatcher will only be matched at
+            ' the start of the file.
             Dim index = 0
             While (
                 s_oneOrMoreBlankLines.TryMatch(leadingTriviaToKeep, index) OrElse
-                s_bannerMatcher.TryMatch(leadingTriviaToKeep, index))
+                s_bannerMatcher.TryMatch(leadingTriviaToKeep, index) OrElse
+                (node.FullSpan.Start = 0 AndAlso s_fileBannerMatcher.TryMatch(leadingTriviaToKeep, index)))
             End While
 
             leadingTriviaToStrip.AddRange(leadingTriviaToKeep.Take(index))


### PR DESCRIPTION
When organizing using/imports, a banner comment (commonly a copyright notice, etc.) doesn't always have a trailing newline.

Fixes #2480.