### PR TITLE
Avoid exceptions for rename conflicts with implicit names

### DIFF
--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -905,7 +905,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
             {
                 foreach (var location in symbol.Locations)
                 {
-                    if (location.IsInSource)
+                    // reverseMappedLocations may not contain the location if the location's token
+                    // does not contain the text of it's name (e.g. the getter of "int X { get; }"
+                    // does not contain the text "get_X" so conflicting renames to "get_X" will not
+                    // have added the getter to reverseMappedLocations).
+                    if (location.IsInSource && reverseMappedLocations.ContainsKey(location))
                     {
                         conflicts.Add(reverseMappedLocations[location]);
                     }


### PR DESCRIPTION
Related to #2511 "Rename doesn't catch conflicts with accessors"

When a rename conflict is introduced by naming something to the name of
a property accessor (e.g. "get_X"), we do not correctly detect that
conflict, and a KeyNotFoundException is thrown (and handled). This fixes
the first chance exception, but does not detect the conflict.