### PR TITLE
Add CS0414 to diagnostic analyzer unsupported error codes list

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.CSharp
                         continue;
 
                     case (int)ErrorCode.WRN_UnreferencedField:
+                    case (int)ErrorCode.WRN_UnreferencedFieldAssg:
                     case (int)ErrorCode.WRN_UnassignedInternalField:
                         // unused field. current live error doesn't support this.
                         continue;


### PR DESCRIPTION
Adds CS0414 (ErrorCode.WRN_UnreferencedFieldAssg / "The field 'X' is
assigned but its value is never used") to the list of error codes that
are not supported in the CSharpCompilerDiagnosticAnalyzer. This allows
CS0414 warnings produced during the build to persist when their relevant
documents are opened in the IDE, which would otherwise cause the
warnings to disappear when the set of live errors is produced.

Tagging for review: @heejaechang @srivatsn