### PR TITLE
Implement support for EnC of constructors and member initializers containing lambdas

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -1704,5 +1704,274 @@ class C
                 Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default));
         }
+
+        [Fact]
+        public void LambdasInInitializers()
+        {
+            var source0 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int G(Func<int, int> f) => 1;
+
+    public int A = G(<N:0>a => a + 1</N:0>);
+
+    public C() : this(G(<N:1>a => a + 2</N:1>))
+    {
+        G(<N:2>a => a + 3</N:2>);
+    }
+
+    public C(int x)
+    {
+        G(<N:3>a => a + 4</N:3>);
+    }
+}");
+            var source1 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int G(Func<int, int> f) => 1;
+
+    public int A = G(<N:0>a => a - 1</N:0>);
+
+    public C() : this(G(<N:1>a => a - 2</N:1>))
+    {
+        G(<N:2>a => a - 3</N:2>);
+    }
+
+    public C(int x)
+    {
+        G(<N:3>a => a - 4</N:3>);
+    }
+}");
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var ctor00 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
+            var ctor10 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor(System.Int32 x)");
+            var ctor01 = compilation1.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
+            var ctor11 = compilation1.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor(System.Int32 x)");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, ctor00, ctor01, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true),
+                    new SemanticEdit(SemanticEditKind.Update, ctor10, ctor11, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__2_0, <>9__2_1, <>9__3_0, <>9__3_1, <.ctor>b__2_0, <.ctor>b__2_1, <.ctor>b__3_0, <.ctor>b__3_1}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__2_0", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldc.i4.2
+  IL_0002:  sub
+  IL_0003:  stloc.0
+  IL_0004:  br.s       IL_0006
+  IL_0006:  ldloc.0
+  IL_0007:  ret
+}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__2_1", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldc.i4.3
+  IL_0002:  sub
+  IL_0003:  stloc.0
+  IL_0004:  br.s       IL_0006
+  IL_0006:  ldloc.0
+  IL_0007:  ret
+}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__3_0", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldc.i4.4
+  IL_0002:  sub
+  IL_0003:  stloc.0
+  IL_0004:  br.s       IL_0006
+  IL_0006:  ldloc.0
+  IL_0007:  ret
+}");
+            diff1.VerifyIL("C.<>c.<.ctor>b__3_1", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldc.i4.1
+  IL_0002:  sub
+  IL_0003:  stloc.0
+  IL_0004:  br.s       IL_0006
+  IL_0006:  ldloc.0
+  IL_0007:  ret
+}");
+        }
+
+        [Fact]
+        public void UpdateParameterlessConstructorInPresenceOfFieldInitializersWithLambdas()
+        {
+            var source0 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0>a => a + 1</N:0>);
+}");
+            var source1 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0>a => a + 1</N:0>);
+    int B = F(b => b + 1);                    // new field
+
+    public C()                                // new ctor
+    {
+        F(c => c + 1);
+    }
+}");
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var b1 = compilation1.GetMember<FieldSymbol>("C.B");
+            var ctor0 = compilation0.GetMember<MethodSymbol>("C..ctor");
+            var ctor1 = compilation1.GetMember<MethodSymbol>("C..ctor");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Insert, null, b1),
+                    new SemanticEdit(SemanticEditKind.Update, ctor0, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__2_0#1, <>9__2_0, <>9__2_2#1, <.ctor>b__2_0#1, <.ctor>b__2_0, <.ctor>b__2_2#1}");
+
+            diff1.VerifyIL("C..ctor", @"
+{
+  // Code size      130 (0x82)
+  .maxstack  3
+  IL_0000:  ldarg.0
+  IL_0001:  ldsfld     ""System.Func<int, int> C.<>c.<>9__2_0""
+  IL_0006:  dup
+  IL_0007:  brtrue.s   IL_0020
+  IL_0009:  pop
+  IL_000a:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_000f:  ldftn      ""int C.<>c.<.ctor>b__2_0(int)""
+  IL_0015:  newobj     ""System.Func<int, int>..ctor(object, System.IntPtr)""
+  IL_001a:  dup
+  IL_001b:  stsfld     ""System.Func<int, int> C.<>c.<>9__2_0""
+  IL_0020:  call       ""int C.F(System.Func<int, int>)""
+  IL_0025:  stfld      ""int C.A""
+  IL_002a:  ldarg.0
+  IL_002b:  ldsfld     ""System.Func<int, int> C.<>c.<>9__2_2#1""
+  IL_0030:  dup
+  IL_0031:  brtrue.s   IL_004a
+  IL_0033:  pop
+  IL_0034:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_0039:  ldftn      ""int C.<>c.<.ctor>b__2_2#1(int)""
+  IL_003f:  newobj     ""System.Func<int, int>..ctor(object, System.IntPtr)""
+  IL_0044:  dup
+  IL_0045:  stsfld     ""System.Func<int, int> C.<>c.<>9__2_2#1""
+  IL_004a:  call       ""int C.F(System.Func<int, int>)""
+  IL_004f:  stfld      ""int C.B""
+  IL_0054:  ldarg.0
+  IL_0055:  call       ""object..ctor()""
+  IL_005a:  nop
+  IL_005b:  nop
+  IL_005c:  ldsfld     ""System.Func<int, int> C.<>c.<>9__2_0#1""
+  IL_0061:  dup
+  IL_0062:  brtrue.s   IL_007b
+  IL_0064:  pop
+  IL_0065:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_006a:  ldftn      ""int C.<>c.<.ctor>b__2_0#1(int)""
+  IL_0070:  newobj     ""System.Func<int, int>..ctor(object, System.IntPtr)""
+  IL_0075:  dup
+  IL_0076:  stsfld     ""System.Func<int, int> C.<>c.<>9__2_0#1""
+  IL_007b:  call       ""int C.F(System.Func<int, int>)""
+  IL_0080:  pop
+  IL_0081:  ret
+}
+");
+        }
+
+        [Fact(Skip = "2504"), WorkItem(2504)]
+        public void InsertConstructorInPresenceOfFieldInitializersWithLambdas()
+        {
+            var source0 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0>a => a + 1</N:0>);
+}");
+            var source1 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0>a => a + 1</N:0>);
+    int B = F(b => b + 1);                    // new field
+
+    public C(int x)                           // new ctor
+    {
+        F(c => c + 1);
+    }
+}");
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var b1 = compilation1.GetMember<FieldSymbol>("C.B");
+            var ctor1 = compilation1.GetMember<MethodSymbol>("C..ctor");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Insert, null, b1),
+                    new SemanticEdit(SemanticEditKind.Insert, null, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<> c}",
+                "C.<>c: {<>9__2_0#1, <>9__2_0, <>9__2_2#1, <.ctor>b__2_0#1, <.ctor>b__2_0, <.ctor>b__2_2#1}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -5917,7 +5917,7 @@ public class C
 
         [WorkItem(918650)]
         [Fact]
-        public void OutofMemoryDuringEditAndContinue()
+        public void ManyGenerations()
         {
             var source =
 @"class C

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Emit\EditAndContinue\EncHoistedLocalMetadata.cs" />
     <Compile Include="Emit\EmitOptions.cs" />
     <Compile Include="Emit\EditAndContinue\EncVariableSlotAllocator.cs" />
+    <Compile Include="Emit\SemanticEditKind.cs" />
     <Compile Include="InternalImplementationOnlyAttribute.cs" />
     <Compile Include="InternalUtilities\AssemblyLocationLightUp.cs" />
     <Compile Include="Emit\EditAndContinueMethodDebugInformation.cs" />

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -14,22 +14,20 @@ namespace Microsoft.CodeAnalysis.Emit
 {
     internal abstract class DefinitionMap
     {
-        protected struct MethodUpdate
+        protected struct MappedMethod
         {
-            public MethodUpdate(IMethodSymbolInternal previousMethod, bool preserveLocalVariables, Func<SyntaxNode, SyntaxNode> syntaxMap)
+            public MappedMethod(IMethodSymbolInternal previousMethodOpt, Func<SyntaxNode, SyntaxNode> syntaxMap)
             {
-                this.PreviousMethod = previousMethod;
-                this.PreserveLocalVariables = preserveLocalVariables;
+                this.PreviousMethod = previousMethodOpt;
                 this.SyntaxMap = syntaxMap;
             }
 
             public readonly IMethodSymbolInternal PreviousMethod;
-            public readonly bool PreserveLocalVariables;
             public readonly Func<SyntaxNode, SyntaxNode> SyntaxMap;
         }
 
         protected readonly PEModule module;
-        protected readonly IReadOnlyDictionary<IMethodSymbol, MethodUpdate> methodUpdates;
+        protected readonly IReadOnlyDictionary<IMethodSymbol, MappedMethod> mappedMethods;
 
         protected DefinitionMap(PEModule module, IEnumerable<SemanticEdit> edits)
         {
@@ -37,28 +35,42 @@ namespace Microsoft.CodeAnalysis.Emit
             Debug.Assert(edits != null);
 
             this.module = module;
-            this.methodUpdates = GetMethodUpdates(edits);
+            this.mappedMethods = GetMappedMethods(edits);
         }
 
-        private static IReadOnlyDictionary<IMethodSymbol, MethodUpdate> GetMethodUpdates(IEnumerable<SemanticEdit> edits)
+        private static IReadOnlyDictionary<IMethodSymbol, MappedMethod> GetMappedMethods(IEnumerable<SemanticEdit> edits)
         {
-            var methodUpdates = new Dictionary<IMethodSymbol, MethodUpdate>();
+            var mappedMethods = new Dictionary<IMethodSymbol, MappedMethod>();
             foreach (var edit in edits)
             {
-                if (edit.Kind == SemanticEditKind.Update)
+                // We should always "preserve locals" of iterator and async methods since the state machine 
+                // might be active without MoveNext method being on stack. We don't enforce this requirement here,
+                // since a method may be incorrectly marked by Iterator/AsyncStateMachine attribute by the user, 
+                // in which case we can't reliably figure out that it's an error in semantic edit set. 
+
+                // We should also "preserve locals" of any updated method containing lambdas. The goal is to 
+                // treat lambdas the same as method declarations. Lambdas declared in a method body that escape 
+                // the method (are assigned to a field, added to an event, e.g.) might be invoked after the method 
+                // is updated and when it no longer contains active statements. If we didn't map the lambdas of 
+                // the updated body to the original lambdas we would run the out-of-date lambda bodies, 
+                // which would not happen if the lambdas were named methods.
+
+                // TODO (bug https://github.com/dotnet/roslyn/issues/2504)
+                // Note that in some cases an Insert might also need to map syntax. For example, a new constructor added 
+                // to a class that has field/property initializers with lambdas. These lambdas get "copied" into the constructor
+                // (assuming it doesn't have "this" constructor initializer) and thus their generated names need to be preserved. 
+
+                if (edit.Kind == SemanticEditKind.Update && edit.PreserveLocalVariables)
                 {
                     var method = edit.NewSymbol as IMethodSymbol;
                     if (method != null)
                     {
-                        methodUpdates.Add(method, new MethodUpdate(
-                            (IMethodSymbolInternal)edit.OldSymbol,
-                            edit.PreserveLocalVariables,
-                            edit.SyntaxMap));
+                        mappedMethods.Add(method, new MappedMethod((IMethodSymbolInternal)edit.OldSymbol, edit.SyntaxMap));
                     }
                 }
             }
 
-            return methodUpdates;
+            return mappedMethods;
         }
 
         internal abstract Cci.IDefinition MapDefinition(Cci.IDefinition definition);
@@ -141,33 +153,19 @@ namespace Microsoft.CodeAnalysis.Emit
 
         internal VariableSlotAllocator TryCreateVariableSlotAllocator(EmitBaseline baseline, IMethodSymbol method)
         {
-            MethodDefinitionHandle handle;
-            if (!this.TryGetMethodHandle(baseline, (Cci.IMethodDefinition)method, out handle))
+            MappedMethod mappedMethod;
+            if (!this.mappedMethods.TryGetValue(method, out mappedMethod))
+            {
+                return null;
+            }
+
+            // TODO (bug https://github.com/dotnet/roslyn/issues/2504):
+            // Handle cases when the previous method doesn't exist.
+
+            MethodDefinitionHandle previousHandle;
+            if (!this.TryGetMethodHandle(baseline, (Cci.IMethodDefinition)method, out previousHandle))
             {
                 // Unrecognized method. Must have been added in the current compilation.
-                return null;
-            }
-
-            MethodUpdate methodUpdate;
-            if (!this.methodUpdates.TryGetValue(method, out methodUpdate))
-            {
-                // Not part of changeset. No need to preserve locals.
-                return null;
-            }
-
-            if (!methodUpdate.PreserveLocalVariables)
-            {
-                // We should always "preserve locals" of iterator and async methods since the state machine 
-                // might be active without MoveNext method being on stack. We don't enforce this requirement here,
-                // since a method may be incorrectly marked by Iterator/AsyncStateMachine attribute by the user, 
-                // in which case we can't reliably figure out that it's an error in semantic edit set. 
-
-                // We should also "preserve locals" of any updated method containing lambdas. The goal is to 
-                // treat lambdas the same as method declarations. Lambdas declared in a method body that escape 
-                // the method (are assigned to a field, added to an event, e.g.) might be invoked after the method 
-                // is updated and when it no longer contains active statements. If we didn't map the lambdas of 
-                // the updated body to the original lambdas we would run the out-of-date lambda bodies, 
-                // which would not happen if the lambdas were named methods.
                 return null;
             }
 
@@ -182,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Emit
             string stateMachineTypeNameOpt = null;
             TSymbolMatcher symbolMap;
 
-            uint methodIndex = (uint)MetadataTokens.GetRowNumber(handle);
+            uint methodIndex = (uint)MetadataTokens.GetRowNumber(previousHandle);
             DebugId methodId;
 
             // Check if method has changed previously. If so, we already have a map.
@@ -224,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 // Method has not changed since initial generation. Generate a map
                 // using the local names provided with the initial metadata.
-                var debugInfo = baseline.DebugInformationProvider(handle);
+                var debugInfo = baseline.DebugInformationProvider(previousHandle);
 
                 methodId = new DebugId(debugInfo.MethodOrdinal, 0);
 
@@ -233,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     MakeLambdaAndClosureMaps(debugInfo.Lambdas, debugInfo.Closures, out lambdaMap, out closureMap);
                 }
 
-                ITypeSymbol stateMachineType = TryGetStateMachineType(handle);
+                ITypeSymbol stateMachineType = TryGetStateMachineType(previousHandle);
                 if (stateMachineType != null)
                 {
                     // method is async/iterator kickoff method
@@ -249,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 }
                 else
                 {
-                    previousLocals = TryGetLocalSlotMapFromMetadata(handle, debugInfo);
+                    previousLocals = TryGetLocalSlotMapFromMetadata(previousHandle, debugInfo);
                     if (previousLocals.IsDefault)
                     {
                         // TODO: Report error that metadata is not supported.
@@ -262,8 +260,8 @@ namespace Microsoft.CodeAnalysis.Emit
 
             return new EncVariableSlotAllocator(
                 symbolMap,
-                methodUpdate.SyntaxMap,
-                methodUpdate.PreviousMethod,
+                mappedMethod.SyntaxMap,
+                mappedMethod.PreviousMethod,
                 methodId,
                 previousLocals,
                 lambdaMap,

--- a/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
@@ -5,38 +5,12 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
-    public enum SemanticEditKind
-    {
-        /// <summary>
-        /// No change.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// Node value was updated.
-        /// </summary>
-        Update = 1,
-
-        /// <summary>
-        /// Node was inserted.
-        /// </summary>
-        Insert = 2,
-
-        /// <summary>
-        /// Node was deleted.
-        /// </summary>
-        Delete = 3,
-    }
-
     /// <summary>
     /// Describes a symbol edit between two compilations. 
     /// For example, an addition of a method, an update of a method, removal of a type, etc.
     /// </summary>
     public struct SemanticEdit : IEquatable<SemanticEdit>
     {
-        // TODO (tomat): we might need more detailed description of the edit, 
-        // like "method body update", etc.
-
         /// <summary>
         /// The type of edit.
         /// </summary>
@@ -89,9 +63,29 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <param name="preserveLocalVariables">
         /// True if the edit is an update of an active method and local values should be preserved; false otherwise.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="oldSymbol"/> or <paramref name="newSymbol"/> is null and the edit isn't an <see cref="SemanticEditKind.Insert"/> or <see cref="SemanticEditKind.Delete"/>, respectively.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="kind"/> is not a valid kind.
+        /// </exception>
         public SemanticEdit(SemanticEditKind kind, ISymbol oldSymbol, ISymbol newSymbol, Func<SyntaxNode, SyntaxNode> syntaxMap = null, bool preserveLocalVariables = false)
         {
-            // TODO (tomat): more validation
+            if (oldSymbol == null && kind != SemanticEditKind.Insert)
+            {
+                throw new ArgumentNullException(nameof(oldSymbol));
+            }
+
+            if (newSymbol == null && kind != SemanticEditKind.Delete)
+            {
+                throw new ArgumentNullException(nameof(newSymbol));
+            }
+
+            if (kind <= SemanticEditKind.None || kind > SemanticEditKind.Delete)
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
             this.Kind = kind;
             this.OldSymbol = oldSymbol;
             this.NewSymbol = newSymbol;

--- a/src/Compilers/Core/Portable/Emit/SemanticEditKind.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEditKind.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Emit
+{
+    public enum SemanticEditKind
+    {
+        /// <summary>
+        /// No change.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Node value was updated.
+        /// </summary>
+        Update = 1,
+
+        /// <summary>
+        /// Node was inserted.
+        /// </summary>
+        Insert = 2,
+
+        /// <summary>
+        /// Node was deleted.
+        /// </summary>
+        Delete = 3,
+    }
+}

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
@@ -1249,5 +1249,284 @@ End Class")
   IL_000f:  ret
 }")
         End Sub
+
+        <Fact>
+        Public Sub LambdasInInitializers()
+            Dim source0 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function G(f As Func(Of Integer, Integer)) As Integer
+        Return 1
+    End Function
+
+    Dim A As Integer = G(<N:0>Function(a) a + 1</N:0>)
+
+    Sub New()
+        MyClass.New(G(<N:1>Function(a) a + 2</N:1>))
+        G(<N:2>Function(a) a + 3</N:2>)
+    End Sub
+
+    Sub New(x As Integer)
+        G(<N:3>Function(a) a + 4</N:3>)
+    End Sub
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function G(f As Func(Of Integer, Integer)) As Integer
+        Return 1
+    End Function
+
+    Dim A As Integer = G(<N:0>Function(a) a - 1</N:0>)
+
+    Sub New()
+        MyClass.New(G(<N:1>Function(a) a - 2</N:1>))
+        G(<N:2>Function(a) a - 3</N:2>)
+    End Sub
+
+    Sub New(x As Integer)
+        G(<N:3>Function(a) a - 4</N:3>)
+    End Sub
+End Class
+")
+
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim ctor00 = compilation0.GetMembers("C..ctor").Single(Function(m) m.ToTestDisplayString() = "Sub C..ctor()")
+            Dim ctor10 = compilation0.GetMembers("C..ctor").Single(Function(m) m.ToTestDisplayString() = "Sub C..ctor(x As System.Int32)")
+            Dim ctor01 = compilation1.GetMembers("C..ctor").Single(Function(m) m.ToTestDisplayString() = "Sub C..ctor()")
+            Dim ctor11 = compilation1.GetMembers("C..ctor").Single(Function(m) m.ToTestDisplayString() = "Sub C..ctor(x As System.Int32)")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            Dim diff1 = compilation1.EmitDifference(generation0, ImmutableArray.Create(
+                New SemanticEdit(SemanticEditKind.Update, ctor00, ctor01, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True),
+                New SemanticEdit(SemanticEditKind.Update, ctor10, ctor11, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            Dim md1 = diff1.GetMetadata()
+
+            Dim reader1 = md1.Reader
+            diff1.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I2-0, $I2-1, $I3-0, $I3-1, _Lambda$__2-0, _Lambda$__2-1, _Lambda$__3-0, _Lambda$__3-1}")
+
+            diff1.VerifyIL("C._Closure$__._Lambda$__2-0", "
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals init (Integer V_0)
+  IL_0000:  nop
+  IL_0001:  ldarg.1
+  IL_0002:  ldc.i4.2
+  IL_0003:  sub.ovf
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0007
+  IL_0007:  ldloc.0
+  IL_0008:  ret
+}")
+
+            diff1.VerifyIL("C._Closure$__._Lambda$__2-1", "
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals init (Integer V_0)
+  IL_0000:  nop
+  IL_0001:  ldarg.1
+  IL_0002:  ldc.i4.3
+  IL_0003:  sub.ovf
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0007
+  IL_0007:  ldloc.0
+  IL_0008:  ret
+}")
+
+            diff1.VerifyIL("C._Closure$__._Lambda$__3-0", "
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals init (Integer V_0)
+  IL_0000:  nop
+  IL_0001:  ldarg.1
+  IL_0002:  ldc.i4.1
+  IL_0003:  sub.ovf
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0007
+  IL_0007:  ldloc.0
+  IL_0008:  ret
+}")
+
+            diff1.VerifyIL("C._Closure$__._Lambda$__3-1", "
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals init (Integer V_0)
+  IL_0000:  nop
+  IL_0001:  ldarg.1
+  IL_0002:  ldc.i4.4
+  IL_0003:  sub.ovf
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0007
+  IL_0007:  ldloc.0
+  IL_0008:  ret
+}")
+        End Sub
+
+        <Fact>
+        Public Sub UpdateParameterlessConstructorInPresenceOfFieldInitializersWithLambdas()
+            Dim source0 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0>Function(a) a + 1</N:0>)
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0>Function(a) a + 1</N:0>)
+    Dim B As Integer = F(Function(b) b + 1)     ' new field
+
+    Sub New()                                   ' new ctor
+        F(Function(c) c + 1)         
+    End Sub
+End Class
+")
+
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim b1 = compilation1.GetMember(Of FieldSymbol)("C.B")
+            Dim ctor0 = compilation0.GetMember(Of MethodSymbol)("C..ctor")
+            Dim ctor1 = compilation1.GetMember(Of MethodSymbol)("C..ctor")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    New SemanticEdit(SemanticEditKind.Insert, Nothing, b1),
+                    New SemanticEdit(SemanticEditKind.Update, ctor0, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I0-0, $I0-1#1, $I0-2#1, _Lambda$__0-0, _Lambda$__0-1#1, _Lambda$__0-2#1}")
+
+            diff1.VerifyIL("C..ctor", "
+{
+  // Code size      144 (0x90)
+  .maxstack  3
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       ""Sub Object..ctor()""
+  IL_0007:  ldarg.0
+  IL_0008:  ldsfld     ""C._Closure$__.$I0-0 As System.Func(Of Integer, Integer)""
+  IL_000d:  brfalse.s  IL_0016
+  IL_000f:  ldsfld     ""C._Closure$__.$I0-0 As System.Func(Of Integer, Integer)""
+  IL_0014:  br.s       IL_002c
+  IL_0016:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_001b:  ldftn      ""Function C._Closure$__._Lambda$__0-0(Integer) As Integer""
+  IL_0021:  newobj     ""Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)""
+  IL_0026:  dup
+  IL_0027:  stsfld     ""C._Closure$__.$I0-0 As System.Func(Of Integer, Integer)""
+  IL_002c:  call       ""Function C.F(System.Func(Of Integer, Integer)) As Integer""
+  IL_0031:  stfld      ""C.A As Integer""
+  IL_0036:  ldarg.0
+  IL_0037:  ldsfld     ""C._Closure$__.$I0-1#1 As System.Func(Of Integer, Integer)""
+  IL_003c:  brfalse.s  IL_0045
+  IL_003e:  ldsfld     ""C._Closure$__.$I0-1#1 As System.Func(Of Integer, Integer)""
+  IL_0043:  br.s       IL_005b
+  IL_0045:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_004a:  ldftn      ""Function C._Closure$__._Lambda$__0-1#1(Integer) As Integer""
+  IL_0050:  newobj     ""Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)""
+  IL_0055:  dup
+  IL_0056:  stsfld     ""C._Closure$__.$I0-1#1 As System.Func(Of Integer, Integer)""
+  IL_005b:  call       ""Function C.F(System.Func(Of Integer, Integer)) As Integer""
+  IL_0060:  stfld      ""C.B As Integer""
+  IL_0065:  ldsfld     ""C._Closure$__.$I0-2#1 As System.Func(Of Integer, Integer)""
+  IL_006a:  brfalse.s  IL_0073
+  IL_006c:  ldsfld     ""C._Closure$__.$I0-2#1 As System.Func(Of Integer, Integer)""
+  IL_0071:  br.s       IL_0089
+  IL_0073:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_0078:  ldftn      ""Function C._Closure$__._Lambda$__0-2#1(Integer) As Integer""
+  IL_007e:  newobj     ""Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)""
+  IL_0083:  dup
+  IL_0084:  stsfld     ""C._Closure$__.$I0-2#1 As System.Func(Of Integer, Integer)""
+  IL_0089:  call       ""Function C.F(System.Func(Of Integer, Integer)) As Integer""
+  IL_008e:  pop
+  IL_008f:  ret
+}
+")
+        End Sub
+
+        <Fact(Skip:="2504"), WorkItem(2504)>
+        Public Sub InsertConstructorInPresenceOfFieldInitializersWithLambdas()
+            Dim source0 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+    Dim B As Integer = F(Function(b) b + 1)     ' new field
+
+    Sub New(x As Integer)                       ' new ctor
+        F(Function(c) c + 1)         
+    End Sub
+End Class
+")
+
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim b1 = compilation1.GetMember(Of FieldSymbol)("C.B")
+            Dim ctor1 = compilation1.GetMember(Of MethodSymbol)("C..ctor")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    New SemanticEdit(SemanticEditKind.Insert, Nothing, b1),
+                    New SemanticEdit(SemanticEditKind.Insert, Nothing, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I0-0, $I0-1#1, $I0-2#1, _Lambda$__0-0, _Lambda$__0-1#1, _Lambda$__0-2#1}")
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -1224,6 +1224,65 @@ class C : D
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [Fact]
+        public void InstanceConstructorWithInitializerWithLambda_Update1()
+        {
+            string src1 = @"
+class C
+{
+    public C() : this((a, b) => { <AS:0>Console.WriteLine(a + b);</AS:0> }) { }
+}";
+            string src2 = @"
+class C
+{
+    public C() : base((a, b) => { <AS:0>Console.WriteLine(a - b);</AS:0> }) { }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void InstanceConstructorWithInitializerWithLambda_Update2()
+        {
+            string src1 = @"
+class C
+{
+    public C() : <AS:1>this((a, b) => { <AS:0>Console.WriteLine(a + b);</AS:0> })</AS:1> { Console.WriteLine(1); }
+}";
+            string src2 = @"
+class C
+{
+    public C() : <AS:1>this((a, b) => { <AS:0>Console.WriteLine(a + b);</AS:0> })</AS:1> { Console.WriteLine(2); }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void InstanceConstructorWithInitializerWithLambda_Update3()
+        {
+            string src1 = @"
+class C
+{
+    public C() : <AS:1>this((a, b) => { <AS:0>Console.WriteLine(a + b);</AS:0> })</AS:1> { Console.WriteLine(1); }
+}";
+            string src2 = @"
+class C
+{
+    public C() : <AS:1>this((a, b) => { <AS:0>Console.WriteLine(a - b);</AS:0> })</AS:1> { Console.WriteLine(1); }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            // TODO: should be allowed (https://github.com/dotnet/roslyn/issues/1359)
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "this((a, b) => {       Console.WriteLine(a - b);        })"));
+        }
+
         #endregion
 
         #region Field and Property Initializers
@@ -1685,8 +1744,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "z", FeaturesResources.Field));
+            edits.VerifyRudeDiagnostics(active);
         }
 
         [Fact]
@@ -1715,8 +1773,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "z", FeaturesResources.AutoProperty));
+            edits.VerifyRudeDiagnostics(active);
         }
 
         [Fact]
@@ -1745,8 +1802,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "z", FeaturesResources.Field));
+            edits.VerifyRudeDiagnostics(active);
         }
 
         [Fact]
@@ -1775,8 +1831,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "z", FeaturesResources.AutoProperty));
+            edits.VerifyRudeDiagnostics(active);
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -755,7 +755,7 @@ yield return /*2*/ 3;
 foreach (var x in y) { yield return /*3*/ 2; }
 ";
 
