### PR TITLE
Rename: Add conflicts between type/namespace declarations

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3050,5 +3050,93 @@ class C
                 result.AssertLabeledSpansAre("resolved2", "N((long)0)", RelatedLocationType.ResolvedNonReferenceConflict)
             End Using
         End Sub
+
+        <WorkItem(1027506)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub TestConflictBetweenClassAndInterface1()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class {|conflict:C|} { }
+interface [|$$I|] { }
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="C")
+
+                result.AssertLabeledSpansAre("conflict", "C", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1027506)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub TestConflictBetweenClassAndInterface2()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class [|$$C|] { }
+interface {|conflict:I|} { }
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="I")
+
+                result.AssertLabeledSpansAre("conflict", "I", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1027506)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub TestConflictBetweenClassAndNamespace1()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class {|conflict:$$C|} { }
+namespace N { }
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="N")
+
+                result.AssertLabeledSpansAre("conflict", "N", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1027506)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub TestConflictBetweenClassAndNamespace2()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+class {|conflict:C|} { }
+namespace [|$$N|] { }
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="C")
+
+                result.AssertLabeledSpansAre("conflict", "C", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1027506)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub TestNoConflictBetweenTwoNamespaces()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document FilePath="Test.cs"><![CDATA[
+namespace [|$$N1|][ { }
+namespace N2 { }
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="N2")
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2871,6 +2871,104 @@ End Class
                     result.AssertLabeledSpansAre("ref", "Dim x = NameOf(C.zoo)", RelatedLocationType.ResolvedNonReferenceConflict)
                 End Using
             End Sub
+
+            <WorkItem(1027506)>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub TestConflictBetweenClassAndInterface1()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class {|conflict:C|}
+End Class
+Interface [|$$I|]
+End Interface
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="C")
+
+                    result.AssertLabeledSpansAre("conflict", "C", RelatedLocationType.UnresolvableConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1027506)>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub TestConflictBetweenClassAndInterface2()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class [|$$C|]
+End Class
+Interface {|conflict:I|}
+End Interface
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="I")
+
+                    result.AssertLabeledSpansAre("conflict", "I", RelatedLocationType.UnresolvableConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1027506)>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub TestConflictBetweenClassAndNamespace1()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class {|conflict:$$C|}
+End Class
+Namespace N
+End Namespace
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="N")
+
+                    result.AssertLabeledSpansAre("conflict", "N", RelatedLocationType.UnresolvableConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1027506)>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub TestConflictBetweenClassAndNamespace2()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class {|conflict:C|}
+End Class
+Namespace [|$$N|]
+End Namespace
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="C")
+
+                    result.AssertLabeledSpansAre("conflict", "C", RelatedLocationType.UnresolvableConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1027506)>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub TestNoConflictBetweenTwoNamespaces()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Namespace [|$$N1|]
+End Namespace
+Namespace N2
+End Namespace
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="N2")
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -172,13 +172,40 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             IDictionary<Location, Location> reverseMappedLocations,
             CancellationToken cancellationToken)
         {
-            if (renamedSymbol.ContainingSymbol is INamedTypeSymbol)
+            if (renamedSymbol.ContainingSymbol.IsKind(SymbolKind.NamedType))
             {
                 var otherThingsNamedTheSame = renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name)
-                                                       .Where(s => !s.Equals(renamedSymbol) && string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal) &&
-                                                              (s.Kind != SymbolKind.Method || renamedSymbol.Kind != SymbolKind.Method)).ToList();
+                                                       .Where(s => !s.Equals(renamedSymbol) && 
+                                                                   string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal) &&
+                                                                   (s.Kind != SymbolKind.Method || renamedSymbol.Kind != SymbolKind.Method));
 
                 AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
+            }
+
+
+            if (renamedSymbol.IsKind(SymbolKind.Namespace) && renamedSymbol.ContainingSymbol.IsKind(SymbolKind.Namespace))
+            {
+                var otherThingsNamedTheSame = ((INamespaceSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
+                                                        .Where(s => !s.Equals(renamedSymbol) &&
+                                                                    !s.IsKind(SymbolKind.Namespace) &&
+                                                                    string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
+
+                AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
+            }
+
+            if (renamedSymbol.IsKind(SymbolKind.NamedType) && renamedSymbol.ContainingSymbol is INamespaceOrTypeSymbol)
+            {
+                var otherThingsNamedTheSame = ((INamespaceOrTypeSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
+                                                        .Where(s => !s.Equals(renamedSymbol) &&
+                                                                    string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
+
+                var conflictingSymbolLocations = otherThingsNamedTheSame.Where(s => !s.IsKind(SymbolKind.Namespace));
+                if (otherThingsNamedTheSame.Any(s => s.IsKind(SymbolKind.Namespace)))
+                {
+                    conflictingSymbolLocations = conflictingSymbolLocations.Concat(renamedSymbol);
+                }
+
+                AddConflictingSymbolLocations(conflictingSymbolLocations, conflictResolution, reverseMappedLocations);
             }
 
             // Some types of symbols (namespaces, cref stuff, etc) might not have ContainingAssemblies


### PR DESCRIPTION
Fixes internal TFS bug #1027506 "Rename: No unresolvable conflict shown
for interface/class name conflict"

Update the ConflictResolver to catch declaration conflicts between types
of different kinds (classes versus interfaces) and between types &
namespaces. When two different kinds of types conflict, the conflict is
shown on the one that's not currently being renamed. When a type
conflicts with a namespace, the conflict is always shown on the type.

Tagging for Review: @Pilchie @jasonmalinowski @balajikris @brettfo @rchande @jmarolf 