### PR TITLE
EnC: Fix mapping of variables declared in lambdas.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -591,7 +591,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var methodWithBody in compilationState.SynthesizedMethods)
             {
                 var method = methodWithBody.Method;
-                var variableSlotAllocatorOpt = _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method);
+
+                var lambda = method as SynthesizedLambdaMethod;
+                var variableSlotAllocatorOpt = ((object)lambda != null) ? 
+                    _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(lambda, lambda.TopLevelMethod) :
+                    _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method, method);
 
                 // We make sure that an asynchronous mutation to the diagnostic bag does not 
                 // confuse the method body generator by making a fresh bag and then loading
@@ -1184,7 +1188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (lazyVariableSlotAllocator == null)
             {
-                lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method);
+                lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method);
             }
 
             BoundStatement bodyWithoutLambdas = loweredBody;

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -157,9 +157,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return anonymousTypes;
         }
 
-        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method)
+        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod)
         {
-            return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method);
+            return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method, topLevelMethod);
         }
 
         internal override ImmutableArray<AnonymousTypeKey> GetPreviousAnonymousTypes()

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get { return false; }
         }
 
-        internal virtual VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method)
+        internal virtual VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -84,6 +84,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override bool GenerateDebugInfo => !this.IsAsync;
         internal override bool IsExpressionBodied => false;
+        internal MethodSymbol TopLevelMethod => _topLevelMethod;
+
+        internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+        {
+            // Syntax offset of a syntax node contained in a lambda body is calculated by the containing top-level method.
+            // The offset is thus relative to the top-level method body start.
+            return _topLevelMethod.CalculateLocalSyntaxOffset(localPosition, localTree);
+        }
 
         IMethodSymbol ISynthesizedMethodBodyImplementationSymbol.Method => _topLevelMethod;
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -513,11 +513,11 @@ class C
 
     void F()
     {
-		var result = <N:0>from a in new[] { 1 }</N:0>
-		             <N:1>from b in <N:9>new[] { 1 }</N:9></N:1>
-		             <N:2>where <N:7>Z(<N:5>() => a</N:5>) > 0</N:7></N:2>
-		             <N:3>where <N:8>Z(<N:6>() => b</N:6>) > 0</N:8></N:3>
-		             <N:4>select a</N:4>;
+		var <N:10>result = <N:0>from a in new[] { 1 }</N:0>
+		                   <N:1>from b in <N:9>new[] { 1 }</N:9></N:1>
+		                   <N:2>where <N:7>Z(<N:5>() => a</N:5>) > 0</N:7></N:2>
+		                   <N:3>where <N:8>Z(<N:6>() => b</N:6>) > 0</N:8></N:3>
+		                   <N:4>select a</N:4></N:10>;
     }
 }");
 
@@ -534,11 +534,11 @@ class C
 
     void F()
     {
-		var result = <N:0>from a in new[] { 1 }</N:0>
-		             <N:1>from b in <N:9>new[] { 2 }</N:9></N:1>
-		             <N:2>where <N:7>Z(<N:5>() => a</N:5>) > 1</N:7></N:2>
-		             <N:3>where <N:8>Z(<N:6>() => b</N:6>) > 2</N:8></N:3>
-		             <N:4>select a</N:4>;
+		var <N:10>result = <N:0>from a in new[] { 1 }</N:0>
+		                   <N:1>from b in <N:9>new[] { 2 }</N:9></N:1>
+		                   <N:2>where <N:7>Z(<N:5>() => a</N:5>) > 1</N:7></N:2>
+		                   <N:3>where <N:8>Z(<N:6>() => b</N:6>) > 2</N:8></N:3>
+		                   <N:4>select a</N:4></N:10>;
     }
 }");
             var compilation0 = CreateCompilationWithMscorlib(source0.Tree, new[] { SystemCoreRef }, options: ComSafeDebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
@@ -996,13 +996,14 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.2
   IL_0002:  add
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }
 ");
@@ -1036,13 +1037,14 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.3
   IL_0002:  add
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }
 ");
@@ -1091,13 +1093,14 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.4
   IL_0002:  add
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }
 ");
@@ -1706,7 +1709,7 @@ class C
         }
 
         [Fact]