-            var match = GetMethodMatches(src1, src2, stateMachine: StateMachineKind.Iterator);
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Iterator);
             var actual = ToMatchingPairs(match);
 
             // note that yield returns are matched in source order, regardless of the yielded expressions:
@@ -816,6 +816,51 @@ Console.WriteLine(1)/*4*/;
             {
                 { "Console.WriteLine(1)/*1*/;", "Console.WriteLine(1)/*3*/;" },
                 { "Console.WriteLine(1)/*2*/;", "Console.WriteLine(1)/*4*/;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchConstructorWithInitializer1()
+        {
+            var src1 = @"
+(int x = 1) : base(a => a + 1) { Console.WriteLine(1); }
+";
+            var src2 = @"
+(int x = 1) : base(a => a + 1) { Console.WriteLine(1); }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.ConstructorWithParameters);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "a => a + 1", "a => a + 1" },
+                { "{ Console.WriteLine(1); }", "{ Console.WriteLine(1); }" },
+                { "Console.WriteLine(1);", "Console.WriteLine(1);" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchConstructorWithInitializer2()
+        {
+            var src1 = @"
+() : base(a => a + 1) { Console.WriteLine(1); }
+";
+            var src2 = @"
+() { Console.WriteLine(1); }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.ConstructorWithParameters);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "{ Console.WriteLine(1); }", "{ Console.WriteLine(1); }" },
+                { "Console.WriteLine(1);", "Console.WriteLine(1);" }
             };
 
             expected.AssertEqual(actual);
@@ -4750,6 +4795,58 @@ class C
                 Diagnostic(RudeEditKind.NotAccessingCapturedVariableInLambda, "a", "y1", CSharpFeaturesResources.Lambda).WithFirstLine("G(a => x);         // error: disconnecting previously connected closures"));
         }
 
+        [Fact]
+        public void Lambdas_Update_Accessing_Closure_NestedLambdas()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    void G(Func<int, Func<int, int>> f) {}
+
+    void F()                       
+    {                              
+        { int x0 = 0;      // Group #0             
+            { int x1 = 0;  // Group #1               
+                                         
+                G(a => b => x0);
+                G(a => b => x1);
+            }
+        }
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    void G(Func<int, Func<int, int>> f) {}
+
+    void F()
+    {
+        { int x0 = 0;      // Group #0          
+            { int x1 = 0;  // Group #1              
+                                         
+                G(a => b => x0);
+                G(a => b => x1);
+
+                G(a => b => x0);      // ok
+                G(a => b => x1);      // ok
+                G(a => b => x0 + x1); // error
+            }
+        }
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", "lambda", "x0", "x1"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", "lambda", "x0", "x1"));
+        }
+
         #endregion
 
         #region Queries
@@ -5889,7 +5986,7 @@ yield return 1;
 yield return 3;
 ";
 
-            var bodyEdits = GetMethodEdits(src1, src2, stateMachine: StateMachineKind.Iterator);
+            var bodyEdits = GetMethodEdits(src1, src2, kind: MethodKind.Iterator);
 
             bodyEdits.VerifyEdits(
                 "Delete [yield return 2;]@42");
@@ -5939,7 +6036,7 @@ yield return 3;
 yield return 4;
 ";
 
-            var bodyEdits = GetMethodEdits(src1, src2, stateMachine: StateMachineKind.Iterator);
+            var bodyEdits = GetMethodEdits(src1, src2, kind: MethodKind.Iterator);
 
             bodyEdits.VerifyEdits(
                 "Insert [yield return 2;]@42",
@@ -6102,7 +6199,7 @@ await F(1);
 await F(3);
 ";
 
-            var bodyEdits = GetMethodEdits(src1, src2, stateMachine: StateMachineKind.Async);
+            var bodyEdits = GetMethodEdits(src1, src2, kind: MethodKind.Async);
 
             bodyEdits.VerifyEdits(
                 "Delete [await F(2);]@37",
@@ -6227,7 +6324,7 @@ await F(3);
 await F(4);
 ";
 
-            var bodyEdits = GetMethodEdits(src1, src2, stateMachine: StateMachineKind.Async);
+            var bodyEdits = GetMethodEdits(src1, src2, kind: MethodKind.Async);
 
             bodyEdits.VerifyEdits(
                 "Insert [await F(2);]@37",

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -2106,6 +2106,8 @@ class C
         public void PrivateMethodInsert_WithParameters()
         {
             string src1 = @"
+using System;
+
 class C
 {
     static void Main(string[] args)
@@ -2114,6 +2116,8 @@ class C
     }
 }";
             string src2 = @"
+using System;
+
 class C
 {
     void foo(int a) { }
@@ -2127,11 +2131,13 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Insert [void foo(int a) { }]@18",
-                "Insert [(int a)]@26",
-                "Insert [int a]@27");
+                "Insert [void foo(int a) { }]@35",
+                "Insert [(int a)]@43",
+                "Insert [int a]@44");
 
-            edits.VerifyRudeDiagnostics();
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.foo")) });
         }
 
         [WorkItem(755784)]
@@ -3695,7 +3701,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -3781,7 +3787,7 @@ class B
                 ActiveStatementsDescription.Empty,
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -3934,7 +3940,7 @@ class B
                 new[] { srcB2 },
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -3955,7 +3961,7 @@ class B
                 new[] { srcB2 },
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -3976,7 +3982,7 @@ class B
                 new[] { srcB2 },
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -3997,7 +4003,7 @@ class B
                 new[] { srcB2 },
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -4039,6 +4045,257 @@ class B
                 Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()"));
         }
 
+        [Fact]
+        public void InstanceCtor_Partial_Update_LambdaInInitializer1()
+        {
+            string src1 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C()
+    {
+        F(<N:0.2>c => c + 1</N:0.2>);
+    }
+}
+";
+            string src2 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C()
+    {
+        F(<N:0.2>c => c + 2</N:0.2>);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void InstanceCtor_Partial_Update_LambdaInInitializer_Trivia1()
+        {
+            string src1 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C() { F(<N:0.2>c => c + 1</N:0.2>); }
+}
+";
+            string src2 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    /*new trivia*/public C() { F(<N:0.2>c => c + 1</N:0.2>); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void InstanceCtor_Partial_Update_LambdaInInitializer_ExplicitInterfaceImpl1()
+        {
+            string src1 = @"
+using System;
+
+public interface I { int B { get; } }
+public interface J { int B { get; } }
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C : I, J
+{
+    int I.B { get; } = F(<N:0.1>ib => ib + 1</N:0.1>);
+    int J.B { get; } = F(<N:0.2>jb => jb + 1</N:0.2>);
+
+    public C()
+    {
+        F(<N:0.3>c => c + 1</N:0.3>);
+    }
+}
+";
+            string src2 = @"
+using System;
+
+public interface I { int B { get; } }
+public interface J { int B { get; } }
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C : I, J
+{
+    int I.B { get; } = F(<N:0.1>ib => ib + 1</N:0.1>);
+    int J.B { get; } = F(<N:0.2>jb => jb + 1</N:0.2>);
+
+    public C()
+    {
+        F(<N:0.3>c => c + 2</N:0.3>);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void InstanceCtor_Partial_Insert_Parameterless_LambdaInInitializer1()
+        {
+            string src1 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+}
+";
+            string src2 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C()   // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact, WorkItem(2504)]
+        public void InstanceCtor_Partial_Insert_WithParameters_LambdaInInitializer1()
+        {
+            string src1 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+}
+";
+            string src2 = @"
+using System;
+
+partial class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int B { get; } = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int x)                                 // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "public C(int x)"));
+
+            // TODO: bug https://github.com/dotnet/roslyn/issues/2504
+            //edits.VerifySemantics(
+            //    ActiveStatementsDescription.Empty,
+            //    new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
         [WorkItem(2068)]
         [Fact]
         public void Insert_ExternConstruct()
@@ -4073,7 +4330,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4089,7 +4346,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4135,7 +4392,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4248,7 +4505,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4261,7 +4518,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4277,7 +4534,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4290,7 +4547,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4306,7 +4563,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4319,7 +4576,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4335,7 +4592,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4353,8 +4610,8 @@ class B
                 ActiveStatementsDescription.Empty,
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)")),
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(int)")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(int)"), preserveLocalVariables: true),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)"), preserveLocalVariables: true),
                 });
         }
 
