### PR TITLE
Make defaultValue a required parameter for ExtensionManager.PerformFunction*()

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 // Underscores will become an accelerator in the VS smart tag.  So we double all
                 // underscores so they actually get represented as an underscore in the UI.
                 var extensionManager = this.Workspace.Services.GetService<IExtensionManager>();
-                var text = extensionManager.PerformFunction(Provider, () => CodeAction.Title, string.Empty);
+                var text = extensionManager.PerformFunction(Provider, () => CodeAction.Title, defaultValue: string.Empty);
                 return text.Replace("_", "__");
             }
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 // 'null' / empty collection from within GetPreviewAsync().
 
                 return true;
-        }
+            }
         }
 
         public virtual async Task<object> GetPreviewAsync(CancellationToken cancellationToken)
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 }
 
                 // GetPreviewPane() below needs to run on UI thread. We use ConfigureAwait(true) to stay on the UI thread.
-            }).ConfigureAwait(true);
+            }, defaultValue: null).ConfigureAwait(true);
 
             var previewPaneService = Workspace.Services.GetService<IPreviewPaneService>();
             if (previewPaneService == null)
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
                 return false;
             }
-            }
+        }
 
         public virtual Task<IEnumerable<SuggestedActionSet>> GetActionSetsAsync(CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionWithFlavors.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionWithFlavors.cs
@@ -50,8 +50,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             // Light bulb will always invoke this property on the UI thread.
             AssertIsForeground();
 
-                if (_actionSets == null)
-                {
+            if (_actionSets == null)
+            {
                 var extensionManager = this.Workspace.Services.GetService<IExtensionManager>();
 
                 _actionSets = await extensionManager.PerformFunctionAsync(Provider, async () =>
@@ -75,11 +75,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                     return builder.ToImmutable();
                     // We use ConfigureAwait(true) to stay on the UI thread.
-                }).ConfigureAwait(true);
-                }
-
-                return _actionSets;
+                }, defaultValue: ImmutableArray<SuggestedActionSet>.Empty).ConfigureAwait(true);
             }
+
+            return _actionSets;
+        }
 
         private async Task<SuggestedActionSet> GetPreviewChangesSuggestedActionSetAsync(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Extensions
             this IExtensionManager extensionManager,
             object extension,
             Func<T> function,
-            T defaultValue = default(T))
+            T defaultValue)
         {
             try
             {
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Extensions
             this IExtensionManager extensionManager,
             object extension,
             Func<Task<T>> function,
-            T defaultValue = default(T))
+            T defaultValue)
         {
             try
             {
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Extensions
                 t1 =>
                 {
                     var query = from e in extensions
-                                let types = extensionManager.PerformFunction(e, () => nodeTypeGetter(e))
+                                let types = extensionManager.PerformFunction(e, () => nodeTypeGetter(e), defaultValue: SpecializedCollections.EmptyEnumerable<Type>())
                                 where types != null
                                 where !types.Any() || types.Any(t2 => t1 == t2 || t1.GetTypeInfo().IsSubclassOf(t2))
                                 select e;
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Extensions
                 k =>
                 {
                     var query = from e in extensions
-                                let kinds = extensionManager.PerformFunction(e, () => tokenKindGetter(e))
+                                let kinds = extensionManager.PerformFunction(e, () => tokenKindGetter(e), defaultValue: SpecializedCollections.EmptyEnumerable<int>())
                                 where kinds != null
                                 where !kinds.Any() || kinds.Contains(k)
                                 select e;


### PR DESCRIPTION
Fixes internal TFS bug 1166482.

In cases where a fix provider throws an unhandled exception, ```ExtensionManager.PerformFunction*()``` was correctly handling the exception by displaying an 'info bar' alerting the user about the crash. However, because the ```defaultValue``` parameter for ```ExtensionManager.PerformFunction*()``` was optional, in some cases, we would end up returning ```default(ImmutableArray<T>)``` as opposed to ```ImmutableArray<T>.Empty``` to the VS platform's light bulb  engine. The difference is significant in this case since ```ImmutableArray<T>``` is a struct and since it is returned as an ```IEnumerable<T>```. The platform code checks whether the returned ```IEnumerable<T>``` is ```null``` (which it won't be) and then calls ```.Any()``` on it and this results in an ```InvalidOperationException``` from ```ImmutableArray<T>```...

In addition to supplying the correct ```defaultValue``` of ```ImmutableArray<T>.Empty``` to avoid the above crash, I am also making ```defaultValue``` a **required** parameter (so that future consumers of ```ExtensionManager.PerformFunction*()``` don't run into this problem).