### PR TITLE
FormatEngine honors IndentationStyle during LineOp

### DIFF
--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Moq
@@ -57,8 +58,18 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
             End Using
         End Sub
 
-        Public Sub AssertGeneratedResultIs(workspaceElement As XElement, leftItemToSelectText As String, rightItemToSelectText As String, expectedText As XElement)
+        Public Sub AssertGeneratedResultIs(workspaceElement As XElement, leftItemToSelectText As String, rightItemToSelectText As String, expectedText As XElement, Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing)
             Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceElement)
+                If changedOptionSet IsNot Nothing Then
+                    Dim optionSet = workspace.Options
+
+                    For Each entry In changedOptionSet
+                        optionSet = optionSet.WithChangedOption(entry.Key, entry.Value)
+                    Next
+
+                    workspace.Services.GetService(Of IOptionService)().SetOptions(optionSet)
+                End If
+
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim snapshot = document.GetTextAsync().Result.FindCorrespondingEditorTextSnapshot()
 

--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -1,6 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Formatting.FormattingOptions
+Imports Microsoft.CodeAnalysis.Options
 
 #Disable Warning RS0007 ' Avoid zero-length array allocations. This is non-shipping test code.
 
@@ -823,6 +826,60 @@ End Class
                 leftItemToSelectText:="Program",
                 rightItemToSelectText:="S",
                 expectedVirtualSpace:=4)
+        End Sub
+
+        <WorkItem(2509, "https://github.com/dotnet/roslyn/issues/2509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar)>
+        Public Sub GenerateEventHandler_WithNoneIndent()
+            Dim changingOptions = New Dictionary(Of OptionKey, Object)()
+            changingOptions.Add(New OptionKey(FormattingOptions.SmartIndent, LanguageNames.VisualBasic), IndentStyle.None)
+            AssertGeneratedResultIs(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+Private WithEvents foo As System.Console
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                "foo", "CancelKeyPress",
+                <Result>
+Class C
+Private WithEvents foo As System.Console
+
+Private Sub foo_CancelKeyPress(sender As Object, e As ConsoleCancelEventArgs) Handles foo.CancelKeyPress
+
+End Sub
+End Class
+                </Result>, changingOptions)
+        End Sub
+
+        <WorkItem(2509, "https://github.com/dotnet/roslyn/issues/2509")>
+    <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar)>
+        Public Sub GenerateEventHandler_WithBlockIndent()
+            Dim changingOptions = New Dictionary(Of OptionKey, Object)()
+            changingOptions.Add(New OptionKey(FormattingOptions.SmartIndent, LanguageNames.VisualBasic), IndentStyle.Block)
+            AssertGeneratedResultIs(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Private WithEvents foo As System.Console
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                "foo", "CancelKeyPress",
+                <Result>
+Class C
+    Private WithEvents foo As System.Console
+
+    Private Sub foo_CancelKeyPress(sender As Object, e As ConsoleCancelEventArgs) Handles foo.CancelKeyPress
+
+    End Sub
+End Class
+                </Result>, changingOptions)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
@@ -25,8 +26,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
         Private ReadOnly _formatter As FormatterMock
         Private ReadOnly _inlineRenameService As InlineRenameServiceMock
 
-        Public Sub New(test As XElement)
+        Public Sub New(test As XElement, Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing)
             Workspace = TestWorkspaceFactory.CreateWorkspace(test)
+            If changedOptionSet IsNot Nothing Then
+                Dim optionSet = Workspace.Options
+
+                For Each entry In changedOptionSet
+                    optionSet = optionSet.WithChangedOption(entry.Key, entry.Value)
+                Next
+
+                Workspace.Services.GetService(Of IOptionService)().SetOptions(optionSet)
+            End If
+
             View = Workspace.Documents.Single().GetTextView()
             EditorOperations = Workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(View)
 

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -6,6 +6,9 @@ Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Formatting.FormattingOptions
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Operations
@@ -1053,6 +1056,72 @@ Module M1
 
 End Module
 </Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <WorkItem(2509, "https://github.com/dotnet/roslyn/issues/2509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub CommitAfterTypingWithNoneIndent()
+            Dim changingOptions = New Dictionary(Of OptionKey, Object)()
+            changingOptions.Add(New OptionKey(FormattingOptions.SmartIndent, LanguageNames.VisualBasic), IndentStyle.None)
+            Using testData = New CommitTestData(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>Class Program
+    Sub Main(args As String())
+    $$
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>, changingOptions)
+
+                Dim expected = <Code>Class Program
+    Sub Main(args As String())
+    Dim s = 1
+Dim ss = 2
+    End Sub
+End Class
+</Code>
+
+                testData.EditorOperations.InsertText("Dim s = 1")
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.InsertText("Dim ss = 2")
+
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <WorkItem(2509, "https://github.com/dotnet/roslyn/issues/2509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub CommitAfterTypingWithBlockIndent()
+            Dim changingOptions = New Dictionary(Of OptionKey, Object)()
+            changingOptions.Add(New OptionKey(FormattingOptions.SmartIndent, LanguageNames.VisualBasic), IndentStyle.Block)
+            Using testData = New CommitTestData(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>Class Program
+    Sub Main(args As String())
+    $$
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>, changingOptions)
+
+                Dim expected = <Code>Class Program
+    Sub Main(args As String())
+    Dim s = 1
+    Dim ss = 2
+    End Sub
+End Class
+</Code>
+
+                testData.EditorOperations.InsertText("Dim s = 1")
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.InsertText("Dim ss = 2")
+
                 Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().TextBuffer.CurrentSnapshot.GetText())
             End Using
         End Sub


### PR DESCRIPTION
Fix #2509 FormatEngine should honor the user selected IndentationStyle
option while performing Line Operation