### PR TITLE
Snippets: Don't NullRef when an IVsTextBuffer cannot be found

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -355,6 +355,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             var buffer = EditorAdaptersFactoryService.GetBufferAdapter(TextView.TextBuffer);
+            if (buffer == null)
+            {
+                // Without a buffer adapter we cannot find the IVsExpansion
+                return false;
+            }
+
             buffer.GetLineIndexOfPosition(surfaceBufferSpan.Start.Position, out startLine, out startIndex);
             buffer.GetLineIndexOfPosition(surfaceBufferSpan.End.Position, out endLine, out endIndex);
 


### PR DESCRIPTION
Fixes internal TFS bug #831378

With this change, snippets will still not work in Inline Diff Mode, but
they will no longer cause NullRef dialogs.

NOTE: This is a proposed fix for the 1.0 Stable milestone. We can revisit this in a future milestone if needed.

Tagging for Review: @Pilchie @jasonmalinowski @balajikris @rchande @brettfo @jmarolf 