### PR TITLE
Only offer encapsulate on fields of types

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -912,7 +912,10 @@ partial class Program {
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void ErrorTolerance()
         {
-            var text = @"a b c [|b|]";
+            var text = @"class Program 
+{
+    a b c [|b|]
+}";
 
             using (var workspace = CreateWorkspaceFromFile(text, null, null))
             {

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -980,5 +980,25 @@ namespace ConsoleApplication1
 
             Test(text, expected);
         }
+
+        [WorkItem(1096007, "https://github.com/dotnet/roslyn/issues/282")]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void DoNotEncapsulateOutsideTypeDeclaration()
+        {
+            TestMissing(@"
+var [|x|] = 1;");
+
+            TestMissing(@"
+namespace N
+{
+    var [|x|] = 1;
+}");
+
+            TestMissing(@"
+enum E
+{
+    [|x|] = 1;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -557,5 +557,30 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False)
 
         End Sub
+
+        <WorkItem(1096007, "https://github.com/dotnet/roslyn/issues/282")>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        Public Sub DoNotEncapsulateOutsideTypeDeclaration()
+            Dim globalField = <File>
+Dim [|x|] = 1
+</File>.ConvertTestSourceTag()
+            TestMissing(globalField)
+
+
+            Dim namespaceField = <File>
+Namespace N
+    Dim [|x|] = 1
+End Namespace            
+</File>.ConvertTestSourceTag()
+            TestMissing(namespaceField)
+
+            Dim enumField = <File>
+Enum E
+     [|x|] = 1
+End Enum
+</File>.ConvertTestSourceTag()
+            TestMissing(enumField)
+
+        End Sub
     End Class
 End Namespace

--- a/src/Features/CSharp/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -132,8 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
 
         private bool CanEncapsulate(FieldDeclarationSyntax field)
         {
-            return field.Parent is TypeDeclarationSyntax
-                || field.Parent is EnumDeclarationSyntax;
+            return field.Parent is TypeDeclarationSyntax;
         }
 
         protected override Tuple<string, string> GeneratePropertyAndFieldNames(IFieldSymbol field)

--- a/src/Features/CSharp/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
                                     .OfType<FieldDeclarationSyntax>()
                                     .Where(n => n.Span.IntersectsWith(span));
 
-            var declarations = fields.Select(f => f.Declaration);
+            var declarations = fields.Where(CanEncapsulate).Select(f => f.Declaration);
 
             IEnumerable<VariableDeclaratorSyntax> declarators;
             if (span.IsEmpty)
@@ -128,6 +128,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
             return declarators.Select(d => semanticModel.GetDeclaredSymbol(d, cancellationToken) as IFieldSymbol)
                                 .WhereNotNull()
                                 .Where(f => f.Name.Length != 0);
+        }
+
+        private bool CanEncapsulate(FieldDeclarationSyntax field)
+        {
+            return field.Parent is TypeDeclarationSyntax
+                || field.Parent is EnumDeclarationSyntax;
         }
 
         protected override Tuple<string, string> GeneratePropertyAndFieldNames(IFieldSymbol field)

--- a/src/Features/VisualBasic/EncapsulateField/VisualBasicEncapsulateFieldService.vb
+++ b/src/Features/VisualBasic/EncapsulateField/VisualBasicEncapsulateFieldService.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EncapsulateField
 
             Dim fields = root.DescendantNodes(Function(n) n.Span.IntersectsWith(span)) _
                                                         .OfType(Of FieldDeclarationSyntax)() _
-                                                        .Where(Function(n) n.Span.IntersectsWith(span))
+                                                        .Where(Function(n) n.Span.IntersectsWith(span) AndAlso CanEncapsulate(n))
 
             Dim names As IEnumerable(Of ModifiedIdentifierSyntax)
             If span.IsEmpty Then
@@ -75,6 +75,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EncapsulateField
                                                         .OfType(Of IFieldSymbol)() _
                                                         .WhereNotNull() _
                                                         .Where(Function(f) f.Name.Length > 0)
+        End Function
+
+        Private Function CanEncapsulate(field As FieldDeclarationSyntax) As Boolean
+            Return TypeOf field.Parent Is EnumBlockSyntax OrElse TypeOf field.Parent Is TypeBlockSyntax
         End Function
 
         Protected Function MakeUnique(baseName As String, originalFieldName As String, containingType As INamedTypeSymbol, Optional willChangeFieldName As Boolean = True) As String

--- a/src/Features/VisualBasic/EncapsulateField/VisualBasicEncapsulateFieldService.vb
+++ b/src/Features/VisualBasic/EncapsulateField/VisualBasicEncapsulateFieldService.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EncapsulateField
         End Function
 
         Private Function CanEncapsulate(field As FieldDeclarationSyntax) As Boolean
-            Return TypeOf field.Parent Is EnumBlockSyntax OrElse TypeOf field.Parent Is TypeBlockSyntax
+            Return TypeOf field.Parent Is TypeBlockSyntax
         End Function
 
         Protected Function MakeUnique(baseName As String, originalFieldName As String, containingType As INamedTypeSymbol, Optional willChangeFieldName As Boolean = True) As String


### PR DESCRIPTION
Fixes #282 

This change limits the Encapsulate Field code fix to only offer fixes for fields that are members of a type.

@Pilchie @jasonmalinowski  @dpoeschl  @rchande  please review