### PR TITLE
Suppress instances of CA2001

### DIFF
--- a/src/Compilers/Helpers/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Helpers/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -75,6 +75,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", 
+            MessageId = "System.Reflection.Assembly.LoadFrom",
+            Justification = @"We need to call Assembly.LoadFrom in order to load analyzer assemblies. 
+We can’t use Assembly.Load(AssemblyName) because we need to be able to load assemblies outside of the csc/vbc/vbcscompiler/VS binding paths.
+We can’t use Assembly.Load(byte[]) because VS won’t load resource assemblies for those due to an assembly binding optimization.
+That leaves Assembly.LoadFrom(string) as the only option that works everywhere.")]
         protected override Assembly LoadCore(string fullPath)
         {
             if (_shadowCopyDirectory == null)

--- a/src/Compilers/Helpers/SimpleAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Helpers/SimpleAnalyzerAssemblyLoader.cs
@@ -17,6 +17,12 @@ namespace Microsoft.CodeAnalysis
     /// </remarks>
     internal sealed class SimpleAnalyzerAssemblyLoader : AbstractAnalyzerAssemblyLoader
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods",
+            MessageId = "System.Reflection.Assembly.LoadFrom",
+            Justification = @"We need to call Assembly.LoadFrom in order to load analyzer assemblies. 
+We can’t use Assembly.Load(AssemblyName) because we need to be able to load assemblies outside of the csc/vbc/vbcscompiler/VS binding paths.
+We can’t use Assembly.Load(byte[]) because VS won’t load resource assemblies for those due to an assembly binding optimization.
+That leaves Assembly.LoadFrom(string) as the only option that works everywhere.")]
         protected override Assembly LoadCore(string fullPath)
         {
             return Assembly.LoadFrom(fullPath);


### PR DESCRIPTION
Suppress FxCop CA2001 (AvoidCallingProblematicMethods) errors that are being reported for Roslyn's use of Assembly.LoadFrom().