### PR TITLE
EnC: Renaming captured variables is rude

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -4847,6 +4847,72 @@ class C
                 Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", "lambda", "x0", "x1"));
         }
 
+        [Fact]
+        public void Lambdas_RenameCapturedLocal()
+        {
+            string src1 = @"
+using System;
+using System.Diagnostics;
+
+class Program
+{
+    static void Main()
+    {
+        int x = 1;
+        Func<int> f = () => x;
+    }
+}";
+            string src2 = @"
+using System;
+using System.Diagnostics;
+
+class Program
+{
+    static void Main()
+    {
+        int X = 1;
+        Func<int> f = () => X;
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.RenamingCapturedVariable, "X", "x", "X"));
+        }
+
+        [Fact]
+        public void Lambdas_RenameCapturedParameter()
+        {
+            string src1 = @"
+using System;
+using System.Diagnostics;
+
+class Program
+{
+    static void Main(int x)
+    {
+        Func<int> f = () => x;
+    }
+}";
+            string src2 = @"
+using System;
+using System.Diagnostics;
+
+class Program
+{
+    static void Main(int X)
+    {
+        Func<int> f = () => X;
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Renamed, "int X", "parameter"));
+        }
+
         #endregion
 
         #region Queries

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.ChangingCapturedVariableType,
                 RudeEditKind.AccessingCapturedVariableInLambda,
                 RudeEditKind.NotAccessingCapturedVariableInLambda,
+                RudeEditKind.RenamingCapturedVariable
             };
 
             var arg3 = new HashSet<RudeEditKind>()

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
@@ -3983,6 +3983,71 @@ End Class
                 Diagnostic(RudeEditKind.AccessingCapturedVariableInLambda, "Function(a)", "Me", VBFeaturesResources.LambdaExpression).WithFirstLine("G(Function(a) x)       ' error: disconnecting previously connected closures"),
                 Diagnostic(RudeEditKind.NotAccessingCapturedVariableInLambda, "Function(a)", "y1", VBFeaturesResources.LambdaExpression).WithFirstLine("G(Function(a) x)       ' error: disconnecting previously connected closures"))
         End Sub
+
+        <Fact>
+        Public Sub Lambdas_RenameCapturedLocal1()
+            Dim src1 = "
+Imports System
+Imports System.Diagnostics
+
+Class Program
+
+    Shared Sub Main()
+        Dim x As Integer = 1
+        Dim f As Func(Of Integer) = Function() x
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Diagnostics
+
+Class Program
+
+    Shared Sub Main()
+        Dim X As Integer = 1
+        Dim f As Func(Of Integer) = Function() X
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            ' Note that lifted variable is a field, which can't be renamed
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.RenamingCapturedVariable, "X", "x", "X"))
+        End Sub
+
+        <Fact>
+        Public Sub Lambdas_RenameCapturedLocal2()
+            Dim src1 = "
+Imports System
+Imports System.Diagnostics
+
+Class Program
+
+    Shared Sub Main()
+        Dim x As Integer = 1
+        Dim f As Func(Of Integer) = Function() x
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Diagnostics
+
+Class Program
+
+    Shared Sub Main()
+        Dim y As Integer = 1
+        Dim f As Func(Of Integer) = Function() y
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.RenamingCapturedVariable, "y", "x", "y"))
+        End Sub
 #End Region
 
 #Region "Queries"
@@ -5343,7 +5408,6 @@ End Class
                 Diagnostic(RudeEditKind.NotAccessingCapturedVariableInLambda, "Select", "a", VBFeaturesResources.SelectClause),
                 Diagnostic(RudeEditKind.NotAccessingCapturedVariableInLambda, "Function()", "a", VBFeaturesResources.LambdaExpression))
         End Sub
-
 
         <Fact>
         Public Sub Queries_Insert1()

--- a/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.GenericTypeInitializerUpdate,              FeaturesResources.ModifyingTheInitializerInGenericType) },
             { GetDescriptorPair(RudeEditKind.PartialTypeInitializerUpdate,              FeaturesResources.ModifyingTheInitializerInPartialType) },
             { GetDescriptorPair(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas,  FeaturesResources.InsertConstructorToTypeWithInitializersWithLambdas) },
+            { GetDescriptorPair(RudeEditKind.RenamingCapturedVariable,                  FeaturesResources.RenamingCapturedVariable) },
             { GetDescriptorPair(RudeEditKind.StackAllocUpdate,                          FeaturesResources.ModifyingAWhichContainsStackalloc) },
             { GetDescriptorPair(RudeEditKind.ExperimentalFeaturesEnabled,               FeaturesResources.ModifyingAFileWithExperimentalFeaturesEnabled) },
             { GetDescriptorPair(RudeEditKind.AwaitStatementUpdate,                      FeaturesResources.UpdatingAStatementContainingAwaitExpression) },

--- a/src/Features/Core/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditKind.cs
@@ -83,8 +83,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         UpdateStaticLocal = 67,
 
         InsertConstructorToTypeWithInitializersWithLambdas = 68,
-
-        // 69 can be used
+        RenamingCapturedVariable = 69,
 
         InsertHandlesClause = 70,
         InsertFile = 71,

--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -1636,6 +1636,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Renaming a captured variable, from &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing..
+        /// </summary>
+        internal static string RenamingCapturedVariable {
+            get {
+                return ResourceManager.GetString("RenamingCapturedVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Represents an object whose operations will be resolved at runtime..
         /// </summary>
         internal static string RepresentsAnObjectWhoseOperations {

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -540,6 +540,9 @@
   <data name="InsertConstructorToTypeWithInitializersWithLambdas" xml:space="preserve">
     <value>Adding a constructor to a type with a field or property initializer that contains an anonymous function will prevent the debug session from continuing.</value>
   </data>
+  <data name="RenamingCapturedVariable" xml:space="preserve">
+    <value>Renaming a captured variable, from '{0}' to '{1}' will prevent the debug session from continuing.</value>
+  </data>
   <data name="ModifyingACatchFinallyHandler" xml:space="preserve">
     <value>Modifying a catch/finally handler with an active statement in the try block will prevent the debug session from continuing.</value>
   </data>


### PR DESCRIPTION
Since captured variables are hosted to fields they can't be renamed.

Fixes #2726.