### PR TITLE
A method declared with __arglist is not a candidate with a keyword argument list

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // There are two forms of __arglist expression. In a method with an __arglist parameter,
             // it is legal to use __arglist as an expression of type RuntimeArgumentHandle. In 
-            // a call to such a method, it is legal to use __arglist(x, y, z) as the final argument.\
+            // a call to such a method, it is legal to use __arglist(x, y, z) as the final argument.
             // This method only handles the first usage; the second usage is parsed as a call syntax.
 
             // The native compiler allows __arglist in a lambda:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -121,7 +121,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // them in the given order.
 
             // (1) Is there any argument without a corresponding parameter?
-            //
 
             if (unmatchedArgumentIndex != null)
             {
@@ -138,7 +137,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // (2) was there any named argument that specified a parameter that was already
             //     supplied with a positional parameter?
 
-
             int? nameUsedForPositional = NameUsedForPositional(arguments, argsToParameters);
             if (nameUsedForPositional != null)
             {
@@ -148,10 +146,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             // (3) Is there any non-optional parameter without a corresponding argument?
 
             int? requiredParameterMissing = CheckForMissingRequiredParameter(argsToParameters, parameters, isMethodGroupConversion, expanded);
-
             if (requiredParameterMissing != null)
             {
                 return ArgumentAnalysisResult.RequiredParameterMissing(requiredParameterMissing.Value);
+            }
+
+            // __arglist cannot be used with named arguments (as it doesn't have a name)
+            if (arguments.Names.Count != 0 && symbol.GetIsVararg())
+            {
+                return ArgumentAnalysisResult.RequiredParameterMissing(parameters.Length);
             }
 
             // We're good; this one might be applicable in the given form.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -8078,5 +8078,26 @@ class C
     Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "x").WithArguments("x").WithLocation(41, 16)
                 );
         }
+
+        [Fact, WorkItem(2631, "https://github.com/dotnet/roslyn/issues/2631")]
+        public void ArglistCompilerCrash()
+        {
+            var source =
+@"class Program
+{
+    static void M(object x) { }
+    static void M(object x, object y) { }
+    static void M(object x, object y, object z) { }
+    static void M(object x, object y, object z, __arglist) { }
+    static void M(object x, params object[] args) { }
+    static void Main(string[] args)
+    {
+        M(x: 1, y: 2, z: 3);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(source);
+            compilation.VerifyDiagnostics();
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #2631

This repairs the compiler crash reported in #2631. The problem was we were not preventing an __arglist method from being considered a candidate when the argument list uses keyword notation. That ain't never gonna work because there would be no way to specify the __arglist parameter (it has no name).

@VSadov @AlekseyTs @agocke Please review.