### PR TITLE
Handle converting between interface implementation kinds

### DIFF
--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -867,6 +867,19 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                     _g.IndexerDeclaration(parameters: new[] { _g.ParameterDeclaration("p", _g.IdentifierName("a")) }, type: _g.IdentifierName("t"), accessibility: Accessibility.Internal, modifiers: DeclarationModifiers.Abstract),
                     _g.IdentifierName("i")),
                 "public t this[a p]\r\n{\r\n    get\r\n    {\r\n    }\r\n\r\n    set\r\n    {\r\n    }\r\n}");
+
+            // convert private to public
+            var pim = _g.AsPrivateInterfaceImplementation(
+                    _g.MethodDeclaration("m", returnType: _g.IdentifierName("t"), accessibility: Accessibility.Private, modifiers: DeclarationModifiers.Abstract),
+                    _g.IdentifierName("i"));
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.AsPublicInterfaceImplementation(pim, _g.IdentifierName("i2")),
+                "public t m()\r\n{\r\n}");
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.AsPublicInterfaceImplementation(pim, _g.IdentifierName("i2"), "m2"),
+                "public t m2()\r\n{\r\n}");
         }
 
         [Fact]
@@ -895,6 +908,19 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                     _g.CustomEventDeclaration("ep", _g.IdentifierName("t"), modifiers: DeclarationModifiers.Abstract),
                     _g.IdentifierName("i")),
                 "event t i.ep\r\n{\r\n    add\r\n    {\r\n    }\r\n\r\n    remove\r\n    {\r\n    }\r\n}");
+
+            // convert public to private
+            var pim = _g.AsPublicInterfaceImplementation(
+                    _g.MethodDeclaration("m", returnType: _g.IdentifierName("t"), accessibility: Accessibility.Private, modifiers: DeclarationModifiers.Abstract),
+                    _g.IdentifierName("i"));
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.AsPrivateInterfaceImplementation(pim, _g.IdentifierName("i2")),
+                "t i2.m()\r\n{\r\n}");
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                _g.AsPrivateInterfaceImplementation(pim, _g.IdentifierName("i2"), "m2"),
+                "t i2.m2()\r\n{\r\n}");
         }
 
         [Fact]

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -309,13 +309,31 @@ namespace Microsoft.CodeAnalysis.Editing
         /// Converts method, property and indexer declarations into public interface implementations.
         /// This is equivalent to an implicit C# interface implementation (you can access it via the interface or directly via the named member.)
         /// </summary>
-        public abstract SyntaxNode AsPublicInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType);
+        public SyntaxNode AsPublicInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType)
+        {
+            return this.AsPublicInterfaceImplementation(declaration, interfaceType, null);
+        }
+
+        /// <summary>
+        /// Converts method, property and indexer declarations into public interface implementations.
+        /// This is equivalent to an implicit C# interface implementation (you can access it via the interface or directly via the named member.)
+        /// </summary>
+        public abstract SyntaxNode AsPublicInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType, string interfaceMemberName);
 
         /// <summary>
         /// Converts method, property and indexer declarations into private interface implementations.
         /// This is equivalent to a C# explicit interface implementation (you can declare it for access via the interface, but cannot call it directly).
         /// </summary>
-        public abstract SyntaxNode AsPrivateInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType);
+        public SyntaxNode AsPrivateInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType)
+        {
+            return this.AsPrivateInterfaceImplementation(declaration, interfaceType, null);
+        }
+
+        /// <summary>
+        /// Converts method, property and indexer declarations into private interface implementations.
+        /// This is equivalent to a C# explicit interface implementation (you can declare it for access via the interface, but cannot call it directly).
+        /// </summary>
+        public abstract SyntaxNode AsPrivateInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceType, string interfaceMemberName);
 
         /// <summary>
         /// Creates a class declaration.

