### PR TITLE
Blended node pooling

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -73,12 +73,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public void Dispose()
         {
-            var blendedTokens = _blendedTokens;
-            if (blendedTokens != null)
+            if (_blendedTokens != null)
             {
-                Array.Clear(_blendedTokens, 0, _blendedTokens.Length);
-                s_blendedNodesPool.Free(_blendedTokens);
-                _blendedTokens = null;
+                if (_blendedTokens.Length < 4096)
+                {
+                    Array.Clear(_blendedTokens, 0, _blendedTokens.Length);
+                    s_blendedNodesPool.Free(_blendedTokens);
+                    _blendedTokens = null;
+                }
+                else
+                {
+                    s_blendedNodesPool.ForgetTrackedObject(_blendedTokens);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -77,9 +77,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (blendedTokens != null)
             {
                 _blendedTokens = null;
-                Array.Clear(blendedTokens, 0, blendedTokens.Length);
                 if (blendedTokens.Length < 4096)
                 {
+                    Array.Clear(blendedTokens, 0, blendedTokens.Length);
                     s_blendedNodesPool.Free(blendedTokens);
                 }
                 else


### PR DESCRIPTION
Limit the size of BlendedNode arrays returned to the pool in C# incremental parsing. The 4096 value was determined by gathering statistics on typing scenarios in a reasonably large solution. The pathological case described in #2551 has over 2^19 elements.
Fixes #2551 