@@ -4370,8 +4627,8 @@ class B
                 ActiveStatementsDescription.Empty,
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)")),
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(int)")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(int)"), preserveLocalVariables: true),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)"), preserveLocalVariables: true),
                 });
         }
 
@@ -4390,7 +4647,7 @@ class B
                 ActiveStatementsDescription.Empty,
                 new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)"))
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(m => m.ToString() == "C.C(bool)"), preserveLocalVariables: true)
                 });
         }
 
@@ -4438,7 +4695,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4451,7 +4708,7 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -4498,10 +4755,34 @@ class B
         }
 
         [Fact]
-        public void PropertyInitializerUpdate_StackAllocInConstructor()
+        public void PropertyInitializerUpdate_StackAllocInConstructor1()
         {
             var src1 = "unsafe class C { int a { get; } = 1; public C() { int* a = stackalloc int[10]; } }";
             var src2 = "unsafe class C { int a { get; } = 2; public C() { int* a = stackalloc int[10]; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            // TODO (tomat): diagnostic should point to the property initializer
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.Constructor));
+        }
+
+        [Fact]
+        public void PropertyInitializerUpdate_StackAllocInConstructor2()
+        {
+            var src1 = "unsafe class C { int a { get; } = 1; public C() : this(1) { int* a = stackalloc int[10]; } public C(int a) { } }";
+            var src2 = "unsafe class C { int a { get; } = 2; public C() : this(1) { int* a = stackalloc int[10]; } public C(int a) { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
+        [Fact]
+        public void PropertyInitializerUpdate_StackAllocInConstructor3()
+        {
+            var src1 = "unsafe class C { int a { get; } = 1; public C() { } public C(int b) { int* a = stackalloc int[10]; } }";
+            var src2 = "unsafe class C { int a { get; } = 2; public C() { } public C(int b) { int* a = stackalloc int[10]; } }";
 
             var edits = GetTopEdits(src1, src2);
 
@@ -4521,9 +4802,7 @@ class B
             edits.VerifyEdits(
                 "Update [a = 1]@14 -> [a = 2]@14");
 
-            // TODO (tomat): no errors
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "()", FeaturesResources.Constructor));
+            edits.VerifySemanticDiagnostics();
         }
 
         [Fact]
@@ -4534,9 +4813,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "()", FeaturesResources.Constructor));
+            edits.VerifySemanticDiagnostics();
         }
 
         [Fact]
@@ -4550,9 +4827,7 @@ class B
             edits.VerifyEdits(
                 "Update [a = 1]@33 -> [a = 2]@33");
 
-            // TODO (tomat): no errors
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "from", FeaturesResources.Constructor));
+            edits.VerifySemanticDiagnostics();
         }
 
         [Fact]
@@ -4563,9 +4838,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "from", FeaturesResources.Constructor));
+            edits.VerifySemanticDiagnostics();
         }
 
         [Fact]
@@ -4651,10 +4924,7 @@ class B
             var src2 = "class C { int a = F(2, (x, y) => x + y); }";
 
             var edits = GetTopEdits(src1, src2);
-
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "(x, y)", FeaturesResources.Field));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4665,9 +4935,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "(x, y)", FeaturesResources.AutoProperty));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4678,9 +4946,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "x", FeaturesResources.Field));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4691,9 +4957,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "x", FeaturesResources.AutoProperty));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4704,9 +4968,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "from", FeaturesResources.Field));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4717,9 +4979,7 @@ class B
 
             var edits = GetTopEdits(src1, src2);
 
-            // TODO (tomat): no errors
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "from", FeaturesResources.AutoProperty));
+            edits.VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -4742,6 +5002,624 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_ImplicitCtor_EditInitializerWithLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 2</N:0.1>);
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_ImplicitCtor_EditInitializerWithoutLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = 1;
+    int B = F(<N:0.0>b => b + 1</N:0.0>);
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = 2;
+    int B = F(<N:0.0>b => b + 1</N:0.0>);
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_CtorIncludingInitializers_EditInitializerWithLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C() {}
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 2</N:0.1>);
+
+    public C() {}
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_CtorIncludingInitializers_EditInitializerWithoutLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = 1;
+    int B = F(<N:0.0>b => b + 1</N:0.0>);
+
+    public C() {}
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = 2;
+    int B = F(<N:0.0>b => b + 1</N:0.0>);
+
+    public C() {}
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializers_EditInitializerWithLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) {}
+    public C(bool b) {}
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 2</N:0.1>);
+
+    public C(int a) {}
+    public C(bool b) {}
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] 
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[0], syntaxMap[0]),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[1], syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditInitializerWithLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(<N:0.3>d => d + 1</N:0.3>); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 2</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(<N:0.3>d => d + 1</N:0.3>); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[0], syntaxMap[0]),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[1], syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditInitializerWithLambda_Trivia1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(<N:0.3>d => d + 1</N:0.3>); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B =   F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(<N:0.3>d => d + 1</N:0.3>); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[0], syntaxMap[0]),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[1], syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(d => d + 1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 2</N:0.2>); }
+    public C(bool b) { F(d => d + 1); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Int32 a)"), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithLambda_Trivia1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(d => d + 1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+        public C(int a) { F(<N:0.2>c => c + 1</N:0.2>); }
+    public C(bool b) { F(d => d + 1); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Int32 a)"), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithoutLambda1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) { Console.WriteLine(1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) { Console.WriteLine(2); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Boolean b)"), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_EditContructorNotIncludingInitializers()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(a => a + 1);
+    int B = F(b => b + 1);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) : this(1) { Console.WriteLine(1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(a => a + 1);
+    int B = F(b => b + 1);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) : this(1) { Console.WriteLine(2); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Boolean b)"))
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_RemoveCtorInitializer1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    unsafe public C(int a) { char* buffer = stackalloc char[16]; F(c => c + 1); }
+    public C(bool b) : this(1) { Console.WriteLine(1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    unsafe public C(int a) { char* buffer = stackalloc char[16]; F(c => c + 1); }
+    public C(bool b) { Console.WriteLine(1); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Boolean b)"), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_AddCtorInitializer1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(a => a + 1);
+    int B = F(b => b + 1);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) { Console.WriteLine(1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(a => a + 1);
+    int B = F(b => b + 1);
+
+    public C(int a) { F(c => c + 1); }
+    public C(bool b) : this(1) { Console.WriteLine(1); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Boolean b)"))
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_Lambdas_UpdateBaseCtorInitializerWithLambdas1()
+        {
+            string src1 = @"
+using System;
+
+class B
+{
+    public B(int a) { }
+}
+
+class C : B
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(bool b)
+      : base(F(<N:0.2>c => c + 1</N:0.2>))
+    { 
+        F(<N:0.3>d => d + 1</N:0.3>);
+    }
+}
+";
+            string src2 = @"
+using System;
+
+class B
+{
+    public B(int a) { }
+}
+
+class C : B
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(<N:0.1>b => b + 1</N:0.1>);
+
+    public C(bool b)
+      : base(F(<N:0.2>c => c + 2</N:0.2>))
+    {
+        F(<N:0.3>d => d + 1</N:0.3>);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(ctor => ctor.ToTestDisplayString() == "C..ctor(System.Boolean b)"), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInitializerUpdate_ActiveStatements1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    <AS:0>int A = <N:0.0>1</N:0.0></AS:0>;
+    int B = 1;
+
+    public C(int a) { Console.WriteLine(1); }
+    public C(bool b) { Console.WriteLine(1); }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    <AS:0>int A = <N:0.0>1</N:0.0></AS:0>;
+    int B = 2;
+
+    public C(int a) { Console.WriteLine(1); }
+    public C(bool b) { Console.WriteLine(1); }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+            var activeStatements = GetActiveStatements(src1, src2);
+
+            edits.VerifySemantics(
+                activeStatements,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[0], syntaxMap[0]),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[1], syntaxMap[0]),
+                });
         }
 
         #endregion
@@ -4811,7 +5689,7 @@ class B
                 new[]
                 {
                     SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.a")),
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
                 });
         }
 
@@ -5003,6 +5881,179 @@ class C
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.Field, FeaturesResources.Class),
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.Field, FeaturesResources.Class),
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.Field, FeaturesResources.Class));
+        }
+
+        [Fact]
+        public void FieldInsert_WithInitializersAndLambdas1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+
+    public C()
+    {
+        F(<N:0.1>c => c + 1</N:0.1>);
+    }
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(b => b + 1);                    // new field
+
+    public C()
+    {
+        F(<N:0.1>c => c + 1</N:0.1>);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0])
+                });
+        }
+
+        [Fact]
+        public void FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(b => b + 1);                    // new field
+
+    public C()                                // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0])
+                });
+        }
+
+        [Fact, WorkItem(2504)]
+        public void FieldInsert_ConstructorInsert_WithInitializersAndLambdas1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+    int B = F(b => b + 1);                    // new field
+
+    public C(int x)                           // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "public C(int x)"));
+
+            // TODO (bug https://github.com/dotnet/roslyn/issues/2504):
+            //edits.VerifySemantics(
+            //    ActiveStatementsDescription.Empty,
+            //    new[]
+            //    {
+            //        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
+            //        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0])
+            //    });
+        }
+
+        [Fact, WorkItem(2504)]
+        public void FieldInsert_ConstructorInsert_WithInitializersButNoExistingLambdas1()
+        {
+            string src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(null);
+}
+";
+            string src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(null);
+    int B = F(b => b + 1);                    // new field
+
+    public C(int x)                           // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single())
+                });
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var diagnostics = new List<RudeEditDiagnostic>();
             var actualNewActiveStatements = new LinePositionSpan[oldActiveStatements.Length];
             var actualNewExceptionRegions = new ImmutableArray<LinePositionSpan>[oldActiveStatements.Length];
-            var updatedActiveMethodMatches = new List<AbstractEditAndContinueAnalyzer.UpdatedMethodInfo>();
+            var updatedActiveMethodMatches = new List<AbstractEditAndContinueAnalyzer.UpdatedMemberInfo>();
             var editMap = Analyzer.BuildEditMap(editScript);
 
             DocumentId documentId = DocumentId.CreateNewId(ProjectId.CreateNewId("TestEnCProject"), "TestEnCDocument");
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var newModel = newCompilation.GetSemanticModel(newRoot.SyntaxTree);
 
             var oldActiveStatements = activeStatements.OldSpans.AsImmutable();
-            var updatedActiveMethodMatches = new List<AbstractEditAndContinueAnalyzer.UpdatedMethodInfo>();
+            var updatedActiveMethodMatches = new List<AbstractEditAndContinueAnalyzer.UpdatedMemberInfo>();
             var triviaEdits = new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
             var actualLineEdits = new List<LineChange>();
             var actualSemanticEdits = new List<SemanticEdit>();
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                         newNodes.Add(newNode);
                     }
                 }
-                else
+                else if (!expectedSemanticEdits[i].PreserveLocalVariables)
                 {
                     Assert.Null(actualSyntaxMap);
                 }

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.ExperimentalFeaturesEnabled,
                 RudeEditKind.AwaitStatementUpdate,
                 RudeEditKind.InsertFile,
+                RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas,
             };
 
             var arg2 = new HashSet<RudeEditKind>()

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -1652,8 +1652,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function()", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics(active)
         End Sub
 
         <Fact, WorkItem(815933)>
@@ -1674,8 +1673,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Sub()", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics(active)
         End Sub
 
         <Fact>
@@ -1694,8 +1692,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function()", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics(active)
         End Sub
 
         <Fact, WorkItem(849649)>
@@ -1807,8 +1804,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementUpdate, "3"),
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function()", FeaturesResources.Field))
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "3"))
         End Sub
 
         <Fact, WorkItem(849649)>
@@ -1829,8 +1825,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Sub()", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics(active)
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -2002,7 +2002,7 @@ End Class
                 Diagnostic(RudeEditKind.AwaitStatementUpdate, "a += Await F(1)"))
         End Sub
 
-        <Fact(Skip:="TODO: Enable lambda edits")>
+        <Fact>
         Public Sub MethodWithLambda_Update()
             Dim src1 = "
 Class C

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -1742,7 +1742,9 @@ End Class
                 "Insert [a]@30",
                 "Insert [As Integer]@32")
 
-            edits.VerifyRudeDiagnostics()
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
@@ -2608,7 +2610,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2667,9 +2669,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                {SemanticEdit(SemanticEditKind.Update, Function(c)
-                                                           Return c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single()
-                                                       End Function)})
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2800,7 +2800,7 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {srcB1},
                                   {srcB2},
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2816,7 +2816,7 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {srcB1},
                                   {srcB2},
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2832,7 +2832,7 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {srcB1},
                                   {srcB2},
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2848,7 +2848,7 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {srcB1},
                                   {srcB2},
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2864,7 +2864,7 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {srcB1},
                                   {srcB2},
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2901,6 +2901,271 @@ End Class
                                   Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Friend Sub New()"))
         End Sub
 
+        <Fact>
+        Public Sub InstanceCtor_Partial_Update_LambdaInInitializer1()
+            Dim src1 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>)), A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
+    Dim A3, A4 As New Func(Of Integer, Integer)(<N:0.2>Function(a34) a34 + 1</N:0.2>)
+    Dim A5(F(<N:0.3>Function(a51) a51 + 1</N:0.3>), F(<N:0.4>Function(a52) a52 + 1</N:0.4>)) As Integer
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.5>Function(b) b + 1</N:0.5>)
+
+    Public Sub New()
+        F(<N:0.6>Function(c) c + 1</N:0.6>)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>)), A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
+    Dim A3, A4 As New Func(Of Integer, Integer)(<N:0.2>Function(a34) a34 + 1</N:0.2>)
+    Dim A5(F(<N:0.3>Function(a51) a51 + 1</N:0.3>), F(<N:0.4>Function(a52) a52 + 1</N:0.4>)) As Integer
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.5>Function(b) b + 1</N:0.5>)
+
+    Public Sub New()
+        F(<N:0.6>Function(c) c + 2</N:0.6>)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub InstanceCtor_Partial_Update_LambdaInInitializer_Trivia1()
+            Dim src1 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Public Sub New()
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+       Public Sub New()
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub InstanceCtor_Partial_Update_LambdaInInitializer_ExplicitInterfaceImpl1()
+            Dim src1 As String = "
+Imports System
+
+Public Interface I
+    ReadOnly Property B As Integer
+End Interface
+
+Public Interface J
+    ReadOnly Property B As Integer
+End Interface
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    Implements I, J
+
+    Private ReadOnly Property I_B As Integer = F(<N:0.1>Function(ib) ib + 1</N:0.1>) Implements I.B
+    Private ReadOnly Property J_B As Integer = F(<N:0.2>Function(jb) jb + 1</N:0.2>) Implements J.B
+
+    Public Sub New()
+        F(<N:0.3>Function(c) c + 1</N:0.3>)
+    End Sub
+End Class
+"
+            Dim src2 As String = "
+Imports System
+
+Public Interface I
+    ReadOnly Property B As Integer
+End Interface
+
+Public Interface J
+    ReadOnly Property B As Integer
+End Interface
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    Implements I, J
+
+    Private ReadOnly Property I_B As Integer = F(<N:0.1>Function(ib) ib + 1</N:0.1>) Implements I.B
+    Private ReadOnly Property J_B As Integer = F(<N:0.2>Function(jb) jb + 1</N:0.2>) Implements J.B
+
+    Public Sub New()
+        F(<N:0.3>Function(c) c + 2</N:0.3>)   ' update
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub InstanceCtor_Partial_Insert_Parameterless_LambdaInInitializer1()
+            Dim src1 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(a) a + 1</N:0.1>)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(a) a + 1</N:0.1>)
+
+    Sub New()      ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact, WorkItem(2504)>
+        Public Sub InstanceCtor_Partial_Insert_WithParameters_LambdaInInitializer1()
+            Dim src1 As String = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+End Class
+"
+            Dim src2 As String = "
+Imports System
+
+Partial Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    ReadOnly Property B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(x As Integer)              ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "Sub New(x As Integer)"))
+
+            ' TODO bug https://github.com/dotnet/roslyn/issues/2504
+            ' edits.VerifySemantics(
+            '     ActiveStatementsDescription.Empty,
+            '     {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap(0))})
+
+        End Sub
 #End Region
 
 #Region "Declare"
@@ -3525,6 +3790,176 @@ End Class
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.Field, FeaturesResources.Class))
         End Sub
 
