### PR TITLE
Null check in AnalyzerHelper for Languages that don't participate in the compilation

### DIFF
--- a/src/Features/Core/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Diagnostics/AnalyzerHelper.cs
@@ -124,8 +124,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool enabledByDefault)
         {
             return GetEffectiveSeverity(
-                options.GeneralDiagnosticOption,
-                options.SpecificDiagnosticOptions,
+                options?.GeneralDiagnosticOption ?? ReportDiagnostic.Default,
+                options?.SpecificDiagnosticOptions,
                 ruleId,
                 defaultSeverity,
                 enabledByDefault);
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool enabledByDefault)
         {
             ReportDiagnostic report = ReportDiagnostic.Default;
-            var isSpecified = specificOptions.TryGetValue(ruleId, out report);
+            var isSpecified = specificOptions?.TryGetValue(ruleId, out report) ?? false;
             if (!isSpecified)
             {
                 report = enabledByDefault ? ReportDiagnostic.Default : ReportDiagnostic.Suppress;


### PR DESCRIPTION
Added a null check in the AnalyzerHelper for Languages that don't
participate in the compilation. Since TypeScript doesn't participate in
the Compilation we get a null reference exception on the compilation
options.
