### PR TITLE
Pattern matcher alloc

### DIFF
--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                 if (partCount == 0)
                 {
-                    return SpecializedCollections.EmptyArray<TextChunk>();
+                    return Array.Empty<TextChunk>();
                 }
 
                 var result = new TextChunk[partCount];
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (pattern.IndexOf('.') < 0)
             {
                 // PERF: Avoid string.Split allocations when the pattern doesn't contain a dot.
-                _dotSeparatedSegments = pattern.Length > 0 ? new Segment[1] { _fullPatternSegment } : SpecializedCollections.EmptyArray<Segment>();
+                _dotSeparatedSegments = pattern.Length > 0 ? new Segment[1] { _fullPatternSegment } : Array.Empty<Segment>();
             }
             else
             {

--- a/src/Features/Core/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Shared/Utilities/PatternMatcher.cs
@@ -165,9 +165,19 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             _compareInfo = culture.CompareInfo;
 
             _fullPatternSegment = new Segment(pattern, verbatimIdentifierPrefixIsWordCharacter);
-            _dotSeparatedSegments = pattern.Split(s_dotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
-                                            .Select(text => new Segment(text.Trim(), verbatimIdentifierPrefixIsWordCharacter))
-                                            .ToArray();
+
+            if (pattern.IndexOf('.') < 0)
+            {
+                // PERF: Avoid string.Split allocations when the pattern doesn't contain a dot.
+                _dotSeparatedSegments = pattern.Length > 0 ? new Segment[1] { _fullPatternSegment } : SpecializedCollections.EmptyArray<Segment>();
+            }
+            else
+            {
+                _dotSeparatedSegments = pattern.Split(s_dotCharacterArray, StringSplitOptions.RemoveEmptyEntries)
+                                                .Select(text => new Segment(text.Trim(), verbatimIdentifierPrefixIsWordCharacter))
+                                                .ToArray();
+            }
+
             _invalidPattern = _dotSeparatedSegments.Length == 0 || _dotSeparatedSegments.Any(s => s.IsInvalid);
         }
 


### PR DESCRIPTION
In one performance trace I noticed allocations coming from the string.Split call from the PatternMatcher constructor. I special-cased the code path when the pattern doesn't contain a dot.