### PR TITLE
Add global undo to ContainedLanguageCodeSupport.TryRenameElement

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host;
@@ -314,18 +315,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 var newSolution = Renamer.RenameSymbolAsync(document.Project.Solution, symbol, newName, optionSet, cancellationToken).WaitAndGetResult(cancellationToken);
                 var changedDocuments = newSolution.GetChangedDocuments(document.Project.Solution);
 
-                // Notify third parties about the coming rename operation on the workspace, and let
-                // any exceptions propagate through
-                refactorNotifyServices.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocuments, symbol, newName, throwOnFailure: true);
-
-                if (!workspace.TryApplyChanges(newSolution))
+                var undoTitle = string.Format(EditorFeaturesResources.RenameTo, symbol.Name, newName);
+                using (var workspaceUndoTransaction = workspace.OpenGlobalUndoTransaction(undoTitle))
                 {
-                    Exceptions.ThrowEFail();
-                }
+                    // Notify third parties about the coming rename operation on the workspace, and let
+                    // any exceptions propagate through
+                    refactorNotifyServices.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocuments, symbol, newName, throwOnFailure: true);
 
-                // Notify third parties about the completed rename operation on the workspace, and
-                // let any exceptions propagate through
-                refactorNotifyServices.TryOnAfterGlobalSymbolRenamed(workspace, changedDocuments, symbol, newName, throwOnFailure: true);
+                    if (!workspace.TryApplyChanges(newSolution))
+                    {
+                        Exceptions.ThrowEFail();
+                    }
+
+                    // Notify third parties about the completed rename operation on the workspace, and
+                    // let any exceptions propagate through
+                    refactorNotifyServices.TryOnAfterGlobalSymbolRenamed(workspace, changedDocuments, symbol, newName, throwOnFailure: true);
+
+                    workspaceUndoTransaction.Commit();
+                }
 
                 RenameTrackingDismisser.DismissRenameTracking(workspace, changedDocuments);
                 return true;


### PR DESCRIPTION
Fixes internal TFS bug #1035934 "Undo didn't work in code file after
rename control's ID in properties"

Wrap the contents of ContainedLanguageCodeSupport,.TryRenameElement in a
global undo. This allows the undo of a rename done from the aspx
designer (for example) to correctly revert the C#/VB part of the rename
as well.

CR: @Pilchie @jasonmalinowski @rchande @balajikris @basoundr @brettfo