+        <Fact>
+        Public Sub FieldInsert_WithInitializersAndLambdas1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+
+    Public Sub New()
+        F(<N:0.1>Function(c) c + 1</N:0.1>)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(Function(b) b + 1)   ' new field
+
+    Public Sub New()
+        F(<N:0.1>Function(c) c + 1</N:0.1>)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+
+    Dim B As Integer = F(Function(b) b + 1)   ' new field
+
+    Sub New()                                 ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact, WorkItem(2504)>
+        Public Sub FieldInsert_ConstructorInsert_WithInitializersAndLambdas1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+
+    Dim B As Integer = F(Function(b) b + 1)   ' new field
+
+    Sub New(x As Integer)                     ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
+                 SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single())})
+
+            ' TODO (bug https//github.com/dotnet/roslyn/issues/2504):
+            'edits.VerifySemantics(
+            '    ActiveStatementsDescription.Empty,
+            '    {
+            '        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
+            '        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))
+            '    })
+
+        End Sub
+
+        <Fact, WorkItem(2504)>
+        Public Sub FieldInsert_ConstructorInsert_WithInitializersButNoExistingLambdas1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(Nothing)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 0
+    End Function
+
+    Dim A As Integer = F(Nothing)
+    Dim B As Integer = F(Function(b) b + 1)   ' new field
+
+    Sub New(x As Integer)                     ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {
+                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
+                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single())
+                })
+        End Sub
+
 #End Region
 
 #Region "Properties"
@@ -3683,16 +4118,16 @@ End Structure
 
         <Fact>
         Public Sub PropertyInsert_IntoLayoutClass_Sequential()
-            Dim src1 = <![CDATA[
+            Dim src1 = "
 Imports System.Runtime.InteropServices
 
 <StructLayoutAttribute(LayoutKind.Sequential)>
 Class C
     Private a As Integer
 End Class
-]]>.Value
+"
 
-            Dim src2 = <![CDATA[
+            Dim src2 = "
 Imports System.Runtime.InteropServices
 
 <StructLayoutAttribute(LayoutKind.Sequential)>
@@ -3719,7 +4154,7 @@ Class C
         End Set
     End Property
 End Class
-]]>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "Private Property b As Integer", FeaturesResources.AutoProperty, FeaturesResources.Class),
@@ -3739,7 +4174,7 @@ End Class
                 "Update [a As Integer = 0]@14 -> [a As Integer = 1]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3752,7 +4187,7 @@ End Class
                 "Update [a, b As Integer = 0]@14 -> [a, b As Integer = 1]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3765,7 +4200,7 @@ End Class
                 "Update [Property a As Integer = 0]@10 -> [Property a As Integer = 1]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3778,7 +4213,7 @@ End Class
                 "Update [Property a As New C(0)]@10 -> [Property a As New C(1)]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3791,7 +4226,7 @@ End Class
                 "Update [a(1)]@14 -> [a(2)]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3804,7 +4239,7 @@ End Class
                 "Update [a As New D(1)]@14 -> [a As New D(2)]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3817,7 +4252,7 @@ End Class
                 "Update [a, b As New C(1)]@14 -> [a, b As New C(2)]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3830,7 +4265,7 @@ End Class
                 "Update [Property a As New D(1)]@10 -> [Property a As New D(2)]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3843,7 +4278,7 @@ End Class
                 "Update [a = 1]@14 -> [a = 2]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3856,7 +4291,7 @@ End Class
                 "Update [Property a = 1]@10 -> [Property a = 2]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3869,7 +4304,7 @@ End Class
                 "Update [a As Integer = 0]@14 -> [a As Integer]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3882,7 +4317,7 @@ End Class
                 "Update [Property a As Integer = 0]@10 -> [Property a As Integer]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3895,7 +4330,7 @@ End Class
                 "Update [Property a As Integer = 0]@14 -> [Property a As Integer]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3908,7 +4343,7 @@ End Class
                 "Update [a As Integer]@14 -> [a As Integer = 0]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -3921,7 +4356,7 @@ End Class
                 "Update [Property a As Integer]@10 -> [Property a As Integer = 0]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4065,8 +4500,11 @@ End Class
             Dim src2 = "Class C : Shared a As Integer = 0 : " & vbLf & "Shared Sub New() : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
+            edits.VerifyEdits(
+                "Update [a As Integer]@17 -> [a As Integer = 0]@17")
+
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4075,8 +4513,11 @@ End Class
             Dim src2 = "Module C : Dim a As Integer = 0 : " & vbLf & "Sub New() : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
+            edits.VerifyEdits(
+                "Update [a As Integer]@15 -> [a As Integer = 0]@15")
+
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4086,7 +4527,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4096,7 +4537,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4106,7 +4547,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4116,7 +4557,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4126,7 +4567,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4136,7 +4577,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4146,7 +4587,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4156,7 +4597,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4166,8 +4607,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)")),
-                                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)"), preserveLocalVariables:=True),
+                                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4177,8 +4618,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)")),
-                                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)"), preserveLocalVariables:=True),
+                                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4188,7 +4629,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4198,7 +4639,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4208,7 +4649,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4218,7 +4659,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4228,8 +4669,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)"), preserveLocalVariables:=True),
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4239,8 +4680,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Integer)"), preserveLocalVariables:=True),
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.ToString() = "Private Sub New(a As Boolean)"), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4330,7 +4771,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4340,7 +4781,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4363,44 +4804,40 @@ End Class
                 Diagnostic(RudeEditKind.GenericTypeInitializerUpdate, "Property a", FeaturesResources.AutoProperty))
         End Sub
 
-        <Fact(Skip:="726990")>
+        <Fact>
         Public Sub FieldUpdate_LambdaInConstructor()
             Dim src1 = "Class C : Dim a As Integer = 1 : " & vbLf & "Sub New()" & vbLf & "F(Sub() System.Console.WriteLine()) : End Sub : End Class"
             Dim src2 = "Class C : Dim a As Integer = 2 : " & vbLf & "Sub New()" & vbLf & "F(Sub() System.Console.WriteLine()) : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Sub()", "constructor"))
+            edits.VerifySemanticDiagnostics()
         End Sub
 
-        <Fact(Skip:="726990")>
+        <Fact>
         Public Sub PropertyUpdate_LambdaInConstructor()
             Dim src1 = "Class C : Property a As Integer = 1 : " & vbLf & "Sub New()" & vbLf & "F(Sub() System.Console.WriteLine()) : End Sub : End Class"
             Dim src2 = "Class C : Property a As Integer = 2 : " & vbLf & "Sub New()" & vbLf & "F(Sub() System.Console.WriteLine()) : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Sub()", "constructor"))
+            edits.VerifySemanticDiagnostics()
         End Sub
 
-        <Fact(Skip:="726990")>
+        <Fact>
         Public Sub FieldUpdate_QueryInConstructor()
             Dim src1 = "Class C : Dim a As Integer = 1 : " & vbLf & "Sub New()" & vbLf & "F(From a In b Select c) : End Sub : End Class"
             Dim src2 = "Class C : Dim a As Integer = 2 : " & vbLf & "Sub New()" & vbLf & "F(From a In b Select c) : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "From", "constructor"))
+            edits.VerifySemanticDiagnostics()
         End Sub
 
-        <Fact(Skip:="726990")>
+        <Fact>
         Public Sub PropertyUpdate_QueryInConstructor()
             Dim src1 = "Class C : Property a As Integer = 1 : " & vbLf & "Sub New()" & vbLf & "F(From a In b Select c) : End Sub : End Class"
             Dim src2 = "Class C : Property a As Integer = 2 : " & vbLf & "Sub New()" & vbLf & "F(From a In b Select c) : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "From", "constructor"))
+            edits.VerifySemanticDiagnostics()
         End Sub
 
         <Fact>
@@ -4495,7 +4932,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4510,7 +4947,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.b")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4525,7 +4962,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4541,7 +4978,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4555,7 +4992,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4572,7 +5009,7 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4647,8 +5084,7 @@ End Class
             Dim src2 = "Class C : Dim a As Integer = F(2, Function(x, y) x + y) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function(x, y)", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4657,8 +5093,7 @@ End Class
             Dim src2 = "Class C : Property a As Integer = F(2, Function(x, y) x + y) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function(x, y)", FeaturesResources.AutoProperty))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4667,8 +5102,7 @@ End Class
             Dim src2 = "Class C : Dim a As Integer = F(2, Function(x)" & vbLf & "Return x" & vbLf & "End Function) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function(x)", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4677,8 +5111,7 @@ End Class
             Dim src2 = "Class C : Property a As Integer = F(2, Function(x)" & vbLf & "Return x" & vbLf & "End Function) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, "Function(x)", FeaturesResources.AutoProperty))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4687,8 +5120,7 @@ End Class
             Dim src2 = "Class C : Dim a = F(2, From foo In bar Select baz) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "From", FeaturesResources.Field))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4697,8 +5129,7 @@ End Class
             Dim src2 = "Class C : Property a = F(2, From foo In bar Select baz) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, "From", FeaturesResources.AutoProperty))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -4758,6 +5189,649 @@ End Class
                 Diagnostic(RudeEditKind.ModifiersUpdate, "Const x = 0", FeaturesResources.ConstField))
         End Sub
 
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_ImplicitCtor_EditInitializerWithLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 2</N:0.1>)
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_ImplicitCtor_EditInitializerWithoutLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = 1
+    Dim B As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = 2
+    Dim B As Integer = F(<N:0.0>Function(b) b + 2</N:0.0>)
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_CtorIncludingInitializers_EditInitializerWithLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 2</N:0.1>)
+
+    Sub New
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_CtorIncludingInitializers_EditInitializerWithoutLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = 1
+    Dim B As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+
+    Sub New
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = 2
+    Dim B As Integer = F(<N:0.0>Function(b) b + 2</N:0.0>)
+
+    Sub New
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializers_EditInitializerWithLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+    End Sub
+
+    Sub New(b As Boolean)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 2</N:0.1>)
+
+    Sub New(a As Integer)
+    End Sub
+
+    Sub New(b As Boolean)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditInitializerWithLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(<N:0.3>Function(d) d + 1</N:0.3>)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(b) b + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 2</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(<N:0.3>Function(d) d + 1</N:0.3>)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditInitializerWithLambda_Trivia1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(<N:0.3>Function(d) d + 1</N:0.3>)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer =      F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(<N:0.3>Function(d) d + 1</N:0.3>)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(Function(d) d + 1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer)
+        F(<N:0.2>Function(c) c + 2</N:0.2>)
+    End Sub
+
+    Sub New(b As Boolean)
+        F(Function(d) d + 1)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(a As System.Int32)"), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithLambda_Trivia1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer) 
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+    
+    Sub New(b As Boolean)
+        F(Function(d) d + 1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+        Sub New(a As Integer) 
+        F(<N:0.2>Function(c) c + 1</N:0.2>)
+    End Sub
+    
+    Sub New(b As Boolean) 
+        F(Function(d) d + 1) 
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(a As System.Int32)"), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_MultipleCtorsIncludingInitializersContainingLambdas_EditContructorWithoutLambda1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        Console.WriteLine(2)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(b As System.Boolean)"), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_EditContructorNotIncludingInitializers()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+    Dim B As Integer = F(Function(b) b + 1)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        MyClass.New(1)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+    Dim B As Integer = F(Function(b) b + 1)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        MyClass.New(1)
+        Console.WriteLine(2)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(b As System.Boolean)"))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_RemoveCtorInitializer1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer) 
+        ' method with a static local is currently non-editable
+        Static s As Integer = 1
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        MyClass.New(1)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(<N:0.0>Function(a) a + 1</N:0.0>)
+    Dim B As Integer = F(<N:0.1>Function(b) b + 1</N:0.1>)
+
+    Sub New(a As Integer) 
+        ' method with a static local is currently non-editable
+        Static s As Integer = 1
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(b As System.Boolean)"), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_AddCtorInitializer1()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+    Dim B As Integer = F(Function(b) b + 1)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+    End Function
+
+    Dim A As Integer = F(Function(a) a + 1)
+    Dim B As Integer = F(Function(b) b + 1)
+
+    Sub New(a As Integer) 
+        F(Function(c) c + 1)
+    End Sub
+    
+    Sub New(b As Boolean)
+        MyClass.New(1)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(ctor) ctor.ToTestDisplayString() = "Sub C..ctor(b As System.Boolean)"))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_ImplicitCtor_ArrayBounds1()
+            Dim src1 = "Class C : Dim a((<N:0.0>Function(n) n + 1</N:0.0>)(1)), b(1) : End Class"
+            Dim src2 = "Class C : Dim a((<N:0.0>Function(n) n + 1</N:0.0>)(2)), b(1) : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [a((       Function(n) n + 1        )(1))]@14 -> [a((       Function(n) n + 1        )(2))]@14")
+
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty,
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_ImplicitCtor_AsNew1()
+            Dim src1 = "Class C : Dim a, b As New C((<N:0.0>Function(n) n + 1</N:0.0>)(1))" & vbCrLf & "Sub New(a As Integer) : End Sub : End Class"
+            Dim src2 = "Class C : Dim a, b As New C((<N:0.0>Function(n) n + 1</N:0.0>)(2))" & vbCrLf & "Sub New(a As Integer) : End Sub : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty,
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact>
+        Public Sub FieldInitializerUpdate_ActiveStatements1()
+            Dim src1 As String = "
+Imports System
+
+Class C
+    <AS:0>Dim A As Integer = <N:0.0>1</N:0.0></AS:0>
+    Dim B As Integer = 1
+
+    Public Sub New(a As Integer) 
+        Console.WriteLine(1)
+    End Sub
+
+    Public Sub New(b As Boolean) 
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim src2 As String = "
+Imports System
+
+Class C
+    <AS:0>Dim A As Integer = <N:0.0>1</N:0.0></AS:0>
+    Dim B As Integer = 2
+
+    Public Sub New(a As Integer) 
+        Console.WriteLine(1)
+    End Sub
+
+    Public Sub New(b As Boolean) 
+        Console.WriteLine(1)
+    End Sub
+End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+            Dim activeStatements = GetActiveStatements(src1, src2)
+
+            edits.VerifySemantics(
+                activeStatements,
+                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
+                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
+        End Sub
 #End Region
 
 #Region "Events"

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -4177,7 +4177,7 @@ End Class
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
-        <Fact>
+        <Fact(Skip:="2543"), WorkItem(2543)>
         Public Sub Field_InitializerUpdate2()
             Dim src1 = "Class C : Dim a, b As Integer = 0 : End Class"
             Dim src2 = "Class C : Dim a, b As Integer = 1 : End Class"
@@ -4242,7 +4242,7 @@ End Class
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
-        <Fact>
+        <Fact(Skip:="2543"), WorkItem(2543)>
         Public Sub Field_InitializerUpdate_AsNew2()
             Dim src1 = "Class C : Dim a, b As New C(1) : End Class"
             Dim src2 = "Class C : Dim a, b As New C(2) : End Class"
@@ -4935,7 +4935,7 @@ End Class
                                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
-        <Fact>
+        <Fact(Skip:="2543"), WorkItem(2543)>
         Public Sub PrivateFieldInsert2()
             Dim src1 = "Class C : Private a As Integer = 1 : End Class"
             Dim src2 = "Class C : Private a, b As Integer = 1 : End Class"
@@ -5777,7 +5777,7 @@ End Class
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), syntaxMap(0))})
         End Sub
 
-        <Fact>
+        <Fact(Skip:="2543"), WorkItem(2543)>
         Public Sub FieldInitializerUpdate_Lambdas_ImplicitCtor_AsNew1()
             Dim src1 = "Class C : Dim a, b As New C((<N:0.0>Function(n) n + 1</N:0.0>)(1))" & vbCrLf & "Sub New(a As Integer) : End Sub : End Class"
             Dim src2 = "Class C : Dim a, b As New C((<N:0.0>Function(n) n + 1</N:0.0>)(2))" & vbCrLf & "Sub New(a As Integer) : End Sub : End Class"

--- a/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -52,9 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// <see cref="PropertyDeclarationSyntax"/> for property initializers and expression bodies.
         /// <see cref="IndexerDeclarationSyntax"/> for indexer expression bodies.
         /// </returns>
-        internal override SyntaxNode FindMemberDeclaration(SyntaxNode root, SyntaxNode node)
+        internal override SyntaxNode FindMemberDeclaration(SyntaxNode rootOpt, SyntaxNode node)
         {
-            while (node != root)
+            while (node != rootOpt)
             {
                 switch (node.Kind())
                 {
@@ -381,10 +381,56 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
-        internal override Func<SyntaxNode, SyntaxNode> CreateSyntaxMapForEquivalentNodes(SyntaxNode oldRoot, SyntaxNode newRoot)
+        protected override bool AreEquivalent(SyntaxNode left, SyntaxNode right)
         {
-            Debug.Assert(SyntaxFactory.AreEquivalent(oldRoot, newRoot));
-            return newNode => SyntaxUtilities.FindPartner(newRoot, oldRoot, newNode);
+            return SyntaxFactory.AreEquivalent(left, right);
+        }
+
+        internal override SyntaxNode FindPartner(SyntaxNode leftRoot, SyntaxNode rightRoot, SyntaxNode leftNode)
+        {
+            return SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
+        }
+
+        internal override SyntaxNode FindPartnerInMemberInitializer(SemanticModel leftModel, INamedTypeSymbol leftType, SyntaxNode leftNode, INamedTypeSymbol rightType, CancellationToken cancellationToken)
+        {
+            var leftEqualsClause = leftNode.FirstAncestorOrSelf<EqualsValueClauseSyntax>(
+                node => node.Parent.IsKind(SyntaxKind.PropertyDeclaration) || node.Parent.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration));
+
+            if (leftEqualsClause == null)
+            {
+                return null;
+            }
+
+            SyntaxNode rightEqualsClause;
+            if (leftEqualsClause.Parent.IsKind(SyntaxKind.PropertyDeclaration))
+            {
+                var leftDeclaration = (PropertyDeclarationSyntax)leftEqualsClause.Parent;
+                var leftSymbol = leftModel.GetDeclaredSymbol(leftDeclaration, cancellationToken);
+                Debug.Assert(leftSymbol != null);
+
+                var rightProperty = rightType.GetMembers(leftSymbol.Name).Single();
+                var rightDeclaration = (PropertyDeclarationSyntax)GetSymbolSyntax(rightProperty, cancellationToken);
+
+                rightEqualsClause = rightDeclaration.Initializer;
+            }
+            else
+            {
+                var leftDeclarator = (VariableDeclaratorSyntax)leftEqualsClause.Parent;
+                var leftSymbol = leftModel.GetDeclaredSymbol(leftDeclarator, cancellationToken);
+                Debug.Assert(leftSymbol != null);
+
+                var rightField = rightType.GetMembers(leftSymbol.Name).Single();
+                var rightDeclarator = (VariableDeclaratorSyntax)GetSymbolSyntax(rightField, cancellationToken);
+
+                rightEqualsClause = rightDeclarator.Initializer;
+            }
+
+            if (rightEqualsClause == null)
+            {
+                return null;
+            }
+
+            return FindPartner(leftEqualsClause, rightEqualsClause, leftNode);
         }
 
         internal override bool IsClosureScope(SyntaxNode node)
@@ -449,6 +495,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 // - for query lambdas the root is the query clause containing the lambda (e.g. where).
 
                 return new StatementSyntaxComparer(oldBody, newBody).ComputeMatch(oldBody.Parent, newBody.Parent, knownMatches);
+            }
+
+            if (oldBody.Parent.IsKind(SyntaxKind.ConstructorDeclaration))
+            {
+                // We need to include contructor initializer in the match, since it may contain lambdas.
+                // Use the constructor declaration as a root.
+                Debug.Assert(oldBody.IsKind(SyntaxKind.Block));
+                Debug.Assert(newBody.IsKind(SyntaxKind.Block));
+                Debug.Assert(newBody.Parent.IsKind(SyntaxKind.ConstructorDeclaration));
+
+                return StatementSyntaxComparer.Default.ComputeMatch(oldBody.Parent, newBody.Parent, knownMatches);
             }
 
             return StatementSyntaxComparer.Default.ComputeMatch(oldBody, newBody, knownMatches);
@@ -762,42 +819,25 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return SyntaxUtilities.HasBackingField((PropertyDeclarationSyntax)propertyDeclaration);
         }
 