-        public void LambdasInInitializers()
+        public void LambdasInInitializers1()
         {
             var source0 = MarkedSource(@"
 using System;
@@ -1750,7 +1753,7 @@ class C
             var compilation1 = compilation0.WithSource(source1.Tree);
             var v0 = CompileAndVerify(compilation0);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
-
+            
             var ctor00 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
             var ctor10 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor(System.Int32 x)");
             var ctor01 = compilation1.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
@@ -1775,13 +1778,14 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.2
   IL_0002:  sub
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }");
 
@@ -1789,13 +1793,14 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.3
   IL_0002:  sub
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }");
 
@@ -1803,27 +1808,163 @@ class C
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.4
   IL_0002:  sub
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
 }");
             diff1.VerifyIL("C.<>c.<.ctor>b__3_1", @"
 {
   // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
+  .locals init ([int] V_0,
+                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.1
   IL_0002:  sub
-  IL_0003:  stloc.0
+  IL_0003:  stloc.1
   IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.0
+  IL_0006:  ldloc.1
   IL_0007:  ret
+}");
+        }
+
+        [Fact]
+        public void LambdasInInitializers2()
+        {
+            var source0 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int G(Func<int, int> f) => 1;
+
+    public int A = G(<N:0>a => { int <N:4>v1 = 1</N:4>; return 1; }</N:0>);
+
+    public C() : this(G(<N:1>a => { int <N:5>v2 = 1</N:5>; return 2; }</N:1>))
+    {
+        G(<N:2>a => { int <N:6>v3 = 1</N:6>; return 3; }</N:2>);
+    }
+
+    public C(int x)
+    {
+        G(<N:3>a => { int <N:7>v4 = 1</N:7>; return 4; }</N:3>);
+    }
+}");
+            var source1 = MarkedSource(@"
+using System;
+
+class C
+{
+    static int G(Func<int, int> f) => 1;
+
+    public int A = G(<N:0>a => { int <N:4>v1 = 10</N:4>; return 1; }</N:0>);
+
+    public C() : this(G(<N:1>a => { int <N:5>v2 = 10</N:5>; return 2; }</N:1>))
+    {
+        G(<N:2>a => { int <N:6>v3 = 10</N:6>; return 3; }</N:2>);
+    }
+
+    public C(int x)
+    {
+        G(<N:3>a => { int <N:7>v4 = 10</N:7>; return 4; }</N:3>);
+    }
+}");
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var ctor00 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
+            var ctor10 = compilation0.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor(System.Int32 x)");
+            var ctor01 = compilation1.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor()");
+            var ctor11 = compilation1.GetMembers("C..ctor").Single(m => m.ToTestDisplayString() == "C..ctor(System.Int32 x)");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, ctor00, ctor01, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true),
+                    new SemanticEdit(SemanticEditKind.Update, ctor10, ctor11, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__2_0, <>9__2_1, <>9__3_0, <>9__3_1, <.ctor>b__2_0, <.ctor>b__2_1, <.ctor>b__3_0, <.ctor>b__3_1}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__2_0", @"
+{
+  // Code size       10 (0xa)
+  .maxstack  1
+  .locals init (int V_0, //v2
+                [int] V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   10
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.2
+  IL_0005:  stloc.2
+  IL_0006:  br.s       IL_0008
+  IL_0008:  ldloc.2
+  IL_0009:  ret
+}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__2_1", @"
+{
+  // Code size       10 (0xa)
+  .maxstack  1
+  .locals init (int V_0, //v3
+                [int] V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   10
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.3
+  IL_0005:  stloc.2
+  IL_0006:  br.s       IL_0008
+  IL_0008:  ldloc.2
+  IL_0009:  ret
+}");
+
+            diff1.VerifyIL("C.<>c.<.ctor>b__3_0", @"
+{
+  // Code size       10 (0xa)
+  .maxstack  1
+  .locals init (int V_0, //v4
+                [int] V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   10
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.4
+  IL_0005:  stloc.2
+  IL_0006:  br.s       IL_0008
+  IL_0008:  ldloc.2
+  IL_0009:  ret
+}");
+            diff1.VerifyIL("C.<>c.<.ctor>b__3_1", @"
+{
+  // Code size       10 (0xa)
+  .maxstack  1
+  .locals init (int V_0, //v1
+                [int] V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   10
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.1
+  IL_0005:  stloc.2
+  IL_0006:  br.s       IL_0008
+  IL_0008:  ldloc.2
+  IL_0009:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
@@ -988,7 +988,7 @@ class Test
           <bucket flagCount=""1"" flags=""1"" slotId=""0"" localName=""d5"" />
         </dynamicLocals>
         <encLocalSlotMap>
-          <slot kind=""0"" offset=""10"" />
+          <slot kind=""0"" offset=""73"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -153,8 +153,8 @@ class Test
       <customDebugInfo>
         <forward declaringType=""Test"" methodName=""Main"" />
         <encLocalSlotMap>
-          <slot kind=""30"" offset=""0"" />
-          <slot kind=""0"" offset=""54"" />
+          <slot kind=""30"" offset=""56"" />
+          <slot kind=""0"" offset=""110"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
@@ -324,8 +324,8 @@ class Test
       <customDebugInfo>
         <forward declaringType=""Test"" methodName=""Main"" />
         <encLocalSlotMap>
-          <slot kind=""30"" offset=""0"" />
-          <slot kind=""0"" offset=""54"" />
+          <slot kind=""30"" offset=""56"" />
+          <slot kind=""0"" offset=""110"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -289,8 +289,8 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".cctor"" />
         <encLocalSlotMap>
-          <slot kind=""0"" offset=""29"" />
-          <slot kind=""0"" offset=""93"" />
+          <slot kind=""0"" offset=""-118"" />
+          <slot kind=""0"" offset=""-54"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
@@ -318,7 +318,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".cctor"" />
         <encLocalSlotMap>
-          <slot kind=""30"" offset=""0"" />
+          <slot kind=""30"" offset=""-45"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -151,10 +151,11 @@ namespace Microsoft.CodeAnalysis.Emit
         protected abstract ImmutableArray<EncLocalInfo> TryGetLocalSlotMapFromMetadata(MethodDefinitionHandle handle, EditAndContinueMethodDebugInformation debugInfo);
         protected abstract ITypeSymbol TryGetStateMachineType(Handle methodHandle);
 
-        internal VariableSlotAllocator TryCreateVariableSlotAllocator(EmitBaseline baseline, IMethodSymbol method)
+        internal VariableSlotAllocator TryCreateVariableSlotAllocator(EmitBaseline baseline, IMethodSymbol method, IMethodSymbol topLevelMethod)
         {
+            // Top-level methods are always included in the semantic edit list. Lambda methods are not.
             MappedMethod mappedMethod;
-            if (!this.mappedMethods.TryGetValue(method, out mappedMethod))
+            if (!this.mappedMethods.TryGetValue(topLevelMethod, out mappedMethod))
             {
                 return null;
             }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         // syntax:
         private readonly Func<SyntaxNode, SyntaxNode> _syntaxMapOpt;
-        private readonly IMethodSymbolInternal _previousMethod;
+        private readonly IMethodSymbolInternal _previousTopLevelMethod;
         private readonly DebugId _methodId;
 
         // locals:
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Emit
         public EncVariableSlotAllocator(
             SymbolMatcher symbolMap,
             Func<SyntaxNode, SyntaxNode> syntaxMapOpt,
-            IMethodSymbolInternal previousMethod,
+            IMethodSymbolInternal previousTopLevelMethod,
             DebugId methodId,
             ImmutableArray<EncLocalInfo> previousLocals,
             IReadOnlyDictionary<int, KeyValuePair<DebugId, int>> lambdaMapOpt,
@@ -51,13 +51,13 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<Cci.ITypeReference, int> awaiterMapOpt)
         {
             Debug.Assert(symbolMap != null);
-            Debug.Assert(previousMethod != null);
+            Debug.Assert(previousTopLevelMethod != null);
             Debug.Assert(!previousLocals.IsDefault);
 
             _symbolMap = symbolMap;
             _syntaxMapOpt = syntaxMapOpt;
             _previousLocals = previousLocals;
-            _previousMethod = previousMethod;
+            _previousTopLevelMethod = previousTopLevelMethod;
             _methodId = methodId;
             _hoistedLocalSlotsOpt = hoistedLocalSlotsOpt;
             _hoistedLocalSlotCount = hoistedLocalSlotCount;
@@ -87,11 +87,19 @@ namespace Microsoft.CodeAnalysis.Emit
 
         public override DebugId? MethodId => _methodId;
 
+        private int CalculateSyntaxOffsetInPreviousMethod(int position, SyntaxTree tree)
+        {
+            // Note that syntax offset of a syntax node contained in a lambda body is calculated by the containing top-level method,
+            // not by the lambda method. The offset is thus relative to the top-level method body start. We can thus avoid mapping 
+            // the current lambda symbol or body to the corresponding previous lambda symbol or body, whcih is non-trivial. 
+            return _previousTopLevelMethod.CalculateLocalSyntaxOffset(position, tree);
+        }
+
         public override void AddPreviousLocals(ArrayBuilder<Cci.ILocalDefinition> builder)
         {
             builder.AddRange(_previousLocals.Select((info, index) => new SignatureOnlyLocalDefinition(info.Signature, index)));
         }
-
+        
         private bool TryGetPreviousLocalId(SyntaxNode currentDeclarator, LocalDebugId currentId, out LocalDebugId previousId)
         {
             if (_syntaxMapOpt == null)
@@ -111,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 return false;
             }
 
-            int syntaxOffset = _previousMethod.CalculateLocalSyntaxOffset(previousDeclarator.SpanStart, previousDeclarator.SyntaxTree);
+            int syntaxOffset = CalculateSyntaxOffsetInPreviousMethod(previousDeclarator.SpanStart, previousDeclarator.SyntaxTree);
             previousId = new LocalDebugId(syntaxOffset, currentId.Ordinal);
             return true;
         }
@@ -216,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 return false;
             }
 
-            previousSyntaxOffset = _previousMethod.CalculateLocalSyntaxOffset(previousSyntax.SpanStart, previousSyntax.SyntaxTree);
+            previousSyntaxOffset = CalculateSyntaxOffsetInPreviousMethod(previousSyntax.SpanStart, previousSyntax.SyntaxTree);
             return true;
         }
 
@@ -247,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 previousSyntax = previousLambdaSyntax;
             }
 
-            previousSyntaxOffset = _previousMethod.CalculateLocalSyntaxOffset(previousSyntax.SpanStart, previousSyntax.SyntaxTree);
+            previousSyntaxOffset = CalculateSyntaxOffsetInPreviousMethod(previousSyntax.SpanStart, previousSyntax.SyntaxTree);
             return true;
         }
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 var generator = synthesizedDef.Method;
                 var synthesizedSymbol = (ISymbol)synthesizedDef;
 
-                switch (GetChange(generator))
+                switch (GetChange((IDefinition)generator))
                 {
                     case SymbolChange.Updated:
                         // The generator has been updated. Some synthesized members should be reused, others updated or added.

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -28,6 +28,20 @@ Friend Module CompilationUtils
         Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references)), options)
     End Function
 
+    Public Function CreateCompilationWithMscorlib45(sourceTrees As IEnumerable(Of SyntaxTree),
+                                                    Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                                    Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+        Dim additionalRefs = {MscorlibRef_v4_0_30316_17626}
+        Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, If(references Is Nothing, additionalRefs, additionalRefs.Concat(references)), options)
+    End Function
+
+    Public Function CreateCompilationWithMscorlib45AndVBRuntime(sourceTrees As IEnumerable(Of SyntaxTree),
+                                                                Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                                                Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+        Dim additionalRefs = {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}
+        Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, If(references Is Nothing, additionalRefs, additionalRefs.Concat(references)), options)
+    End Function
+
     Public Function CreateCompilationWithMscorlib(sourceTree As SyntaxTree,
                                                   Optional references As IEnumerable(Of MetadataReference) = Nothing,
                                                   Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -177,8 +177,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return anonymousTypes
         End Function
 
-        Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol) As VariableSlotAllocator
-            Return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method)
+        Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
+            Return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method, topLevelMethod)
         End Function
 
         Friend Overrides Function GetPreviousAnonymousTypes() As ImmutableArray(Of AnonymousTypeKey)

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -311,7 +311,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Friend Overridable Function TryCreateVariableSlotAllocator(method As MethodSymbol) As VariableSlotAllocator
+        Friend Overridable Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -866,7 +866,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="method">Method symbol for the rewritten lambda body.</param>
         ''' <param name="lambda">Original lambda node.</param>
         ''' <returns>Lambda body rewritten as a body of the given method symbol.</returns>
-        Public Function RewriteLambdaAsMethod(method As MethodSymbol, lambda As BoundLambda) As BoundBlock
+        Public Function RewriteLambdaAsMethod(method As SynthesizedLambdaMethod, lambda As BoundLambda) As BoundBlock
 
             ' report use site errors for attributes that are needed later on in the rewriter
             Dim lambdaSyntax = lambda.Syntax
@@ -893,7 +893,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) method name.
             Const methodOrdinal As Integer = -1
 
