### PR TITLE
Don't ignore reference properties and documentation provider passed to MetadataReference.CreateFromAssembly

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
@@ -108,6 +108,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(MetadataImageKind.Assembly, r.Properties.Kind);
             Assert.False(r.Properties.EmbedInteropTypes);
             Assert.True(r.Properties.Aliases.IsEmpty);
+            Assert.Same(DocumentationProvider.Default, r.DocumentationProvider);
+        }
+
+        [Fact]
+        public void CreateFromAssembly_WithPropertiesAndDocumentation()
+        {
+            var doc = new TestDocumentationProvider();
+            var assembly = typeof(object).Assembly;
+            var r = (PortableExecutableReference)MetadataReference.CreateFromAssembly(assembly, new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a", "b"), embedInteropTypes: true), documentation: doc);
+            Assert.Equal(assembly.Location, r.FilePath);
+            Assert.Equal(assembly.Location, r.Display);
+            Assert.Equal(MetadataImageKind.Assembly, r.Properties.Kind);
+            Assert.True(r.Properties.EmbedInteropTypes);
+            AssertEx.Equal(ImmutableArray.Create("a", "b"), r.Properties.Aliases);
+            Assert.Same(doc, r.DocumentationProvider);
         }
 
         private class TestDocumentationProvider : DocumentationProvider

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -249,6 +249,13 @@ namespace Microsoft.CodeAnalysis
         /// <param name="assembly">Path to the module file.</param>
         /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is null.</exception>
         /// <exception cref="NotSupportedException"><paramref name="assembly"/> is dynamic, doesn't have a location, or the platform doesn't support reading from the location.</exception>
+        /// <remarks>
+        /// Performance considerations:
+        /// <para>
+        /// It is recommended to use <see cref="AssemblyMetadata.CreateFromFile(string)"/> API when creating multiple references to the same assembly.
+        /// Reusing <see cref="AssemblyMetadata"/> object allows for sharing data accross these references.
+        /// </para>
+        /// </remarks>
         public static MetadataReference CreateFromAssembly(Assembly assembly)
         {
             return CreateFromAssembly(assembly, default(MetadataReferenceProperties));
@@ -300,7 +307,7 @@ namespace Microsoft.CodeAnalysis
             // which might also lock the file until the reference is GC'd.
             var metadata = AssemblyMetadata.CreateFromStream(peStream);
 
-            return metadata.GetReference(documentation, filePath: location);
+            return metadata.GetReference(documentation, properties.Aliases, properties.EmbedInteropTypes, filePath: location);
         }
     }
 }


### PR DESCRIPTION
Fixes #897.