### PR TITLE
Fix resource case sensitivity for Linux build.

### DIFF
--- a/src/Compilers/Test/Resources/Core/CompilerTestResources.vbproj
+++ b/src/Compilers/Test/Resources/Core/CompilerTestResources.vbproj
@@ -257,12 +257,8 @@
     <Content Include="SymbolsTests\MultiModule\MultiModule.dll" />
     <Content Include="SymbolsTests\MultiModule\MultiModule.vb" />
     <Content Include="SymbolsTests\MultiTargeting\c1.dll" />
-    <Content Include="SymbolsTests\MultiTargeting\c1.dll" />
-    <Content Include="SymbolsTests\MultiTargeting\c3.dll" />
     <Content Include="SymbolsTests\MultiTargeting\c3.dll" />
     <Content Include="SymbolsTests\MultiTargeting\c4.dll" />
-    <Content Include="SymbolsTests\MultiTargeting\c4.dll" />
-    <Content Include="SymbolsTests\MultiTargeting\c7.dll" />
     <Content Include="SymbolsTests\MultiTargeting\c7.dll" />
     <Content Include="SymbolsTests\MultiTargeting\Source1.vb" />
     <Content Include="SymbolsTests\MultiTargeting\Source1Module.netmodule" />
@@ -339,7 +335,6 @@
     <Content Include="SymbolsTests\snPublicKey.snk" />
     <Content Include="SymbolsTests\snPublicKey2.snk" />
     <Content Include="SymbolsTests\TypeForwarders\Forwarded.netmodule" />
-    <Content Include="SymbolsTests\TypeForwarders\TypeForwarder.dll" />
     <Content Include="SymbolsTests\TypeForwarders\TypeForwarder.dll" />
     <Content Include="SymbolsTests\TypeForwarders\TypeForwarder.vb" />
     <Content Include="SymbolsTests\TypeForwarders\TypeForwarder1.cs" />

--- a/src/Compilers/Test/Resources/Core/SymbolsTests/CyclicInheritance/CyclicInheritance.resx
+++ b/src/Compilers/Test/Resources/Core/SymbolsTests/CyclicInheritance/CyclicInheritance.resx
@@ -121,12 +121,12 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Class1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>class1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Class1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Class2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>class2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Class2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Class3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>class3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Class3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/src/Compilers/Test/Resources/Core/SymbolsTests/Metadata/Metadata.resx
+++ b/src/Compilers/Test/Resources/Core/SymbolsTests/Metadata/Metadata.resx
@@ -136,7 +136,7 @@
     <value>DynamicAttribute.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="InvalidCharactersInAssemblyName" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>invalidcharactersinassemblyname.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>InvalidCharactersInAssemblyName.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="MDTestAttributeApplicationLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>MDTestAttributeApplicationLib.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/src/Compilers/Test/Resources/Core/SymbolsTests/NoPia/NoPia.resx
+++ b/src/Compilers/Test/Resources/Core/SymbolsTests/NoPia/NoPia.resx
@@ -121,16 +121,16 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="A" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>a.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>A.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="B" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>b.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>B.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="C" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>c.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>C.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="D" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>d.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>D.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ExternalAsm1" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>ExternalAsm1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -142,42 +142,42 @@
     <value>GeneralPiaCopy.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Library1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>library1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Library1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Library2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>library2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Library2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="LocalTypes1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>localtypes1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>LocalTypes1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="LocalTypes2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>localtypes2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>LocalTypes2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="LocalTypes3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>localtypes3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>LocalTypes3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="MissingPIAAttributes" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>MissingPIAAttributes.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NoPIAGenerics1_Asm1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>nopiagenerics1-asm1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>NoPIAGenerics1-Asm1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia1.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia1Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia1copy.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia1Copy.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia2.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia3.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia4" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia4.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia4.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Pia5" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>pia5.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Pia5.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/src/Compilers/VisualBasic/Test/Semantic/Resource.resx
+++ b/src/Compilers/VisualBasic/Test/Semantic/Resource.resx
@@ -119,37 +119,37 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Async_Overload_Change_3_vb" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\async_overload_change_3.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\Async_Overload_Change_3.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestBaseline1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestbaseline1.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestBaseline1.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestBaseline2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestbaseline2.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestBaseline2.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestBaseline3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestbaseline3.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestBaseline3.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestBaseline4" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestbaseline4.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestBaseline4.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestBaseline5" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestbaseline5.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestBaseline5.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestSource1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestsource1.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestSource1.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestSource2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestsource2.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestSource2.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestSource3" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestsource3.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestSource3.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestSource4" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestsource4.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestSource4.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="BinaryOperatorsTestSource5" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\binaryoperatorstestsource5.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\BinaryOperatorsTestSource5.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="EmitSimpleBaseLine1" xml:space="preserve">
     <value>&lt;Global&gt;
@@ -182,21 +182,21 @@
           &lt;/Global&gt;</value>
   </data>
   <data name="LongTypeNameNative_vb" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\longtypenamenative.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\LongTypeNameNative.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="LongTypeName_vb" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\longtypename.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\LongTypeName.vb.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="OverloadResolutionTestSource" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>semantics\overloadresolutiontestsource.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Semantics\OverloadResolutionTestSource.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="PrintResultTestSource" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Semantics\PrintResultTestSource.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="T_1247520" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>binding\t_1247520.cs;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>Binding\T_1247520.cs;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="T_68086" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>binding\t_68086.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>Binding\T_68086.vb;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>


### PR DESCRIPTION
The Linux build instruction at https://github.com/dotnet/roslyn/wiki/Linux-Instructions didn't work due to case sensitivity on the resource file names. With these fixes the build passes.