-            Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, SlotAllocatorOpt, stateMachineTypeOpt)
+            Dim slotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method.TopLevelMethod)
+            Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, slotAllocatorOpt, stateMachineTypeOpt)
         End Function
 
         Public Overrides Function VisitTryCast(node As BoundTryCast) As BoundNode

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
@@ -99,6 +99,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 lambdaKind)
         End Function
 
+        Public ReadOnly Property TopLevelMethod As MethodSymbol
+            Get
+                Return _topLevelMethod
+            End Get
+        End Property
+
         Public Overrides ReadOnly Property TypeParameters As ImmutableArray(Of TypeParameterSymbol)
             Get
                 Return _typeParameters
@@ -206,22 +212,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Friend Overrides Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
-            Dim syntax = TryCast(Me.Syntax, LambdaExpressionSyntax)
-
-            ' Assign -1 offset to all variables that are associated with the header.
-            ' We can't assign >=0 since user-defined variables defined in the first statement of the body have 0
-            ' and user-defined variables need to have a unique syntax offset.
-            If syntax Is Nothing OrElse localPosition = syntax.SubOrFunctionHeader.SpanStart Then
-                Return -1
-            End If
-
-            ' All other locals are declared within the body of the lambda:
-            Debug.Assert(syntax.Span.Contains(localPosition))
-            Dim multiLine = TryCast(syntax, MultiLineLambdaExpressionSyntax)
-            Dim bodyStart = If(multiLine IsNot Nothing, multiLine.Statements.Span.Start, DirectCast(Me.Syntax, SingleLineLambdaExpressionSyntax).Body.SpanStart)
-
-            Debug.Assert(localPosition >= bodyStart)
-            Return localPosition - bodyStart
+            ' Syntax offset of a syntax node contained in a lambda body is calculated by the containing top-level method.
+            ' The offset is thus relative to the top-level method body start.
+            Return _topLevelMethod.CalculateLocalSyntaxOffset(localPosition, localTree)
         End Function
 
         ' The lambda method body needs to be updated when the containing top-level method body is updated.