--- a/src/Workspaces/Core/Portable/PublicAPI.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.txt
@@ -287,6 +287,8 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddReturnAttributes(Microsoft.Cod
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddReturnAttributes(Microsoft.CodeAnalysis.SyntaxNode declaration, params Microsoft.CodeAnalysis.SyntaxNode[] attributes) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Argument(Microsoft.CodeAnalysis.RefKind refKind, Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Argument(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPrivateInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPublicInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Attribute(Microsoft.CodeAnalysis.AttributeData attribute) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Attribute(string name, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> attributeArguments = null) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Attribute(string name, params Microsoft.CodeAnalysis.SyntaxNode[] attributeArguments) -> Microsoft.CodeAnalysis.SyntaxNode
@@ -851,8 +853,8 @@ abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddExpression(Microsoft.
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddInterfaceType(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Argument(string name, Microsoft.CodeAnalysis.RefKind refKind, Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayTypeExpression(Microsoft.CodeAnalysis.SyntaxNode type) -> Microsoft.CodeAnalysis.SyntaxNode
-abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPrivateInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType) -> Microsoft.CodeAnalysis.SyntaxNode
-abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPublicInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType) -> Microsoft.CodeAnalysis.SyntaxNode
+abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPrivateInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType, string interfaceMemberName) -> Microsoft.CodeAnalysis.SyntaxNode
+abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AsPublicInterfaceImplementation(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.SyntaxNode interfaceType, string interfaceMemberName) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AssignmentStatement(Microsoft.CodeAnalysis.SyntaxNode left, Microsoft.CodeAnalysis.SyntaxNode right) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.Attribute(Microsoft.CodeAnalysis.SyntaxNode name, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> attributeArguments = null) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AttributeArgument(string name, Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -850,7 +850,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             declaration = WithBody(declaration, allowDefault:=True)
             declaration = WithAccessibility(declaration, Accessibility.Public)
 
-            Dim memberName = If(interfaceMemberName IsNot Nothing, interfaceMemberName, GetMemberName(declaration))
+            Dim memberName = If(interfaceMemberName IsNot Nothing, interfaceMemberName, GetInterfaceMemberName(declaration))
             declaration = WithName(declaration, memberName)
             declaration = WithImplementsClause(declaration, SyntaxFactory.ImplementsClause(SyntaxFactory.QualifiedName(type, SyntaxFactory.IdentifierName(memberName))))
 
@@ -867,26 +867,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             declaration = WithBody(declaration, allowDefault:=False)
             declaration = WithAccessibility(declaration, Accessibility.Private)
 
-            Dim memberName = If(interfaceMemberName IsNot Nothing, interfaceMemberName, GetMemberName(declaration))
+            Dim memberName = If(interfaceMemberName IsNot Nothing, interfaceMemberName, GetInterfaceMemberName(declaration))
             declaration = WithName(declaration, GetNameAsIdentifier(interfaceTypeName) & "_" & memberName)
             declaration = WithImplementsClause(declaration, SyntaxFactory.ImplementsClause(SyntaxFactory.QualifiedName(type, SyntaxFactory.IdentifierName(memberName))))
 
             Return declaration
         End Function
 
-        Private Function GetMemberName(declaration As SyntaxNode) As String
-            If GetImplementsClause(declaration) Is Nothing Then
-                Return GetName(declaration)
-            Else
-                Dim fullName = GetName(declaration)
-                If fullName IsNot Nothing Then
-                    Dim last = fullName.Split({"_"c}, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()
-                    If last IsNot Nothing Then
-                        Return last
-                    End If
+        Private Function GetInterfaceMemberName(declaration As SyntaxNode) As String
+            Dim clause = GetImplementsClause(declaration)
+            If clause IsNot Nothing Then
+                Dim qname = clause.InterfaceMembers.FirstOrDefault(Function(n) n.Right IsNot Nothing)
+                If qname IsNot Nothing Then
+                    Return qname.Right.ToString()
                 End If
-                Return fullName
             End If
+            Return GetName(declaration)
         End Function
 
         Private Function GetImplementsClause(declaration As SyntaxNode) As ImplementsClauseSyntax

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -1408,6 +1408,21 @@ End Property</x>.Value)
     Set(value As t)
     End Set
 End Property</x>.Value)
+
+            ' convert private method to public 
+            Dim pim = _g.AsPrivateInterfaceImplementation(
+                    _g.MethodDeclaration("m", returnType:=_g.IdentifierName("t")),
+                    _g.IdentifierName("i"))
+
+            VerifySyntax(Of MethodBlockBaseSyntax)(
+                _g.AsPublicInterfaceImplementation(pim, _g.IdentifierName("i2")),
+<x>Public Function m() As t Implements i2.m
+End Function</x>.Value)
+
+            VerifySyntax(Of MethodBlockBaseSyntax)(
+                _g.AsPublicInterfaceImplementation(pim, _g.IdentifierName("i2"), "m2"),
+<x>Public Function m2() As t Implements i2.m2
+End Function</x>.Value)
         End Sub
 
         <Fact>
@@ -1449,6 +1464,21 @@ End Property</x>.Value)
     Set(value As t)
     End Set
 End Property</x>.Value)
+
+            ' convert public method to private
+            Dim pim = _g.AsPublicInterfaceImplementation(
+                    _g.MethodDeclaration("m", returnType:=_g.IdentifierName("t")),
+                    _g.IdentifierName("i"))
+
+            VerifySyntax(Of MethodBlockBaseSyntax)(
+                _g.AsPrivateInterfaceImplementation(pim, _g.IdentifierName("i2")),
+<x>Private Function i2_m() As t Implements i2.m
+End Function</x>.Value)
+
+            VerifySyntax(Of MethodBlockBaseSyntax)(
+                _g.AsPrivateInterfaceImplementation(pim, _g.IdentifierName("i2"), "m2"),
+<x>Private Function i2_m2() As t Implements i2.m2
+End Function</x>.Value)
         End Sub
 
         <Fact>
@@ -1906,8 +1936,8 @@ End Interface</x>.Value)
             Assert.Equal("p", _g.GetName(_g.ParameterDeclaration("p")))
             Assert.Equal("p", _g.GetName(_g.PropertyDeclaration("p", _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract)))
             Assert.Equal("p", _g.GetName(_g.PropertyDeclaration("p", _g.IdentifierName("t"))))
