### PR TITLE
Apply spacing rules to fixed, default, sizeof

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -69,20 +69,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // For spacing around: typeof, default, and sizeof; treat like a Method Call
-            if (currentKind == SyntaxKind.OpenParenToken &&
-                (currentParentKind == SyntaxKind.TypeOfExpression || currentParentKind == SyntaxKind.DefaultExpression || currentParentKind == SyntaxKind.SizeOfExpression))
+            if (currentKind == SyntaxKind.OpenParenToken && IsFunctionLikeKeywordExpressionKind(currentParentKind))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterMethodCallName);
             }
 
-            if (previousKind == SyntaxKind.OpenParenToken &&
-                (previousParentKind == SyntaxKind.TypeOfExpression || previousParentKind == SyntaxKind.DefaultExpression || previousParentKind == SyntaxKind.SizeOfExpression))
+            if (previousKind == SyntaxKind.OpenParenToken && IsFunctionLikeKeywordExpressionKind(previousParentKind))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
 
-            if (currentKind == SyntaxKind.CloseParenToken &&
-                (currentParentKind == SyntaxKind.TypeOfExpression || currentParentKind == SyntaxKind.DefaultExpression || currentParentKind == SyntaxKind.SizeOfExpression))
+            if (currentKind == SyntaxKind.CloseParenToken && IsFunctionLikeKeywordExpressionKind(currentParentKind))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
@@ -111,11 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // For spacing between the parenthesis and the expression inside the control flow expression
-            if (previousKind == SyntaxKind.OpenParenToken &&
-                (previousParentKind == SyntaxKind.IfStatement || previousParentKind == SyntaxKind.WhileStatement || previousParentKind == SyntaxKind.SwitchStatement ||
-                previousParentKind == SyntaxKind.ForStatement || previousParentKind == SyntaxKind.ForEachStatement || previousParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.LockStatement ||
-                previousParentKind == SyntaxKind.FixedStatement))
+            if (previousKind == SyntaxKind.OpenParenToken && IsControlFlowLikeKeywordStatementKind(previousParentKind))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -136,11 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            if (currentKind == SyntaxKind.CloseParenToken &&
-                (currentParentKind == SyntaxKind.IfStatement || currentParentKind == SyntaxKind.WhileStatement || currentParentKind == SyntaxKind.SwitchStatement ||
-                currentParentKind == SyntaxKind.ForStatement || currentParentKind == SyntaxKind.ForEachStatement || currentParentKind == SyntaxKind.DoStatement ||
-                currentParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement || currentParentKind == SyntaxKind.LockStatement ||
-                currentParentKind == SyntaxKind.FixedStatement))
+            if (currentKind == SyntaxKind.CloseParenToken && IsControlFlowLikeKeywordStatementKind(currentParentKind))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -337,6 +326,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private bool HasFormattableBracketParent(SyntaxToken token)
         {
             return token.Parent.IsKind(SyntaxKind.ArrayRankSpecifier, SyntaxKind.BracketedArgumentList, SyntaxKind.BracketedParameterList, SyntaxKind.ImplicitArrayCreationExpression);
+        }
+
+        private bool IsFunctionLikeKeywordExpressionKind(SyntaxKind syntaxKind)
+        {
+            return (syntaxKind == SyntaxKind.TypeOfExpression || syntaxKind == SyntaxKind.DefaultExpression || syntaxKind == SyntaxKind.SizeOfExpression);
+        }
+
+        private bool IsControlFlowLikeKeywordStatementKind(SyntaxKind syntaxKind)
+        {
+            return (syntaxKind == SyntaxKind.IfStatement || syntaxKind == SyntaxKind.WhileStatement || syntaxKind == SyntaxKind.SwitchStatement ||
+                syntaxKind == SyntaxKind.ForStatement || syntaxKind == SyntaxKind.ForEachStatement || syntaxKind == SyntaxKind.DoStatement ||
+                syntaxKind == SyntaxKind.CatchDeclaration || syntaxKind == SyntaxKind.UsingStatement || syntaxKind == SyntaxKind.LockStatement ||
+                syntaxKind == SyntaxKind.FixedStatement);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -68,18 +68,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
 
-            // For spacing in the parenthesis of typeof, treat like a Method Call
-            if (currentKind == SyntaxKind.OpenParenToken && currentParentKind == SyntaxKind.TypeOfExpression)
+            // For spacing around: typeof, default, and sizeof; treat like a Method Call
+            if (currentKind == SyntaxKind.OpenParenToken &&
+                (currentParentKind == SyntaxKind.TypeOfExpression || currentParentKind == SyntaxKind.DefaultExpression || currentParentKind == SyntaxKind.SizeOfExpression))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterMethodCallName);
             }
 
