### PR TITLE
Fix an InvalidCastException in simplifier.

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
@@ -2373,6 +2373,46 @@ namespace N
 
             Test(input, expected)
         End Sub
+
+        <Fact, WorkItem(2232, "https://github.com/dotnet/roslyn/issues/2232"), Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub CSharp_DontSimplifyToPredefinedTypeNameInQualifiedName()
+            Dim input =
+        <Workspace>
+            <Project Language="C#" CommonReferences="true">
+                <Document>
+                    <![CDATA[
+using System;
+namespace N
+{
+    class Program
+    {
+        void Main()
+        {
+            var x = new {|SimplifyParent:System.Int32|}.Blah;
+        }
+    }
+}]]>
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+                  <![CDATA[
+using System;
+namespace N
+{
+    class Program
+    {
+        void Main()
+        {
+            var x = new Int32.Blah;
+        }
+    }
+}]]></text>
+
+            Test(input, expected)
+        End Sub
 #End Region
 
 #Region "Normal Visual Basic Tests"
@@ -4244,6 +4284,36 @@ Module Program
     Sub Main()
         Dim x = N.A.X ' Simplify type name 'N.A' 
         Dim a As A = Nothing
+    End Sub
+End Module]]></text>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, WorkItem(2232, "https://github.com/dotnet/roslyn/issues/2232"), Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_DontSimplifyToPredefinedTypeNameInQualifiedName()
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+                    <![CDATA[
+Imports System
+Module Module1
+    Sub Main()
+        Dim x = New {|SimplifyParent:System.Int32|}.Blah
+    End Sub
+End Module]]>
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+                  <![CDATA[
+Imports System
+Module Module1
+    Sub Main()
+        Dim x = New System.Int32.Blah
     End Sub
 End Module]]></text>
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -1331,8 +1331,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                             return true;
                         }
 
-                        if (PreferPredefinedTypeKeywordInDeclarations(name, optionSet, semanticModel) ||
-                            PreferPredefinedTypeKeywordInMemberAccess(name, optionSet, semanticModel))
+                        // Don't simplify to predefined type if name is part of a QualifiedName.
+                        // QualifiedNames can't contain PredefinedTypeNames (although MemberAccessExpressions can).
+                        // In other words, the left side of a QualifiedName can't be a PredefinedTypeName.
+                        if (!name.Parent.IsKind(SyntaxKind.QualifiedName) &&
+                            (PreferPredefinedTypeKeywordInDeclarations(name, optionSet, semanticModel) ||
+                             PreferPredefinedTypeKeywordInMemberAccess(name, optionSet, semanticModel)))
                         {
                             var type = semanticModel.GetTypeInfo(name, cancellationToken).Type;
                             if (type != null)

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -1288,7 +1288,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     End If
 
                     Dim aliasInfo = semanticModel.GetAliasInfo(name, cancellationToken)
-                    If nameHasNoAlias AndAlso aliasInfo Is Nothing Then
+
+                    ' Don't simplify to predefined type if name is part of a QualifiedName.
+                    ' QualifiedNames can't contain PredefinedTypeNames (although MemberAccessExpressions can).
+                    ' In other words, the left side of a QualifiedName can't be a PredefinedTypeName.
+                    If nameHasNoAlias AndAlso aliasInfo Is Nothing AndAlso Not name.Parent.IsKind(SyntaxKind.QualifiedName) Then
                         If PreferPredefinedTypeKeywordInDeclarations(name, optionSet) OrElse
                            PreferPredefinedTypeKeywordInMemberAccess(name, optionSet) Then
                             Dim type = semanticModel.GetTypeInfo(name).Type


### PR DESCRIPTION
Fixes #2232

Prevent crash by avoiding QualifiedName->PredefinedTypeName simplification inside QualifiedNames.