--- a/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
@@ -56,7 +56,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #End If
 
             If lazyVariableSlotAllocator Is Nothing Then
-                lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method)
+                ' synthesized lambda methods are handled in LambdaRewriter.RewriteLambdaAsMethod
+                Debug.Assert(TypeOf method IsNot SynthesizedLambdaMethod)
+                lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method)
             End If
 
             ' Lowers lambda expressions into expressions that construct delegates.    

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
@@ -519,8 +519,8 @@ End Class
     <method containingType=""C"" name=""_Lambda$__2-0"">
       <customDebugInfo>
         <encLocalSlotMap>
-          <slot kind=""21"" offset=""-1"" />
-          <slot kind=""4"" offset=""0"" />
+          <slot kind=""21"" offset=""48"" />
+          <slot kind=""4"" offset=""80"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -42,9 +42,9 @@ End Module
         <method containingType="Program+_Closure$__+VB$StateMachine___Lambda$__0-0" name="MoveNext">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="20" offset="-1"/>
-                    <slot kind="27" offset="-1"/>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="20" offset="4"/>
+                    <slot kind="27" offset="4"/>
+                    <slot kind="21" offset="4"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -58,7 +58,7 @@ End Class
         <method containingType="C+_Closure$__" name="_Lambda$__2-0">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="13"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -128,9 +128,9 @@ End Module
         <method containingType="M1+C1`1+_Closure$__3-1`2" name="_Lambda$__0" parameterNames="lifted, notLifted">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="30" offset="-1"/>
