### PR TITLE
Change workspace output pane to IntelliSense

### DIFF
--- a/src/VisualStudio/Setup/VSPackage.Designer.cs
+++ b/src/VisualStudio/Setup/VSPackage.Designer.cs
@@ -61,7 +61,7 @@ namespace Roslyn.VisualStudio.Setup {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Workspace.
+        ///   Looks up a localized string similar to IntelliSense.
         /// </summary>
         internal static string WorkspaceOutputPaneTitle {
             get {

--- a/src/VisualStudio/Setup/VSPackage.resx
+++ b/src/VisualStudio/Setup/VSPackage.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WorkspaceOutputPaneTitle" xml:space="preserve">
-    <value>Workspace</value>
+    <value>IntelliSense</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #2380 

This changes the name of the output pane that the VS workspace uses to log workspace failure events, so as not to be confused with TFS notifications.

@Pilchie, @jasonmalinowski, @dpoeschl  please review