### PR TITLE
Add support for explicit interface members in DocumentCommentId

### DIFF
--- a/src/Diagnostics/FxCop/Test/Design/CodeFixes/CA1033FixerTests.cs
+++ b/src/Diagnostics/FxCop/Test/Design/CodeFixes/CA1033FixerTests.cs
@@ -196,8 +196,8 @@ public class ImplementsGeneral  : IGeneral
             VerifyCSharpFix(code, expectedFixedCode);
         }
 
-        [WorkItem(2650, "https://github.com/dotnet/roslyn/issues/2650")]
-        [Fact(Skip = "2650"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [WorkItem(2616, "https://github.com/dotnet/roslyn/issues/2616")]
+        [Fact(Skip ="2616"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public void CA1033SimpleDiagnosticCasesCSharp_Indexer()
         {
             var code = @"

--- a/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
@@ -1025,19 +1025,19 @@ public class C  : I
 
             var solution = GetSolution(code);
             var typeC = (INamedTypeSymbol)GetSymbols(solution, "C").First();
-            var method = typeC.GetMembers().First(m => m.Kind == SymbolKind.Method);
+            var property = typeC.GetMembers().First(m => m.Kind == SymbolKind.Property);
 
             var editor = SymbolEditor.Create(solution);
 
-            var newMethod = editor.EditOneDeclarationAsync(method, (e, d) =>
+            var newProperty = editor.EditOneDeclarationAsync(property, (e, d) =>
             {
                 // nothing
             });
 
             var typeI = (INamedTypeSymbol)GetSymbols(solution, "I").First();
-            var imethod = typeI.GetMembers().First(m => m.Kind == SymbolKind.Method);
+            var iproperty = typeI.GetMembers().First(m => m.Kind == SymbolKind.Property);
 
-            var newIMethod = editor.EditOneDeclarationAsync(imethod, (e, d) =>
+            var newIProperty = editor.EditOneDeclarationAsync(iproperty, (e, d) =>
             {
                 // nothing;
             });

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
@@ -28,12 +28,23 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(symbol, sym);
         }
 
-        private void CheckDeclarationId<TSymbol>(string expectedId, Compilation compilation, Func<TSymbol, bool> test)
+        private TSymbol CheckDeclarationId<TSymbol>(string expectedId, Compilation compilation, Func<TSymbol, bool> test)
             where TSymbol : ISymbol
         {
             var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId(expectedId, compilation);
             Assert.Equal(true, symbol is TSymbol);
             Assert.Equal(true, test((TSymbol)symbol));
+
+            return (TSymbol)symbol;
+        }
+
+        private void CheckDeclarationIdExact<TSymbol>(string expectedId, Compilation compilation, Func<TSymbol, bool> test)
+            where TSymbol : ISymbol
+        {
+            var symbol = CheckDeclarationId(expectedId, compilation, test);
+
+            var id = DocumentationCommentId.CreateDeclarationId(symbol);
+            Assert.Equal(expectedId, id);
         }
 
         private void CheckReferenceId(string expectedId, INamespaceOrTypeSymbol symbol, Compilation compilation)
@@ -232,9 +243,9 @@ namespace Acme
 }
 ");
 
-            CheckDeclarationId<IPropertySymbol>("P:Acme.Widget.Width", compilation, p => p.Name == "Width");
-            CheckDeclarationId<IPropertySymbol>("P:Acme.Widget.Item(System.Int32)", compilation, p => p.Parameters.Length == 1);
-            CheckDeclarationId<IPropertySymbol>("P:Acme.Widget.Item(System.String,System.Int32)", compilation, p => p.Parameters.Length == 2);
+            CheckDeclarationIdExact<IPropertySymbol>("P:Acme.Widget.Width", compilation, p => p.Name == "Width");
+            CheckDeclarationIdExact<IPropertySymbol>("P:Acme.Widget.Item(System.Int32)", compilation, p => p.Parameters.Length == 1);
+            CheckDeclarationIdExact<IPropertySymbol>("P:Acme.Widget.Item(System.String,System.Int32)", compilation, p => p.Parameters.Length == 2);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #2650 

SymbolEditor uses DocumentCommentId's to track symbols between solution versions.  DocumentCommentId did not handle generating id's for indexers correct (no parameters) and did not encode/decode C# indexer names correctly when the indexer was an explicit interface implementations (that includes the interface type as part of the name.)

@mavasani @pilchie please review