### PR TITLE
Add "Brace Matching" color

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Implementation\BraceMatching\BraceHighlightingViewTaggerProvider.cs" />
     <Compile Include="Implementation\BraceMatching\BraceHighlightTag.cs" />
     <Compile Include="Implementation\BraceMatching\BraceMatchingService.cs" />
+    <Compile Include="Implementation\BraceMatching\ClassificationTypeDefinitions.cs" />
     <Compile Include="Implementation\CallHierarchy\AbstractCallHierarchyCommandHandler.cs" />
     <Compile Include="Implementation\CallHierarchy\CallHierarchyDetail.cs" />
     <Compile Include="Implementation\CallHierarchy\CallHierarchyItem.cs" />

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -638,6 +638,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Brace Matching.
+        /// </summary>
+        internal static string FontAndColors_BraceMatching {
+            get {
+                return ResourceManager.GetString("FontAndColors_BraceMatching", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inline Rename.
         /// </summary>
         internal static string FontAndColors_InlineRename {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -733,4 +733,7 @@ Do you want to proceed?</value>
   <data name="CursorMustBeOnAMemberName" xml:space="preserve">
     <value>Cursor must be on a member name.</value>
   </data>
+  <data name="FontAndColors_BraceMatching" xml:space="preserve">
+    <value>Brace Matching</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightTag.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightTag.cs
@@ -6,15 +6,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
 {
     internal class BraceHighlightTag : TextMarkerTag
     {
-        internal const string TagId = "bracehighlight";
-
         public static readonly BraceHighlightTag StartTag = new BraceHighlightTag(navigateToStart: true);
         public static readonly BraceHighlightTag EndTag = new BraceHighlightTag(navigateToStart: false);
 
         public bool NavigateToStart { get; }
 
         private BraceHighlightTag(bool navigateToStart)
-            : base(TagId)
+            : base(ClassificationTypeDefinitions.BraceMatchingName)
         {
             this.NavigateToStart = navigateToStart;
         }

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/ClassificationTypeDefinitions.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/ClassificationTypeDefinitions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Language.StandardClassification;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
+{
+    internal sealed class ClassificationTypeDefinitions
+    {
+        public const string BraceMatchingName = "brace matching";
+
+        [Export]
+        [Name(BraceMatchingName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
+        internal readonly ClassificationTypeDefinition BraceMatching;
+
+        [Export(typeof(EditorFormatDefinition))]
+        [ClassificationType(ClassificationTypeNames = BraceMatchingName)]
+        [Name(BraceMatchingName)]
+        [Order(After = Priority.High)]
+        [UserVisible(true)]
+        private class BraceMatchingFormatDefinition : ClassificationFormatDefinition
+        {
+            private BraceMatchingFormatDefinition()
+            {
+                this.DisplayName = EditorFeaturesResources.FontAndColors_BraceMatching;
+                this.BackgroundColor = Color.FromRgb(0xDB, 0xE0, 0xCC);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Partial fix for internal TFS bug #927616 ""Brace Matching (Highlight)"
Color setting is ignored"

This change adds a new "Brace Matching" color (not to be confused with
the existing "Brace Matching (Highlight)" and "Brace Matching
(Rectangle)" colors) that controls the appearance of brace matching. It
is user customizable and the Background color controls the fill
("Highlight") and the Foreground color controls the outline
("Rectangle").

The default background color was chosen to match Visual Studio 2013's
default "Brace Matching (Highlight)" color.

There will also be a related closed-source change for the themed colors,
and that change will complete the bug.