### PR TITLE
Suppress an false positive error reported by FxCop

### DIFF
--- a/src/Compilers/Core/Portable/Desktop/AssemblyPortabilityPolicy.cs
+++ b/src/Compilers/Core/Portable/Desktop/AssemblyPortabilityPolicy.cs
@@ -52,6 +52,12 @@ namespace Microsoft.CodeAnalysis
             DtdProcessing = DtdProcessing.Prohibit,
         };
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         internal static AssemblyPortabilityPolicy LoadFromXml(Stream input)
         {
             // Note: Unlike Fusion XML reader the XmlReader doesn't allow whitespace in front of <?xml version=""1.0"" encoding=""utf-8"" ?>

--- a/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
@@ -42,6 +42,12 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="IOException"></exception>
         /// <exception cref="XmlException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private static KeyValuePair<string, XDocument> MakeValue(XmlReferenceResolver resolver, string resolvedPath)
         {
             CacheMissCount++;

--- a/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
@@ -29,6 +29,12 @@ namespace Microsoft.CodeAnalysis
         private static readonly XmlReaderSettings s_xmlSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
 
         // internal for testing
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         internal XmlException ParseInternal(string text)
         {
             _textReader.SetText(text);

--- a/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
@@ -52,6 +52,12 @@ namespace Microsoft.CodeAnalysis
         /// Creates and loads the rule set from a file
         /// </summary>
         /// <param name="filePath">The file path to load the rule set</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         public static RuleSet LoadFromFile(string filePath)
         {
             // First read the file without doing any validation

--- a/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
@@ -50,6 +50,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             DtdProcessing = DtdProcessing.Prohibit,
         };
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private void ParseInternal<TArg>(string text, Action<XmlReader, TArg> callback, TArg arg)
         {
             _textReader.SetText(text);

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -23,6 +23,12 @@ namespace Microsoft.CodeAnalysis
             return new ContentBasedXmlDocumentationProvider(xmlDocCommentBytes);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private XDocument GetXDocument(CancellationToken cancellationToken)
         {
             using (var stream = GetSourceStream(cancellationToken))


### PR DESCRIPTION
FxCop is currenly reporting a false positive error for calls to XmlReader.Create() in projects that compile against the .NET portable (core) framework. Suppress this error until the rule owners fix the rule to account for portable framework.

Fixes internal bugs 1169525, 1169526, 1169527