-        internal override bool HasInitializer(SyntaxNode declaration, out bool isStatic)
+        internal override bool IsDeclarationWithInitializer(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
                 case SyntaxKind.VariableDeclarator:
-                    var fieldDeclaration = (VariableDeclaratorSyntax)declaration;
-                    if (fieldDeclaration.Initializer != null)
-                    {
-                        isStatic = ((FieldDeclarationSyntax)declaration.Parent.Parent).Modifiers.Any(SyntaxKind.StaticKeyword);
-                        return true;
-                    }
-
-                    isStatic = false;
-                    return false;
+                    return ((VariableDeclaratorSyntax)declaration).Initializer != null;
 
                 case SyntaxKind.PropertyDeclaration:
-                    var propertyDeclaration = (PropertyDeclarationSyntax)declaration;
-                    if (propertyDeclaration.Initializer != null)
-                    {
-                        isStatic = propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword);
-                        return true;
-                    }
-
-                    isStatic = false;
-                    return false;
+                    return ((PropertyDeclarationSyntax)declaration).Initializer != null;
 
                 default:
-                    isStatic = false;
                     return false;
             }
         }
 
-        internal override bool IncludesInitializers(SyntaxNode constructorDeclaration)
+        internal override bool IsConstructorWithMemberInitializers(SyntaxNode constructorDeclaration)
         {
-            var ctor = (ConstructorDeclarationSyntax)constructorDeclaration;
-            return ctor.Initializer == null || ctor.Initializer.IsKind(SyntaxKind.BaseConstructorInitializer);
+            var ctor = constructorDeclaration as ConstructorDeclarationSyntax;
+            return ctor != null && (ctor.Initializer == null || ctor.Initializer.IsKind(SyntaxKind.BaseConstructorInitializer));
         }
 
         internal override bool IsPartial(INamedTypeSymbol type)
@@ -809,6 +849,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         protected override ISymbol GetSymbolForEdit(SemanticModel model, SyntaxNode node, EditKind editKind, Dictionary<SyntaxNode, EditKind> editMap, CancellationToken cancellationToken)
         {
+            if (node.IsKind(SyntaxKind.Parameter))
+            {
+                return null;
+            }
+
             if (editKind == EditKind.Update)
             {
                 if (node.IsKind(SyntaxKind.EnumDeclaration))
@@ -2185,8 +2230,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                // TODO (#749): handle lambdas in initializers & constructors
-                ClassifyDeclarationBodyRudeUpdates(newNode, allowLambdas: false);
+                ClassifyDeclarationBodyRudeUpdates(newNode);
             }
 
             private void ClassifyUpdate(MethodDeclarationSyntax oldNode, MethodDeclarationSyntax newNode)
@@ -2219,8 +2263,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     (SyntaxNode)oldNode.Body ?? oldNode.ExpressionBody?.Expression,
                     (SyntaxNode)newNode.Body ?? newNode.ExpressionBody?.Expression,
                     containingMethodOpt: newNode,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private bool ClassifyMethodModifierUpdate(SyntaxTokenList oldModifiers, SyntaxTokenList newModifiers)
@@ -2265,8 +2308,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     (SyntaxNode)oldNode.Body ?? oldNode.ExpressionBody?.Expression,
                     (SyntaxNode)newNode.Body ?? newNode.ExpressionBody?.Expression,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private void ClassifyUpdate(OperatorDeclarationSyntax oldNode, OperatorDeclarationSyntax newNode)
@@ -2293,8 +2335,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     (SyntaxNode)oldNode.Body ?? oldNode.ExpressionBody?.Expression,
                     (SyntaxNode)newNode.Body ?? newNode.ExpressionBody?.Expression,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private void ClassifyUpdate(AccessorDeclarationSyntax oldNode, AccessorDeclarationSyntax newNode)
@@ -2318,8 +2359,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     oldNode.Body,
                     newNode.Body,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent.Parent.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent.Parent.Parent);
             }
 
             private void ClassifyUpdate(EnumMemberDeclarationSyntax oldNode, EnumMemberDeclarationSyntax newNode)
@@ -2342,13 +2382,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                // TODO (#749): handle lambdas in initializers & constructors
                 ClassifyMethodBodyRudeUpdate(
                     oldNode.Body,
                     newNode.Body,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: false);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private void ClassifyUpdate(DestructorDeclarationSyntax oldNode, DestructorDeclarationSyntax newNode)
@@ -2357,8 +2395,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     oldNode.Body,
                     newNode.Body,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private void ClassifyUpdate(PropertyDeclarationSyntax oldNode, PropertyDeclarationSyntax newNode)
@@ -2401,8 +2438,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         oldBody,
                         newBody,
                         containingMethodOpt: null,
-                        containingType: containingType,
-                        allowLambdas: true);
+                        containingType: containingType);
 
                     return;
                 }
@@ -2417,8 +2453,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 if (newNode.Initializer != null)
                 {
-                    // TODO (#749): handle lambdas in initializers & constructors
-                    ClassifyDeclarationBodyRudeUpdates(newNode.Initializer, allowLambdas: false);
+                    ClassifyDeclarationBodyRudeUpdates(newNode.Initializer);
                 }
             }
 
@@ -2451,8 +2486,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     oldBody,
                     newBody,
                     containingMethodOpt: null,
-                    containingType: (TypeDeclarationSyntax)newNode.Parent,
-                    allowLambdas: true);
+                    containingType: (TypeDeclarationSyntax)newNode.Parent);
             }
 
             private void ClassifyUpdate(TypeParameterSyntax oldNode, TypeParameterSyntax newNode)
@@ -2518,8 +2552,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 SyntaxNode oldBody,
                 SyntaxNode newBody,
                 MethodDeclarationSyntax containingMethodOpt,
-                TypeDeclarationSyntax containingType,
-                bool allowLambdas)
+                TypeDeclarationSyntax containingType)
             {
                 Debug.Assert(oldBody is BlockSyntax || oldBody is ExpressionSyntax || oldBody == null);
                 Debug.Assert(newBody is BlockSyntax || newBody is ExpressionSyntax || newBody == null);
@@ -2542,7 +2575,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 if (newBody != null)
                 {
-                    ClassifyDeclarationBodyRudeUpdates(newBody, allowLambdas);
+                    ClassifyDeclarationBodyRudeUpdates(newBody);
                 }
             }
 
@@ -2564,7 +2597,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 }
             }
 
-            public void ClassifyDeclarationBodyRudeUpdates(SyntaxNode newDeclarationOrBody, bool allowLambdas)
+            public void ClassifyDeclarationBodyRudeUpdates(SyntaxNode newDeclarationOrBody)
             {
                 foreach (var node in newDeclarationOrBody.DescendantNodesAndSelf(ChildrenCompiledInBody))
                 {
@@ -2573,37 +2606,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         case SyntaxKind.StackAllocArrayCreationExpression:
                             ReportError(RudeEditKind.StackAllocUpdate, node, _newNode);
                             return;
-
-                        case SyntaxKind.ParenthesizedLambdaExpression:
-                        case SyntaxKind.SimpleLambdaExpression:
-                            if (!allowLambdas)
-                            {
-                                // TODO (tomat): allow 
-                                ReportError(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, node, _newNode);
-                                return;
-                            }
-
-                            break;
-
-                        case SyntaxKind.AnonymousMethodExpression:
-                            if (!allowLambdas)
-                            {
-                                // TODO (tomat): allow 
-                                ReportError(RudeEditKind.RUDE_EDIT_ANON_METHOD, node, _newNode);
-                                return;
-                            }
-
-                            break;
-
-                        case SyntaxKind.QueryExpression:
-                            if (!allowLambdas)
-                            {
-                                // TODO (tomat): allow 
-                                ReportError(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, node, _newNode);
-                                return;
-                            }
-
-                            break;
                     }
                 }
             }
@@ -2641,9 +2643,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 newMember.FirstAncestorOrSelf<TypeDeclarationSyntax>(),
                 isTriviaUpdate: true);
 
-            // TODO (#749): handle lambdas in initializers & constructors
-            classifier.ClassifyDeclarationBodyRudeUpdates(newMember, 
-                allowLambdas: !newMember.IsKind(SyntaxKind.ConstructorDeclaration) && !newMember.IsKind(SyntaxKind.VariableDeclarator));
+            classifier.ClassifyDeclarationBodyRudeUpdates(newMember);
         }
 
         #endregion

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -133,10 +133,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         /// <summary>
-        /// Returns a function that maps nodes of <paramref name="newRoot"/> to corresponding nodes of <paramref name="oldRoot"/>,
-        /// assuming that the bodies only differ in trivia.
+        /// Maps <paramref name="leftNode"/> descendant of <paramref name="leftRoot"/> to corresponding descendant node
+        /// of <paramref name="rightRoot"/>, assuming that the trees only differ in trivia
         /// </summary>
