### PR TITLE
Enable Emit unit-tests for C# and VB compilers in CIBuild.

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -59,8 +59,6 @@
         Include="Binaries\$(Configuration)\**\*.UnitTests*.dll" 
         Exclude="
         Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.Compilers.CSharp.Emit.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.Compilers.VisualBasic.Emit.UnitTests.dll;
         Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll;" />
     </ItemGroup>
 


### PR DESCRIPTION
Related to #2375.