### PR TITLE
Getting the speculative type info for "dynamic" returns the dynamic type.

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -3433,6 +3433,30 @@ class Program
             }
         }
 
+        [WorkItem(814, "https://github.com/dotnet/roslyn/issues/814")]
+        [Fact]
+        public void TypeOfDynamic()
+        {
+            var source = @"
+using System;
+using System.Dynamic;
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            dynamic a = 5;
+        }   
+     }
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var typeSyntax = SyntaxFactory.ParseTypeName("dynamic");
+            int spanStart = source.IndexOf("dynamic a = 5;");
+            var dynamicType = model.GetSpeculativeTypeInfo(spanStart, typeSyntax, SpeculativeBindingOption.BindAsTypeOrNamespace);
+            Assert.Equal(TypeKind.Dynamic, dynamicType.Type.TypeKind);
+        }
+
         #region "regression helper"
         private void Regression(string text)
         {


### PR DESCRIPTION
Fixes #814

@VSadov @jaredpar @AlekseyTs Please review.