-        internal abstract Func<SyntaxNode, SyntaxNode> CreateSyntaxMapForEquivalentNodes(SyntaxNode oldRoot, SyntaxNode newRoot);
+        internal abstract SyntaxNode FindPartner(SyntaxNode leftRoot, SyntaxNode rightRoot, SyntaxNode leftNode);
+
+        internal abstract SyntaxNode FindPartnerInMemberInitializer(SemanticModel leftModel, INamedTypeSymbol leftType, SyntaxNode leftNode, INamedTypeSymbol rightType, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns a node that represents a body of a lambda containing specified <paramref name="node"/>,
@@ -194,6 +196,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract bool StatementLabelEquals(SyntaxNode node1, SyntaxNode node2);
 
         /// <summary>
+        /// Determines if two syntax nodes are the same, disregarding trivia differences.
+        /// </summary>
+        protected abstract bool AreEquivalent(SyntaxNode left, SyntaxNode right);
+
+        /// <summary>
         /// Returns true if the code emitted for the old active statement part (<paramref name="statementPart"/> of <paramref name="oldStatement"/>) 
         /// is the same as the code emitted for the corresponding new active statement part (<paramref name="statementPart"/> of <paramref name="newStatement"/>). 
         /// </summary>
@@ -201,7 +208,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// A rude edit is reported if an active statement is changed and this method returns true.
         /// </remarks>
         protected abstract bool AreEquivalentActiveStatements(SyntaxNode oldStatement, SyntaxNode newStatement, int statementPart);
-
+        
         protected abstract ISymbol GetSymbolForEdit(SemanticModel model, SyntaxNode node, EditKind editKind, Dictionary<SyntaxNode, EditKind> editMap, CancellationToken cancellationToken);
 
         /// <summary>
@@ -268,15 +275,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Return true if the declaration is a field/property declaration with an initializer. 
         /// Shall return false for enum members.
         /// </summary>
-        internal abstract bool HasInitializer(SyntaxNode declaration, out bool isStatic);
+        internal abstract bool IsDeclarationWithInitializer(SyntaxNode declaration);
 
-        private bool HasInitializer(SyntaxNode declaration)
-        {
-            bool isStatic;
-            return HasInitializer(declaration, out isStatic);
-        }
+        /// <summary>
+        /// Return true if the declaration is a constructor declaration to which field/property initializers are emitted. 
+        /// </summary>
+        internal abstract bool IsConstructorWithMemberInitializers(SyntaxNode declaration);
 
-        internal abstract bool IncludesInitializers(SyntaxNode constructorDeclaration);
         internal abstract bool IsPartial(INamedTypeSymbol type);
         internal abstract SyntaxNode EmptyCompilationUnit { get; }
 
@@ -388,7 +393,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // 2) If there are syntactic rude edits we'll report them faster without waiting for semantic analysis.
                 //    The user may fix them before they address all the semantic errors.
 
-                var updatedMethods = new List<UpdatedMethodInfo>();
+                var updatedMethods = new List<UpdatedMemberInfo>();
                 var diagnostics = new List<RudeEditDiagnostic>();
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -540,7 +545,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ImmutableArray<ActiveStatementSpan> oldActiveStatements,
             [Out]LinePositionSpan[] newActiveStatements,
             [Out]ImmutableArray<LinePositionSpan>[] newExceptionRegions,
-            [Out]List<UpdatedMethodInfo> updatedMethods,
+            [Out]List<UpdatedMemberInfo> updatedMethods,
             [Out]List<RudeEditDiagnostic> diagnostics)
         {
             Debug.Assert(oldActiveStatements.Length == newActiveStatements.Length);
@@ -778,7 +783,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        internal struct UpdatedMethodInfo
+        internal struct UpdatedMemberInfo
         {
             // Index in top edit script.
             public readonly int EditOrdinal;
@@ -802,7 +807,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // only true if the body itself has the suspension point, not if it contains async/iterator lambda
             public readonly bool HasStateMachineSuspensionPoint;
 
-            public UpdatedMethodInfo(
+            public UpdatedMemberInfo(
                 int editOrdinal, 
                 SyntaxNode oldBody, 
                 SyntaxNode newBody, 
@@ -837,7 +842,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ImmutableArray<ActiveStatementSpan> oldActiveStatements,
             [Out]LinePositionSpan[] newActiveStatements,
             [Out]ImmutableArray<LinePositionSpan>[] newExceptionRegions,
-            [Out]List<UpdatedMethodInfo> updatedMethods,
+            [Out]List<UpdatedMemberInfo> updatedMembers,
             [Out]List<KeyValuePair<ActiveStatementId, TextSpan>> updatedTrackingSpans,
             [Out]List<RudeEditDiagnostic> diagnostics)
         {
@@ -872,7 +877,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // We need to adjust the tracking span design and UpdateUneditedSpans to account for such empty spans.
                 if (hasActiveStatement)
                 {
-                    var newSpan = HasInitializer(edit.OldNode) ?
+                    var newSpan = IsDeclarationWithInitializer(edit.OldNode) ?
                         GetDeletedNodeActiveSpan(topEditScript.Match.Matches, edit.OldNode) :
                         GetDeletedNodeDiagnosticSpan(topEditScript.Match.Matches, edit.OldNode);
 
@@ -976,14 +981,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var bodyMatch = ComputeBodyMatch(oldBody, newBody, activeNodes.Where(n => n.EnclosingLambdaBodyOpt == null).ToArray(), diagnostics, out hasStateMachineSuspensionPoint);
             var map = ComputeMap(bodyMatch, activeNodes, ref lazyActiveOrMatchedLambdas, diagnostics);
 
-            // TODO: include field initializers
-            if (IsMethod(edit.OldNode))
-            {
-                // Save the body match for local variable mapping.
-                // We'll use it to tell the compiler what local variables to preserve in an active method.
-                // An edited async/iterator method is considered active.
-                updatedMethods.Add(new UpdatedMethodInfo(editOrdinal, oldBody, newBody, map, lazyActiveOrMatchedLambdas, hasActiveStatement, hasStateMachineSuspensionPoint));
-            }
+            // Save the body match for local variable mapping.
+            // We'll use it to tell the compiler what local variables to preserve in an active method.
+            // An edited async/iterator method is considered active.
+            updatedMembers.Add(new UpdatedMemberInfo(editOrdinal, oldBody, newBody, map, lazyActiveOrMatchedLambdas, hasActiveStatement, hasStateMachineSuspensionPoint));
 
             for (int i = 0; i < activeNodes.Length; i++)
             {
@@ -1135,6 +1136,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         {
                             lambdaBodyMatches = ArrayBuilder<Match<SyntaxNode>>.GetInstance();
                         }
+
                         if (lazyActiveOrMatchedLambdas == null)
                         {
                             lazyActiveOrMatchedLambdas = new Dictionary<SyntaxNode, LambdaInfo>();
@@ -1986,6 +1988,22 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
+        private struct ConstructorEdit
+        {
+            public readonly INamedTypeSymbol OldType;
+
+            // { new field/property initializer or constructor declaration -> syntax map }
+            public readonly Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode>> ChangedDeclarations;
+
+            public ConstructorEdit(INamedTypeSymbol oldType)
+            {
+                Debug.Assert(oldType != null);
+
+                OldType = oldType;
+                ChangedDeclarations = new Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode>>();
+            }
+        }
+
         // internal for testing
         internal void AnalyzeSemantics(
             EditScript<SyntaxNode> editScript,
@@ -1993,20 +2011,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             SourceText oldText,
             ImmutableArray<ActiveStatementSpan> oldActiveStatements,
             List<KeyValuePair<SyntaxNode, SyntaxNode>> triviaEdits,
-            List<UpdatedMethodInfo> updatedMethods,
+            List<UpdatedMemberInfo> updatedMembers,
             SemanticModel oldModel,
             SemanticModel newModel,
             [Out]List<SemanticEdit> semanticEdits,
             [Out]List<RudeEditDiagnostic> diagnostics,
             CancellationToken cancellationToken)
         {
-            // { new type -> old type }
-            Dictionary<INamedTypeSymbol, INamedTypeSymbol> instanceConstructorUpdates = null;
-            Dictionary<INamedTypeSymbol, INamedTypeSymbol> staticConstructorUpdates = null;
+            // { new type -> contructor update }
+            Dictionary<INamedTypeSymbol, ConstructorEdit> instanceConstructorEdits = null;
+            Dictionary<INamedTypeSymbol, ConstructorEdit> staticConstructorEdits = null;
 
             INamedTypeSymbol layoutAttribute = null;
             var newSymbolsWithEdit = new HashSet<ISymbol>();
-            int updatedMethodIndex = 0;
+            int updatedMemberIndex = 0;
             for (int i = 0; i < editScript.Edits.Length; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -2014,7 +2032,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var edit = editScript.Edits[i];
 
                 ISymbol oldSymbol, newSymbol;
-                Func<SyntaxNode, SyntaxNode> syntaxMap;
+                Func<SyntaxNode, SyntaxNode> syntaxMapOpt;
                 SemanticEditKind editKind;
 
                 switch (edit.Kind)
@@ -2062,7 +2080,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             }
 
                             editKind = SemanticEditKind.Update;
-                            syntaxMap = null;
+                            syntaxMapOpt = null;
                         }
 
                         break;
@@ -2072,7 +2090,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         // and we don't need to report them to the compiler either.
 
                         // Reordering of fields is not allowed since it changes the layout of the type.
-                        Debug.Assert(!HasInitializer(edit.OldNode) && !HasInitializer(edit.NewNode));
+                        Debug.Assert(!IsDeclarationWithInitializer(edit.OldNode) && !IsDeclarationWithInitializer(edit.NewNode));
                         continue;
 
                     case EditKind.Insert:
@@ -2087,7 +2105,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
 
-                            syntaxMap = null;
+                            syntaxMapOpt = null;
                             oldSymbol = null;
                             newSymbol = GetSymbolForEdit(newModel, edit.NewNode, edit.Kind, editMap, cancellationToken);
 
@@ -2104,22 +2122,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 break;
                             }
 
-                            bool isStatic;
-                            bool hasFieldInitializer = HasInitializer(edit.NewNode, out isStatic);
+                            var newType = (INamedTypeSymbol)newModel.GetDeclaredSymbol(newTypeSyntax, cancellationToken);
+                            var oldType = TryGetPartnerType(newTypeSyntax, editScript.Match, oldModel, cancellationToken);
 
-                            if (hasFieldInitializer)
-                            {
-                                // Insertion of a field with an initializer forces the corresponding constructors to be recompiled.
-                                var newType = (INamedTypeSymbol)newModel.GetDeclaredSymbol(newTypeSyntax, cancellationToken);
-                                var oldType = TryGetPartnerType(newTypeSyntax, editScript.Match, oldModel, cancellationToken);
-
-                                // There has to be a matching old type syntax since the parent hasn't been inserted.
-                                Debug.Assert(oldType != null);
-
-                                ForceConstructorUpdate(oldType, newType, edit.NewNode.Span, isStatic, ref instanceConstructorUpdates, ref staticConstructorUpdates, diagnostics);
-                                ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, edit.NewNode, newModel, ref layoutAttribute);
-                                break;
-                            }
+                            // There has to be a matching old type syntax since the containing type hasn't been inserted.
+                            Debug.Assert(oldType != null);
+                            Debug.Assert(newType != null);
 
                             // Inserting a parameterless constructor needs special handling:
                             // 1) static ctor
@@ -2141,11 +2149,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             IMethodSymbol newCtor = AsParameterlessConstructor(newSymbol);
                             if (newCtor != null)
                             {
-                                var oldType = TryGetPartnerType(newTypeSyntax, editScript.Match, oldModel, cancellationToken);
-
-                                // There has to be a matching old type syntax since the containing type hasn't been inserted.
-                                Debug.Assert(oldType != null);
-
                                 oldSymbol = TryGetParameterlessConstructor(oldType, newSymbol.IsStatic);
 
                                 if (newCtor.IsStatic)
@@ -2170,10 +2173,43 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     }
                                 }
                             }
-                            else
+
+                            if (editKind == SemanticEditKind.Insert)
                             {
                                 ReportInsertedMemberSymbolRudeEdits(diagnostics, newSymbol);
                                 ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, edit.NewNode, newModel, ref layoutAttribute);
+                            }
+
+                            bool isConstructorWithMemberInitializers; 
+                            if ((isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(edit.NewNode)) ||
+                                IsDeclarationWithInitializer(edit.NewNode))
+                            {
+                                if (DeferConstructorEdit(
+                                    oldType,
+                                    newType,
+                                    editKind,
+                                    edit.NewNode,
+                                    newSymbol,
+                                    newModel,
+                                    isConstructorWithMemberInitializers, 
+                                    ref syntaxMapOpt,
+                                    ref instanceConstructorEdits,
+                                    ref staticConstructorEdits,
+                                    diagnostics,
+                                    cancellationToken))
+                                {
+                                    if (newSymbol.Kind == SymbolKind.Method)
+                                    {
+                                        // Don't add a separate semantic edit for a field/property with an initializer.
+                                        // All edits of initializers will be aggregated to edits of constructors where these initializers are emitted.
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        // A semantic edit to create the field/property is gonna be added.
+                                        Debug.Assert(editKind == SemanticEditKind.Insert);
+                                    }
+                                }
                             }
                         }
 
@@ -2182,19 +2218,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     case EditKind.Update:
                         {
                             editKind = SemanticEditKind.Update;
-                            bool isStatic;
-                            if (HasInitializer(edit.OldNode, out isStatic) || HasInitializer(edit.NewNode, out isStatic))
-                            {
-                                var newInitType = (INamedTypeSymbol)newModel.GetDeclaredSymbol(TryGetContainingTypeDeclaration(edit.NewNode), cancellationToken);
-                                var oldInitType = (INamedTypeSymbol)oldModel.GetDeclaredSymbol(TryGetContainingTypeDeclaration(edit.OldNode), cancellationToken);
-
-                                ForceConstructorUpdate(oldInitType, newInitType, edit.NewNode.Span, isStatic, ref instanceConstructorUpdates, ref staticConstructorUpdates, diagnostics);
-
-                                // There is no action the compiler needs to take in addition 
-                                // to updating the corresponding constructor.
-                                continue;
-                            }
-
+                            
                             newSymbol = GetSymbolForEdit(newModel, edit.NewNode, edit.Kind, editMap, cancellationToken);
                             if (newSymbol == null)
                             {
@@ -2205,21 +2229,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             oldSymbol = GetSymbolForEdit(oldModel, edit.OldNode, edit.Kind, editMap, cancellationToken);
                             Debug.Assert((newSymbol == null) == (oldSymbol == null));
 
-                            // this edit is an active method update:
-                            if (updatedMethodIndex < updatedMethods.Count && updatedMethods[updatedMethodIndex].EditOrdinal == i)
+                            if (updatedMemberIndex < updatedMembers.Count && updatedMembers[updatedMemberIndex].EditOrdinal == i)
                             {
-                                var updatedMethod = updatedMethods[updatedMethodIndex];
+                                var updatedMember = updatedMembers[updatedMemberIndex];
 
                                 bool newBodyHasLambdas;
                                 ReportLambdaAndClosureRudeEdits(
                                     oldModel, 
-                                    updatedMethod.OldBody,
+                                    updatedMember.OldBody,
                                     oldSymbol,
                                     newModel, 
-                                    updatedMethod.NewBody,
+                                    updatedMember.NewBody,
                                     newSymbol, 
-                                    updatedMethod.ActiveOrMatchedLambdasOpt, 
-                                    updatedMethod.Map, 
+                                    updatedMember.ActiveOrMatchedLambdasOpt, 
+                                    updatedMember.Map, 
                                     diagnostics, 
                                     out newBodyHasLambdas,
                                     cancellationToken);
@@ -2232,20 +2255,47 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 // 3) The new member contains lambdas
                                 //    We need to map new lambdas in the method to the matching old ones. 
                                 //    If the old method has lambdas but the new one doesn't there is nothing to preserve.
-                                if (updatedMethod.HasActiveStatement || updatedMethod.HasStateMachineSuspensionPoint || newBodyHasLambdas)
+                                if (updatedMember.HasActiveStatement || updatedMember.HasStateMachineSuspensionPoint || newBodyHasLambdas)
                                 {
-                                    syntaxMap = CreateSyntaxMap(updatedMethod.Map.Reverse);
+                                    syntaxMapOpt = CreateSyntaxMap(updatedMember.Map.Reverse);
                                 }
                                 else
                                 {
-                                    syntaxMap = null;
+                                    syntaxMapOpt = null;
                                 }
 
-                                updatedMethodIndex++;
+                                updatedMemberIndex++;
                             }
                             else
                             {
-                                syntaxMap = null;
+                                syntaxMapOpt = null;
+                            }
+
+                            // If a constructor changes from including initializers to not including initializers
+                            // we don't need to aggregate syntax map from all initializers for the constructor update semantic edit.
+                            bool isConstructorWithMemberInitializers;
+                            if ((isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(edit.NewNode)) || 
+                                IsDeclarationWithInitializer(edit.OldNode) || 
+                                IsDeclarationWithInitializer(edit.NewNode))
+                            {
+                                if (DeferConstructorEdit(
+                                    oldSymbol.ContainingType,
+                                    newSymbol.ContainingType,
+                                    editKind,
+                                    edit.NewNode,
+                                    newSymbol,
+                                    newModel,
+                                    isConstructorWithMemberInitializers,
+                                    ref syntaxMapOpt,
+                                    ref instanceConstructorEdits, 
+                                    ref staticConstructorEdits,
+                                    diagnostics,
+                                    cancellationToken))
+                                {
+                                    // Don't add a separate semantic edit for a field/property with an initializer.
+                                    // All edits of initializers will be aggregated to edits of constructors where these initializers are emitted.
+                                    continue;
+                                }
                             }
                         }
 
@@ -2255,41 +2305,61 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         throw ExceptionUtilities.Unreachable;
                 }
 
-                semanticEdits.Add(new SemanticEdit(editKind, oldSymbol, newSymbol, syntaxMap, preserveLocalVariables: syntaxMap != null));
+                semanticEdits.Add(new SemanticEdit(editKind, oldSymbol, newSymbol, syntaxMapOpt, preserveLocalVariables: syntaxMapOpt != null));
                 newSymbolsWithEdit.Add(newSymbol);
             }
 
             foreach (var edit in triviaEdits)
             {
-                var oldSymbol = oldModel.GetDeclaredSymbol(edit.Key, cancellationToken);
-                var newSymbol = newModel.GetDeclaredSymbol(edit.Value, cancellationToken);
+                var oldSymbol = GetSymbolForEdit(oldModel, edit.Key, EditKind.Update, editMap, cancellationToken);
+                var newSymbol = GetSymbolForEdit(newModel, edit.Value, EditKind.Update, editMap, cancellationToken);
 
-                if (IsMethod(edit.Key))
+                int start, end;
+
+                // We need to provide syntax map to the compiler if the member is active (see member update above):
+                bool isActiveMember =
+                    TryGetOverlappingActiveStatements(oldText, edit.Key.Span, oldActiveStatements, out start, out end) ||
+                    IsStateMachineMethod(edit.Key) ||
+                    ContainsLambda(edit.Key);
+
+                var syntaxMap = isActiveMember ? CreateSyntaxMapForEquivalentNodes(edit.Key, edit.Value) : null;
+
+                // only trivia changed:
+                Debug.Assert(IsConstructorWithMemberInitializers(edit.Key) == IsConstructorWithMemberInitializers(edit.Value));
+                Debug.Assert(IsDeclarationWithInitializer(edit.Key) == IsDeclarationWithInitializer(edit.Value));
+
+                bool isConstructorWithMemberInitializers;
+                if ((isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(edit.Value)) || 
+                    IsDeclarationWithInitializer(edit.Value))
                 {
-                    int start, end;
-
-                    bool preserveLocalVariables =
-                        TryGetOverlappingActiveStatements(oldText, edit.Key.Span, oldActiveStatements, out start, out end) ||
-                        IsStateMachineMethod(edit.Key) ||
-                        ContainsLambda(edit.Key);
-
-                    var syntaxMap = preserveLocalVariables ? CreateSyntaxMapForEquivalentNodes(edit.Key, edit.Value) : null;
-
-                    semanticEdits.Add(new SemanticEdit(SemanticEditKind.Update, oldSymbol, newSymbol, syntaxMap, preserveLocalVariables));
-                    newSymbolsWithEdit.Add(newSymbol);
+                    if (DeferConstructorEdit(
+                        oldSymbol.ContainingType, 
+                        newSymbol.ContainingType,
+                        SemanticEditKind.Update,
+                        edit.Value,
+                        newSymbol, 
+                        newModel,
+                        isConstructorWithMemberInitializers,
+                        ref syntaxMap, 
+                        ref instanceConstructorEdits, 
+                        ref staticConstructorEdits, 
+                        diagnostics,
+                        cancellationToken))
+                    {
+                        // Don't add a separate semantic edit for a field/property with an initializer.
+                        // All edits of initializers will be aggregated to edits of constructors where these initializers are emitted.
+                        continue;
+                    }
                 }
-                else
-                {
-                    // we don't track trivia changes outside of method bodies and field/property initializers
-                    Debug.Assert(HasInitializer(edit.Key) || HasInitializer(edit.Value));
-                    ForceConstructorUpdate(oldSymbol.ContainingType, newSymbol.ContainingType, edit.Value.Span, newSymbol.IsStatic, ref instanceConstructorUpdates, ref staticConstructorUpdates, diagnostics);
-                }
+
+                semanticEdits.Add(new SemanticEdit(SemanticEditKind.Update, oldSymbol, newSymbol, syntaxMap, isActiveMember));
+                newSymbolsWithEdit.Add(newSymbol);
             }
 
-            if (instanceConstructorUpdates != null)
+            if (instanceConstructorEdits != null)
             {
-                AddConstructorUpdates(
-                    instanceConstructorUpdates,
+                AddConstructorEdits(
+                    instanceConstructorEdits,
                     editScript.Match,
                     oldText,
                     oldModel,
@@ -2301,10 +2371,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     cancellationToken: cancellationToken);
             }
 
-            if (staticConstructorUpdates != null)
+            if (staticConstructorEdits != null)
             {
-                AddConstructorUpdates(
-                    staticConstructorUpdates,
+                AddConstructorEdits(
+                    staticConstructorEdits,
                     editScript.Match,
                     oldText,
                     oldModel,
@@ -2447,12 +2517,65 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return (INamedTypeSymbol)partnerModel.GetDeclaredSymbol(partner, cancellationToken);
         }
 
+        private Func<SyntaxNode, SyntaxNode> CreateSyntaxMapForEquivalentNodes(SyntaxNode oldRoot, SyntaxNode newRoot)
+        {
+            AreEquivalent(newRoot, oldRoot);
+            return newNode =>
+            {
+                if (!newRoot.FullSpan.Contains(newNode.SpanStart))
+                {
+                    return null;
+                }
+
+                return FindPartner(newRoot, oldRoot, newNode);
+            };
+        }
+
         private static Func<SyntaxNode, SyntaxNode> CreateSyntaxMap(IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap)
         {
             return newNode =>
             {
                 SyntaxNode oldNode;
                 return reverseMap.TryGetValue(newNode, out oldNode) ? oldNode : null;
+            };
+        }
+
+        private Func<SyntaxNode, SyntaxNode> CreateSyntaxMapForPartialTypeConstructor(
+            INamedTypeSymbol oldType,
+            INamedTypeSymbol newType,
+            SemanticModel newModel,
+            Func<SyntaxNode, SyntaxNode> ctorSyntaxMapOpt)
+        {
+            return newNode => ctorSyntaxMapOpt?.Invoke(newNode) ?? FindPartnerInMemberInitializer(newModel, newType, newNode, oldType, default(CancellationToken));
+        }
+
+        private Func<SyntaxNode, SyntaxNode> CreateAggregateSyntaxMap(
+            IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseTopMatches,
+            IReadOnlyDictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode>> changedDeclarations)
+        {
+            return newNode =>
+            {
+                // containing declaration
+                var newDeclaration = FindMemberDeclaration(null, newNode);
+
+                // The node is in a field, property or constructor declaration that has been changed:
+                Func<SyntaxNode, SyntaxNode> syntaxMapOpt;
+                if (changedDeclarations.TryGetValue(newDeclaration, out syntaxMapOpt))
+                {
+                    // If syntax map is not available the declaration was either
+                    // 1) updated but is not active
+                    // 2) inserted
+                    return syntaxMapOpt?.Invoke(newNode);
+                }
+
+                // The node is in a declaration that hasn't been changed:
+                SyntaxNode oldDeclaration;
+                if (reverseTopMatches.TryGetValue(newDeclaration, out oldDeclaration))
+                {
+                    return FindPartner(newDeclaration, oldDeclaration, newNode);
+                }
+
+                return null;
             };
         }
 
@@ -2475,45 +2598,74 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return method.Parameters.Length == 0 ? method : null;
         }
 
-        private void ForceConstructorUpdate(
+        private bool DeferConstructorEdit(
             INamedTypeSymbol oldType,
             INamedTypeSymbol newType,
-            TextSpan span,
-            bool isStatic,
-            ref Dictionary<INamedTypeSymbol, INamedTypeSymbol> instanceConstructorUpdates,
-            ref Dictionary<INamedTypeSymbol, INamedTypeSymbol> staticConstructorUpdates,
-            [Out]List<RudeEditDiagnostic> diagnostics)
+            SemanticEditKind editKind,
+            SyntaxNode newDeclaration,
+            ISymbol newSymbol,
+            SemanticModel newModel,
+            bool isConstructor,
+            ref Func<SyntaxNode, SyntaxNode> syntaxMapOpt,
+            ref Dictionary<INamedTypeSymbol, ConstructorEdit> instanceConstructorEdits,
+            ref Dictionary<INamedTypeSymbol, ConstructorEdit> staticConstructorEdits,
+            [Out]List<RudeEditDiagnostic> diagnostics,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(oldType != null);
             Debug.Assert(newType != null);
 
             if (IsPartial(newType))
             {
-                // rude edit: Editing a field initializer of a partial type.
-                diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.PartialTypeInitializerUpdate, span));
-                return;
+                // Since we don't calculate match accross partial declarations we need to disallow
+                // adding and updating fields/properties with initializers of a partial type declaration.
+                // Assuming this restriction we can allow editing all constructors of partial types. 
+                // The ones that include initializers won't differ in the field initialization.
+
+                if (!isConstructor)
+                {
+                    // rude edit: Editing a field/property initializer of a partial type.
+                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.PartialTypeInitializerUpdate, newDeclaration.Span));
+                    return false;
+                }
+
+                // TODO (bug https://github.com/dotnet/roslyn/issues/2504)
+                if (editKind == SemanticEditKind.Insert && HasMemberInitializerContainingLambda(oldType, newSymbol.IsStatic, cancellationToken))
+                {
+                    // rude edit: Adding a constructor to a type with a field or property initializer that contains an anonymous function
+                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, GetDiagnosticSpan(newDeclaration, EditKind.Insert)));
+                    return false;
+                }
+
+                syntaxMapOpt = CreateSyntaxMapForPartialTypeConstructor(oldType, newType, newModel, syntaxMapOpt);
+                return false;
             }
 