-            Assert.Equal("", _g.GetName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"))))
-            Assert.Equal("", _g.GetName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract)))
+            Assert.Equal("Item", _g.GetName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"))))
+            Assert.Equal("Item", _g.GetName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract)))
             Assert.Equal("f", _g.GetName(_g.FieldDeclaration("f", _g.IdentifierName("t"))))
             Assert.Equal("v", _g.GetName(_g.EnumMember("v")))
             Assert.Equal("ef", _g.GetName(_g.EventDeclaration("ef", _g.IdentifierName("t"))))
@@ -1931,8 +1961,8 @@ End Interface</x>.Value)
             Assert.Equal("p", _g.GetName(_g.WithName(_g.ParameterDeclaration("x"), "p")))
             Assert.Equal("p", _g.GetName(_g.WithName(_g.PropertyDeclaration("x", _g.IdentifierName("t")), "p")))
             Assert.Equal("p", _g.GetName(_g.WithName(_g.PropertyDeclaration("x", _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract), "p")))
-            Assert.Equal("", _g.GetName(_g.WithName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t")), "this")))
-            Assert.Equal("", _g.GetName(_g.WithName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract), "this")))
+            Assert.Equal("X", _g.GetName(_g.WithName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t")), "X")))
+            Assert.Equal("X", _g.GetName(_g.WithName(_g.IndexerDeclaration({_g.ParameterDeclaration("i")}, _g.IdentifierName("t"), modifiers:=DeclarationModifiers.Abstract), "X")))
             Assert.Equal("f", _g.GetName(_g.WithName(_g.FieldDeclaration("x", _g.IdentifierName("t")), "f")))
             Assert.Equal("v", _g.GetName(_g.WithName(_g.EnumMember("x"), "v")))
             Assert.Equal("ef", _g.GetName(_g.WithName(_g.EventDeclaration("x", _g.IdentifierName("t")), "ef")))


### PR DESCRIPTION
Fixes #2616 

Added new overloads of AsPublicInterfaceImplentation and AsPrivateInterfaceImplemenation that adds an extra last parameter that is the interface member's name.  If not supplied (null or calling via old overload) the method attempts to infer the member name from the existing member name (for backward compatibility) but this may not always be possible, so it is best to always supply the interface member name if you are modifying an declaration from existing code.

@mavasani @pilchie