### PR TITLE
Update AnalyzerFileReference.DisplayName

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -134,7 +134,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var textFile = directory.CreateFile("Foo.txt").WriteAllText("I am the very model of a modern major general.");
             AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile.Path);
 
-            Assert.Equal(expected: "Foo.txt", actual: reference.Display);
+            Assert.Equal(expected: "Foo", actual: reference.Display);
+        }
+
+        [Fact]
+        public void ValidAnalyzerReference_DisplayName()
+        {
+            var directory = Temp.CreateDirectory();
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(alphaDll.Path);
+
+            Assert.Equal(expected: "Alpha", actual: reference.Display);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (_lazyDisplayName == null)
                 {
-                    _lazyDisplayName = Path.GetFileName(this.FullPath);
+                    _lazyDisplayName = Path.GetFileNameWithoutExtension(this.FullPath);
                 }
 
                 return _lazyDisplayName;


### PR DESCRIPTION
Don't show the file extension for in the `DisplayName` for
`AnalyzerFileReference`.