-            Dictionary<INamedTypeSymbol, INamedTypeSymbol> constructorUpdates;
-            if (isStatic)
+            Dictionary<INamedTypeSymbol, ConstructorEdit> constructorEdits;
+            if (newSymbol.IsStatic)
             {
-                constructorUpdates = staticConstructorUpdates ??
-                    (staticConstructorUpdates = new Dictionary<INamedTypeSymbol, INamedTypeSymbol>());
+                constructorEdits = staticConstructorEdits ??
+                    (staticConstructorEdits = new Dictionary<INamedTypeSymbol, ConstructorEdit>());
             }
             else
             {
-                constructorUpdates = instanceConstructorUpdates ??
-                    (instanceConstructorUpdates = new Dictionary<INamedTypeSymbol, INamedTypeSymbol>());
+                constructorEdits = instanceConstructorEdits ??
+                    (instanceConstructorEdits = new Dictionary<INamedTypeSymbol, ConstructorEdit>());
             }
 
-            if (!constructorUpdates.ContainsKey(newType))
+            ConstructorEdit edit;
+            if (!constructorEdits.TryGetValue(newType, out edit))
             {
-                constructorUpdates.Add(newType, oldType);
+                constructorEdits.Add(newType, edit = new ConstructorEdit(oldType));
             }
+
+            edit.ChangedDeclarations.Add(newDeclaration, syntaxMapOpt);
+
+            return true;
         }
 
-        private void AddConstructorUpdates(
-            Dictionary<INamedTypeSymbol, INamedTypeSymbol> updates,
+        private void AddConstructorEdits(
+            Dictionary<INamedTypeSymbol, ConstructorEdit> updatedTypes,
             Match<SyntaxNode> topMatch,
             SourceText oldText,
             SemanticModel oldModel,
@@ -2524,11 +2676,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             [Out]List<RudeEditDiagnostic> diagnostics,
             CancellationToken cancellationToken)
         {
-            foreach (var entry in updates)
+            foreach (var updatedType in updatedTypes)
             {
-                var newType = entry.Key;
-                var oldType = entry.Value;
-                Debug.Assert(oldType != null);
+                var newType = updatedType.Key;
+                var update = updatedType.Value;
+                var oldType = update.OldType;
+
+                Debug.Assert(!IsPartial(oldType));
+                Debug.Assert(!IsPartial(newType));
+
+                bool anyInitializerUpdates = update.ChangedDeclarations.Keys.Any(IsDeclarationWithInitializer);
+
+                bool? lazyOldTypeHasMemberInitializerContainingLambda = null;
 
                 foreach (var newCtor in isStatic ? newType.StaticConstructors : newType.InstanceConstructors)
                 {
@@ -2542,46 +2701,111 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     if (!newCtor.IsImplicitlyDeclared)
                     {
                         // Constructors have to have a single declaration syntax, they can't be partial
-                        var newDeclaration = newCtor.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
+                        var newDeclaration = FindMemberDeclaration(null, GetSymbolSyntax(newCtor, cancellationToken));
 
-                        // Partial type field initializers were filtered out previously and rude edits reported.
+                        // Partial types were filtered out previously and rude edits reported.
                         Debug.Assert(newDeclaration.SyntaxTree == topMatch.NewRoot.SyntaxTree);
 
-                        if (!IncludesInitializers(newDeclaration))
+                        // Constructor that doesn't contain initializers had a corresponding semantic edit produced previously 
+                        // or was not not edited. In either case we should not produce a semantic edit for it.
+                        if (!IsConstructorWithMemberInitializers(newDeclaration))
+                        {
+                            continue;
+                        }
+
+                        // If no initializer updates were made in the type we only need to produce semantic edits for constructors
+                        // whose body has been updated, otherwise we need to produce edits for all contructors that include initializers.
+                        if (!anyInitializerUpdates && !update.ChangedDeclarations.ContainsKey(newDeclaration))
                         {
                             continue;
                         }
 
                         SyntaxNode oldDeclaration;
-                        if (!topMatch.TryGetOldNode(newDeclaration, out oldDeclaration))
+                        if (topMatch.TryGetOldNode(newDeclaration, out oldDeclaration))
                         {
-                            // new constructor inserted, we don't need to update it
-                            continue;
-                        }
+                            // If the constructor wasn't explicitly edited and its body edit is disallowed report an error.
+                            int diagnosticCount = diagnostics.Count;
+                            ReportMemberUpdateRudeEdits(diagnostics, newDeclaration, span: null);
+                            if (diagnostics.Count > diagnosticCount)
+                            {
+                                continue;
+                            }
 
-                        // TODO (tomat): report a better location (perhaps the first updated field initializer?)
-                        int diagnosticCount = diagnostics.Count;
-                        ReportMemberUpdateRudeEdits(diagnostics, newDeclaration, span: null);
-                        if (diagnostics.Count > diagnosticCount)
+                            oldCtor = oldModel.GetDeclaredSymbol(oldDeclaration, cancellationToken);
+                            Debug.Assert(oldCtor != null);
+                        }
+                        else if (newCtor.Parameters.Length == 0)
                         {
-                            continue;
+                            oldCtor = TryGetParameterlessConstructor(oldType, isStatic);
                         }
+                        else
+                        {
+                            // TODO (bug https://github.com/dotnet/roslyn/issues/2504)
+                            if (HasMemberInitializerContainingLambda(oldType, isStatic, ref lazyOldTypeHasMemberInitializerContainingLambda, cancellationToken))
+                            {
+                                // rude edit: Adding a constructor to a type with a field or property initializer that contains an anonymous function
+                                diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, GetDiagnosticSpan(newDeclaration, EditKind.Insert)));
+                                continue;
+                            }
 
-                        oldCtor = oldModel.GetDeclaredSymbol(oldDeclaration, cancellationToken);
+                            // no initializer contains lambdas => we don't need a syntax map
+                            oldCtor = null;
+                        }
                     }
                     else
                     {
                         oldCtor = TryGetParameterlessConstructor(oldType, isStatic);
                     }
 
-                    // Note that active statements in field initializers don't require us to preserve locals
-                    // of the constructor. They don't contain any local declarators that span statements (explicit or temp).
-                    // And the constructor body haven't changed.
+                    // We assume here that the type is not partial and thus we collected all changed
+                    // field and property initializers in update.ChangedDeclarations and we only need 
+                    // the current top match to map nodes from all unchanged initializers.
+                    //
+                    // We will create an aggregate syntax map even in cases when we don't neccessarily need it,
+                    // for example if none of the edited declarations are active. It's ok to have a map that we don't need.
+                    var aggregateSyntaxMap = (oldCtor != null && update.ChangedDeclarations.Count > 0) ? 
+                        CreateAggregateSyntaxMap(topMatch.ReverseMatches, update.ChangedDeclarations) : null;
 
-                    // TODO: preserve local variables if the constructor or the initializers contain lambdas
-                    semanticEdits.Add(new SemanticEdit((oldCtor == null) ? SemanticEditKind.Insert : SemanticEditKind.Update, oldCtor, newCtor));
+                    semanticEdits.Add(new SemanticEdit(
+                        (oldCtor == null) ? SemanticEditKind.Insert : SemanticEditKind.Update, 
+                        oldCtor, 
+                        newCtor, 
+                        aggregateSyntaxMap,
+                        preserveLocalVariables: aggregateSyntaxMap != null));
                 }
             }
+        }
+
+        private bool HasMemberInitializerContainingLambda(INamedTypeSymbol type, bool isStatic, ref bool? lazyHasMemberInitializerContainingLambda, CancellationToken cancellationToken)
+        {
+            if (lazyHasMemberInitializerContainingLambda == null)
+            {
+                // checking the old type for existing lambdas (it's ok for the new initializers to contain lambdas)
+                lazyHasMemberInitializerContainingLambda = HasMemberInitializerContainingLambda(type, isStatic, cancellationToken);
+            }
+
+            return lazyHasMemberInitializerContainingLambda.Value;
+        }
+
+        private bool HasMemberInitializerContainingLambda(INamedTypeSymbol type, bool isStatic, CancellationToken cancellationToken)
+        {
+            // checking the old type for existing lambdas (it's ok for the new initializers to contain lambdas)
+
+            foreach (var member in type.GetMembers())
+            {
+                if (member.IsStatic == isStatic && 
+                    (member.Kind == SymbolKind.Field || member.Kind == SymbolKind.Property) &&
+                    member.DeclaringSyntaxReferences.Length > 0) // skip generated fields (e.g. VB auto-property backing fields)
+                {
+                    var syntax = GetSymbolSyntax(member, cancellationToken);
+                    if (IsDeclarationWithInitializer(syntax) && ContainsLambda(syntax))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private static ISymbol TryGetParameterlessConstructor(INamedTypeSymbol type, bool isStatic)
@@ -2799,7 +3023,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             newBodyHasLambdas = false;
 
-            foreach (var newLambda in newMemberBody.DescendantNodes())
+            foreach (var newLambda in newMemberBody.DescendantNodesAndSelf())
             {
                 SyntaxNode newLambdaBody1, newLambdaBody2;
                 if (TryGetLambdaBodies(newLambda, out newLambdaBody1, out newLambdaBody2))
@@ -2820,7 +3044,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // Similarly for addition. We don't allow removal of lambda that has captures from multiple scopes.
 
-            foreach (var oldLambda in oldMemberBody.DescendantNodes())
+            foreach (var oldLambda in oldMemberBody.DescendantNodesAndSelf())
             {
                 SyntaxNode oldLambdaBody1, oldLambdaBody2;
                 if (TryGetLambdaBodies(oldLambda, out oldLambdaBody1, out oldLambdaBody2) && !map.Forward.ContainsKey(oldLambda))
@@ -2940,7 +3164,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private SyntaxNode GetSymbolSyntax(ISymbol local, CancellationToken cancellationToken)
+        protected SyntaxNode GetSymbolSyntax(ISymbol local, CancellationToken cancellationToken)
         {
             return local.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
         }
@@ -3343,7 +3567,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // lambda parameters and C# constructor parameters are lifted to their own scope:
                 if ((member as IMethodSymbol)?.MethodKind == MethodKind.AnonymousFunction || HasParameterClosureScope(member))
                 {
-                    var result = localOrParameter.ContainingSymbol.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
+                    var result = GetSymbolSyntax(localOrParameter, cancellationToken);
                     Debug.Assert(IsLambda(result));
                     return result;
                 }
@@ -3351,7 +3575,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return memberBody;
             }
 
-            SyntaxNode node = localOrParameter.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
+            SyntaxNode node = GetSymbolSyntax(localOrParameter, cancellationToken);
             while (true)
             {
                 if (IsClosureScope(node))

--- a/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.GenericTypeTriviaUpdate,                   FeaturesResources.ModifyingTriviaInMethodInsideTheContext) },
             { GetDescriptorPair(RudeEditKind.GenericTypeInitializerUpdate,              FeaturesResources.ModifyingTheInitializerInGenericType) },
             { GetDescriptorPair(RudeEditKind.PartialTypeInitializerUpdate,              FeaturesResources.ModifyingTheInitializerInPartialType) },
+            { GetDescriptorPair(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas,  FeaturesResources.InsertConstructorToTypeWithInitializersWithLambdas) },
             { GetDescriptorPair(RudeEditKind.StackAllocUpdate,                          FeaturesResources.ModifyingAWhichContainsStackalloc) },
             { GetDescriptorPair(RudeEditKind.ExperimentalFeaturesEnabled,               FeaturesResources.ModifyingAFileWithExperimentalFeaturesEnabled) },
             { GetDescriptorPair(RudeEditKind.AwaitStatementUpdate,                      FeaturesResources.UpdatingAStatementContainingAwaitExpression) },
@@ -75,9 +76,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.ActiveStatementLambdaRemoved,              FeaturesResources.RemovingThatContainsActiveStatement) },
             { GetDescriptorPair(RudeEditKind.InsertFile,                                FeaturesResources.AddingANewFile) },
 
-            { GetDescriptorPair(RudeEditKind.RUDE_EDIT_ANON_METHOD,                     FeaturesResources.ModifyingAWhichContainsAnonymousMethod) },
-            { GetDescriptorPair(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION,               FeaturesResources.ModifyingAWhichContainsLambda) },
-            { GetDescriptorPair(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION,                FeaturesResources.ModifyingAWhichContainsQuery) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.ModifyingAWhichContainsComplexQuery) },
 
             // VB specific,

--- a/src/Features/Core/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditKind.cs
@@ -82,15 +82,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         UpdateCatchHandlerAroundActiveStatement = 66,
         UpdateStaticLocal = 67,
 
-        // 68-69 can be used
+        InsertConstructorToTypeWithInitializersWithLambdas = 68,
+
+        // 69 can be used
 
         InsertHandlesClause = 70,
         InsertFile = 71,
 
         // TODO: remove values below
-        RUDE_EDIT_ANON_METHOD = 0x100,
-        RUDE_EDIT_LAMBDA_EXPRESSION = 0x101,
-        RUDE_EDIT_QUERY_EXPRESSION = 0x102,
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,
     }
 }

