### PR TITLE
Refine construction of DynamicFlagsCustomTypeInfo

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
@@ -113,8 +113,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 compilation.Assembly,
                 compilation.GetSpecialType(SpecialType.System_Byte));
 
-            var flags = CSharpCompilation.DynamicTransformsEncoder.Encode(local.Type, customModifiersCount: 0, refKind: RefKind.None).ToArray();
-            var bytes = new DynamicFlagsCustomTypeInfo(flags).GetCustomTypeInfoPayload();
+            var flags = CSharpCompilation.DynamicTransformsEncoder.Encode(local.Type, customModifiersCount: 0, refKind: RefKind.None);
+            var bytes = DynamicFlagsCustomTypeInfo.Create(flags).GetCustomTypeInfoPayload();
             hasCustomTypeInfoPayload = bytes != null;
             if (!hasCustomTypeInfoPayload)
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/SymbolExtensions.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 
@@ -20,8 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal static ReadOnlyCollection<byte> GetCustomTypeInfoPayload(this MethodSymbol method)
         {
-            bool[] dynamicFlags = CSharpCompilation.DynamicTransformsEncoder.Encode(method.ReturnType, method.ReturnTypeCustomModifiers.Length, RefKind.None).ToArray();
-            var dynamicFlagsInfo = new DynamicFlagsCustomTypeInfo(dynamicFlags);
+            var dynamicFlags = CSharpCompilation.DynamicTransformsEncoder.Encode(method.ReturnType, method.ReturnTypeCustomModifiers.Length, RefKind.None);
+            var dynamicFlagsInfo = DynamicFlagsCustomTypeInfo.Create(dynamicFlags);
             return dynamicFlagsInfo.GetCustomTypeInfoPayload();
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -546,7 +546,8 @@ public class Outer<T, U>
 
         private static CustomTypeInfo MakeCustomTypeInfo(params bool[] flags)
         {
-            var dynamicFlagsInfo = new DynamicFlagsCustomTypeInfo(flags);
+            Assert.NotNull(flags);
+            var dynamicFlagsInfo = DynamicFlagsCustomTypeInfo.Create(ImmutableArray.CreateRange(flags));
             return new CustomTypeInfo(DynamicFlagsCustomTypeInfo.PayloadTypeId, dynamicFlagsInfo.GetCustomTypeInfoPayload());
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
@@ -16,22 +16,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void BoolArrayConstructor()
         {
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(new bool[0]));
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(new bool[0]));
 
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false), 0x00);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true), 0x01);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false), 0x00);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true, false), 0x01);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, true), 0x02);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(true, true), 0x03);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false), 0x00);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(true), 0x01);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false), 0x00);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(true, false), 0x01);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, true), 0x02);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(true, true), 0x03);
 
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, true), 0x04);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, true), 0x08);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, true), 0x10);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, true), 0x20);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, true), 0x40);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, false, true), 0x80);
-            ValidateBytes(MakeDynamicFlagsCustomTypeInfo(false, false, false, false, false, false, false, false, true), 0x00, 0x01);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, true), 0x04);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, true), 0x08);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, false, true), 0x10);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, false, false, true), 0x20);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, false, false, false, true), 0x40);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, false, false, false, false, true), 0x80);
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(false, false, false, false, false, false, false, false, true), 0x00, 0x01);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void CustomTypeInfoConstructor_OtherGuid()
         {
-            ValidateBytes(new DynamicFlagsCustomTypeInfo(DkmClrCustomTypeInfo.Create(Guid.NewGuid(), new ReadOnlyCollection<byte>(new byte[] { 0x01 }))));
+            ValidateBytes(DynamicFlagsCustomTypeInfo.Create(DkmClrCustomTypeInfo.Create(Guid.NewGuid(), new ReadOnlyCollection<byte>(new byte[] { 0x01 }))));
         }
 
         [Fact]
@@ -102,12 +102,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void SkipOne()
         {
-            var dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(DynamicFlagsCustomTypeInfo.PayloadTypeId, null);
+            var dynamicFlagsCustomTypeInfo = DynamicFlagsCustomTypeInfo.Create((bool[])null);
 
             ValidateBytes(dynamicFlagsCustomTypeInfo.SkipOne());
 
             var dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(new byte[] { 0x80 }));
