### PR TITLE
C#: Mark return value synthesized local as long-lived

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -610,7 +610,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         // debuggable code. This function is a stub for the logic that decides that.
         private bool ShouldUseIndirectReturn()
         {
-            return _optimizations == OptimizationLevel.Debug || _builder.InExceptionHandler;
+            // If the method/lambda body is a block we define a sequence point for the closing brace of the body
+            // and associate it with the ret instruction. If there is a return statement we need to store the value 
+            // to a long-lived synthesized local since a sequence point requires an empty evaluation stack.
+            //
+            // The emitted pattern is:
+            //   <evaluate return statement expression>
+            //   stloc $ReturnValue
+            //   ldloc  $ReturnValue // sequence point
+            //   ret
+            //
+            // Do not emit this pattern if the method doesn't include user code or doesn't have a block blody.
+            return _optimizations == OptimizationLevel.Debug && _method.GenerateDebugInfo && _methodBodySyntaxOpt?.IsKind(SyntaxKind.Block) == true || 
+                   _builder.InExceptionHandler;
         }
 
         // Compiler generated return mapped to a block is very likely the synthetic return
@@ -626,11 +638,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitReturnStatement(BoundReturnStatement boundReturnStatement)
         {
-            this.EmitExpression(boundReturnStatement.ExpressionOpt, true);
+            var expressionOpt = boundReturnStatement.ExpressionOpt;
+
+            this.EmitExpression(expressionOpt, used: true);
 
             if (ShouldUseIndirectReturn())
             {
-                if (boundReturnStatement.ExpressionOpt != null)
+                if (expressionOpt != null)
                 {
                     _builder.EmitLocalStore(LazyReturnTemp);
                 }
@@ -653,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             {
                 if (_indirectReturnState == IndirectReturnState.Needed && CanHandleReturnLabel(boundReturnStatement))
                 {
-                    if (boundReturnStatement.ExpressionOpt != null)
+                    if (expressionOpt != null)
                     {
                         _builder.EmitLocalStore(LazyReturnTemp);
                     }
@@ -662,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
                 else
                 {
-                    _builder.EmitRet(boundReturnStatement.ExpressionOpt == null);
+                    _builder.EmitRet(expressionOpt == null);
                 }
             }
         }
@@ -1435,7 +1449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         /// <summary>
         /// Allocates a temp without identity.
         /// </summary>
-        private LocalDefinition AllocateTemp(TypeSymbol type, CSharpSyntaxNode syntaxNode)
+        private LocalDefinition AllocateTemp(TypeSymbol type, SyntaxNode syntaxNode)
         {
             return _builder.LocalSlotManager.AllocateSlot(
                 _module.Translate(type, syntaxNode, _diagnostics),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1075,9 +1075,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return base.CallsAreOmitted(syntaxTree);
         }
 
-        internal override bool GenerateDebugInfo
-        {
-            get { return !IsAsync; }
-        }
+        internal override bool GenerateDebugInfo => !IsAsync && !IsIterator;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -544,7 +544,8 @@ public class C : I
 {
   // Code size       37 (0x25)
   .maxstack  1
-  .locals init (I V_0)
+  .locals init (I V_0,
+                I V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  brfalse.s  IL_000d
@@ -561,9 +562,9 @@ public class C : I
   IL_0019:  newobj     ""A..ctor()""
   IL_001e:  stloc.0
   IL_001f:  ldloc.0
-  IL_0020:  stloc.0
+  IL_0020:  stloc.1
   IL_0021:  br.s       IL_0023
-  IL_0023:  ldloc.0
+  IL_0023:  ldloc.1
   IL_0024:  ret
 }");
             // Optimized
@@ -627,7 +628,8 @@ public class C : I
 {
   // Code size       39 (0x27)
   .maxstack  2
-  .locals init (I V_0)
+  .locals init (I V_0,
+                I V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  ldc.i4.0
@@ -646,9 +648,9 @@ public class C : I
   IL_001b:  newobj     ""C..ctor()""
   IL_0020:  stloc.0
   IL_0021:  ldloc.0
-  IL_0022:  stloc.0
+  IL_0022:  stloc.1
   IL_0023:  br.s       IL_0025
-  IL_0025:  ldloc.0
+  IL_0025:  ldloc.1
   IL_0026:  ret
 }");
             // Optimized
@@ -716,7 +718,8 @@ public class C : I
 {
   // Code size       51 (0x33)
   .maxstack  2
-  .locals init (I V_0)
+  .locals init (I V_0,
+                I V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  ldc.i4.0
@@ -741,9 +744,9 @@ public class C : I
   IL_0027:  newobj     ""A..ctor()""
   IL_002c:  stloc.0
   IL_002d:  ldloc.0
-  IL_002e:  stloc.0
+  IL_002e:  stloc.1
   IL_002f:  br.s       IL_0031
-  IL_0031:  ldloc.0
+  IL_0031:  ldloc.1
   IL_0032:  ret
 }");
             // Optimized
@@ -821,7 +824,8 @@ public class C : I
 {
   // Code size       52 (0x34)
   .maxstack  2
-  .locals init (I V_0)
+  .locals init (I V_0,
+                I V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  ldc.i4.0
@@ -847,9 +851,9 @@ public class C : I
   IL_0028:  newobj     ""A..ctor()""
   IL_002d:  stloc.0
   IL_002e:  ldloc.0
-  IL_002f:  stloc.0
+  IL_002f:  stloc.1
   IL_0030:  br.s       IL_0032
-  IL_0032:  ldloc.0
+  IL_0032:  ldloc.1
   IL_0033:  ret
 }");
             // Optimized
@@ -2171,7 +2175,8 @@ public class C : I
 {
   // Code size       32 (0x20)
   .maxstack  2
-  .locals init (I V_0)
+  .locals init (I V_0,
+                I V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.0
@@ -2188,9 +2193,9 @@ public class C : I
   IL_0014:  newobj     ""B..ctor()""
   IL_0019:  stloc.0
   IL_001a:  ldloc.0
-  IL_001b:  stloc.0
+  IL_001b:  stloc.1
   IL_001c:  br.s       IL_001e
-  IL_001e:  ldloc.0
+  IL_001e:  ldloc.1
   IL_001f:  ret
 }");
             // Optimized

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -1204,20 +1204,14 @@ class Program
 
             dbg.VerifyIL("Program.M", @"
 {
-  // Code size       18 (0x12)
-  .maxstack  2
-  .locals init (Program.<M>d__1 V_0,
-                System.Collections.Generic.IEnumerator<int> V_1)
+  // Code size       14 (0xe)
+  .maxstack  3
   IL_0000:  ldc.i4.0
   IL_0001:  newobj     ""Program.<M>d__1..ctor(int)""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldarg.0
-  IL_0009:  stfld      ""System.Collections.Generic.IEnumerable<int> Program.<M>d__1.items""
-  IL_000e:  ldloc.0
-  IL_000f:  stloc.1
-  IL_0010:  ldloc.1
-  IL_0011:  ret
+  IL_0006:  dup
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""System.Collections.Generic.IEnumerable<int> Program.<M>d__1.items""
+  IL_000d:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -1378,7 +1378,8 @@ class C : I
   // Code size       86 (0x56)
   .maxstack  2
   .locals init (I V_0, //i
-                I V_1)
+                I V_1,
+                I V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.1
@@ -1430,9 +1431,9 @@ class C : I
   IL_004a:  callvirt   ""void I.DoNothing()""
   IL_004f:  nop
   IL_0050:  ldloc.0
-  IL_0051:  stloc.1
+  IL_0051:  stloc.2
   IL_0052:  br.s       IL_0054
-  IL_0054:  ldloc.1
+  IL_0054:  ldloc.2
   IL_0055:  ret
 }");
             // Optimized

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -5224,7 +5224,7 @@ M
 
             verifier.VerifyIL("C.<>c__DisplayClass0_0.<F1>b__0", @"
 {
-  // Code size       21 (0x15)
+  // Code size       19 (0x13)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<>c__DisplayClass0_0.c""
@@ -5234,13 +5234,12 @@ M
   IL_000a:  br.s       IL_0012
   IL_000c:  call       ""void C.M()""
   IL_0011:  nop
-  IL_0012:  br.s       IL_0014
-  IL_0014:  ret
+  IL_0012:  ret
 }");
 
             verifier.VerifyIL("C.F2", @"
 {
-  // Code size       15 (0xf)
+  // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_0005
@@ -5248,8 +5247,7 @@ M
   IL_0005:  ldarg.0
   IL_0006:  call       ""void C.M()""
   IL_000b:  nop
-  IL_000c:  br.s       IL_000e
-  IL_000e:  ret
+  IL_000c:  ret
 }");
         }
 
@@ -5353,7 +5351,7 @@ M
 
             verifier.VerifyIL("C<T>.<>c__DisplayClass0_0.<F1>b__0()", @"
 {
-  // Code size       21 (0x15)
+  // Code size       19 (0x13)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C<T> C<T>.<>c__DisplayClass0_0.c""
@@ -5363,13 +5361,12 @@ M
   IL_000a:  br.s       IL_0012
   IL_000c:  call       ""T C<T>.M()""
   IL_0011:  pop
-  IL_0012:  br.s       IL_0014
-  IL_0014:  ret
+  IL_0012:  ret
 }");
 
             verifier.VerifyIL("C<T>.F2", @"
 {
-  // Code size       15 (0xf)
+  // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_0005
@@ -5377,8 +5374,7 @@ M
   IL_0005:  ldarg.0
   IL_0006:  call       ""T C<T>.M()""
   IL_000b:  pop
-  IL_000c:  br.s       IL_000e
-  IL_000e:  ret
+  IL_000c:  ret
 }");
         }
 
@@ -5482,7 +5478,7 @@ M
 
             verifier.VerifyIL("C.<>c__DisplayClass0_0.<F1>b__0", @"
 {
-  // Code size       21 (0x15)
+  // Code size       19 (0x13)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<>c__DisplayClass0_0.c""
@@ -5492,13 +5488,12 @@ M
   IL_000a:  br.s       IL_0012
   IL_000c:  call       ""void* C.M()""
   IL_0011:  pop
-  IL_0012:  br.s       IL_0014
-  IL_0014:  ret
+  IL_0012:  ret
 }");
 
             verifier.VerifyIL("C.F2", @"
 {
-  // Code size       15 (0xf)
+  // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_0005
@@ -5506,8 +5501,7 @@ M
   IL_0005:  ldarg.0
   IL_0006:  call       ""void* C.M()""
   IL_000b:  pop
-  IL_000c:  br.s       IL_000e
-  IL_000e:  ret
+  IL_000c:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -54,7 +54,6 @@ class C
                 // Type: display class
                 CheckEncLogDefinitions(reader1,
                     Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                    Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                     Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
                     Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                     Row(1, TableIndex.Field, EditAndContinueOperation.Default),
@@ -116,8 +115,7 @@ class C
 
             // Method updates
             CheckEncLogDefinitions(reader1,
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default));
         }
@@ -225,8 +223,7 @@ class C
 
             // Method updates
             CheckEncLogDefinitions(reader1,
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
@@ -282,8 +279,7 @@ class C
 
             // Method updates
             CheckEncLogDefinitions(reader1,
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default));
         }
@@ -357,8 +353,7 @@ class C : D
 
             // Method updates
             CheckEncLogDefinitions(reader1,
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -422,7 +417,6 @@ partial class C
 
             // Method updates
             CheckEncLogDefinitions(reader1,
-                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default));
@@ -484,10 +478,7 @@ class C
 
             // Method updates for lambdas:
             CheckEncLogDefinitions(reader1,
-                Row(9, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(10, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(11, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(12, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(6, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(12, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(16, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(17, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -569,12 +560,9 @@ class C
 
             // Method updates for lambdas:
             CheckEncLogDefinitions(reader1,
+                Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(8, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(9, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(10, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(11, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(12, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(13, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(11, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -656,7 +644,6 @@ class C
             CheckEncLogDefinitions(reader1,
                 Row(6, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(8, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(12, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -741,7 +728,6 @@ class C
                 Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(8, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(9, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(10, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -826,7 +812,6 @@ class C
             CheckEncLogDefinitions(reader1,
                 Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(6, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -905,7 +890,6 @@ class C
             CheckEncLogDefinitions(reader1,
                 Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(6, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -994,32 +978,23 @@ class C
             // updated:
             diff1.VerifyIL("C.<>c.<F>b__1_0", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.2
   IL_0002:  add
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }
 ");
             // added:
             diff1.VerifyIL("C.<>c.<F>b__1_1#1", @"
 {
-  // Code size        9 (0x9)
+  // Code size        5 (0x5)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.s   20
   IL_0003:  add
-  IL_0004:  stloc.0
-  IL_0005:  br.s       IL_0007
-  IL_0007:  ldloc.0
-  IL_0008:  ret
+  IL_0004:  ret
 }
 ");
 
@@ -1035,48 +1010,35 @@ class C
             // updated:
             diff2.VerifyIL("C.<>c.<F>b__1_0", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.3
   IL_0002:  add
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }
 ");
             // updated:
             diff2.VerifyIL("C.<>c.<F>b__1_1#1", @"
 {
-  // Code size        9 (0x9)
+  // Code size        5 (0x5)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.s   30
   IL_0003:  add
-  IL_0004:  stloc.0
-  IL_0005:  br.s       IL_0007
-  IL_0007:  ldloc.0
-  IL_0008:  ret
+  IL_0004:  ret
 }
 ");
 
             // added:
             diff2.VerifyIL("C.<>c.<F>b__1_2#2", @"
 {
-  // Code size       12 (0xc)
+  // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4     0x300
   IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  br.s       IL_000a
-  IL_000a:  ldloc.0
-  IL_000b:  ret
+  IL_0007:  ret
 }
 ");
 
@@ -1091,48 +1053,35 @@ class C
             // updated:
             diff3.VerifyIL("C.<>c.<F>b__1_0", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.4
   IL_0002:  add
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }
 ");
             // updated:
             diff3.VerifyIL("C.<>c.<F>b__1_1#1", @"
 {
-  // Code size        9 (0x9)
+  // Code size        5 (0x5)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.s   40
   IL_0003:  add
-  IL_0004:  stloc.0
-  IL_0005:  br.s       IL_0007
-  IL_0007:  ldloc.0
-  IL_0008:  ret
+  IL_0004:  ret
 }
 ");
 
             // updated:
             diff3.VerifyIL("C.<>c.<F>b__1_2#2", @"
 {
-  // Code size       12 (0xc)
+  // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4     0x400
   IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  br.s       IL_000a
-  IL_000a:  ldloc.0
-  IL_000b:  ret
+  IL_0007:  ret
 }
 ");
         }
@@ -1701,8 +1650,7 @@ class C
             // Note that even if the change is in the inner lambda such a change will usually impact sequence point 
             // spans in outer lambda and the method body. So although the IL doesn't change we usually need to update the outer methods.
             CheckEncLogDefinitions(reader1,
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default));
@@ -1776,61 +1724,41 @@ class C
 
             diff1.VerifyIL("C.<>c.<.ctor>b__2_0", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.2
   IL_0002:  sub
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }");
 
             diff1.VerifyIL("C.<>c.<.ctor>b__2_1", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.3
   IL_0002:  sub
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }");
 
             diff1.VerifyIL("C.<>c.<.ctor>b__3_0", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.4
   IL_0002:  sub
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }");
             diff1.VerifyIL("C.<>c.<.ctor>b__3_1", @"
 {
-  // Code size        8 (0x8)
+  // Code size        4 (0x4)
   .maxstack  2
-  .locals init ([int] V_0,
-                int V_1)
   IL_0000:  ldarg.1
   IL_0001:  ldc.i4.1
   IL_0002:  sub
-  IL_0003:  stloc.1
-  IL_0004:  br.s       IL_0006
-  IL_0006:  ldloc.1
-  IL_0007:  ret
+  IL_0003:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -365,7 +365,6 @@ class C
                     CheckEncLogDefinitions(md1.Reader,
                         Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(5, TableIndex.TypeDef, EditAndContinueOperation.Default),
                         Row(1, TableIndex.PropertyMap, EditAndContinueOperation.Default),
                         Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddField),
@@ -538,7 +537,7 @@ class C
                 using (var md1 = diff1.GetMetadata())
                 {
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default));
                 }
             }
@@ -736,8 +735,7 @@ class C
                     // - Finally method
                     // - MoveNext method
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                         Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                         Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -746,10 +744,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       63 (0x3f)
+  // Code size       57 (0x39)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -760,39 +757,34 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0034
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0030
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.2
-  IL_0024:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0029:  ldarg.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0030:  ldc.i4.1
-  IL_0031:  stloc.1
-  IL_0032:  br.s       IL_0018
-  IL_0034:  ldarg.0
-  IL_0035:  ldc.i4.m1
-  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003b:  ldc.i4.0
-  IL_003c:  stloc.1
-  IL_003d:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.2
+  IL_0022:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_002e:  ldc.i4.1
+  IL_002f:  ret
+  IL_0030:  ldarg.0
+  IL_0031:  ldc.i4.m1
+  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ret
 }
 ");
                     v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       63 (0x3f)
+  // Code size       57 (0x39)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -803,31 +795,27 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0034
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0030
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0029:  ldarg.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0030:  ldc.i4.1
-  IL_0031:  stloc.1
-  IL_0032:  br.s       IL_0018
-  IL_0034:  ldarg.0
-  IL_0035:  ldc.i4.m1
-  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003b:  ldc.i4.0
-  IL_003c:  stloc.1
-  IL_003d:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_002e:  ldc.i4.1
+  IL_002f:  ret
+  IL_0030:  ldarg.0
+  IL_0031:  ldc.i4.m1
+  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ret
 }");
                 }
             }
@@ -1161,8 +1149,7 @@ class C
                     // - Finally method
                     // - MoveNext method
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
                         Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
                         Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -1171,10 +1158,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       75 (0x4b)
+  // Code size       69 (0x45)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1185,35 +1171,31 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0040
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldarg.0
-  IL_0024:  ldfld      ""int C.<F>d__0.p""
-  IL_0029:  stfld      ""int C.<F>d__0.<x>5__1""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.2
-  IL_0030:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0035:  ldarg.0
-  IL_0036:  ldc.i4.1
-  IL_0037:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003c:  ldc.i4.1
-  IL_003d:  stloc.1
-  IL_003e:  br.s       IL_0018
-  IL_0040:  ldarg.0
-  IL_0041:  ldc.i4.m1
-  IL_0042:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0047:  ldc.i4.0
-  IL_0048:  stloc.1
-  IL_0049:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldfld      ""int C.<F>d__0.p""
+  IL_0027:  stfld      ""int C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.2
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldc.i4.0
+  IL_0044:  ret
 }
 ");
                 }
@@ -1274,8 +1256,7 @@ class C
                 {
                     // 1 field def added & 3 methods updated
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                         Row(7, TableIndex.Field, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -1286,10 +1267,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      103 (0x67)
+  // Code size       97 (0x61)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1300,43 +1280,39 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0050
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_004c
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4     0x4d2
-  IL_0028:  stfld      ""int C.<F>d__0.<y>5__2""
-  IL_002d:  ldarg.0
-  IL_002e:  ldarg.0
-  IL_002f:  ldfld      ""int C.<F>d__0.p""
-  IL_0034:  stfld      ""int C.<F>d__0.<x>5__1""
-  IL_0039:  ldarg.0
-  IL_003a:  ldarg.0
-  IL_003b:  ldfld      ""int C.<F>d__0.<y>5__2""
-  IL_0040:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0045:  ldarg.0
-  IL_0046:  ldc.i4.1
-  IL_0047:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_004c:  ldc.i4.1
-  IL_004d:  stloc.1
-  IL_004e:  br.s       IL_0018
-  IL_0050:  ldarg.0
-  IL_0051:  ldc.i4.m1
-  IL_0052:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0057:  ldarg.0
-  IL_0058:  ldfld      ""int C.<F>d__0.<x>5__1""
-  IL_005d:  call       ""void System.Console.WriteLine(int)""
-  IL_0062:  nop
-  IL_0063:  ldc.i4.0
-  IL_0064:  stloc.1
-  IL_0065:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4     0x4d2
+  IL_0026:  stfld      ""int C.<F>d__0.<y>5__2""
+  IL_002b:  ldarg.0
+  IL_002c:  ldarg.0
+  IL_002d:  ldfld      ""int C.<F>d__0.p""
+  IL_0032:  stfld      ""int C.<F>d__0.<x>5__1""
+  IL_0037:  ldarg.0
+  IL_0038:  ldarg.0
+  IL_0039:  ldfld      ""int C.<F>d__0.<y>5__2""
+  IL_003e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0043:  ldarg.0
+  IL_0044:  ldc.i4.1
+  IL_0045:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_004a:  ldc.i4.1
+  IL_004b:  ret
+  IL_004c:  ldarg.0
+  IL_004d:  ldc.i4.m1
+  IL_004e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0053:  ldarg.0
+  IL_0054:  ldfld      ""int C.<F>d__0.<x>5__1""
+  IL_0059:  call       ""void System.Console.WriteLine(int)""
+  IL_005e:  nop
+  IL_005f:  ldc.i4.0
+  IL_0060:  ret
 }
 ");
                 }
@@ -1396,8 +1372,7 @@ class C
                 {
                     // 1 field def added & 3 methods updated
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                         Row(7, TableIndex.Field, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -1408,10 +1383,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       91 (0x5b)
+  // Code size       85 (0x55)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1422,39 +1396,35 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0044
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0040
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4     0x4d2
-  IL_0028:  stfld      ""int C.<F>d__0.<y>5__2""
-  IL_002d:  ldarg.0
-  IL_002e:  ldarg.0
-  IL_002f:  ldfld      ""int C.<F>d__0.<y>5__2""
-  IL_0034:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0039:  ldarg.0
-  IL_003a:  ldc.i4.1
-  IL_003b:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0040:  ldc.i4.1
-  IL_0041:  stloc.1
-  IL_0042:  br.s       IL_0018
-  IL_0044:  ldarg.0
-  IL_0045:  ldc.i4.m1
-  IL_0046:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_004b:  ldarg.0
-  IL_004c:  ldfld      ""int C.<F>d__0.p""
-  IL_0051:  call       ""void System.Console.WriteLine(int)""
-  IL_0056:  nop
-  IL_0057:  ldc.i4.0
-  IL_0058:  stloc.1
-  IL_0059:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4     0x4d2
+  IL_0026:  stfld      ""int C.<F>d__0.<y>5__2""
+  IL_002b:  ldarg.0
+  IL_002c:  ldarg.0
+  IL_002d:  ldfld      ""int C.<F>d__0.<y>5__2""
+  IL_0032:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0037:  ldarg.0
+  IL_0038:  ldc.i4.1
+  IL_0039:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003e:  ldc.i4.1
+  IL_003f:  ret
+  IL_0040:  ldarg.0
+  IL_0041:  ldc.i4.m1
+  IL_0042:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0047:  ldarg.0
+  IL_0048:  ldfld      ""int C.<F>d__0.p""
+  IL_004d:  call       ""void System.Console.WriteLine(int)""
+  IL_0052:  nop
+  IL_0053:  ldc.i4.0
+  IL_0054:  ret
 }
 ");
                 }
@@ -1515,8 +1485,7 @@ class C
                 {
                     // 1 field def added & 3 methods updated
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                         Row(5, TableIndex.Field, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -1527,10 +1496,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       90 (0x5a)
+  // Code size       84 (0x54)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1541,38 +1509,34 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0043
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003f
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.r8     1
-  IL_002c:  stfld      ""double C.<F>d__0.<x>5__2""
-  IL_0031:  ldarg.0
-  IL_0032:  ldc.i4.2
-  IL_0033:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0038:  ldarg.0
-  IL_0039:  ldc.i4.1
-  IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003f:  ldc.i4.1
-  IL_0040:  stloc.1
-  IL_0041:  br.s       IL_0018
-  IL_0043:  ldarg.0
-  IL_0044:  ldc.i4.m1
-  IL_0045:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_004a:  ldarg.0
-  IL_004b:  ldfld      ""double C.<F>d__0.<x>5__2""
-  IL_0050:  call       ""void System.Console.WriteLine(double)""
-  IL_0055:  nop
-  IL_0056:  ldc.i4.0
-  IL_0057:  stloc.1
-  IL_0058:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.r8     1
+  IL_002a:  stfld      ""double C.<F>d__0.<x>5__2""
+  IL_002f:  ldarg.0
+  IL_0030:  ldc.i4.2
+  IL_0031:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0036:  ldarg.0
+  IL_0037:  ldc.i4.1
+  IL_0038:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003d:  ldc.i4.1
+  IL_003e:  ret
+  IL_003f:  ldarg.0
+  IL_0040:  ldc.i4.m1
+  IL_0041:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0046:  ldarg.0
+  IL_0047:  ldfld      ""double C.<F>d__0.<x>5__2""
+  IL_004c:  call       ""void System.Console.WriteLine(double)""
+  IL_0051:  nop
+  IL_0052:  ldc.i4.0
+  IL_0053:  ret
 }
 ");
                 }
@@ -1643,8 +1607,7 @@ class C
                 {
                     // 1 field def added & 3 methods updated
                     CheckEncLogDefinitions(md1.Reader,
-                        Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                        Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                         Row(7, TableIndex.Field, EditAndContinueOperation.Default),
                         Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -1655,10 +1618,9 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      170 (0xaa)
+  // Code size      161 (0xa1)
   .maxstack  5
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1669,73 +1631,69 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_006f
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_006b
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  nop
-  IL_0023:  ldarg.0
-  IL_0024:  ldc.i4.1
-  IL_0025:  newarr     ""double""
-  IL_002a:  dup
-  IL_002b:  ldc.i4.0
-  IL_002c:  ldc.r8     1
-  IL_0035:  stelem.r8
-  IL_0036:  stfld      ""double[] C.<F>d__0.<>s__4""
-  IL_003b:  ldarg.0
-  IL_003c:  ldc.i4.0
-  IL_003d:  stfld      ""int C.<F>d__0.<>s__2""
-  IL_0042:  br.s       IL_008c
-  IL_0044:  ldarg.0
-  IL_0045:  ldarg.0
-  IL_0046:  ldfld      ""double[] C.<F>d__0.<>s__4""
-  IL_004b:  ldarg.0
-  IL_004c:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_0051:  ldelem.r8
-  IL_0052:  box        ""double""
-  IL_0057:  stfld      ""object C.<F>d__0.<item>5__3""
-  IL_005c:  nop
-  IL_005d:  ldarg.0
-  IL_005e:  ldc.i4.1
-  IL_005f:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0064:  ldarg.0
-  IL_0065:  ldc.i4.1
-  IL_0066:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_006b:  ldc.i4.1
-  IL_006c:  stloc.1
-  IL_006d:  br.s       IL_0018
-  IL_006f:  ldarg.0
-  IL_0070:  ldc.i4.m1
-  IL_0071:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0076:  nop
-  IL_0077:  ldarg.0
-  IL_0078:  ldnull
-  IL_0079:  stfld      ""object C.<F>d__0.<item>5__3""
-  IL_007e:  ldarg.0
-  IL_007f:  ldarg.0
-  IL_0080:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_0085:  ldc.i4.1
-  IL_0086:  add
-  IL_0087:  stfld      ""int C.<F>d__0.<>s__2""
-  IL_008c:  ldarg.0
-  IL_008d:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_0092:  ldarg.0
-  IL_0093:  ldfld      ""double[] C.<F>d__0.<>s__4""
-  IL_0098:  ldlen
-  IL_0099:  conv.i4
-  IL_009a:  blt.s      IL_0044
-  IL_009c:  ldarg.0
-  IL_009d:  ldnull
-  IL_009e:  stfld      ""double[] C.<F>d__0.<>s__4""
-  IL_00a3:  ldc.i4.0
-  IL_00a4:  stloc.1
-  IL_00a5:  br         IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  nop
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.1
+  IL_0023:  newarr     ""double""
+  IL_0028:  dup
+  IL_0029:  ldc.i4.0
+  IL_002a:  ldc.r8     1
+  IL_0033:  stelem.r8
+  IL_0034:  stfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0039:  ldarg.0
+  IL_003a:  ldc.i4.0
+  IL_003b:  stfld      ""int C.<F>d__0.<>s__2""
+  IL_0040:  br.s       IL_0088
+  IL_0042:  ldarg.0
+  IL_0043:  ldarg.0
+  IL_0044:  ldfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0049:  ldarg.0
+  IL_004a:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_004f:  ldelem.r8
+  IL_0050:  box        ""double""
+  IL_0055:  stfld      ""object C.<F>d__0.<item>5__3""
+  IL_005a:  nop
+  IL_005b:  ldarg.0
+  IL_005c:  ldc.i4.1
+  IL_005d:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0062:  ldarg.0
+  IL_0063:  ldc.i4.1
+  IL_0064:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0069:  ldc.i4.1
+  IL_006a:  ret
+  IL_006b:  ldarg.0
+  IL_006c:  ldc.i4.m1
+  IL_006d:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0072:  nop
+  IL_0073:  ldarg.0
+  IL_0074:  ldnull
+  IL_0075:  stfld      ""object C.<F>d__0.<item>5__3""
+  IL_007a:  ldarg.0
+  IL_007b:  ldarg.0
+  IL_007c:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_0081:  ldc.i4.1
+  IL_0082:  add
+  IL_0083:  stfld      ""int C.<F>d__0.<>s__2""
+  IL_0088:  ldarg.0
+  IL_0089:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_008e:  ldarg.0
+  IL_008f:  ldfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0094:  ldlen
+  IL_0095:  conv.i4
+  IL_0096:  blt.s      IL_0042
+  IL_0098:  ldarg.0
+  IL_0099:  ldnull
+  IL_009a:  stfld      ""double[] C.<F>d__0.<>s__4""
+  IL_009f:  ldc.i4.0
+  IL_00a0:  ret
 }
 ");
                 }
@@ -2416,10 +2374,10 @@ class C
 
             // 1 field def added & 4 methods updated (MoveNext and kickoff for F and G)
             CheckEncLogDefinitions(md1.Reader,
+                Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(8, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(9, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(10, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(11, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(12, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(13, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                 Row(11, TableIndex.Field, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -2563,8 +2521,8 @@ class C
 ");
             // 1 field def added & 2 methods updated
             CheckEncLogDefinitions(md2.Reader,
-                Row(14, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(15, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(11, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(12, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                 Row(12, TableIndex.Field, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
@@ -2705,10 +2663,10 @@ class C
 ");
             // 2 field defs added - G and H awaiters & 4 methods updated: G, H kickoff and MoveNext
             CheckEncLogDefinitions(md3.Reader,
+                Row(13, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(14, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(15, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(16, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(17, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(18, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(19, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                 Row(13, TableIndex.Field, EditAndContinueOperation.Default),
                 Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddField),

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -462,20 +462,22 @@ class B
                     CheckNames(readers, reader1.GetFieldDefNames());
                     CheckNames(readers, reader1.GetPropertyDefNames(), "R");
                     CheckNames(readers, reader1.GetMethodDefNames(), "get_R");
+
                     CheckEncLog(reader1,
                         Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
                         Row(9, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                        Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                        Row(1, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                         Row(2, TableIndex.PropertyMap, EditAndContinueOperation.Default),
                         Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
                         Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
                         Row(2, TableIndex.PropertyMap, EditAndContinueOperation.AddProperty),
                         Row(2, TableIndex.Property, EditAndContinueOperation.Default),
                         Row(3, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
+
                     CheckEncMap(reader1,
                         Handle(9, TableIndex.TypeRef),
                         Handle(5, TableIndex.MethodDef),
-                        Handle(2, TableIndex.StandAloneSig),
+                        Handle(1, TableIndex.StandAloneSig),
                         Handle(2, TableIndex.PropertyMap),
                         Handle(2, TableIndex.Property),
                         Handle(3, TableIndex.MethodSemantics),
@@ -504,7 +506,6 @@ class B
                             Row(11, TableIndex.TypeRef, EditAndContinueOperation.Default),
                             Row(12, TableIndex.TypeRef, EditAndContinueOperation.Default),
                             Row(13, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                            Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                             Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                             Row(2, TableIndex.Field, EditAndContinueOperation.Default),
                             Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
@@ -545,7 +546,6 @@ class B
                             Handle(9, TableIndex.CustomAttribute),
                             Handle(10, TableIndex.CustomAttribute),
                             Handle(11, TableIndex.CustomAttribute),
-                            Handle(3, TableIndex.StandAloneSig),
                             Handle(3, TableIndex.Property),
                             Handle(4, TableIndex.Property),
                             Handle(4, TableIndex.MethodSemantics),
@@ -4801,32 +4801,34 @@ class B
 
             diff1.VerifyIL("C.M", @"
 {
-  // Code size       37 (0x25)
+  // Code size       40 (0x28)
   .maxstack  3
   .locals init (C V_0, //c
                 [unchanged] V_1,
                 [int] V_2,
-                C V_3,
-                int V_4)
+                [int] V_3,
+                C V_4,
+                int V_5,
+                int V_6)
   IL_0000:  nop
   IL_0001:  newobj     ""C..ctor()""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  stloc.3
-  IL_0009:  ldloc.3
-  IL_000a:  callvirt   ""int C.P.get""
-  IL_000f:  stloc.s    V_4
-  IL_0011:  ldloc.3
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldc.i4.1
-  IL_0015:  add
-  IL_0016:  callvirt   ""void C.P.set""
-  IL_001b:  nop
-  IL_001c:  ldloc.s    V_4
-  IL_001e:  stloc.s    V_4
-  IL_0020:  br.s       IL_0022
-  IL_0022:  ldloc.s    V_4
-  IL_0024:  ret
+  IL_0008:  stloc.s    V_4
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  callvirt   ""int C.P.get""
+  IL_0011:  stloc.s    V_5
+  IL_0013:  ldloc.s    V_4
+  IL_0015:  ldloc.s    V_5
+  IL_0017:  ldc.i4.1
+  IL_0018:  add
+  IL_0019:  callvirt   ""void C.P.set""
+  IL_001e:  nop
+  IL_001f:  ldloc.s    V_5
+  IL_0021:  stloc.s    V_6
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.s    V_6
+  IL_0027:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2792,10 +2792,9 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      137 (0x89)
+  // Code size      131 (0x83)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -2806,65 +2805,61 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_007e
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_007a
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0021:  nop
-  IL_0022:  ldarg.0
-  IL_0023:  ldarg.0
-  IL_0024:  ldfld      ""C C.<F>d__0.<>4__this""
-  IL_0029:  callvirt   ""System.Collections.Generic.IEnumerable<int> C.F()""
-  IL_002e:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-  IL_0033:  ldarg.0
-  IL_0034:  ldc.i4.0
-  IL_0035:  stfld      ""bool C.<F>d__0.<>s__2""
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldfld      ""C C.<F>d__0.<>4__this""
+  IL_0027:  callvirt   ""System.Collections.Generic.IEnumerable<int> C.F()""
+  IL_002c:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+  IL_0031:  ldarg.0
+  IL_0032:  ldc.i4.0
+  IL_0033:  stfld      ""bool C.<F>d__0.<>s__2""
   .try
   {
-    IL_003a:  ldarg.0
-    IL_003b:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-    IL_0040:  ldarg.0
-    IL_0041:  ldflda     ""bool C.<F>d__0.<>s__2""
-    IL_0046:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
+    IL_0038:  ldarg.0
+    IL_0039:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+    IL_003e:  ldarg.0
+    IL_003f:  ldflda     ""bool C.<F>d__0.<>s__2""
+    IL_0044:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
+    IL_0049:  nop
+    IL_004a:  nop
     IL_004b:  nop
-    IL_004c:  nop
-    IL_004d:  nop
-    IL_004e:  leave.s    IL_0065
+    IL_004c:  leave.s    IL_0063
   }
   finally
   {
-    IL_0050:  ldarg.0
-    IL_0051:  ldfld      ""bool C.<F>d__0.<>s__2""
-    IL_0056:  brfalse.s  IL_0064
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-    IL_005e:  call       ""void System.Threading.Monitor.Exit(object)""
-    IL_0063:  nop
-    IL_0064:  endfinally
+    IL_004e:  ldarg.0
+    IL_004f:  ldfld      ""bool C.<F>d__0.<>s__2""
+    IL_0054:  brfalse.s  IL_0062
+    IL_0056:  ldarg.0
+    IL_0057:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+    IL_005c:  call       ""void System.Threading.Monitor.Exit(object)""
+    IL_0061:  nop
+    IL_0062:  endfinally
   }
-  IL_0065:  ldarg.0
-  IL_0066:  ldnull
-  IL_0067:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-  IL_006c:  ldarg.0
-  IL_006d:  ldc.i4.1
-  IL_006e:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0073:  ldarg.0
-  IL_0074:  ldc.i4.1
-  IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_007a:  ldc.i4.1
-  IL_007b:  stloc.1
-  IL_007c:  br.s       IL_0018
-  IL_007e:  ldarg.0
-  IL_007f:  ldc.i4.m1
-  IL_0080:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0085:  ldc.i4.0
-  IL_0086:  stloc.1
-  IL_0087:  br.s       IL_0018
+  IL_0063:  ldarg.0
+  IL_0064:  ldnull
+  IL_0065:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+  IL_006a:  ldarg.0
+  IL_006b:  ldc.i4.1
+  IL_006c:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0071:  ldarg.0
+  IL_0072:  ldc.i4.1
+  IL_0073:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0078:  ldc.i4.1
+  IL_0079:  ret
+  IL_007a:  ldarg.0
+  IL_007b:  ldc.i4.m1
+  IL_007c:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0081:  ldc.i4.0
+  IL_0082:  ret
 }");
 
 #if TODO 

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1864,7 +1864,8 @@ class UsePia
 {
   // Code size       41 (0x29)
   .maxstack  2
-  .locals init (ITest28 V_0)
+  .locals init (ITest28 V_0,
+                ITest28 V_1)
   IL_0000:  nop
   IL_0001:  ldstr      ""00000000-0000-0000-0000-000000000000""
   IL_0006:  newobj     ""System.Guid..ctor(string)""
@@ -1877,9 +1878,9 @@ class UsePia
   IL_001d:  callvirt   ""void ITest28.P1.set""
   IL_0022:  nop
   IL_0023:  ldloc.0
-  IL_0024:  stloc.0
+  IL_0024:  stloc.1
   IL_0025:  br.s       IL_0027
-  IL_0027:  ldloc.0
+  IL_0027:  ldloc.1
   IL_0028:  ret
 }
 ";

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -414,6 +414,9 @@ namespace ConsoleApplication1
     <method containingType=""ConsoleApplication1.Program"" name=""GetNextInt"" parameterNames=""random"">
       <customDebugInfo>
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" document=""0"" />
@@ -574,6 +577,139 @@ class TestCase
     </method>
   </methods>
 </symbols>");
+        }
+
+        [Fact]
+        public void TestAsyncDebug4()
+        {
+            var text = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static async Task<int> F()
+    {
+        await Task.Delay(1);
+        return 1;
+    }
+}";
+            var v = CompileAndVerify(CreateCompilationWithMscorlib45(text, options: TestOptions.DebugDll));
+
+            v.VerifyIL("C.F", @"
+{
+  // Code size       52 (0x34)
+  .maxstack  2
+  .locals init (C.<F>d__0 V_0,
+                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> V_1)
+  IL_0000:  newobj     ""C.<F>d__0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Create()""
+  IL_000c:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.m1
+  IL_0013:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0018:  ldloc.0
+  IL_0019:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_001e:  stloc.1
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<C.<F>d__0>(ref C.<F>d__0)""
+  IL_0028:  ldloc.0
+  IL_0029:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_002e:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
+  IL_0033:  ret
+}",
+sequencePoints: "C.F");
+
+            v.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+{
+  // Code size      168 (0xa8)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                System.Runtime.CompilerServices.TaskAwaiter V_2,
+                C.<F>d__0 V_3,
+                System.Exception V_4)
+ ~IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+   ~IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0048
+   -IL_000e:  nop
+   -IL_000f:  ldc.i4.1
+    IL_0010:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
+    IL_0015:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_001a:  stloc.2
+   ~IL_001b:  ldloca.s   V_2
+    IL_001d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0022:  brtrue.s   IL_0064
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.0
+    IL_0028:  stfld      ""int C.<F>d__0.<>1__state""
+   <IL_002d:  ldarg.0
+    IL_002e:  ldloc.2
+    IL_002f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0034:  ldarg.0
+    IL_0035:  stloc.3
+    IL_0036:  ldarg.0
+    IL_0037:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_003c:  ldloca.s   V_2
+    IL_003e:  ldloca.s   V_3
+    IL_0040:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
+    IL_0045:  nop
+    IL_0046:  leave.s    IL_00a7
+   >IL_0048:  ldarg.0
+    IL_0049:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_004e:  stloc.2
+    IL_004f:  ldarg.0
+    IL_0050:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0055:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_005b:  ldarg.0
+    IL_005c:  ldc.i4.m1
+    IL_005d:  dup
+    IL_005e:  stloc.0
+    IL_005f:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0064:  ldloca.s   V_2
+    IL_0066:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_006b:  nop
+    IL_006c:  ldloca.s   V_2
+    IL_006e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+   -IL_0074:  ldc.i4.1
+    IL_0075:  stloc.1
+    IL_0076:  leave.s    IL_0092
+  }
+  catch System.Exception
+  {
+   ~IL_0078:  stloc.s    V_4
+    IL_007a:  ldarg.0
+    IL_007b:  ldc.i4.s   -2
+    IL_007d:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0082:  ldarg.0
+    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0088:  ldloc.s    V_4
+    IL_008a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_008f:  nop
+    IL_0090:  leave.s    IL_00a7
+  }
+ -IL_0092:  ldarg.0
+  IL_0093:  ldc.i4.s   -2
+  IL_0095:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_009a:  ldarg.0
+  IL_009b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00a0:  ldloc.1
+  IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00a6:  nop
+  IL_00a7:  ret
+}
+", sequencePoints: "C+<F>d__0.MoveNext");
         }
 
         [WorkItem(836491, "DevDiv")]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -164,34 +164,33 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x22"" endOffset=""0x6a"" />
+          <slot startOffset=""0x20"" endOffset=""0x66"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""1"" offset=""37"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x22"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x29"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" document=""0"" />
-        <entry offset=""0x45"" hidden=""true"" document=""0"" />
-        <entry offset=""0x4c"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x4d"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""0"" />
-        <entry offset=""0x5d"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" document=""0"" />
-        <entry offset=""0x68"" hidden=""true"" document=""0"" />
-        <entry offset=""0x6b"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x27"" hidden=""true"" document=""0"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" document=""0"" />
+        <entry offset=""0x41"" hidden=""true"" document=""0"" />
+        <entry offset=""0x48"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x49"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""0"" />
+        <entry offset=""0x59"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x64"" hidden=""true"" document=""0"" />
+        <entry offset=""0x67"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x6f"">
+      <scope startOffset=""0x0"" endOffset=""0x69"">
         <namespace name=""System.Collections.Generic"" />
-        <scope startOffset=""0x21"" endOffset=""0x6f"">
+        <scope startOffset=""0x1f"" endOffset=""0x69"">
           <constant name=""x"" value=""1"" type=""Int32"" />
-          <scope startOffset=""0x2b"" endOffset=""0x4d"">
+          <scope startOffset=""0x29"" endOffset=""0x49"">
             <constant name=""y"" value=""2"" type=""Int32"" />
           </scope>
         </scope>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
@@ -505,7 +505,7 @@ class Test
         </dynamicLocals>
         <encLocalSlotMap>
           <slot kind=""0"" offset=""23"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -602,7 +602,7 @@ class Test
         </dynamicLocals>
         <encLocalSlotMap>
           <slot kind=""0"" offset=""19"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -667,7 +667,7 @@ class Test
         </dynamicLocals>
         <encLocalSlotMap>
           <slot kind=""0"" offset=""23"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -849,7 +849,7 @@ struct Test
         </dynamicLocals>
         <encLocalSlotMap>
           <slot kind=""0"" offset=""23"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -888,7 +888,7 @@ struct Test
         </dynamicLocals>
         <encLocalSlotMap>
           <slot kind=""0"" offset=""19"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -1003,6 +1003,9 @@ class Test
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__2_2"" parameterNames=""d6"">
       <customDebugInfo>
         <forward declaringType=""Test"" methodName=""Main"" parameterNames=""args"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""125"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""11"" startColumn=""35"" endLine=""11"" endColumn=""36"" document=""0"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -51,13 +51,12 @@ class Program
         <forward declaringType=""Program"" methodName=""F"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x19"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -105,13 +104,12 @@ class Program
         <forward declaringType=""Program"" methodName=""F"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x19"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -136,12 +134,24 @@ class Program
 
             var v = CompileAndVerify(text, options: TestOptions.DebugDll);
 
+            v.VerifyIL("Program.Foo", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  3
+  IL_0000:  ldc.i4.s   -2
+  IL_0002:  newobj     ""Program.<Foo>d__0..ctor(int)""
+  IL_0007:  dup
+  IL_0008:  ldarg.0
+  IL_0009:  stfld      ""Program Program.<Foo>d__0.<>4__this""
+  IL_000e:  ret
+}
+", sequencePoints: "Program.Foo");
+
             v.VerifyIL("Program.<Foo>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       63 (0x3f)
+  // Code size       57 (0x39)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Foo>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -152,68 +162,47 @@ class Program
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0034
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0030
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int Program.<Foo>d__0.<>1__state""
- -IL_0021:  nop
- -IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  stfld      ""int Program.<Foo>d__0.<>2__current""
-  IL_0029:  ldarg.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  stfld      ""int Program.<Foo>d__0.<>1__state""
-  IL_0030:  ldc.i4.1
-  IL_0031:  stloc.1
-  IL_0032:  br.s       IL_0018
- ~IL_0034:  ldarg.0
-  IL_0035:  ldc.i4.m1
-  IL_0036:  stfld      ""int Program.<Foo>d__0.<>1__state""
- -IL_003b:  ldc.i4.0
-  IL_003c:  stloc.1
-  IL_003d:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int Program.<Foo>d__0.<>1__state""
+ -IL_001f:  nop
+ -IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  stfld      ""int Program.<Foo>d__0.<>2__current""
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  stfld      ""int Program.<Foo>d__0.<>1__state""
+  IL_002e:  ldc.i4.1
+  IL_002f:  ret
+ ~IL_0030:  ldarg.0
+  IL_0031:  ldc.i4.m1
+  IL_0032:  stfld      ""int Program.<Foo>d__0.<>1__state""
+ -IL_0037:  ldc.i4.0
+  IL_0038:  ret
 }
 ", 
                 sequencePoints: "Program+<Foo>d__0.MoveNext");
 
-            v.VerifyPdb(@"
+            v.VerifyPdb("Program+<Foo>d__0.MoveNext", @"
 <symbols>
   <methods>
-    <method containingType=""Program"" name=""Foo"">
-      <customDebugInfo>
-        <forwardIterator name=""&lt;Foo&gt;d__0"" />
-      </customDebugInfo>
-    </method>
-    <method containingType=""Program"" name=""F"">
-      <customDebugInfo>
-        <using>
-          <namespace usingCount=""0"" />
-        </using>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""22"" document=""0"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""23"" endLine=""9"" endColumn=""24"" document=""0"" />
-      </sequencePoints>
-    </method>
     <method containingType=""Program+&lt;Foo&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""Program"" methodName=""F"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x22"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x34"" hidden=""true"" document=""0"" />
-        <entry offset=""0x3b"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x20"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x30"" hidden=""true"" document=""0"" />
+        <entry offset=""0x37"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -338,30 +327,29 @@ class Program
       <customDebugInfo>
         <forward declaringType=""Program"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x3b"" endOffset=""0xd7"" />
-          <slot startOffset=""0x84"" endOffset=""0xd0"" />
+          <slot startOffset=""0x39"" endOffset=""0xc5"" />
+          <slot startOffset=""0x7e"" endOffset=""0xc3"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x3b"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x3c"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""0"" />
-        <entry offset=""0x48"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x5f"" hidden=""true"" document=""0"" />
-        <entry offset=""0x66"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x7d"" hidden=""true"" document=""0"" />
-        <entry offset=""0x84"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x85"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x91"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""0"" />
-        <entry offset=""0xa8"" hidden=""true"" document=""0"" />
-        <entry offset=""0xaf"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""0"" />
-        <entry offset=""0xc9"" hidden=""true"" document=""0"" />
-        <entry offset=""0xd0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
-        <entry offset=""0xd1"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x39"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x3a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""0"" />
+        <entry offset=""0x46"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""0"" />
+        <entry offset=""0x62"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x77"" hidden=""true"" document=""0"" />
+        <entry offset=""0x7e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x7f"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x8b"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""0"" />
+        <entry offset=""0xa0"" hidden=""true"" document=""0"" />
+        <entry offset=""0xa7"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""0"" />
+        <entry offset=""0xbc"" hidden=""true"" document=""0"" />
+        <entry offset=""0xc3"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""0"" />
+        <entry offset=""0xc4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -432,7 +420,6 @@ class Test<T>
         <encLocalSlotMap>
           <slot kind=""temp"" />
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -613,6 +600,9 @@ public class Test
         <using>
           <namespace usingCount=""3"" />
         </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""0"" />
@@ -684,7 +674,6 @@ public class Test
         <encLocalSlotMap>
           <slot kind=""temp"" />
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -717,17 +706,16 @@ public class Test
         <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""0"" />
-        <entry offset=""0x44"" hidden=""true"" document=""0"" />
-        <entry offset=""0x4b"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""0"" />
-        <entry offset=""0x62"" hidden=""true"" document=""0"" />
-        <entry offset=""0x69"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x40"" hidden=""true"" document=""0"" />
+        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""0"" />
+        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""0"" />
       </sequencePoints>
     </method>
     <method containingType=""Test`1+&lt;IterMethod&gt;d__4"" name=""MoveNext"">
@@ -735,17 +723,16 @@ public class Test
         <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" document=""0"" />
-        <entry offset=""0x44"" hidden=""true"" document=""0"" />
-        <entry offset=""0x4b"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x62"" hidden=""true"" document=""0"" />
-        <entry offset=""0x69"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" document=""0"" />
+        <entry offset=""0x40"" hidden=""true"" document=""0"" />
+        <entry offset=""0x47"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""0"" />
+        <entry offset=""0x63"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -791,26 +778,25 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x2c"" endOffset=""0x8a"" />
-          <slot startOffset=""0x2c"" endOffset=""0x8a"" />
+          <slot startOffset=""0x2a"" endOffset=""0x82"" />
+          <slot startOffset=""0x2a"" endOffset=""0x82"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x2d"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""0"" />
-        <entry offset=""0x34"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""0"" />
-        <entry offset=""0x40"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x57"" hidden=""true"" document=""0"" />
-        <entry offset=""0x5e"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" document=""0"" />
-        <entry offset=""0x80"" hidden=""true"" document=""0"" />
-        <entry offset=""0x87"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""0"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""0"" />
+        <entry offset=""0x3e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x53"" hidden=""true"" document=""0"" />
+        <entry offset=""0x5a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" document=""0"" />
+        <entry offset=""0x7a"" hidden=""true"" document=""0"" />
+        <entry offset=""0x81"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x8b"">
+      <scope startOffset=""0x0"" endOffset=""0x83"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -850,12 +836,11 @@ class C
 
             v.VerifyIL("C.<F>d__1.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       74 (0x4a)
+  // Code size       68 (0x44)
   .maxstack  2
   .locals init (int V_0,
-                bool V_1,
-                bool V_2)
-  IL_0000:  ldarg.0
+                bool V_1)
+ ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__1.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
@@ -865,39 +850,35 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_003e
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003a
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_0021:  nop
-  IL_0022:  call       ""bool C.B()""
-  IL_0027:  stloc.2
-  IL_0028:  ldloc.2
-  IL_0029:  brfalse.s  IL_0046
-  IL_002b:  nop
-  IL_002c:  ldarg.0
-  IL_002d:  ldc.i4.1
-  IL_002e:  stfld      ""int C.<F>d__1.<>2__current""
-  IL_0033:  ldarg.0
-  IL_0034:  ldc.i4.1
-  IL_0035:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_003a:  ldc.i4.1
-  IL_003b:  stloc.1
-  IL_003c:  br.s       IL_0018
-  IL_003e:  ldarg.0
-  IL_003f:  ldc.i4.m1
-  IL_0040:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_0045:  nop
-  IL_0046:  ldc.i4.0
-  IL_0047:  stloc.1
-  IL_0048:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__1.<>1__state""
+ -IL_001f:  nop
+ -IL_0020:  call       ""bool C.B()""
+  IL_0025:  stloc.1
+ ~IL_0026:  ldloc.1
+  IL_0027:  brfalse.s  IL_0042
+ -IL_0029:  nop
+ -IL_002a:  ldarg.0
+  IL_002b:  ldc.i4.1
+  IL_002c:  stfld      ""int C.<F>d__1.<>2__current""
+  IL_0031:  ldarg.0
+  IL_0032:  ldc.i4.1
+  IL_0033:  stfld      ""int C.<F>d__1.<>1__state""
+  IL_0038:  ldc.i4.1
+  IL_0039:  ret
+ ~IL_003a:  ldarg.0
+  IL_003b:  ldc.i4.m1
+  IL_003c:  stfld      ""int C.<F>d__1.<>1__state""
+ -IL_0041:  nop
+ -IL_0042:  ldc.i4.0
+  IL_0043:  ret
 }
-");
+", sequencePoints: "C+<F>d__1.MoveNext");
 
             v.VerifyPdb("C+<F>d__1.MoveNext", @"
 <symbols>
@@ -909,22 +890,21 @@ class C
         </using>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
           <slot kind=""1"" offset=""11"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x22"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" document=""0"" />
-        <entry offset=""0x28"" hidden=""true"" document=""0"" />
-        <entry offset=""0x2b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""0"" />
-        <entry offset=""0x3e"" hidden=""true"" document=""0"" />
-        <entry offset=""0x45"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
-        <entry offset=""0x46"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" document=""0"" />
+        <entry offset=""0x26"" hidden=""true"" document=""0"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""0"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""0"" />
+        <entry offset=""0x41"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x42"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x4a"">
+      <scope startOffset=""0x0"" endOffset=""0x44"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -1075,25 +1055,24 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x32"" endOffset=""0xfa"" />
+          <slot startOffset=""0x30"" endOffset=""0xe9"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x32"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x3d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x49"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x55"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x61"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x78"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""0"" />
-        <entry offset=""0xaf"" hidden=""true"" document=""0"" />
-        <entry offset=""0xb6"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""0"" />
-        <entry offset=""0xed"" hidden=""true"" document=""0"" />
-        <entry offset=""0xf4"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x30"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x3b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x47"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x53"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x5f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x76"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""0"" />
+        <entry offset=""0xa8"" hidden=""true"" document=""0"" />
+        <entry offset=""0xaf"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""0"" />
+        <entry offset=""0xe1"" hidden=""true"" document=""0"" />
+        <entry offset=""0xe8"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1267,10 +1246,9 @@ class C
 
             v.VerifyIL("C.<M>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      132 (0x84)
+  // Code size      126 (0x7e)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1281,51 +1259,47 @@ class C
   IL_000d:  ldc.i4.1
   IL_000e:  beq.s      IL_0014
   IL_0010:  br.s       IL_0016
-  IL_0012:  br.s       IL_001a
-  IL_0014:  br.s       IL_0079
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0075
   IL_0016:  ldc.i4.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ret
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.m1
-  IL_001c:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0021:  ldarg.0
-  IL_0022:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
-  IL_0027:  stfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_002c:  ldarg.0
-  IL_002d:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0032:  ldc.i4.1
-  IL_0033:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
-  IL_0038:  ldarg.0
-  IL_0039:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_003e:  ldc.i4.1
-  IL_003f:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
-  IL_0044:  ldarg.0
-  IL_0045:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_004a:  ldc.i4.1
-  IL_004b:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
-  IL_0050:  ldarg.0
-  IL_0051:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0056:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
-  IL_005c:  newobj     ""System.Action..ctor(object, System.IntPtr)""
-  IL_0061:  callvirt   ""void System.Action.Invoke()""
-  IL_0066:  nop
-  IL_0067:  ldarg.0
-  IL_0068:  ldc.i4.1
-  IL_0069:  stfld      ""int C.<M>d__0.<>2__current""
-  IL_006e:  ldarg.0
-  IL_006f:  ldc.i4.1
-  IL_0070:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0075:  ldc.i4.1
-  IL_0076:  stloc.1
-  IL_0077:  br.s       IL_0018
-  IL_0079:  ldarg.0
-  IL_007a:  ldc.i4.m1
-  IL_007b:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0080:  ldc.i4.0
-  IL_0081:  stloc.1
-  IL_0082:  br.s       IL_0018
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_0025:  stfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_002a:  ldarg.0
+  IL_002b:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0030:  ldc.i4.1
+  IL_0031:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
+  IL_0036:  ldarg.0
+  IL_0037:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_003c:  ldc.i4.1
+  IL_003d:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
+  IL_0042:  ldarg.0
+  IL_0043:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0048:  ldc.i4.1
+  IL_0049:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
+  IL_004e:  ldarg.0
+  IL_004f:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0054:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
+  IL_005a:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_005f:  callvirt   ""void System.Action.Invoke()""
+  IL_0064:  nop
+  IL_0065:  ldarg.0
+  IL_0066:  ldc.i4.1
+  IL_0067:  stfld      ""int C.<M>d__0.<>2__current""
+  IL_006c:  ldarg.0
+  IL_006d:  ldc.i4.1
+  IL_006e:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0073:  ldc.i4.1
+  IL_0074:  ret
+  IL_0075:  ldarg.0
+  IL_0076:  ldc.i4.m1
+  IL_0077:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_007c:  ldc.i4.0
+  IL_007d:  ret
 }
 ");
 
@@ -1336,23 +1310,22 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x21"" endOffset=""0x83"" />
+          <slot startOffset=""0x1f"" endOffset=""0x7d"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x38"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x44"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
-        <entry offset=""0x50"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
-        <entry offset=""0x67"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x79"" hidden=""true"" document=""0"" />
-        <entry offset=""0x80"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x2a"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x36"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x42"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""0"" />
+        <entry offset=""0x4e"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""0"" />
+        <entry offset=""0x65"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x75"" hidden=""true"" document=""0"" />
+        <entry offset=""0x7c"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1418,21 +1391,20 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x21"" endOffset=""0xeb"" />
+          <slot startOffset=""0x1f"" endOffset=""0xe2"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x22"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x2e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x86"" hidden=""true"" document=""0"" />
-        <entry offset=""0x8d"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""0"" />
-        <entry offset=""0xe5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x82"" hidden=""true"" document=""0"" />
+        <entry offset=""0x89"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""0"" />
+        <entry offset=""0xe1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1550,20 +1522,19 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x21"" endOffset=""0x90"" />
+          <slot startOffset=""0x1f"" endOffset=""0x8a"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x21"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x22"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
-        <entry offset=""0x2e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
-        <entry offset=""0x86"" hidden=""true"" document=""0"" />
-        <entry offset=""0x8d"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""0"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x82"" hidden=""true"" document=""0"" />
+        <entry offset=""0x89"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1601,13 +1572,12 @@ class C
         <forward declaringType=""C"" methodName=""Main"" parameterNames=""args"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""0"" />
-        <entry offset=""0x19"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
-        <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""0"" />
+        <entry offset=""0x17"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x18"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -107,7 +107,7 @@ class Test
         </using>
         <encLocalSlotMap>
           <slot kind=""1"" offset=""12"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -128,7 +128,7 @@ class Test
         <encLocalSlotMap>
           <slot kind=""30"" offset=""0"" />
           <slot kind=""0"" offset=""26"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
         <encLambdaMap>
           <methodOrdinal>1</methodOrdinal>
@@ -155,7 +155,7 @@ class Test
         <encLocalSlotMap>
           <slot kind=""30"" offset=""56"" />
           <slot kind=""0"" offset=""110"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""56"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -173,6 +173,9 @@ class Test
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_1"" name=""&lt;M&gt;b__1"" parameterNames=""y"">
       <customDebugInfo>
         <forward declaringType=""Test"" methodName=""Main"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""136"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""14"" document=""0"" />
@@ -278,7 +281,7 @@ class Test
         </using>
         <encLocalSlotMap>
           <slot kind=""1"" offset=""11"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -299,7 +302,7 @@ class Test
         <encLocalSlotMap>
           <slot kind=""30"" offset=""0"" />
           <slot kind=""0"" offset=""26"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
         <encLambdaMap>
           <methodOrdinal>1</methodOrdinal>
@@ -326,7 +329,7 @@ class Test
         <encLocalSlotMap>
           <slot kind=""30"" offset=""56"" />
           <slot kind=""0"" offset=""110"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""56"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -344,6 +347,9 @@ class Test
     <method containingType=""Test+&lt;&gt;c__DisplayClass1_1"" name=""&lt;M&gt;b__1"" parameterNames=""y"">
       <customDebugInfo>
         <forward declaringType=""Test"" methodName=""Main"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""122"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""17"" startColumn=""40"" endLine=""17"" endColumn=""41"" document=""0"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -291,7 +291,7 @@ class C
         <encLocalSlotMap>
           <slot kind=""0"" offset=""-118"" />
           <slot kind=""0"" offset=""-54"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""-147"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -319,14 +319,13 @@ class C
         <forward declaringType=""C"" methodName="".cctor"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""-45"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x1e"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x1a"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1a"" attributes=""0"" />
       </scope>
     </method>
   </methods>
@@ -458,6 +457,241 @@ class C2
         <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""51"" document=""0"" />
         <entry offset=""0x2a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""39"" document=""0"" />
       </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+
+        #endregion
+
+        #region ReturnStatement
+
+        [Fact]
+        public void Return_Method1()
+        {
+            var source = @"
+class Program
+{
+    static int Main()
+    {
+        return 1;
+    }
+}
+";
+
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            // In order to place a breakpoint on the closing brace we need to save the return expression value to 
+            // a local and then load it again (since sequence point needs an empty stack). This variable has to be marked as long-lived.
+            v.VerifyIL("Program.Main", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0)
+ -IL_0000:  nop
+ -IL_0001:  ldc.i4.1
+  IL_0002:  stloc.0
+  IL_0003:  br.s       IL_0005
+ -IL_0005:  ldloc.0
+  IL_0006:  ret
+}", sequencePoints: "Program.Main");
+
+            v.VerifyPdb("Program.Main", @"
+<symbols>
+  <methods>
+    <method containingType=""Program"" name=""Main"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""18"" document=""0"" />
+        <entry offset=""0x5"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+
+        [Fact]
+        public void Return_Property1()
+        {
+            var source = @"
+class C
+{
+    static int P
+    {
+        get { return 1; }
+    }
+}
+";
+
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            // In order to place a breakpoint on the closing brace we need to save the return expression value to 
+            // a local and then load it again (since sequence point needs an empty stack). This variable has to be marked as long-lived.
+            v.VerifyIL("C.P.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0)
+ -IL_0000:  nop
+ -IL_0001:  ldc.i4.1
+  IL_0002:  stloc.0
+  IL_0003:  br.s       IL_0005
+ -IL_0005:  ldloc.0
+  IL_0006:  ret
+}", sequencePoints: "C.get_P");
+
+            v.VerifyPdb("C.get_P", @"
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""get_P"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""14"" document=""0"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""15"" endLine=""6"" endColumn=""24"" document=""0"" />
+        <entry offset=""0x5"" startLine=""6"" startColumn=""25"" endLine=""6"" endColumn=""26"" document=""0"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+
+        [Fact]
+        public void Return_Void1()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        return;
+    }
+}
+";
+
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            v.VerifyIL("Program.Main", @"
+{
+  // Code size        4 (0x4)
+  .maxstack  0
+ -IL_0000:  nop
+ -IL_0001:  br.s       IL_0003
+ -IL_0003:  ret
+}", sequencePoints: "Program.Main");
+        }
+
+        [Fact]
+        public void Return_ExpressionBodied1()
+        {
+            var source = @"
+class Program
+{
+    static int Main() => 1;
+}
+";
+
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            v.VerifyIL("Program.Main", @"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+ -IL_0000:  ldc.i4.1
+  IL_0001:  ret
+}", sequencePoints: "Program.Main");
+        }
+
+        [Fact]
+        public void Return_FromExceptionHandler1()
+        {
+            var source = @"
+using System;
+
+class Program
+{
+    static int Main() 
+    {
+        try
+        {
+            Console.WriteLine();
+            return 1;
+        }
+        catch (Exception)
+        {
+            return 2;
+        }
+    }
+}
+";
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            v.VerifyIL("Program.Main", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (int V_0)
+ -IL_0000:  nop
+  .try
+  {
+   -IL_0001:  nop
+   -IL_0002:  call       ""void System.Console.WriteLine()""
+    IL_0007:  nop
+   -IL_0008:  ldc.i4.1
+    IL_0009:  stloc.0
+    IL_000a:  leave.s    IL_0012
+  }
+  catch System.Exception
+  {
+   -IL_000c:  pop
+   -IL_000d:  nop
+   -IL_000e:  ldc.i4.2
+    IL_000f:  stloc.0
+    IL_0010:  leave.s    IL_0012
+  }
+ -IL_0012:  ldloc.0
+  IL_0013:  ret
+}", sequencePoints: "Program.Main");
+
+            v.VerifyPdb("Program.Main", @"
+<symbols>
+  <methods>
+    <method containingType=""Program"" name=""Main"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""1"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""0"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""0"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""33"" document=""0"" />
+        <entry offset=""0x8"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""22"" document=""0"" />
+        <entry offset=""0xc"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""26"" document=""0"" />
+        <entry offset=""0xd"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""0"" />
+        <entry offset=""0xe"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""22"" document=""0"" />
+        <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""0"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x14"">
+        <namespace name=""System"" />
+      </scope>
     </method>
   </methods>
 </symbols>");
@@ -1517,7 +1751,7 @@ public class SeqPointForWhile
           <slot kind=""0"" offset=""29"" />
           <slot kind=""0"" offset=""56"" />
           <slot kind=""0"" offset=""126"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -2122,7 +2356,7 @@ public class SeqPointAfterReturn
           <slot kind=""1"" offset=""138"" />
           <slot kind=""1"" offset=""238"" />
           <slot kind=""1"" offset=""330"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -2184,7 +2418,7 @@ public class SeqPointAfterReturn
         <encLocalSlotMap>
           <slot kind=""0"" offset=""15"" />
           <slot kind=""1"" offset=""42"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -2257,7 +2491,7 @@ class Test
         <encLocalSlotMap>
           <slot kind=""0"" offset=""15"" />
           <slot kind=""0"" offset=""147"" />
-          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -1454,6 +1454,9 @@ class C
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__2_0"" parameterNames=""x"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".ctor"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""-23"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""6"" startColumn=""35"" endLine=""6"" endColumn=""36"" document=""0"" />
@@ -1464,6 +1467,9 @@ class C
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__3_0"" parameterNames=""x"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".ctor"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""-38"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""0"" />
@@ -1509,6 +1515,9 @@ class C
         <using>
           <namespace usingCount=""1"" />
         </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""18"" endLine=""7"" endColumn=""19"" document=""0"" />
@@ -1549,6 +1558,9 @@ class C
     <method containingType=""C"" name=""get_Item"" parameterNames=""x"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""get_P2"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""28"" document=""0"" />
@@ -1649,6 +1661,9 @@ class C : I1, I2
         <using>
           <namespace usingCount=""1"" />
         </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""18"" startColumn=""34"" endLine=""18"" endColumn=""35"" document=""0"" />

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -128,7 +128,8 @@ namespace Microsoft.CodeAnalysis
         StateMachineReturnValue = AsyncMethodReturnValue, // TODO VB: why do we need this in iterators?
 
         /// <summary>
-        /// Stores the return value of a VB function that is not accessible from user code (e.g. operator, lambda, async, iterator).
+        /// VB: Stores the return value of a function that is not accessible from user code (e.g. operator, lambda, async, iterator).
+        /// C#: Stores the return value of a method/lambda with a block body, so that we can put a sequence point on the closing brace of the body.
         /// </summary>
         FunctionReturnValue = 21,
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -4628,8 +4628,7 @@ struct S
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.x""
   IL_0006:  ret
@@ -4667,12 +4666,11 @@ struct S
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""T C<T>.<F>d__0.<t>5__1""
   IL_0006:  ret
-            }
+}
 ");
         }
 
@@ -5342,7 +5340,6 @@ class C
 @"{
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
@@ -5379,7 +5376,6 @@ class C
 @"{
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
@@ -5488,8 +5484,7 @@ class C
 {
   // Code size       11 (0xb)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldtoken    ""T""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ret

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -98,8 +98,7 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                int V_2)
+                int V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__0.{0}""
   IL_0006:  ret

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -35,8 +35,7 @@ class C
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<F>d__0.<>4__this""
   IL_0006:  ret
@@ -137,8 +136,7 @@ class C
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<F>d__0.<>4__this""
   IL_0006:  ret
@@ -248,8 +246,7 @@ class C<T>
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C<T> C<T>.<F>d__0<U>.<>4__this""
   IL_0006:  ret
@@ -337,8 +334,7 @@ class C : I
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<I-F>d__0.<>4__this""
   IL_0006:  ret
@@ -436,8 +432,7 @@ class C : I<int>
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<I<System-Int32>-F>d__0.<>4__this""
   IL_0006:  ret
@@ -866,7 +861,6 @@ class C
 {{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.{0}.<>4__this""
   IL_0006:  ret
@@ -1052,8 +1046,7 @@ class C
 {
   // Code size       12 (0xc)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<F>d__1.<>4__this""
   IL_0006:  ldfld      ""object C.x""
@@ -1165,8 +1158,7 @@ class Derived : Base
 {
   // Code size       12 (0xc)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""Derived Derived.<M>d__1.<>4__this""
   IL_0006:  ldfld      ""int Base.x""

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1297,8 +1297,7 @@ class C
 @"{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<F>d__2.<>4__this""
   IL_0006:  ret
@@ -1307,8 +1306,7 @@ class C
 @"{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<F>d__2.<o>5__3""
   IL_0006:  ret
@@ -1352,9 +1350,8 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                int V_2,
-                bool V_3)
+                int V_1,
+                bool V_2)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""T[] C.<F>d__0<T>.o""
   IL_0006:  ret
@@ -1364,9 +1361,8 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                int V_2,
-                bool V_3)
+                int V_1,
+                bool V_2)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0<T>.<i>5__1""
   IL_0006:  ret
@@ -1376,9 +1372,8 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                int V_2,
-                bool V_3)
+                int V_1,
+                bool V_2)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""T C.<F>d__0<T>.<t>5__2""
   IL_0006:  ret
@@ -2029,8 +2024,7 @@ static class C
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.x""
   IL_0006:  ret
@@ -2106,8 +2100,7 @@ class C
 {{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""{0} C.{1}.{2}""
   IL_0006:  ret
@@ -2116,22 +2109,22 @@ class C
             // M1(int, int)
             displayClassName = "<M1>d__0";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
             locals.Clear();
 
             // M1(int, float)
             displayClassName = "<M1>d__1";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "float", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
             locals.Clear();
 
             // M2(int, float)
             displayClassName = "<M2>d__2";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "float", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
             locals.Clear();
 
             // M2(int, T)
@@ -2139,15 +2132,15 @@ class C
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
             typeName += "<T>";
             displayClassName += "<T>";
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "T", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "T", displayClassName, "y"));
             locals.Clear();
 
             // M2(int, int)
             displayClassName = "<M2>d__4";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "int", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
             locals.Clear();
 
             locals.Free();
@@ -2207,33 +2200,33 @@ class C
             // M1(int)
             displayClassName = "<M1>d__0";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
             locals.Clear();
 
             // M1(int, float)
             displayClassName = "<M1>d__1";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "float", "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "float", "float", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
             locals.Clear();
 
             // M2(int, float)
             displayClassName = "<M2>d__2";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "float", "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(ilTemplate, "float", "float", displayClassName, "y"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
             locals.Clear();
 
             // M2(T)
             displayClassName = "<M2>d__3";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "T", "T", displayClassName + "<T>", "x"));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "T", "T", displayClassName + "<T>", "x"));
             locals.Clear();
 
             // M2(int)
             displayClassName = "<M2>d__4";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(ilTemplate, "int", "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
             locals.Clear();
 
             locals.Free();
@@ -2275,39 +2268,38 @@ class C
 {{
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init ({0} V_0)
-  IL_0000:  ldarg.{1}
+  IL_0000:  ldarg.{0}
   IL_0001:  ret
 }}";
 
             // y => x.ToString()
             displayClassName = "<>c__DisplayClass0_0";
             GetLocals(runtime, "C." + displayClassName + ".<M1>b__0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "y", expectedILOpt: String.Format(voidRetILTemplate, 1));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
             locals.Clear();
 
             // z => x
             displayClassName = "<>c__DisplayClass0_0";
             GetLocals(runtime, "C." + displayClassName + ".<M1>b__1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: String.Format(funcILTemplate, "int", 1));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
             locals.Clear();
 
             // y => y.ToString()
             displayClassName = "<>c__1";
             GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "y", expectedILOpt: String.Format(voidRetILTemplate, 1));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
             locals.Clear();
 
             // z => z
             displayClassName = "<>c__1";
             GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "z", expectedILOpt: String.Format(funcILTemplate, "int", 1));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
             locals.Clear();
 
             // t => t
             displayClassName = "<>c__1";
             GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_2", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "t", expectedILOpt: String.Format(funcILTemplate, "T", 1));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "t", expectedILOpt: string.Format(funcILTemplate, 1));
             locals.Clear();
 
             locals.Free();
@@ -2378,32 +2370,32 @@ class C
 
             // M1(int, int)
             GetLocals(runtime, "C.M1(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(voidRetILTemplate, "int", 1));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(voidRetILTemplate, "int", 2));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "int", 1));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "int", 2));
             locals.Clear();
 
             // M1(int, string)
             GetLocals(runtime, "C.M1(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(funcILTemplate, "string", 1));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(funcILTemplate, "string", 2));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "string", 1));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(funcILTemplate, "string", 2));
             locals.Clear();
 
             // M2(int, string)
             GetLocals(runtime, "C.M2(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(voidRetILTemplate, "string", 0));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(voidRetILTemplate, "string", 1));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "string", 0));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "string", 1));
             locals.Clear();
 
             // M2(int, T)
             GetLocals(runtime, "C.M2(Int32,T)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt: String.Format(funcILTemplate, "T", 0), expectedGeneric: true);
-            VerifyLocal(testData, typeName, locals[1], "<>m1<T>", "y", expectedILOpt: String.Format(funcILTemplate, "T", 1), expectedGeneric: true);
+            VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt: string.Format(funcILTemplate, "T", 0), expectedGeneric: true);
+            VerifyLocal(testData, typeName, locals[1], "<>m1<T>", "y", expectedILOpt: string.Format(funcILTemplate, "T", 1), expectedGeneric: true);
             locals.Clear();
 
             // M2(int, int)
             GetLocals(runtime, "C.M2(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: String.Format(funcILTemplate, "int", 0));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: String.Format(refParamILTemplate, "int", 1));
+            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "int", 0));
+            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(refParamILTemplate, "int", 1));
             locals.Clear();
 
             locals.Free();
@@ -2464,8 +2456,7 @@ class C<T>
 {{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init ({0} V_0,
-                bool V_1)
+  .locals init ({0} V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""{0} C<T>.{1}.{2}""
   IL_0006:  ret
@@ -2490,13 +2481,13 @@ class C<T>
             // M1(int)
             displayClassName = "<M1>d__1";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: String.Format(iteratorILTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
             locals.Clear();
 
             // M2(int)
             displayClassName = "<M2>d__2";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: String.Format(iteratorILTemplate, "int", displayClassName, "x"));
+            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
             locals.Clear();
 
             // M2()
@@ -2512,13 +2503,13 @@ class C<T>
             // M3(int)
             displayClassName = "<M3>d__5";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: String.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
+            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
             locals.Clear();
 
             // M4(int)
             displayClassName = "<M4>d__6";
             GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: String.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
+            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
             locals.Clear();
 
             // M4()
@@ -2632,8 +2623,7 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                System.Exception V_2)
+                System.Exception V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.<o>5__1""
   IL_0006:  ret
@@ -2643,8 +2633,7 @@ class C
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
-                bool V_1,
-                System.Exception V_2)
+                System.Exception V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""System.Exception C.<M>d__1.<e>5__2""
   IL_0006:  ret
@@ -2786,7 +2775,6 @@ class C
 {
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldfld      ""int <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<z>i__Field""
   IL_0006:  ret
@@ -2796,7 +2784,6 @@ class C
 {
   // Code size       12 (0xc)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldfld      ""<>f__AnonymousType0<string, string> <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<<>h__TransparentIdentifier0>i__Field""
   IL_0006:  ldfld      ""string <>f__AnonymousType0<string, string>.<x>i__Field""
@@ -2807,7 +2794,6 @@ class C
 {
   // Code size       12 (0xc)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldfld      ""<>f__AnonymousType0<string, string> <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<<>h__TransparentIdentifier0>i__Field""
   IL_0006:  ldfld      ""string <>f__AnonymousType0<string, string>.<y>i__Field""
@@ -2874,7 +2860,6 @@ class C
 {
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.1
   IL_0001:  ret
 }
@@ -2883,7 +2868,6 @@ class C
 {
   // Code size       12 (0xc)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""<>f__AnonymousType1<<>f__AnonymousType0<string, string>, int> C.<>c__DisplayClass0_0.<>h__TransparentIdentifier1""
   IL_0006:  ldfld      ""int <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<z>i__Field""
@@ -2894,7 +2878,6 @@ class C
 {
   // Code size       17 (0x11)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""<>f__AnonymousType1<<>f__AnonymousType0<string, string>, int> C.<>c__DisplayClass0_0.<>h__TransparentIdentifier1""
   IL_0006:  ldfld      ""<>f__AnonymousType0<string, string> <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<<>h__TransparentIdentifier0>i__Field""
@@ -2906,7 +2889,6 @@ class C
 {
   // Code size       17 (0x11)
   .maxstack  1
-  .locals init (string V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""<>f__AnonymousType1<<>f__AnonymousType0<string, string>, int> C.<>c__DisplayClass0_0.<>h__TransparentIdentifier1""
   IL_0006:  ldfld      ""<>f__AnonymousType0<string, string> <>f__AnonymousType1<<>f__AnonymousType0<string, string>, int>.<<>h__TransparentIdentifier0>i__Field""


### PR DESCRIPTION
The compiler emits a sequence point at the closing brace of a method body block so that the user can place a breakpoint there. In order to do that the return value expression needs to be stored into a variable so that the evaluation stack is empty at the sequence point. This return value variable lifespan crosses sequence points (obviously) hence the variable needs to be tracked as long-lived synthesized local.

Fixes internal bug 1120348: [EnC] Method returns null if return statement is modified after execution


<!---
@huboard:{"order":2696.0,"milestone_order":2713,"custom_state":""}
-->