--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -1123,6 +1123,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adding a constructor to a type with a field or property initializer that contains an anonymous function will prevent the debug session from continuing..
+        /// </summary>
+        internal static string InsertConstructorToTypeWithInitializersWithLambdas {
+            get {
+                return ResourceManager.GetString("InsertConstructorToTypeWithInitializersWithLambdas", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adding &apos;{0}&apos; that accesses captured variables &apos;{1}&apos; and &apos;{2}&apos; declared in different scopes will prevent the debug session from continuing..
         /// </summary>
         internal static string InsertLambdaWithMultiScopeCapture {
@@ -1366,15 +1375,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains an anonymous method will prevent the debug session from continuing..
-        /// </summary>
-        internal static string ModifyingAWhichContainsAnonymousMethod {
-            get {
-                return ResourceManager.GetString("ModifyingAWhichContainsAnonymousMethod", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains an Aggregate, Group By, or Join query clauses will prevent the debug session from continuing..
         /// </summary>
         internal static string ModifyingAWhichContainsComplexQuery {
@@ -1384,29 +1384,11 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains a lambda expression will prevent the debug session from continuing..
-        /// </summary>
-        internal static string ModifyingAWhichContainsLambda {
-            get {
-                return ResourceManager.GetString("ModifyingAWhichContainsLambda", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Modifying an active &apos;{0}&apos; which contains &apos;On Error&apos; or &apos;Resume&apos; statements will prevent the debug session from continuing..
         /// </summary>
         internal static string ModifyingAWhichContainsOnErrorResume {
             get {
                 return ResourceManager.GetString("ModifyingAWhichContainsOnErrorResume", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains a query expression will prevent the debug session from continuing..
-        /// </summary>
-        internal static string ModifyingAWhichContainsQuery {
-            get {
-                return ResourceManager.GetString("ModifyingAWhichContainsQuery", resourceCulture);
             }
         }
         

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -537,6 +537,9 @@
   <data name="ModifyingTheInitializerInPartialType" xml:space="preserve">
     <value>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</value>
   </data>
+  <data name="InsertConstructorToTypeWithInitializersWithLambdas" xml:space="preserve">
+    <value>Adding a constructor to a type with a field or property initializer that contains an anonymous function will prevent the debug session from continuing.</value>
+  </data>
   <data name="ModifyingACatchFinallyHandler" xml:space="preserve">
     <value>Modifying a catch/finally handler with an active statement in the try block will prevent the debug session from continuing.</value>
   </data>
@@ -551,15 +554,6 @@
   </data>
   <data name="ModifyingAWhichContainsOnErrorResume" xml:space="preserve">
     <value>Modifying an active '{0}' which contains 'On Error' or 'Resume' statements will prevent the debug session from continuing.</value>
-  </data>
-  <data name="ModifyingAWhichContainsAnonymousMethod" xml:space="preserve">
-    <value>Modifying '{0}' which contains an anonymous method will prevent the debug session from continuing.</value>
-  </data>
-  <data name="ModifyingAWhichContainsLambda" xml:space="preserve">
-    <value>Modifying '{0}' which contains a lambda expression will prevent the debug session from continuing.</value>
-  </data>
-  <data name="ModifyingAWhichContainsQuery" xml:space="preserve">
-    <value>Modifying '{0}' which contains a query expression will prevent the debug session from continuing.</value>
   </data>
   <data name="ModifyingAWhichContainsComplexQuery" xml:space="preserve">
     <value>Modifying '{0}' which contains an Aggregate, Group By, or Join query clauses will prevent the debug session from continuing.</value>

--- a/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -25,8 +25,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' <see cref="ModifiedIdentifierSyntax"/> for fields with shared AsNew initialization "Dim a, b As New C" or array initializer "Dim a(n), b(n)".
         ''' A null reference otherwise.
         ''' </returns>
-        Friend Overrides Function FindMemberDeclaration(root As SyntaxNode, node As SyntaxNode) As SyntaxNode
-            While node IsNot root
+        Friend Overrides Function FindMemberDeclaration(rootOpt As SyntaxNode, node As SyntaxNode) As SyntaxNode
+            While node IsNot rootOpt
                 Select Case node.Kind
                     Case SyntaxKind.SubBlock,
                          SyntaxKind.FunctionBlock,
@@ -179,10 +179,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Dim arrayBounds = TryCast(memberBody, ArgumentListSyntax)
             If arrayBounds IsNot Nothing Then
                 Return ImmutableArray.CreateRange(
-                    arrayBounds.Arguments.SelectMany(Function(argument) model.AnalyzeDataFlow(argument).Captured).Distinct())
+                    arrayBounds.Arguments.
+                        SelectMany(AddressOf GetArgumentExpressions).
+                        SelectMany(Function(expr) model.AnalyzeDataFlow(expr).Captured).
+                        Distinct())
             End If
 
             Throw ExceptionUtilities.UnexpectedValue(memberBody)
+        End Function
+
+        Private Shared Iterator Function GetArgumentExpressions(argument As ArgumentSyntax) As IEnumerable(Of ExpressionSyntax)
+            Select Case argument.Kind
+                Case SyntaxKind.SimpleArgument
+                    Yield DirectCast(argument, SimpleArgumentSyntax).Expression
+
+                Case SyntaxKind.RangeArgument
+                    Dim range = DirectCast(argument, RangeArgumentSyntax)
+                    Yield range.LowerBound
+                    Yield range.UpperBound
+
+                Case SyntaxKind.OmittedArgument
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(argument.Kind)
+            End Select
         End Function
 
         Friend Overrides Function HasParameterClosureScope(member As ISymbol) As Boolean
@@ -442,9 +462,78 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return node
         End Function
 
-        Friend Overrides Function CreateSyntaxMapForEquivalentNodes(oldRoot As SyntaxNode, newRoot As SyntaxNode) As Func(Of SyntaxNode, SyntaxNode)
-            Debug.Assert(SyntaxFactory.AreEquivalent(oldRoot, newRoot))
-            Return Function(newNode) SyntaxUtilities.FindPartner(newRoot, oldRoot, newNode)
+        Friend Overrides Function FindPartnerInMemberInitializer(leftModel As SemanticModel, leftType As INamedTypeSymbol, leftNode As SyntaxNode, rightType As INamedTypeSymbol, cancellationToken As CancellationToken) As SyntaxNode
+            Dim leftInitializer = leftNode.FirstAncestorOrSelf(Of SyntaxNode)(
+                Function(node)
+                    Return node.IsKind(SyntaxKind.EqualsValue) AndAlso (node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) OrElse node.Parent.IsKind(SyntaxKind.PropertyStatement)) OrElse
+                           node.IsKind(SyntaxKind.AsNewClause) AndAlso node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) OrElse
+                           IsArrayBoundsArgument(node)
+                End Function)
+
+            If leftInitializer Is Nothing Then
+                Return Nothing
+            End If
+
+            Dim rightInitializer As SyntaxNode
+            If leftInitializer.Parent.IsKind(SyntaxKind.PropertyStatement) Then
+                ' property initializer
+                Dim leftDeclaration = DirectCast(leftInitializer.Parent, PropertyStatementSyntax)
+                Dim leftSymbol = leftModel.GetDeclaredSymbol(leftDeclaration, cancellationToken)
+                Debug.Assert(leftSymbol IsNot Nothing)
+
+                Dim rightProperty = rightType.GetMembers(leftSymbol.Name).Single()
+                Dim rightDeclaration = DirectCast(GetSymbolSyntax(rightProperty, cancellationToken), PropertyStatementSyntax)
+
+                rightInitializer = rightDeclaration.Initializer
+            ElseIf leftInitializer.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration)
+                ' field initializer or AsNewClause
+                Dim leftDeclarator = DirectCast(leftInitializer.Parent, VariableDeclaratorSyntax)
+
+                Dim leftSymbol = leftModel.GetDeclaredSymbol(leftDeclarator.Names.First(), cancellationToken)
+                Debug.Assert(leftSymbol IsNot Nothing)
+
+                Dim rightSymbol = rightType.GetMembers(leftSymbol.Name).Single()
+                Dim rightDeclarator = DirectCast(GetSymbolSyntax(rightSymbol, cancellationToken).Parent, VariableDeclaratorSyntax)
+
+                rightInitializer = If(leftInitializer.IsKind(SyntaxKind.EqualsValue), rightDeclarator.Initializer, DirectCast(rightDeclarator.AsClause, SyntaxNode))
+            Else
+                ' ArrayBounds argument
+                Dim leftArguments = DirectCast(leftInitializer.Parent, ArgumentListSyntax)
+                Dim argumentIndex = GetItemIndexByPosition(leftArguments.Arguments, leftInitializer.Span.Start)
+
+                Dim leftIdentifier = leftArguments.Parent
+                Debug.Assert(leftIdentifier.IsKind(SyntaxKind.ModifiedIdentifier))
+
+                Dim leftSymbol = leftModel.GetDeclaredSymbol(leftIdentifier, cancellationToken)
+                Debug.Assert(leftSymbol IsNot Nothing)
+
+                Dim rightSymbol = rightType.GetMembers(leftSymbol.Name).Single()
+                Dim rightIdentifier = DirectCast(GetSymbolSyntax(rightSymbol, cancellationToken), ModifiedIdentifierSyntax)
+
+                rightInitializer = rightIdentifier.ArrayBounds.Arguments(argumentIndex)
+            End If
+
+            If rightInitializer Is Nothing Then
+                Return Nothing
+            End If
+
+            Return FindPartner(leftInitializer, rightInitializer, leftNode)
+        End Function
+
+        Friend Overrides Function FindPartner(leftRoot As SyntaxNode, rightRoot As SyntaxNode, leftNode As SyntaxNode) As SyntaxNode
+            Return SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode)
+        End Function
+
+        Private Shared Function IsArrayBoundsArgument(node As SyntaxNode) As Boolean
+            Dim argumentSyntax = TryCast(node, ArgumentSyntax)
+
+            If argumentSyntax IsNot Nothing Then
+                Debug.Assert(argumentSyntax.Parent.IsKind(SyntaxKind.ArgumentList))
+                Dim identifier = argumentSyntax.Parent.Parent
+                Return identifier.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso identifier.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration)
+            End If
+
+            Return False
         End Function
 
         Friend Overrides Function IsClosureScope(node As SyntaxNode) As Boolean
@@ -726,6 +815,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End If
         End Function
 
+        Protected Overrides Function AreEquivalent(left As SyntaxNode, right As SyntaxNode) As Boolean
+            Return SyntaxFactory.AreEquivalent(left, right)
+        End Function
+
         Protected Overrides Function AreEquivalentActiveStatements(oldStatement As SyntaxNode, newStatement As SyntaxNode, statementPart As Integer) As Boolean
             If oldStatement.RawKind <> newStatement.RawKind Then
                 Return False
@@ -776,11 +869,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return SyntaxUtilities.HasBackingField(propertyDeclaration)
         End Function
 
-        Friend Overrides Function HasInitializer(declaration As SyntaxNode, <Out> ByRef isStatic As Boolean) As Boolean
+        Friend Overrides Function IsDeclarationWithInitializer(declaration As SyntaxNode) As Boolean
             Select Case declaration.Kind
                 Case SyntaxKind.VariableDeclarator
                     Dim declarator = DirectCast(declaration, VariableDeclaratorSyntax)
-                    isStatic = IsDeclarationStatic(declarator)
                     Return GetInitializerExpression(declarator.Initializer, declarator.AsClause) IsNot Nothing
 
                 Case SyntaxKind.ModifiedIdentifier
@@ -788,12 +880,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                  declaration.Parent.IsKind(SyntaxKind.Parameter))
 
                     If Not declaration.Parent.IsKind(SyntaxKind.VariableDeclarator) Then
-                        isStatic = False
                         Return False
                     End If
 
                     Dim declarator = DirectCast(declaration.Parent, VariableDeclaratorSyntax)
-                    isStatic = IsDeclarationStatic(declarator)
 
                     Dim identitifer = DirectCast(declaration, ModifiedIdentifierSyntax)
                     Return identitifer.ArrayBounds IsNot Nothing OrElse
@@ -801,22 +891,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                 Case SyntaxKind.PropertyStatement
                     Dim propertyStatement = DirectCast(declaration, PropertyStatementSyntax)
-                    isStatic = IsDeclarationStatic(propertyStatement.Modifiers, propertyStatement)
                     Return GetInitializerExpression(propertyStatement.Initializer, propertyStatement.AsClause) IsNot Nothing
 
                 Case Else
-                    isStatic = False
                     Return False
             End Select
-        End Function
-
-        Private Shared Function IsDeclarationStatic(declarator As VariableDeclaratorSyntax) As Boolean
-            Dim fieldDeclaration = DirectCast(declarator.Parent, FieldDeclarationSyntax)
-            Return IsDeclarationStatic(fieldDeclaration.Modifiers, fieldDeclaration)
-        End Function
-
-        Private Shared Function IsDeclarationStatic(modifiers As SyntaxTokenList, declaration As DeclarationStatementSyntax) As Boolean
-            Return modifiers.Any(SyntaxKind.SharedKeyword) OrElse declaration.Parent.IsKind(SyntaxKind.ModuleBlock)
         End Function
 
         Private Shared Function GetInitializerExpression(equalsValue As EqualsValueSyntax, asClause As AsClauseSyntax) As ExpressionSyntax
@@ -831,13 +910,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return Nothing
         End Function
 
-        Friend Overrides Function IncludesInitializers(constructorDeclaration As SyntaxNode) As Boolean
+        Friend Overrides Function IsConstructorWithMemberInitializers(declaration As SyntaxNode) As Boolean
+            Dim ctor = TryCast(declaration, ConstructorBlockSyntax)
+            If ctor Is Nothing Then
+                Return False
+            End If
+
             ' Constructor includes field initializers if the first statement 
-            ' isn 't a call to another constructor of the declaring class.
+            ' isn't a call to another constructor of the declaring class or module.
 
-            Debug.Assert(constructorDeclaration.IsKind(SyntaxKind.SubNewStatement))
-
-            Dim ctor = DirectCast(constructorDeclaration.Parent, ConstructorBlockSyntax)
             If ctor.Statements.Count = 0 Then
                 Return True
             End If
@@ -923,6 +1004,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Case SyntaxKind.ModifiedIdentifier
                     If node.Parent.IsKind(SyntaxKind.Parameter) Then
                         Return Nothing
+                    End If
+
+                Case SyntaxKind.VariableDeclarator
+                    ' An update to a field variable declarator might either be
+                    ' 1) variable declarator update (an initializer is changes)
+                    ' 2) modified identifier update (an array bound changes)
+                    ' Handle the first one here. 
+                    If editKind = EditKind.Update AndAlso node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
+                        ' If multiple fields are defined by this declaration pick the first one.
+                        ' We want to analyze the associated initializer just once. Any of the fields is good.
+                        node = DirectCast(node, VariableDeclaratorSyntax).Names.First()
                     End If
             End Select
 
@@ -2334,7 +2426,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                 ' Otherwise only the size of the array changed, which is a legal initializer update
                 ' unless it contains lambdas, queries etc.
-                ClassifyDeclarationBodyRudeUpdates(newNode, allowLambdas:=False)
+                ClassifyDeclarationBodyRudeUpdates(newNode)
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As VariableDeclaratorSyntax, newNode As VariableDeclaratorSyntax)
@@ -2411,7 +2503,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Dim newInitializer = GetInitializerExpression(newEqualsValue, newClause)
 
                 If newInitializer IsNot Nothing AndAlso Not SyntaxFactory.AreEquivalent(oldInitializer, newInitializer) Then
-                    ClassifyDeclarationBodyRudeUpdates(newInitializer, allowLambdas:=False)
+                    ClassifyDeclarationBodyRudeUpdates(newInitializer)
                     Return True
                 End If
 
@@ -2447,8 +2539,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ClassifyMethodBodyRudeUpdate(oldNode,
                                              newNode,
                                              containingMethod:=newNode,
-                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax),
-                                             allowLambdas:=True)
+                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax))
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As MethodStatementSyntax, newNode As MethodStatementSyntax)
@@ -2534,8 +2625,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ClassifyMethodBodyRudeUpdate(oldNode,
                                              newNode,
                                              containingMethod:=Nothing,
-                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax),
-                                             allowLambdas:=True)
+                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax))
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As OperatorStatementSyntax, newNode As OperatorStatementSyntax)
@@ -2555,8 +2645,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ClassifyMethodBodyRudeUpdate(oldNode,
                                              newNode,
                                              containingMethod:=Nothing,
-                                             containingType:=DirectCast(newNode.Parent.Parent, TypeBlockSyntax),
-                                             allowLambdas:=True)
+                                             containingType:=DirectCast(newNode.Parent.Parent, TypeBlockSyntax))
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As AccessorStatementSyntax, newNode As AccessorStatementSyntax)
@@ -2585,8 +2674,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ClassifyMethodBodyRudeUpdate(oldNode,
                                              newNode,
                                              containingMethod:=Nothing,
-                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax),
-                                             allowLambdas:=False)
+                                             containingType:=DirectCast(newNode.Parent, TypeBlockSyntax))
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As SubNewStatementSyntax, newNode As SubNewStatementSyntax)
@@ -2637,8 +2725,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Private Sub ClassifyMethodBodyRudeUpdate(oldBody As MethodBlockBaseSyntax,
                                                      newBody As MethodBlockBaseSyntax,
                                                      containingMethod As MethodBlockSyntax,
-                                                     containingType As TypeBlockSyntax,
-                                                     allowLambdas As Boolean)
+                                                     containingType As TypeBlockSyntax)
 
                 If (oldBody.EndBlockStatement Is Nothing) <> (newBody.EndBlockStatement Is Nothing) Then
                     If oldBody.EndBlockStatement Is Nothing Then
@@ -2655,7 +2742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Debug.Assert(newBody.EndBlockStatement IsNot Nothing)
 
                 ClassifyMemberBodyRudeUpdate(containingMethod, containingType, isTriviaUpdate:=False)
-                ClassifyDeclarationBodyRudeUpdates(newBody, allowLambdas)
+                ClassifyDeclarationBodyRudeUpdates(newBody)
             End Sub
 
             Public Sub ClassifyMemberBodyRudeUpdate(containingMethodOpt As MethodBlockSyntax, containingTypeOpt As TypeBlockSyntax, isTriviaUpdate As Boolean)
@@ -2670,26 +2757,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 End If
             End Sub
 
-            Public Sub ClassifyDeclarationBodyRudeUpdates(newDeclarationOrBody As SyntaxNode, allowLambdas As Boolean)
+            Public Sub ClassifyDeclarationBodyRudeUpdates(newDeclarationOrBody As SyntaxNode)
                 For Each node In newDeclarationOrBody.DescendantNodesAndSelf()
                     Select Case node.Kind
-                        Case SyntaxKind.MultiLineFunctionLambdaExpression,
-                             SyntaxKind.SingleLineFunctionLambdaExpression,
-                             SyntaxKind.MultiLineSubLambdaExpression,
-                             SyntaxKind.SingleLineSubLambdaExpression
-                            ' TODO:
-                            If Not allowLambdas Then
-                                ReportError(RudeEditKind.RUDE_EDIT_LAMBDA_EXPRESSION, node, Me._newNode)
-                                Return
-                            End If
-
-                        Case SyntaxKind.QueryExpression
-                            ' TODO:
-                            If Not allowLambdas Then
-                                ReportError(RudeEditKind.RUDE_EDIT_QUERY_EXPRESSION, node, Me._newNode)
-                                Return
-                            End If
-
                         Case SyntaxKind.AggregateClause,
                              SyntaxKind.GroupByClause,
                              SyntaxKind.SimpleJoinClause,
@@ -2750,11 +2820,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 newMember.FirstAncestorOrSelf(Of TypeBlockSyntax)(),
                 isTriviaUpdate:=True)
 
-            classifier.ClassifyDeclarationBodyRudeUpdates(newMember,
-                                                          allowLambdas:=Not newMember.IsKind(SyntaxKind.ConstructorBlock) AndAlso
-                                                                        Not newMember.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso
-                                                                        Not newMember.IsKind(SyntaxKind.VariableDeclarator) AndAlso
-                                                                        Not newMember.IsKind(SyntaxKind.PropertyStatement))
+            classifier.ClassifyDeclarationBodyRudeUpdates(newMember)
         End Sub
 
 #End Region


### PR DESCRIPTION
Most changes are in the IDE, the compiler changes are cosmetic. 

The IDE needs to understand the relationship between field/property initializers and constructors they will be emitted into. Changes in an initializer need to trigger constructor update. A constructor update needs to be accompanied with a syntax map that covers the constructor body and initializer as well as all field and property initializers that will eventually be included in the constructor.

Fixes #749.