### PR TITLE
Fix elastic formatting rule with comments

### DIFF
--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
@@ -1005,7 +1005,6 @@ public static class C
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
             public void TestUpdateDeclarationMembers_DifferentOrder()
             {
-                // TODO: Why is an extra EndOfLineTrivia being added here?
                 var input = @"
 public static class [|C|]
 {
@@ -1019,7 +1018,6 @@ public static class [|C|]
 public static class C
 {
     public int f2;
-
 
     // Comment 1
     public static char F() { return 0; }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -189,7 +189,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 // the first one is a comment, add two more lines than existing number of lines
                 var numberOfLines = GetNumberOfLines(triviaList);
-                return CreateAdjustNewLinesOperation(numberOfLines + 2 /* +1 for member itself and +1 for a blank line*/, AdjustNewLinesOption.ForceLines);
+                var numberOfLinesBeforeComment = GetNumberOfLines(triviaList.Take(triviaList.IndexOf(firstNonWhitespaceTrivia)));
+                var addedLines = (numberOfLinesBeforeComment < 1) ? 2 : 1;
+                return CreateAdjustNewLinesOperation(numberOfLines + addedLines, AdjustNewLinesOption.ForceLines);
             }
 
             // If we have two members of the same kind, we won't insert a blank line if both members
@@ -444,7 +446,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 || trivia.Kind() == SyntaxKind.EndOfLineTrivia;
         }
 
-        private int GetNumberOfLines(SyntaxTriviaList triviaList)
+        private int GetNumberOfLines(IEnumerable<SyntaxTrivia> triviaList)
         {
             return triviaList.Sum(t => t.ToFullString().Replace("\r\n", "\r").Cast<char>().Count(c => SyntaxFacts.IsNewLine(c)));
         }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingElasticTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingElasticTriviaTests.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
@@ -83,6 +86,53 @@ class B
 
             var newCompilation = Formatter.Format(compilation, new AdhocWorkspace());
             Assert.Equal(expected, newCompilation.ToFullString());
+        }
+
+        [WorkItem(1947, "https://github.com/dotnet/roslyn/issues/1947")]
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ElasticLineBreaksBetweenMembers()
+        {
+            var text = @"
+public class C
+{
+    public string f1;
+
+    // example comment
+    public string f2;
+}
+
+public class SomeAttribute : System.Attribute { }
+";
+
+            var ws = new AdhocWorkspace();
+            var generator = SyntaxGenerator.GetGenerator(ws, LanguageNames.CSharp);
+            var root = SyntaxFactory.ParseCompilationUnit(text);
+            var decl = generator.GetDeclaration(root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First(vd => vd.Identifier.Text == "f2"));
+            var newDecl = generator.AddAttributes(decl, generator.Attribute("Some")).WithAdditionalAnnotations(Formatter.Annotation);
+            var newRoot = root.ReplaceNode(decl, newDecl);
+
+            var expected = @"
+public class C
+{
+    public string f1;
+
+    // example comment
+    [Some]
+    public string f2;
+}
+
+public class SomeAttribute : System.Attribute { }
+";
+
+            var formatted = Formatter.Format(newRoot, ws).ToFullString();
+            Assert.Equal(expected, formatted);
+
+            var elasticOnlyFormatted = Formatter.Format(newRoot, SyntaxAnnotation.ElasticAnnotation, ws).ToFullString();
+            Assert.Equal(expected, elasticOnlyFormatted);
+
+            var annotationFormatted = Formatter.Format(newRoot, Formatter.Annotation, ws).ToFullString();
+            Assert.Equal(expected, annotationFormatted);
         }
     }
 }


### PR DESCRIPTION
Fixes #1947 

Change the elastic formatting rule to take into account the existing number of blank lines before a comment (between two declarations) when determining the correct number of blank lines that should appear between the two declarations.

@pilchie @mavasani @heejaechang  please review