-            if (previousKind == SyntaxKind.OpenParenToken && previousParentKind == SyntaxKind.TypeOfExpression)
+            if (previousKind == SyntaxKind.OpenParenToken &&
+                (previousParentKind == SyntaxKind.TypeOfExpression || previousParentKind == SyntaxKind.DefaultExpression || previousParentKind == SyntaxKind.SizeOfExpression))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
 
-            if (currentKind == SyntaxKind.CloseParenToken && currentParentKind == SyntaxKind.TypeOfExpression)
+            if (currentKind == SyntaxKind.CloseParenToken &&
+                (currentParentKind == SyntaxKind.TypeOfExpression || currentParentKind == SyntaxKind.DefaultExpression || currentParentKind == SyntaxKind.SizeOfExpression))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses);
             }
@@ -111,7 +114,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (previousKind == SyntaxKind.OpenParenToken &&
                 (previousParentKind == SyntaxKind.IfStatement || previousParentKind == SyntaxKind.WhileStatement || previousParentKind == SyntaxKind.SwitchStatement ||
                 previousParentKind == SyntaxKind.ForStatement || previousParentKind == SyntaxKind.ForEachStatement || previousParentKind == SyntaxKind.DoStatement ||
-                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.LockStatement))
+                previousParentKind == SyntaxKind.CatchDeclaration || previousParentKind == SyntaxKind.UsingStatement || previousParentKind == SyntaxKind.LockStatement ||
+                previousParentKind == SyntaxKind.FixedStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }
@@ -135,7 +139,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.CloseParenToken &&
                 (currentParentKind == SyntaxKind.IfStatement || currentParentKind == SyntaxKind.WhileStatement || currentParentKind == SyntaxKind.SwitchStatement ||
                 currentParentKind == SyntaxKind.ForStatement || currentParentKind == SyntaxKind.ForEachStatement || currentParentKind == SyntaxKind.DoStatement ||
-                currentParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement || currentParentKind == SyntaxKind.LockStatement))
+                currentParentKind == SyntaxKind.CatchDeclaration || currentParentKind == SyntaxKind.UsingStatement || currentParentKind == SyntaxKind.LockStatement ||
+                currentParentKind == SyntaxKind.FixedStatement))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceWithinOtherParentheses);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4799,6 +4799,9 @@ class Program
 
         lock(somevar)
         { }
+
+        fixed(char* p = str)
+        { }
     }
 }";
             const string expected = @"
@@ -4837,6 +4840,9 @@ class Program
         { }
 
         lock ( somevar )
+        { }
+
+        fixed ( char* p = str )
         { }
     }
 }";
@@ -6127,6 +6133,8 @@ class Program
     {
         var a = typeof(A);
         var b = M(a);
+        var c = default(A);
+        var d = sizeof(A);
         M();
     }
 }";
@@ -6138,6 +6146,8 @@ class Program
     {
         var a = typeof ( A );
         var b = M ( a );
+        var c = default ( A );
+        var d = sizeof ( A );
         M ( );
     }
 }";


### PR DESCRIPTION
This fixes a couple more spacing issue I found while using codeformatter:

`default()` and `sizeof()` now follow the method call formatting like `typeof()` already does, both before and in the parenthesis.
`fixed() { }` now follows other control flow keywords for spacing within parenthesis.
