### PR TITLE
Do not require an assembly-level ExtensionAttribute...

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -6136,21 +6136,17 @@ public class IA
     }
 }";
             var compilation = CreateCompilationWithMscorlib(source2, new[] { reference1 });
-            compilation.VerifyDiagnostics(
-                // (5,11): error CS1061: 'object' does not contain a definition for 'M' and no extension method 'M' accepting a 
-                // first argument of type 'object' could be found (are you missing a using directive or an assembly reference?)
-                //         o.M();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M").WithArguments("object", "M"));
+            compilation.VerifyDiagnostics(); // we now regognize the extension method even without the assembly-level attribute
 
             var assembly = compilation.Assembly;
             Assert.Equal(assembly.GetAttributes().Length, 0);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(type.GetAttributes().Length, 1);
+            Assert.Equal(type.GetAttributes().Length, 0);
             var method = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E").GetMember<PEMethodSymbol>("M");
-            Assert.Equal(method.GetAttributes().Length, 1);
+            Assert.Equal(method.GetAttributes().Length, 0);
             Assert.True(method.TestIsExtensionBitSet);
-            Assert.False(method.TestIsExtensionBitTrue);
-            Assert.False(method.IsExtensionMethod);
+            Assert.True(method.TestIsExtensionBitTrue);
+            Assert.True(method.IsExtensionMethod);
         }
 
         [WorkItem(530524, "DevDiv")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -2389,7 +2389,8 @@ B");
                 // mscorlib.dll
                 var mscorlib = type.GetMember<FieldSymbol>("F").Type.ContainingAssembly;
                 Assert.Equal(mscorlib.Name, "mscorlib");
-                Assert.False(mscorlib.MightContainExtensionMethods);
+                // We assume every PE assembly may contain extension methods.
+                Assert.True(mscorlib.MightContainExtensionMethods);
 
                 // TODO: Original references are not included in symbol validator.
                 if (isFromSource)
@@ -2432,7 +2433,9 @@ B");
             {
                 var assembly = module.ContainingAssembly;
                 var mightContainExtensionMethods = assembly.MightContainExtensionMethods;
-                Assert.Equal(isFromSource, mightContainExtensionMethods);
+                // Every PE assembly is assumed to be capable of having an extension method.
+                // The source assembly doesn't know (so reports "true") until all methods have been inspected.
+                Assert.True(mightContainExtensionMethods);
                 if (isFromSource)
                 {
                     Assert.Null(sourceAssembly);

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -924,11 +924,6 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, ignoreCase ? AttributeDescription.CaseInsensitiveExtensionAttribute : AttributeDescription.CaseSensitiveExtensionAttribute).HasValue;
         }
 
-        internal bool HasFSharpInterfaceDataVersionAttribute(Handle token)
-        {
-            return FindTargetAttribute(token, AttributeDescription.FSharpInterfaceDataVersionAttribute).HasValue;
-        }
-
         internal bool HasVisualBasicEmbeddedAttribute(Handle token)
         {
             return FindTargetAttribute(token, AttributeDescription.VisualBasicEmbeddedAttribute).HasValue;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -389,8 +389,6 @@ namespace Microsoft.CodeAnalysis
             s_signature_HasThis_Void_String_DeprecationType_UInt32_Type
         };
 
-        private static readonly byte[][] s_signaturesOfFSharpInterfaceDataVersionAttribute = { s_signature_HasThis_Void_Int32_Int32_Int32 };
-
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
         internal static readonly AttributeDescription ComImportAttribute = new AttributeDescription("System.Runtime.InteropServices", "ComImportAttribute", s_signaturesOfComImportAttribute);
@@ -398,7 +396,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription ConditionalAttribute = new AttributeDescription("System.Diagnostics", "ConditionalAttribute", s_signaturesOfConditionalAttribute);
         internal static readonly AttributeDescription CaseInsensitiveExtensionAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ExtensionAttribute", s_signaturesOfExtensionAttribute, matchIgnoringCase: true);
         internal static readonly AttributeDescription CaseSensitiveExtensionAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ExtensionAttribute", s_signaturesOfExtensionAttribute, matchIgnoringCase: false);
-        internal static readonly AttributeDescription FSharpInterfaceDataVersionAttribute = new AttributeDescription("Microsoft.FSharp.Core", "FSharpInterfaceDataVersionAttribute", s_signaturesOfFSharpInterfaceDataVersionAttribute);
 
         internal static readonly AttributeDescription InternalsVisibleToAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InternalsVisibleToAttribute", s_signaturesOfInternalsVisibleToAttribute);
         internal static readonly AttributeDescription AssemblySignatureKeyAttribute = new AttributeDescription("System.Reflection", "AssemblySignatureKeyAttribute", s_signaturesOfAssemblySignatureKeyAttribute);


### PR DESCRIPTION
in order for the C# compiler to recognize extension methods
contained within the assembly. In other words, we assume every
PE assembly may contain extension methods.
Fixes #365

What we want to do with this PR depends on performance run results that we should have by tomorrow morning.
/cc @jaredpar @VSadov @pharring 