### PR TITLE
Fix issue with C# character literals in InitializeComponent() method

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
@@ -447,6 +447,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
             }
         }
 
+        protected void GenerateType(SpecialType specialType)
+        {
+            GenerateType(SemanticModel.Compilation.GetSpecialType(specialType));
+        }
+
         protected void GenerateNullLiteral()
         {
             using (LiteralTag())
@@ -462,6 +467,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
                 // TODO(DustinCa): Add more unit tests to ensure that floats are correct.
                 EncodedText(Convert.ToString(value, CultureInfo.InvariantCulture));
             }
+        }
+
+        protected void GenerateNumber(object value, SpecialType specialType)
+        {
+            GenerateNumber(value, SemanticModel.Compilation.GetSpecialType(specialType));
         }
 
         protected void GenerateChar(char value)

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
@@ -1031,5 +1031,56 @@ class C
             Test(definition, expected)
         End Sub
 
+        <WorkItem(1126037)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub CSAssignments_ControlChar()
+            Dim definition =
+    <Workspace>
+        <Project Language="C#" CommonReferences="true">
+            <Document>
+class C
+{
+    public char Char { get; set; }
+
+    void $$M()
+    {
+        Char = '\u0011';
+    }
+}
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="7">
+        <Expression>
+            <Assignment>
+                <Expression>
+                    <NameRef variablekind="property">
+                        <Expression>
+                            <ThisReference/>
+                        </Expression>
+                        <Name>Char</Name>
+                    </NameRef>
+                </Expression>
+                <Expression>
+                    <Cast>
+                        <Type>System.Char</Type>
+                        <Expression>
+                            <Literal>
+                                <Number type="System.UInt16">17</Number>
+                            </Literal>
+                        </Expression>
+                    </Cast>
+                </Expression>
+            </Assignment>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSInvocations.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSInvocations.vb
@@ -255,9 +255,14 @@ public class C
                 <Type>System.String</Type>
                 <Argument>
                     <Expression>
-                        <Literal>
-                            <Char>.</Char>
-                        </Literal>
+                        <Cast>
+                            <Type>System.Char</Type>
+                            <Expression>
+                                <Literal>
+                                    <Number type="System.UInt16">46</Number>
+                                </Literal>
+                            </Expression>
+                        </Cast>
                     </Expression>
                 </Argument>
                 <Argument>


### PR DESCRIPTION
In C#, if a WinForms InitializeComponent method() includes character
literal containing a unicode escape for a character that is not valid in
XML, it can cause an XML parser exception to be thrown and the WinForms
designer not to load. To work around this problem, we generate a hidden
cast expression in the IMethodXML to cast the numeric value of the
character to a System.Char.  We do this for any character that isn't a
letter or digit. The designer can process this cast in the XML correctly and load
properly.