-            dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+            dynamicFlagsCustomTypeInfo = DynamicFlagsCustomTypeInfo.Create(dkmClrCustomTypeInfo);
 
             dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
             ValidateBytes(dynamicFlagsCustomTypeInfo, 0x40);
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             ValidateBytes(dynamicFlagsCustomTypeInfo, 0x00);
 
             dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(new byte[] { 0x00, 0x02 }));
-            dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+            dynamicFlagsCustomTypeInfo = DynamicFlagsCustomTypeInfo.Create(dkmClrCustomTypeInfo);
 
             dynamicFlagsCustomTypeInfo = dynamicFlagsCustomTypeInfo.SkipOne();
             ValidateBytes(dynamicFlagsCustomTypeInfo, 0x00, 0x01);
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(payload);
 
             var dkmClrCustomTypeInfo = DkmClrCustomTypeInfo.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId, new ReadOnlyCollection<byte>(payload));
-            var dynamicFlagsCustomTypeInfo = new DynamicFlagsCustomTypeInfo(dkmClrCustomTypeInfo);
+            var dynamicFlagsCustomTypeInfo = DynamicFlagsCustomTypeInfo.Create(dkmClrCustomTypeInfo);
             ValidateBytes(dynamicFlagsCustomTypeInfo, payload);
 
             var dkmClrCustomTypeInfo2 = dynamicFlagsCustomTypeInfo.GetCustomTypeInfo();
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private static void ValidateIndexer(params bool[] flags)
         {
-            var customTypeInfo = MakeDynamicFlagsCustomTypeInfo(flags);
+            var customTypeInfo = DynamicFlagsCustomTypeInfo.Create(flags);
             if (flags == null)
             {
                 Assert.False(customTypeInfo[0]);
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private static void ValidateAny(params bool[] flags)
         {
-            var customTypeInfo = MakeDynamicFlagsCustomTypeInfo(flags);
+            var customTypeInfo = DynamicFlagsCustomTypeInfo.Create(flags);
             if (flags == null)
             {
                 Assert.False(customTypeInfo.Any());

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 
@@ -10,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
     {
         public static string GetTypeName(this System.Type type, bool[] dynamicFlags = null, bool escapeKeywordIdentifiers = false)
         {
-            return type.GetTypeName(ResultProviderTestBase.MakeDynamicFlagsCustomTypeInfo(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers);
+            return type.GetTypeName(DynamicFlagsCustomTypeInfo.Create(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers);
         }
 
         public static string GetTypeName(this System.Type type, DkmClrCustomTypeInfo typeInfo, bool escapeKeywordIdentifiers = false)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CustomTypeInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/CustomTypeInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         public DynamicFlagsCustomTypeInfo ToDynamicFlagsCustomTypeInfo()
         {
-            return new DynamicFlagsCustomTypeInfo(PayloadTypeId, Payload);
+            return DynamicFlagsCustomTypeInfo.Create(this);
         }
 
         public DkmClrCustomTypeInfo ToDkmClrCustomTypeInfo()

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo_Factory.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DynamicFlagsCustomTypeInfo_Factory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal partial struct DynamicFlagsCustomTypeInfo
+    {
+        public static DynamicFlagsCustomTypeInfo Create(CustomTypeInfo customTypeInfo)
+        {
+            return new DynamicFlagsCustomTypeInfo(customTypeInfo.PayloadTypeId == PayloadTypeId ? customTypeInfo.Payload : null);
+        }
+
+        public static DynamicFlagsCustomTypeInfo Create(ImmutableArray<bool> dynamicFlags)
+        {
+            Debug.Assert(!dynamicFlags.IsDefaultOrEmpty);
+
+            var builder = ArrayBuilder<bool>.GetInstance(dynamicFlags.Length);
+            builder.AddRange(dynamicFlags);
+            var result = new DynamicFlagsCustomTypeInfo(builder, startIndex: 0);
+            builder.Free();
+            return result;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -36,6 +36,7 @@
     <Compile Include="AssemblyReference.cs" />
     <Compile Include="CustomTypeInfo.cs" />
     <Compile Include="DynamicFlagsCustomTypeInfo.cs" />
+    <Compile Include="DynamicFlagsCustomTypeInfo_Factory.cs" />
     <Compile Include="Placeholders.cs" />
     <Compile Include="ReflectionHelpers.cs" />
     <Compile Include="ImmutableArrayExtensions.cs" />

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ExpansionFlags flags)
         {
             var declaredType = member.Type;
-            var declaredTypeInfo = dynamicFlagsMap.SubstituteDynamicFlags(member.OriginalDefinitionType, new DynamicFlagsCustomTypeInfo(member.TypeInfo)).GetCustomTypeInfo();
+            var declaredTypeInfo = dynamicFlagsMap.SubstituteDynamicFlags(member.OriginalDefinitionType, DynamicFlagsCustomTypeInfo.Create(member.TypeInfo)).GetCustomTypeInfo();
             string memberName;
             // Considering, we're not handling the case of a member inherited from a generic base type.
             var typeDeclaringMember = member.GetExplicitlyImplementedInterface(out memberName) ?? member.DeclaringType;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 throw new ArgumentNullException(nameof(type));
             }
 
-            var dynamicFlags = new DynamicFlagsCustomTypeInfo(typeAndInfo.Info);
+            var dynamicFlags = DynamicFlagsCustomTypeInfo.Create(typeAndInfo.Info);
             var index = 0;
             var pooled = PooledStringBuilder.GetInstance();
             AppendQualifiedTypeName(pooled.Builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsCustomTypeInfo_Factory.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsCustomTypeInfo_Factory.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal partial struct DynamicFlagsCustomTypeInfo
+    {
+        public static DynamicFlagsCustomTypeInfo Create(DkmClrCustomTypeInfo typeInfo)
+        {
+            return new DynamicFlagsCustomTypeInfo(typeInfo != null && typeInfo.PayloadTypeId == PayloadTypeId ? typeInfo.Payload : null);
+        }
+
+        public static DynamicFlagsCustomTypeInfo Create(ArrayBuilder<bool> dynamicFlags)
+        {
+            Debug.Assert(dynamicFlags != null);
+            Debug.Assert(dynamicFlags.Count > 0);
+            return new DynamicFlagsCustomTypeInfo(dynamicFlags, startIndex: 0);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsMap.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicFlagsMap.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return Empty;
             }
 
-            var dynamicFlags = new DynamicFlagsCustomTypeInfo(typeAndInfo.Info);
+            var dynamicFlags = DynamicFlagsCustomTypeInfo.Create(typeAndInfo.Info);
             if (!dynamicFlags.Any())
             {
                 return Empty;
@@ -97,7 +97,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 f++;
             }
 
-            return new DynamicFlagsCustomTypeInfo(substitutedFlags.ToArrayAndFree());
+            var result = DynamicFlagsCustomTypeInfo.Create(substitutedFlags);
+            substitutedFlags.Free();
+            return result;
         }
 
         private void AppendFlagsFor(Type type, ArrayBuilder<bool> builder)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DynamicHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.Debugger.Metadata;
@@ -9,8 +8,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
     internal static class DynamicHelpers
     {
-        private static readonly bool[] TrueArray = new[] { true };
-
         public static DynamicFlagsCustomTypeInfo GetDynamicFlags(this IList<CustomAttributeData> attributes)
         {
             foreach (var attribute in attributes)
@@ -20,7 +17,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     var arguments = attribute.ConstructorArguments;
                     if (arguments.Count == 0)
                     {
-                        return new DynamicFlagsCustomTypeInfo(TrueArray);
+                        var builder = ArrayBuilder<bool>.GetInstance(1);
+                        builder.Add(true);
+                        var result = DynamicFlagsCustomTypeInfo.Create(builder);
+                        builder.Free();
+                        return result;
                     }
                     else if (arguments.Count == 1)
                     {
@@ -36,7 +37,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                             {
                                 builder.Add((bool)typedArg.Value);
                             }
-                            return new DynamicFlagsCustomTypeInfo(builder.ToArrayAndFree());
+                            var result = DynamicFlagsCustomTypeInfo.Create(builder);
+                            builder.Free();
+                            return result;
                         }
                     }
                 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -799,7 +799,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 if (declaredType.IsArray)
                 {
                     elementType = declaredType.GetElementType();
-                    elementTypeInfo = new DynamicFlagsCustomTypeInfo(declaredTypeAndInfo.Info).SkipOne().GetCustomTypeInfo();
+                    elementTypeInfo = DynamicFlagsCustomTypeInfo.Create(declaredTypeAndInfo.Info).SkipOne().GetCustomTypeInfo();
                 }
                 else
                 {
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             if (declaredType.IsPointer)
             {
                 // If this ever happens, the element type info is just .SkipOne().
-                Debug.Assert(!new DynamicFlagsCustomTypeInfo(declaredTypeAndInfo.Info).Any());
+                Debug.Assert(!DynamicFlagsCustomTypeInfo.Create(declaredTypeAndInfo.Info).Any());
                 var elementType = declaredType.GetElementType();
                 return value.IsNull || elementType.IsVoid()
                     ? null

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.TypeNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.Values.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\DynamicFlagsCustomTypeInfo_Factory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeAndCustomInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeWalker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DynamicFlagsMap.cs" />

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/DynamicFlagsCustomTypeInfo_Factory.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/DynamicFlagsCustomTypeInfo_Factory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal partial struct DynamicFlagsCustomTypeInfo
+    {
+        internal static DynamicFlagsCustomTypeInfo Create(params bool[] dynamicFlags)
+        {
+            if (dynamicFlags == null || dynamicFlags.Length == 0)
+            {
+                return default(DynamicFlagsCustomTypeInfo);
+            }
+
+            var builder = ArrayBuilder<bool>.GetInstance(dynamicFlags.Length);
+            builder.AddRange(dynamicFlags);
+            var result = new DynamicFlagsCustomTypeInfo(builder, startIndex: 0);
+            builder.Free();
+            return result;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 value,
                 workList,
                 declaredType: declaredType ?? value.Type,
-                customTypeInfo: new DynamicFlagsCustomTypeInfo(declaredTypeInfo).GetCustomTypeInfo(),
+                customTypeInfo: DynamicFlagsCustomTypeInfo.Create(declaredTypeInfo).GetCustomTypeInfo(),
                 inspectionContext: inspectionContext ?? DefaultInspectionContext,
                 formatSpecifiers: Formatter.NoFormatSpecifiers,
                 resultName: name,
@@ -482,11 +482,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 throw new NotImplementedException();
             }
-        }
-
-        internal static DynamicFlagsCustomTypeInfo MakeDynamicFlagsCustomTypeInfo(params bool[] dynamicFlags)
-        {
-            return new DynamicFlagsCustomTypeInfo(dynamicFlags);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestUtilities.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Debugger\MemberInfo\ParameterInfoImpl.cs" />
     <Compile Include="Debugger\MemberInfo\PropertyInfoImpl.cs" />
     <Compile Include="Debugger\MemberInfo\TypeImpl.cs" />
+    <Compile Include="DynamicFlagsCustomTypeInfo_Factory.cs" />
     <Compile Include="ReflectionUtilities.cs" />
     <Compile Include="ResultProviderTestBase.cs" />
   </ItemGroup>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         <Extension>
         Public Function GetTypeName(type As System.Type, Optional dynamicFlags As Boolean() = Nothing, Optional escapeKeywordIdentifiers As Boolean = False) As String
-            Return type.GetTypeName(ResultProviderTestBase.MakeDynamicFlagsCustomTypeInfo(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers)
+            Return type.GetTypeName(DynamicFlagsCustomTypeInfo.Create(dynamicFlags).GetCustomTypeInfo(), escapeKeywordIdentifiers)
         End Function
 
         <Extension>


### PR DESCRIPTION
Separate factory methods for each of the projects that consumes it and a
little less copying.

(PR feedback from https://github.com/dotnet/roslyn/pull/2699)