### PR TITLE
Add ProvideLanguageCodeExpansionAttribute to packages

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -31,6 +31,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [ProvideLanguageExtension(typeof(CSharpLanguageService), ".cs")]
     [ProvideLanguageService(Guids.CSharpLanguageServiceIdString, "CSharp", languageResourceID: 101, RequestStockColors = true, ShowDropDownOptions = true)]
+    [ProvideLanguageCodeExpansion(typeof(CSharpLanguageService), "CSharp", 115, "csharp", @"%InstallRoot%\VC#\Snippets\%LCID%\SnippetsIndex.xml", 
+        SearchPaths = @"%InstallRoot%\VC#\Snippets\%LCID%\Visual C#\;%MyDocs%\Code Snippets\Visual C#\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\VC#\Snippets\%LCID%\Visual C#\;%MyDocs%\Code Snippets\Visual C#\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageEditorToolsOptionCategory("CSharp", "Formatting", "#107")]
     [ProvideLanguageEditorOptionPage(typeof(Options.AdvancedOptionPage), "CSharp", null, "Advanced", pageNameResourceId: "#102", keywordListResourceId: 306)]
     [ProvideLanguageEditorOptionPage(typeof(Options.Formatting.FormattingStylePage), "CSharp", null, @"Code Style", pageNameResourceId: "#114", keywordListResourceId: 313)]

--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -208,4 +208,8 @@
     <value>Style;Qualify;This;Code Style</value>
     <comment>C# Code Style options page keywords</comment>
   </data>
+  <data name="115" xml:space="preserve">
+    <value>Visual C#</value>
+    <comment>Code Snippets Manager Language Name</comment>
+  </data>
 </root>

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -34,6 +34,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".frm")>
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".pag")>
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".vb")>
+    <ProvideLanguageCodeExpansion(GetType(VisualBasicLanguageService), "Basic", 101, "VB", "%InstallRoot%\VB\Snippets\%LCID%\SnippetIndex.xml",
+        SearchPaths:="%InstallRoot%\VB\Snippets\%LCID%\application\;%InstallRoot%\VB\Snippets\%LCID%\common code patterns\;%InstallRoot%\VB\Snippets\%LCID%\data\;%InstallRoot%\VB\Snippets\%LCID%\fundamentals\;%InstallRoot%\VB\Snippets\%LCID%\os\;%InstallRoot%\VB\Snippets\%LCID%\other\;%InstallRoot%\VB\Snippets\%LCID%\windowsforms\;%MyDocs%\Code Snippets\Visual Basic\My Code Snippets\",
+        ForceCreateDirs:="%MyDocs%\Code Snippets\Visual Basic\My Code Snippets\",
+        ShowRoots:=True)>
     <ProvideLanguageEditorOptionPage(GetType(AdvancedOptionPage), "Basic", Nothing, "Advanced", "#102", 10160)>
     <ProvideLanguageEditorOptionPage(GetType(StyleOptionPage), "Basic", Nothing, "Code Style", "#109", 10161)>
     <ProvideAutomationProperties("TextEditor", "Basic", Guids.TextManagerPackageString, 103, 105, Guids.VisualBasicPackageIdString)>


### PR DESCRIPTION
Partial fix for internal TFS bug #835188 "The language item of the Code
Snippets Manager was changed"

Add a ProvideLanguageCodeExpansionAttribute to the CSharpPackage and
VisualBasicPackage to specify each languages name as it appears in the
Code Snippets Manager, as well as to specify the SearchPaths and
ForceCreateDirs that were previously specified directly in the setup
authoring.

This change also removes the "Refactoring" snippets from the list of C#
SearchPaths and ForceCreateDirs.

There will be a corresponding closed-source change to remove the C# and
VB snippets-related setup authoring, which will complete the fix for bug
#835188.