### PR TITLE
Omit argument values if argument count doesn't match parameter count...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -282,6 +282,28 @@ class C
                 GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names));
         }
 
+        [Fact, WorkItem(1154945, "DevDiv")]
+        public void GetNameIncorrectNumberOfArgumentValues()
+        {
+            var source = @"
+class C
+{
+    void M(int x, int y)
+    {
+    }
+}";
+            var expected = "C.M(int x, int y)";
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names, argumentValues: new string[] { }));
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names, argumentValues: new string[] { "1" }));
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types | DkmVariableInfoFlags.Names, argumentValues: new string[] { "1", "2", "3" }));
+        }
+
         [Fact, WorkItem(1134081, "DevDiv")]
         public void GetFileNameWithoutExtension()
         {
@@ -395,7 +417,6 @@ class C
             ArrayBuilder<string> builder = null;
             if (argumentValues != null)
             {
-                Assert.InRange(argumentValues.Length, 1, int.MaxValue);
                 builder = ArrayBuilder<string>.GetInstance();
                 builder.AddRange(argumentValues);
             }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -41,8 +41,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal string GetName(TMethodSymbol method, bool includeParameterTypes, bool includeParameterNames, ArrayBuilder<string> argumentValues = null)
         {
-            Debug.Assert((argumentValues == null) || (method.Parameters.Length == argumentValues.Count));
-
             var pooled = PooledStringBuilder.GetInstance();
             var builder = pooled.Builder;
 
@@ -50,11 +48,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             AppendFullName(builder, method);
 
             // parameter list...
-            var includeArgumentValues = argumentValues != null;
+            var parameters = method.Parameters;
+            var includeArgumentValues = (argumentValues != null) && (parameters.Length == argumentValues.Count);
             if (includeParameterTypes || includeParameterNames || includeArgumentValues)
             {
                 builder.Append('(');
-                var parameters = method.Parameters;
                 for (int i = 0; i < parameters.Length; i++)
                 {
                     if (i > 0)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
@@ -371,6 +371,25 @@ End Class"
                 GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names))
         End Sub
 
+        <Fact, WorkItem(1154945, "DevDiv")>
+        Public Sub GetNameIncorrectNumberOfArgumentValues()
+            Dim source = "
+Class C
+    Sub M(x As Integer, y As Integer)
+    End Sub
+End Class"
+            Dim expected = "C.M(Integer x, Integer y)"
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names, argumentValues:={}))
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names, argumentValues:={"1"}))
+
+            Assert.Equal(expected,
+                GetName(source, "C.M", DkmVariableInfoFlags.Types Or DkmVariableInfoFlags.Names, argumentValues:={"1", "2", "3"}))
+        End Sub
+
         <Fact>
         Public Sub GetReturnTypeNamePrimitive()
             Dim source = "
@@ -458,7 +477,6 @@ End Class"
             Dim includeParameterNames = argumentFlags.Includes(DkmVariableInfoFlags.Names)
             Dim builder As ArrayBuilder(Of String) = Nothing
             If argumentValues IsNot Nothing Then
-                Assert.InRange(argumentValues.Length, 1, Integer.MaxValue)
                 builder = ArrayBuilder(Of String).GetInstance()
                 builder.AddRange(argumentValues)
             End If


### PR DESCRIPTION
In error cases where GetClrLocalVariableQuery returns no parameters, DkmInspectionContext.GetFrameArguments will return no values (but ErrorCode will not be set on the result).  We'll handle all cases where the argument count doesn't match the parameter count for the current frame (not just "zero" and "matching"), because the code is simpler that way.  This matches the behavior of the old EE.