### PR TITLE
Dont format comments inside ArrayInitializers

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -74,6 +74,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var commonToken1 = this.Token1;
                 var commonToken2 = this.Token2;
 
+                if (commonToken1.IsMissing || commonToken2.IsMissing)
+                {
+                    return false;
+                }
+
+                var span = TextSpan.FromBounds(commonToken1.Span.End, commonToken2.Span.Start);
+
+                if (context.IsSpacingSuppressed(span))
+                {
+                    return false;
+                }
+
                 var triviaList = new TriviaList(commonToken1.TrailingTrivia, commonToken2.LeadingTrivia);
                 Contract.ThrowIfFalse(triviaList.Count > 0);
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -74,13 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var commonToken1 = this.Token1;
                 var commonToken2 = this.Token2;
 
-                if (commonToken1.IsMissing || commonToken2.IsMissing)
-                {
-                    return false;
-                }
-
                 var span = TextSpan.FromBounds(commonToken1.Span.End, commonToken2.Span.Start);
-
                 if (context.IsSpacingSuppressed(span))
                 {
                     return false;

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6220,5 +6220,33 @@ class Program
 }";
             AssertFormat(expected, code);
         }
+
+        [WorkItem(939, "https://github.com/dotnet/roslyn/issues/939")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DontFormatInsideArrayInitializers()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        int[] sss = new[] {
+                       //Comment1
+                2,
+            5,            324534,    345345,
+                        //Comment2
+                            //This comment should not line up with the previous comment
+                    234234
+                     //Comment3
+                ,         234,
+            234234
+                                /*
+                                This is a multiline comment
+                                */
+                    //Comment4
+              };
+    }
+}";
+            AssertFormat(code, code);
         }
     }
+}


### PR DESCRIPTION
Fix #939 Dont format comments inside Array Initializers and any other place where
spacing is suppressed.