### PR TITLE
Workaround for span mapping in elision buffers

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
@@ -38,19 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
                 case BufferMapDirection.Down:
                     {
-                        var spans = bufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, targetBuffer);
-
-                        // Workaround:
-                        // An elision buffer that elides an entire buffer (the length of the elision is 0)
-                        // will return two spans: the null span starting at 0, and a second span that's probably
-                        // the "real" span. 
-                        // If we need to map down from an elision buffer and get back two spans, we will ignore
-                        // the one that starts at 0.
-                        if (span.Snapshot.TextBuffer is IElisionBuffer && spans.Count > 1 && spans[0].Start == 0 && spans[0].Length == 0)
-                        {
-                            return (SnapshotSpan?)spans[1];
-                        }
-
+                        var spans = bufferGraph.Hack_WorkaroundElisionBuffers_MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, targetBuffer);
                         return spans.Select(s => (SnapshotSpan?)s).FirstOrDefault();
                     }
 
@@ -115,6 +103,24 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         {
             return top.SourceBuffers.Contains(bottom) ||
                 top.SourceBuffers.OfType<IProjectionBufferBase>().Any(b => IsSourceBuffer(b, bottom));
+        }
+
+        public static NormalizedSnapshotSpanCollection Hack_WorkaroundElisionBuffers_MapDownToBuffer(this IBufferGraph bufferGraph, SnapshotSpan span, SpanTrackingMode spanTrackingMode, ITextBuffer targetBuffer)
+        {
+            var spans = bufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, targetBuffer);
+
+            // Workaround:
+            // An elision buffer that elides an entire buffer (the length of the elision is 0)
+            // will return two spans: the null span starting at 0, and a second span that's probably
+            // the "real" span. 
+            // If we need to map down from an elision buffer and get back multiple spans, and the
+            // first one [0,0], ignore it.
+            if (span.Snapshot.TextBuffer is IElisionBuffer && spans.Count > 1 && spans[0].Start == 0 && spans[0].Length == 0)
+            {
+                return new NormalizedSnapshotSpanCollection(spans.Skip(1));
+            }
+
+            return spans;
         }
     }
 }

--- a/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
@@ -39,6 +39,18 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 case BufferMapDirection.Down:
                     {
                         var spans = bufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, targetBuffer);
+
+                        // Workaround:
+                        // An elision buffer that elides an entire buffer (the length of the elision is 0)
+                        // will return two spans: the null span starting at 0, and a second span that's probably
+                        // the "real" span. 
+                        // If we need to map down from an elision buffer and get back two spans, we will ignore
+                        // the one that starts at 0.
+                        if (span.Snapshot.TextBuffer is IElisionBuffer && spans.Count > 1 && spans[0].Start == 0 && spans[0].Length == 0)
+                        {
+                            return (SnapshotSpan?)spans[1];
+                        }
+
                         return spans.Select(s => (SnapshotSpan?)s).FirstOrDefault();
                     }
 

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Diagnostics\SuppressMessageAttributeTests.cs" />
     <Compile Include="CodeFixes\ExtensionOrderingTests.cs" />
     <Compile Include="Diagnostics\TestHostDiagnosticUpdateSource.cs" />
+    <Compile Include="Extensions\IBufferGraphExtensionsTests.cs" />
     <Compile Include="Extensions\SourceTextContainerExtensionsTests.cs" />
     <Compile Include="Preview\TestOnly_CompilerDiagnosticAnalyzerProviderService.cs" />
     <Compile Include="DocCommentFormatting\DocCommentFormattingTests.cs" />

--- a/src/EditorFeatures/Test/Extensions/IBufferGraphExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/IBufferGraphExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
+using Microsoft.VisualStudio.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+{
+    public class IBufferGraphExtensionsTests
+    {
+        [Fact]
+        public void TestElisionBufferMappingWorkaround()
+        {
+            var bufferContents = @"
+Some text on a line
+Another line$$
+A third line";
+
+            int position;
+            string text;
+            MarkupTestFile.GetPosition(bufferContents, out text, out position);
+
+            var exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
+            var contentTypeRegistryService = exportProvider.GetExportedValue<IContentTypeRegistryService>();
+            var textBuffer = exportProvider.GetExportedValue<ITextBufferFactoryService>().CreateTextBuffer(text, contentTypeRegistryService.GetContentType("text"));
+
+            var factory = exportProvider.GetExportedValue<IProjectionBufferFactoryService>();
+            var exposedSpans = new SnapshotSpan[] { new SnapshotSpan(textBuffer.CurrentSnapshot, Span.FromBounds(position, position)) };
+            var elision = factory.CreateElisionBuffer(null, new NormalizedSnapshotSpanCollection(exposedSpans), ElisionBufferOptions.None);
+            var textView = exportProvider.GetExportedValue<ITextEditorFactoryService>().CreateTextView(elision);
+
+            var nullSpan = new SnapshotSpan(elision.CurrentSnapshot, Span.FromBounds(0, 0));
+            var span = IBufferGraphExtensions.MapUpOrDownToBuffer(textView.BufferGraph, nullSpan, textBuffer);
+            Assert.Equal(span.Value, new SnapshotSpan(textBuffer.CurrentSnapshot, new Span(position, 0)));
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -577,7 +577,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         internal bool TryGetSubjectBufferSpan(VsTextSpan surfaceBufferTextSpan, out SnapshotSpan subjectBufferSpan)
         {
             var snapshotSpan = TextView.TextSnapshot.GetSpan(surfaceBufferTextSpan);
-            var subjectBufferSpanCollection = TextView.BufferGraph.MapDownToBuffer(snapshotSpan, SpanTrackingMode.EdgeExclusive, SubjectBuffer);
+            var subjectBufferSpanCollection = TextView.BufferGraph.Hack_WorkaroundElisionBuffers_MapDownToBuffer(snapshotSpan, SpanTrackingMode.EdgeExclusive, SubjectBuffer);
 
             // Bail if a snippet span does not map down to exactly one subject buffer span.
             if (subjectBufferSpanCollection.Count == 1)

--- a/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             // our input span was).
             // If we had no such spans, just return.
             var span = WpfTextView.TextViewModel.DataBuffer.CurrentSnapshot.GetSpan(pSpan[0]);
-            var subjectSpan = WpfTextView.BufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeInclusive, _subjectBuffer)
+            var subjectSpan = WpfTextView.BufferGraph.Hack_WorkaroundElisionBuffers_MapDownToBuffer(span, SpanTrackingMode.EdgeInclusive, _subjectBuffer)
                                 .SingleOrDefault(x => x.Length == 1);
 
             if (subjectSpan == default(SnapshotSpan))


### PR DESCRIPTION
When mapping the span [0,0] from an elision buffer to its subject
buffer, we may receive two spans. If one of the spans is [0,0], we will
prefer the second span. This happens when the user invokes completion in
a workflow editor expression text box before any text has been typed.
Per the editor team, this elision buffer behavior is probably a bug, but
there isn't time to get it fixed for the next release. We'll use this
workaround to avoid crashing.

Fixes #2348

Could you review this? @jasonmalinowski @Pilchie @dpoeschl @balajikris @brettfo 