-                    <slot kind="0" offset="4"/>
-                    <slot kind="0" offset="111"/>
+                    <slot kind="30" offset="57"/>
+                    <slot kind="0" offset="127"/>
+                    <slot kind="0" offset="234"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -206,8 +206,8 @@ End Module
         <method containingType="Module1+_Closure$__" name="_Lambda$__0-0">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
-                    <slot kind="0" offset="4"/>
+                    <slot kind="21" offset="8"/>
+                    <slot kind="0" offset="44"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -288,7 +288,7 @@ End Class
         <method containingType="C+_Closure$__" name="_Lambda$__0-0">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-26"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -302,7 +302,7 @@ End Class
         <method containingType="C+_Closure$__" name="_Lambda$__0-1">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-12"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -377,7 +377,7 @@ End Class
         <method containingType="C+_Closure$__" name="_Lambda$__0-0">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-26"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -391,7 +391,7 @@ End Class
         <method containingType="C+_Closure$__" name="_Lambda$__0-1">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-12"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -456,7 +456,7 @@ End Class
         <method containingType="C2+_Closure$__" name="_Lambda$__2-0">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-12"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -3306,7 +3306,7 @@ End Module
         <method containingType="M+_Closure$__0-0" name="_Lambda$__3" parameterNames="y">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-72"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -3320,9 +3320,9 @@ End Module
         <method containingType="M+_Closure$__" name="_Lambda$__0-0" parameterNames="x">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
