### PR TITLE
add base list before trailing trivia

### DIFF
--- a/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
+++ b/src/Diagnostics/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
@@ -53,8 +53,7 @@ using System;
 using System.IO;
 
 // This class violates the rule.
-public class NoDisposeClass
-: IDisposable
+public class NoDisposeClass : IDisposable
 {
     FileStream newFile;
 
@@ -132,8 +131,7 @@ using System;
 using System.IO;
 
 // This class violates the rule.
-public class NoDisposeClass
-: IDisposable
+public class NoDisposeClass : IDisposable
 {
     FileStream newFile;
 
@@ -166,8 +164,7 @@ using System;
 using System.IO;
 
 // This class violates the rule.
-public partial class NoDisposeClass
-: IDisposable
+public partial class NoDisposeClass : IDisposable
 {
     FileStream newFile;
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
@@ -816,8 +816,7 @@ class A
 }";
 
             var expected =
-@"class C
-: A
+@"class C : A
 {
 }
 


### PR DESCRIPTION
Fixes #293 

This turned out not to be a formatter problem specifically, but one of a class of problems that plague manipulation of existing trees.  The formatter had no indentation rule for base lists, but the real problem was that the SyntaxGenerator did not take into account existing trivia before adding the base list.  The typical case when adding base list to existing class declaration is to have at least EOL trivia after the identifier (if following the default formatter style), and that EOL still existed after adding the base list to the class declaration, forcing the base list down the next line.

The fix is to insert the base list before the trailing trivia on the line, and then let the formatter have it.

@pilchie @srivatsn  please review