### PR TITLE
Fix threading issue in VisualStudioProjectManagementService

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/GenerateType/TestGenerateTypeOptionsService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/GenerateType/TestGenerateTypeOptionsService.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
         public string FullFilePath = null;
         public Document ExistingDocument = null;
         public bool AreFoldersValidIdentifiers = true;
+        public string DefaultNamespace = null;
         public bool IsCancelled = false;
 
         // Actual input
@@ -40,7 +41,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
             // Storing the actual values
             ClassName = className;
             GenerateTypeDialogOptions = generateTypeDialogOptions;
-            var defaultNamespace = projectManagementService.GetDefaultNamespace(Project, Project?.Solution.Workspace);
+            if (DefaultNamespace == null)
+            {
+                DefaultNamespace = projectManagementService.GetDefaultNamespace(Project, Project?.Solution.Workspace);
+            }
             return new GenerateTypeOptionsResult(
                 accessibility: Accessibility,
                 typeKind: TypeKind,
@@ -52,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
                 fullFilePath: FullFilePath,
                 existingDocument: ExistingDocument,
                 areFoldersValidIdentifiers: AreFoldersValidIdentifiers,
-                defaultNamespace: defaultNamespace,
+                defaultNamespace: DefaultNamespace,
                 isCancelled: IsCancelled);
         }
 
@@ -67,6 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
             string fullFilePath = null,
             Document existingDocument = null,
             bool areFoldersValidIdentifiers = true,
+            string defaultNamespace = null,
             bool isCancelled = false)
         {
             Accessibility = accessibility;
@@ -79,6 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
             FullFilePath = fullFilePath;
             ExistingDocument = existingDocument;
             AreFoldersValidIdentifiers = areFoldersValidIdentifiers;
+            DefaultNamespace = defaultNamespace;
             IsCancelled = isCancelled;
         }
     }

--- a/src/EditorFeatures/Test/Diagnostics/GenerateType/TestGenerateTypeOptionsService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/GenerateType/TestGenerateTypeOptionsService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
             // Storing the actual values
             ClassName = className;
             GenerateTypeDialogOptions = generateTypeDialogOptions;
-
+            var defaultNamespace = projectManagementService.GetDefaultNamespace(Project, Project?.Solution.Workspace);
             return new GenerateTypeOptionsResult(
                 accessibility: Accessibility,
                 typeKind: TypeKind,
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateType
                 fullFilePath: FullFilePath,
                 existingDocument: ExistingDocument,
                 areFoldersValidIdentifiers: AreFoldersValidIdentifiers,
+                defaultNamespace: defaultNamespace,
                 isCancelled: IsCancelled);
         }
 

--- a/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     }
 
                     var projectManagementService = _document.Project.Solution.Workspace.Services.GetService<IProjectManagementService>();
-                    var defaultNamespace = projectManagementService.GetDefaultNamespace(targetProject, targetProject.Solution.Workspace);
+                    var defaultNamespace = _generateTypeOptionsResult.DefaultNamespace;
 
                     // Case 1 : If the type is generated into the same C# project or
                     // Case 2 : If the type is generated from a C# project to a C# Project

--- a/src/Features/Core/GenerateType/GenerateTypeOptionsResult.cs
+++ b/src/Features/Core/GenerateType/GenerateTypeOptionsResult.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
         public TypeKind TypeKind { get; }
         public string FullFilePath { get; }
         public string TypeName { get; }
+        public string DefaultNamespace { get; }
         public bool AreFoldersValidIdentifiers { get; }
 
         public GenerateTypeOptionsResult(
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             string fullFilePath,
             Document existingDocument,
             bool areFoldersValidIdentifiers,
+            string defaultNamespace,
             bool isCancelled = false)
         {
             this.Accessibility = accessibility;
@@ -43,6 +45,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             this.FullFilePath = fullFilePath;
             this.ExistingDocument = existingDocument;
             this.AreFoldersValidIdentifiers = areFoldersValidIdentifiers;
+            this.DefaultNamespace = defaultNamespace;
             this.IsCancelled = isCancelled;
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/VisualStudioGenerateTypeOptionsServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/VisualStudioGenerateTypeOptionsServiceFactory.cs
@@ -67,6 +67,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
                     _accessSelectString = viewModel.SelectedAccessibilityString;
                     _typeKindSelectString = viewModel.SelectedTypeKindString;
 
+                    var defaultNamespace = projectManagementService.GetDefaultNamespace(viewModel.SelectedProject, viewModel.SelectedProject?.Solution.Workspace);
+
                     return new GenerateTypeOptionsResult(
                         accessibility: viewModel.SelectedAccessibility,
                         typeKind: viewModel.SelectedTypeKind,
@@ -77,6 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
                         folders: viewModel.Folders,
                         fullFilePath: viewModel.FullFilePath,
                         existingDocument: viewModel.SelectedDocument,
+                        defaultNamespace: defaultNamespace,
                         areFoldersValidIdentifiers: viewModel.AreFoldersValidIdentifiers);
                 }
                 else

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
@@ -4,14 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.ProjectManagement;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
+using Microsoft.VisualStudio.Progression;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
 
@@ -40,7 +39,10 @@ namespace Roslyn.VisualStudio.Services.Implementation.ProjectSystem
 
                 try
                 {
-                    defaultNamespace = (string)envDTEProject.ProjectItems.ContainingProject.Properties.Item("DefaultNamespace").Value; // Do not Localize
+                    UIThread.Invoke(new System.Action(() =>
+                    {
+                        defaultNamespace = (string)envDTEProject.ProjectItems.ContainingProject.Properties.Item("DefaultNamespace").Value; // Do not Localize
+                    }));
                 }
                 catch (ArgumentException)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
@@ -6,6 +6,7 @@ using System.Composition;
 using System.Linq;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.ProjectManagement;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -16,10 +17,12 @@ using Roslyn.Utilities;
 namespace Roslyn.VisualStudio.Services.Implementation.ProjectSystem
 {
     [ExportWorkspaceService(typeof(IProjectManagementService), ServiceLayer.Host), Shared]
-    internal class VisualStudioProjectManagementService : IProjectManagementService
+    internal class VisualStudioProjectManagementService : ForegroundThreadAffinitizedObject, IProjectManagementService
     {
         public string GetDefaultNamespace(Microsoft.CodeAnalysis.Project project, Workspace workspace)
         {
+            this.AssertIsForeground();
+
             if (project.Language == LanguageNames.VisualBasic)
             {
                 return "";

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectManagementService.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.ProjectManagement;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
-using Microsoft.VisualStudio.Progression;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
 
@@ -39,10 +38,7 @@ namespace Roslyn.VisualStudio.Services.Implementation.ProjectSystem
 
                 try
                 {
-                    UIThread.Invoke(new System.Action(() =>
-                    {
-                        defaultNamespace = (string)envDTEProject.ProjectItems.ContainingProject.Properties.Item("DefaultNamespace").Value; // Do not Localize
-                    }));
+                    defaultNamespace = (string)envDTEProject.ProjectItems.ContainingProject.Properties.Item("DefaultNamespace").Value; // Do not Localize
                 }
                 catch (ArgumentException)
                 {


### PR DESCRIPTION
Attempting to generate a new file in an ASP.NET 5 web project would
deadlock because we were attempting to get the default namespace from a
worker thread.
    
The solution is to move the work of computing the default namespace from
ComputeOperationsAsync to GetOptions.  GetOptions is always guaranteed
to execute on the UI thread wheras ComputeOperationsAsync happens from a
worker thread.

fixes internal issue 1167819