-                    <slot kind="0" offset="4"/>
-                    <slot kind="0" offset="67"/>
+                    <slot kind="21" offset="-243"/>
+                    <slot kind="0" offset="-214"/>
+                    <slot kind="0" offset="-151"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -3341,7 +3341,7 @@ End Module
         <method containingType="M+_Closure$__" name="_Lambda$__0-1" parameterNames="o">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="21" offset="-182"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
@@ -3355,8 +3355,8 @@ End Module
         <method containingType="M+_Closure$__" name="_Lambda$__0-2" parameterNames="h">
             <customDebugInfo>
                 <encLocalSlotMap>
-                    <slot kind="30" offset="-1"/>
-                    <slot kind="21" offset="-1"/>
+                    <slot kind="30" offset="-84"/>
+                    <slot kind="21" offset="-84"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override int CurrentGenerationOrdinal => 0;
 
-        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol symbol)
+        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol symbol, MethodSymbol topLevelMethod)
         {
             var method = symbol as EEMethodSymbol;
             if (((object)method != null) && Methods.Contains(method))

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Friend Overrides Function TryCreateVariableSlotAllocator(symbol As MethodSymbol) As VariableSlotAllocator
+        Friend Overrides Function TryCreateVariableSlotAllocator(symbol As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
             Dim method = TryCast(symbol, EEMethodSymbol)
             If method IsNot Nothing AndAlso _methods.Contains(method) Then
                 Dim defs = GetLocalDefinitions(method.Locals)

--- a/src/Test/PdbUtilities/Pdb/PdbToXml.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbToXml.cs
@@ -97,7 +97,7 @@ namespace Roslyn.Test.PdbUtilities
                     if (matching.Length == 0)
                     {
                         xmlWriter.WriteLine("<error>");
-                        xmlWriter.WriteLine(string.Format("<message>No method '{0}' found in metadata.</message>", methodName));
+                        xmlWriter.WriteLine(string.Format("<message><![CDATA[No method '{0}' found in metadata.]]></message>", methodName));
                         xmlWriter.WriteLine("<available-methods>");
 
                         foreach (var methodHandle in metadataReader.MethodDefinitions)

--- a/src/Test/Utilities/CompilationDifference.cs
+++ b/src/Test/Utilities/CompilationDifference.cs
@@ -155,5 +155,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var actual = EmitResult.Baseline.SynthesizedMembers.Select(e => e.Key.ToString() + ": {" + string.Join(", ", e.Value.Select(v => v.Name)) + "}");
             AssertEx.SetEqual(expectedSynthesizedTypesAndMemberCounts, actual, itemSeparator: "\r\n");
         }
+
+        public void VerifySynthesizedFields(string typeName, params string[] expectedSynthesizedTypesAndMemberCounts)
+        {
+            var actual = EmitResult.Baseline.SynthesizedMembers.Single(e => e.Key.ToString() == typeName).Value.OfType<IFieldSymbol>().Select(f => f.Name + ": " + f.Type);
+            AssertEx.SetEqual(expectedSynthesizedTypesAndMemberCounts, actual, itemSeparator: "\r\n");
+        }
     }
 }

--- a/src/Test/Utilities/SourceWithMarkedNodes.cs
+++ b/src/Test/Utilities/SourceWithMarkedNodes.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;


### PR DESCRIPTION
Previously we calculated syntax offsets of nodes contained in lambdas relatively to the lambda body start. However, it turns out that it's much simpler to do correct mapping when they are calculated relatively to the containing member body start position. Lambdas can't be edited separately from the containing body so it is sound to tie the nodes contained in the lambda to the containing member.

In addition the VB lambda lowering incorrectly reused variable slot of the containing method when lowering lambdas. Each lambda should have its own allocator.

<!---
@huboard:{"order":2690.0,"milestone_order":2655,"custom_state":""}
-->
