### PR TITLE
Introduce entry named 'Default' in solution explorer context menu for an...

### DIFF
--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             public const int SetSeverityNone = 0x0114;
             public const int OpenDiagnosticHelpLink = 0x0116;
             public const int SetActiveRuleSet = 0x0118;
+            public const int SetSeverityDefault = 0x011b;
         }
     }
 }

--- a/src/VisualStudio/Setup/Commands.vsct
+++ b/src/VisualStudio/Setup/Commands.vsct
@@ -37,15 +37,15 @@
       <Group guid="guidRoslynGrpId" id="grpAnalyzerRemove" priority="0x000">
         <Parent guid="guidRoslynGrpId" id="cmdidAnalyzerContextMenu"/>
       </Group>
-      
+
       <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJWIN_SCOPE" priority="0x001">
         <Parent guid="guidRoslynGrpId" id="cmdidAnalyzerContextMenu"/>
       </Group>
-    
+
       <Group guid="guidRoslynGrpId" id="grpAnalyzerProperties" priority="0x002">
         <Parent guid="guidRoslynGrpId" id="cmdidAnalyzerContextMenu"/>
       </Group>
-    
+
       <Group guid="guidRoslynGrpId" id="grpDiagnosticSeverity" priority="0x000">
         <Parent guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu"/>
       </Group>
@@ -57,7 +57,7 @@
       <Group guid="guidRoslynGrpId" id="grpDiagnosticProperties" priority="0x002">
         <Parent guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu"/>
       </Group>
-    
+
       <Group guid="guidRoslynGrpId" id="grpSetActiveRuleSet">
       </Group>
     </Groups>
@@ -204,7 +204,16 @@
         </Strings>
       </Button>
       <!-- Buttons to set severity of diagnostics -->
-      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityError" priority="100" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityDefault" priority="100" type="Button">
+        <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
+        <Strings>
+          <ButtonText>&amp;Default</ButtonText>
+          <CanonicalName>Default</CanonicalName>
+          <LocCanonicalName>Default</LocCanonicalName>
+          <CommandName>SetSeverityDefault</CommandName>
+        </Strings>
+      </Button>
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityError" priority="200" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Error</ButtonText>
@@ -213,7 +222,7 @@
           <CommandName>SetSeverityError</CommandName>
         </Strings>
       </Button>
-      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityWarning" priority="200" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityWarning" priority="300" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Warning</ButtonText>
@@ -222,7 +231,7 @@
           <CommandName>SetSeverityWarning</CommandName>
         </Strings>
       </Button>
-      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityInfo" priority="300" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityInfo" priority="400" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Info</ButtonText>
@@ -231,7 +240,7 @@
           <CommandName>SetSeverityInfo</CommandName>
         </Strings>
       </Button>
-      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityHidden" priority="400" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityHidden" priority="500" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;Hidden</ButtonText>
@@ -240,7 +249,7 @@
           <CommandName>SetSeverityHidden</CommandName>
         </Strings>
       </Button>
-      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityNone" priority="500" type="Button">
+      <Button guid="guidRoslynGrpId" id="cmdidSetSeverityNone" priority="600" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticSeverityItems" />
         <Strings>
           <ButtonText>&amp;None</ButtonText>
@@ -293,7 +302,7 @@
           <CommandName>&amp;Organize Usings</CommandName>
         </Strings>
       </Menu>
-      
+
       <Menu guid="guidRoslynGrpId" id="cmdidAnalyzerContextMenu" priority="100" type="Context">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLNEXPL_ALL" />
         <Strings>
@@ -311,7 +320,7 @@
           <LocCanonicalName>Analyzers</LocCanonicalName>
         </Strings>
       </Menu>
-    
+
       <Menu guid="guidRoslynGrpId" id="cmdidDiagnosticContextMenu" priority="100" type="Context">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLNEXPL_ALL" />
         <Strings>
@@ -347,17 +356,17 @@
     <CommandPlacement guid="guidVSStd97" id="cmdidPropSheetOrProperties" priority="200">
       <Parent guid="guidRoslynGrpId" id="grpAnalyzerProperties" />
     </CommandPlacement>
-    
+
     <!-- Diagnostic node entries -->
     <CommandPlacement guid="guidVSStd97" id="cmdidPropSheetOrProperties" priority="200">
       <Parent guid="guidRoslynGrpId" id="grpDiagnosticProperties" />
     </CommandPlacement>
-  
+
     <!-- "Set as Active Rule Set" entries -->
     <CommandPlacement guid="guidRoslynGrpId" id="grpSetActiveRuleSet" priority="0x0200">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
     </CommandPlacement>
-    
+
     <CommandPlacement guid="guidRoslynGrpId" id="grpSetActiveRuleSet" priority="0x0200">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_WEBITEMNODE"/>
     </CommandPlacement>
@@ -414,6 +423,7 @@
       <IDSymbol name="cmdidSetActiveRuleSet"          value="0x0118" />
       <IDSymbol name="cmdidSetSeveritySubMenu"        value="0x0119" />
       <IDSymbol name="grpDiagnosticSeverityItems"     value="0x011a" />
+      <IDSymbol name="cmdidSetSeverityDefault"        value="0x011b" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
...alyzers

Fixes #1512

The solution explorer context menu that allows users to change severity of analyzer-reported diagnostics currently displays the following entries -
Error
Warning
Info
Hidden
None

When the context menu is displayed, a check mark is displayed next to the entry representing the severity of diagnostic as configured in the project's ruleset file. This works fine in cases where a severity is explicitly specified for the diagnostic in the ruleset file.

However, in cases where the severity is not explicitly specified in the ruleset file, the diagnostic is assigned its 'default' severity and we don't display a check mark against any entry in the above menu. As noted in #1512, this is confusing because the 'default' severity is also one of the severities listed above.

This change introduces an additional entry named 'Default' in the above menu that will be checked in cases where the dagnostic does not have an explicitly specified severity in the ruleset file. If the user clicks this entry to change the severity of some diagnostic to 'Default', the entry corresponding to this diagnostic is removed from the ruleset file.

**Before:**
![before](https://cloud.githubusercontent.com/assets/10579684/7465648/087a0606-f289-11e4-8010-35d7e661c624.PNG)

**After:**
![after](https://cloud.githubusercontent.com/assets/10579684/7465636/d6fd651e-f288-11e4-8d06-ba0b66a321fc.PNG)

