### PR TITLE
Use csc/vbc.exe as default exes for Csc/Vbc task instead of csc2/vbc2

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             get
             {
-                return "csc2.exe";
+                return "csc.exe";
             }
         }
 

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             get
             {
-                return "vbc2.exe";
+                return "vbc.exe";
             }
         }
 


### PR DESCRIPTION
Exactly as it sounds

@jaredpar @VSadov @gafter @AlekseyTs @pharring 