### PR TITLE
Add elastic attribute spacing rule

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -1511,7 +1511,7 @@ interface I
 }
 class C : I
 {
-    public void Foo([DateTimeConstant(100), Optional]DateTime d1, [IUnknownConstant, Optional]object d2)
+    public void Foo([DateTimeConstant(100), Optional] DateTime d1, [IUnknownConstant, Optional] object d2)
     {
         throw new NotImplementedException();
     }

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -861,7 +861,7 @@ public class [|C|]
 
     [Obsolete]
     public void method1();
-    public void method2([CallerMemberName]string name = """");
+    public void method2([CallerMemberName] string name = """");
 
     [Obsolete]
     public static C operator +(C c1, C c2);
@@ -958,7 +958,7 @@ public class [|C|]
     public event Action event2;
 
     public void method1();
-    public void method2([CallerMemberName]string name = """");
+    public void method2([CallerMemberName] string name = """");
 
     public static C operator +(C c1, C c2);
     public static C operator -(C c1, C c2);

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -25,7 +25,7 @@ class C
 <Code>
 class C
 {
-    void Foo([Out()]string s)
+    void Foo([Out()] string s)
     {
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -256,6 +256,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 //     space operation says give 1 space between two tokens (basically means remove new lines)
                 //     then, engine will pick new line operation and ignore space operation
 
+                // make attributes have a space following
+                if (previousToken.IsKind(SyntaxKind.CloseBracketToken) && previousToken.Parent is AttributeListSyntax
+                    && !(currentToken.Parent is AttributeListSyntax))
+                {
+                    return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+                }
+
                 // make every operation forced
                 return CreateAdjustSpacesOperation(Math.Max(0, operation.Space), AdjustSpacesOption.ForceSpaces);
             }

--- a/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
+++ b/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Formatting\FormattingElasticTriviaTests.cs" />
     <Compile Include="Formatting\FormattingMultipleSpanTests.cs" />
     <Compile Include="Formatting\FormattingTests.cs" />
+    <Compile Include="Formatting\FormattingTreeEditTests.cs" />
     <Compile Include="Formatting\FormattingTriviaTests.cs" />
     <Compile Include="CodeGeneration\AddImportsTests.cs" />
   </ItemGroup>

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTreeEditTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTreeEditTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
+{
+    public class FormattingTreeEditTests : CSharpFormattingTestBase
+    {
+        private Document GetDocument(string code)
+        {
+            var ws = new AdhocWorkspace();
+            var project = ws.AddProject("project", LanguageNames.CSharp);
+            return project.AddDocument("code", SourceText.From(code));
+        }
+        
+        [Fact]
+        public void SpaceAfterAttribute()
+        {
+            string code = @"
+public class C
+{
+    void M(int? p) { }
+}
+";
+            var document = GetDocument(code);
+            var g = SyntaxGenerator.GetGenerator(document);
+            var root = document.GetSyntaxRootAsync().Result;
+            var attr = g.Attribute("MyAttr");
+
+            var param = root.DescendantNodes().OfType<ParameterSyntax>().First();
+            Assert.Equal(@"
+public class C
+{
+    void M([MyAttr] int? p) { }
+}
+", Formatter.Format(root.ReplaceNode(param, g.AddAttributes(param, g.Attribute("MyAttr"))), 
+    document.Project.Solution.Workspace).ToFullString());
+
+            // verify change doesn't affect how attributes appear before other kinds of declarations
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            Assert.Equal(@"
+public class C
+{
+    [MyAttr]
+    void M(int? p) { }
+}
+", Formatter.Format(root.ReplaceNode(method, g.AddAttributes(method, g.Attribute("MyAttr"))),
+    document.Project.Solution.Workspace).ToFullString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2577 

Adds a spacing rule to force one space between attributes and the declaration they are attributing. This, of course, gets overridden by any line space rule.

@heejaechang @pilchie please review

