### PR TITLE
EE: Ignore duplicate types from cor library

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -82,6 +82,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         AllowAwaitInUnsafeContext = 1 << 25,
 
+        /// <summary>
+        /// Ignore duplicate types from the cor library.
+        /// </summary>
+        IgnoreCorLibraryDuplicatedTypes = 1 << 26,
+
         // Groups
 
         AllClearedAtExecutableCodeBoundary = InLockBody | InCatchBlock | InCatchFilter | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Rolsyn reproduces Dev10 compiler behavior which doesn't report an error if one of the 
             // lookups is single viable and other lookup is ambiguous. If one of the lookup results 
             // (either with or without "Attribute" suffix) is single viable and is an attribute type we 
-            // use it  disregarding the second result which may be ambigous. 
+            // use it  disregarding the second result which may be ambiguous. 
 
             // Note: if both are single and attribute types, we still report ambiguity.
 
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!result.IsClear)
                 {
-                    if ((object)symbolWithoutSuffix != null) // was not ambigous, but not viable
+                    if ((object)symbolWithoutSuffix != null) // was not ambiguous, but not viable
                     {
                         result.SetFrom(GenerateNonViableAttributeTypeResult(symbolWithoutSuffix, result.Error, diagnose));
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // Gets the name lookup options for simple generic or non-generic name.
-        private static LookupOptions GetSimpleNameLookupOptions(NameSyntax node, bool isVerbatimIdentifer)
+        private static LookupOptions GetSimpleNameLookupOptions(NameSyntax node, bool isVerbatimIdentifier)
         {
             if (SyntaxFacts.IsAttributeName(node))
             {
@@ -574,7 +574,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //  SPEC:   such that its right-most identifier is a verbatim identifier (§2.4.2), then only
                 //  SPEC:   an attribute without a suffix is matched, thus enabling such an ambiguity to be resolved.
 
-                return isVerbatimIdentifer ? LookupOptions.VerbatimNameAttributeTypeOnly : LookupOptions.AttributeTypeOnly;
+                return isVerbatimIdentifier ? LookupOptions.VerbatimNameAttributeTypeOnly : LookupOptions.AttributeTypeOnly;
             }
             else
             {
@@ -682,7 +682,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SeparatedSyntaxList<TypeSyntax> typeArguments = node.TypeArgumentList.Arguments;
 
             bool isUnboundTypeExpr = node.IsUnboundGenericName;
-            LookupOptions options = GetSimpleNameLookupOptions(node, isVerbatimIdentifer: false);
+            LookupOptions options = GetSimpleNameLookupOptions(node, isVerbatimIdentifier: false);
 
             NamedTypeSymbol unconstructedType = LookupGenericTypeName(
                 diagnostics, basesBeingResolved, qualifierOpt, node, plainName, node.Arity, options);
@@ -1288,6 +1288,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
+                                Debug.Assert(!best.IsFromCorLibrary);
+
                                 // ErrorCode.ERR_SameFullNameAggAgg: The type '{1}' exists in both '{0}' and '{2}'
                                 info = new CSDiagnosticInfo(ErrorCode.ERR_SameFullNameAggAgg, originalSymbols,
                                     new object[] { first.ContainingAssembly, first, second.ContainingAssembly });
@@ -1300,6 +1302,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     Debug.Assert(best.IsFromCompilation);
                                     reportError = false;
+                                }
+                                else if (this.Flags.Includes(BinderFlags.IgnoreCorLibraryDuplicatedTypes) &&
+                                    secondBest.IsFromCorLibrary)
+                                {
+                                    // Ignore duplicate types from the cor library if necessary.
+                                    // (Specifically the framework assemblies loaded at runtime in
+                                    // the EE may contain types also available from mscorlib.dll.)
+                                    return first;
                                 }
                             }
                         }
@@ -1559,22 +1569,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return symbol.ContainingAssembly ?? ((NamespaceSymbol)symbol).ConstituentNamespaces.First().ContainingAssembly;
         }
 
+        [Flags]
+        private enum BestSymbolLocation
+        {
+            None,
+            FromSourceModule,
+            FromAddedModule,
+            FromReferencedAssembly,
+            FromCorLibrary,
+        }
+
+        [DebuggerDisplay("Location = {_location}, Index = {_index}")]
         private struct BestSymbolInfo
         {
-            [Flags]
-            private enum BestSymbolFlags
-            {
-                None = 0x00000000,
-                IndexMask = 0x0FFFFFFF,
-                LocationMask = 0x70000000,
-
-                // The following flags are mutually exclusive.
-                FromSourceModule = 0x10000000,
-                FromAddedModule = 0x20000000,
-                FromReferencedAssembly = 0x40000000,
-            }
-
-            private readonly BestSymbolFlags _flags;
+            private readonly BestSymbolLocation _location;
+            private readonly int _index;
 
             /// <summary>
             /// Returns -1 if None.
@@ -1583,12 +1592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 get
                 {
-                    if (IsNone)
-                    {
-                        return -1;
-                    }
-
-                    return (int)(_flags & BestSymbolFlags.IndexMask);
+                    return IsNone ? -1 : _index;
                 }
             }
 
@@ -1596,7 +1600,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 get
                 {
-                    return (_flags & BestSymbolFlags.FromSourceModule) != 0;
+                    return _location == BestSymbolLocation.FromSourceModule;
                 }
             }
 
@@ -1604,7 +1608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 get
                 {
-                    return (_flags & BestSymbolFlags.FromAddedModule) != 0;
+                    return _location == BestSymbolLocation.FromAddedModule;
                 }
             }
 
@@ -1612,7 +1616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 get
                 {
-                    return (_flags & (BestSymbolFlags.FromSourceModule | BestSymbolFlags.FromAddedModule)) != 0;
+                    return (_location == BestSymbolLocation.FromSourceModule) || (_location == BestSymbolLocation.FromAddedModule);
                 }
             }
 
@@ -1620,39 +1624,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 get
                 {
-                    return (_flags & BestSymbolFlags.LocationMask) == 0;
+                    return _location == BestSymbolLocation.None;
                 }
             }
 
-            public bool IsFromReferencedAssembly
+            public bool IsFromCorLibrary
             {
                 get
                 {
-                    return (_flags & BestSymbolFlags.FromReferencedAssembly) != 0;
+                    return _location == BestSymbolLocation.FromCorLibrary;
                 }
             }
 
-            private BestSymbolInfo(BestSymbolFlags flags)
+            public BestSymbolInfo(BestSymbolLocation location, int index)
             {
-                _flags = flags;
-            }
-
-            public static BestSymbolInfo FromSourceModule(int index)
-            {
-                Debug.Assert((index & (int)(~BestSymbolFlags.IndexMask)) == 0);
-                return new BestSymbolInfo(BestSymbolFlags.FromSourceModule | (BestSymbolFlags)index);
-            }
-
-            public static BestSymbolInfo FromAddedModule(int index)
-            {
-                Debug.Assert((index & (int)(~BestSymbolFlags.IndexMask)) == 0);
-                return new BestSymbolInfo(BestSymbolFlags.FromAddedModule | (BestSymbolFlags)index);
-            }
-
-            public static BestSymbolInfo FromReferencedAssembly(int index)
-            {
-                Debug.Assert((index & (int)(~BestSymbolFlags.IndexMask)) == 0);
-                return new BestSymbolInfo(BestSymbolFlags.FromReferencedAssembly | (BestSymbolFlags)index);
+                Debug.Assert(location != BestSymbolLocation.None);
+                _location = location;
+                _index = index;
             }
 
             /// <summary>
@@ -1661,8 +1649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             public static bool Sort(ref BestSymbolInfo first, ref BestSymbolInfo second)
             {
-                if (!second.IsNone &&
-                    (first.IsNone || (first._flags & BestSymbolFlags.LocationMask) > (second._flags & BestSymbolFlags.LocationMask)))
+                if (IsSecondLocationBetter(first._location, second._location))
                 {
                     BestSymbolInfo temp = first;
                     first = second;
@@ -1672,6 +1659,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return false;
             }
+
+            /// <summary>
+            /// Returns true if the second is a better location than the first.
+            /// </summary>
+            public static bool IsSecondLocationBetter(BestSymbolLocation firstLocation, BestSymbolLocation secondLocation)
+            {
+                Debug.Assert(secondLocation != 0);
+                return (firstLocation == BestSymbolLocation.None) || (firstLocation > secondLocation);
+            }
         }
 
         /// <summary>
@@ -1679,68 +1675,65 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BestSymbolInfo GetBestSymbolInfo(ArrayBuilder<Symbol> symbols, out BestSymbolInfo secondBest)
         {
-            var assemblyBeingBuilt = this.Compilation.SourceAssembly;
-            var moduleBuilt = this.Compilation.SourceModule;
-
             BestSymbolInfo first = default(BestSymbolInfo);
             BestSymbolInfo second = default(BestSymbolInfo);
+            var compilation = this.Compilation;
 
             for (int i = 0; i < symbols.Count; i++)
             {
                 var symbol = symbols[i];
-
-                BestSymbolInfo third;
+                BestSymbolLocation location;
 
                 if (symbol.Kind == SymbolKind.Namespace)
                 {
-                    var ns = ((NamespaceSymbol)symbol).ConstituentNamespaces;
-                    third = default(BestSymbolInfo);
-
-                    for (int j = 0; j < ns.Length; j++)
+                    location = BestSymbolLocation.None;
+                    foreach (var ns in ((NamespaceSymbol)symbol).ConstituentNamespaces)
                     {
-                        if (ns[j].ContainingAssembly == assemblyBeingBuilt)
+                        var current = GetLocation(compilation, ns);
+                        if (BestSymbolInfo.IsSecondLocationBetter(location, current))
                         {
-                            if (ns[j].ContainingModule == moduleBuilt)
+                            location = current;
+                            if (location == BestSymbolLocation.FromSourceModule)
                             {
-                                third = BestSymbolInfo.FromSourceModule(i);
                                 break;
                             }
-                            else if (!third.IsFromAddedModule)
-                            {
-                                Debug.Assert(!third.IsFromCompilation);
-                                third = BestSymbolInfo.FromAddedModule(i);
-                            }
                         }
-                        else if (third.IsNone)
-                        {
-                            third = BestSymbolInfo.FromReferencedAssembly(i);
-                        }
-                    }
-                }
-                else if (symbol.ContainingAssembly == assemblyBeingBuilt)
-                {
-                    if (symbol.ContainingModule == moduleBuilt)
-                    {
-                        third = BestSymbolInfo.FromSourceModule(i);
-                    }
-                    else
-                    {
-                        third = BestSymbolInfo.FromAddedModule(i);
                     }
                 }
                 else
                 {
-                    third = BestSymbolInfo.FromReferencedAssembly(i);
+                    location = GetLocation(compilation, symbol);
                 }
 
+                var third = new BestSymbolInfo(location, i);
                 if (BestSymbolInfo.Sort(ref second, ref third))
                 {
                     BestSymbolInfo.Sort(ref first, ref second);
                 }
             }
 
+            Debug.Assert(!first.IsNone);
+            Debug.Assert(!second.IsNone);
+
             secondBest = second;
             return first;
+        }
+
+        private static BestSymbolLocation GetLocation(CSharpCompilation compilation, Symbol symbol)
+        {
+            var containingAssembly = symbol.ContainingAssembly;
+            if (containingAssembly == compilation.SourceAssembly)
+            {
+                return (symbol.ContainingModule == compilation.SourceModule) ?
+                    BestSymbolLocation.FromSourceModule :
+                    BestSymbolLocation.FromAddedModule;
+            }
+            else
+            {
+                return (containingAssembly == containingAssembly.CorLibrary) ?
+                    BestSymbolLocation.FromCorLibrary :
+                    BestSymbolLocation.FromReferencedAssembly;
+            }
         }
 
         /// <remarks>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -426,7 +426,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim currentResult As SingleLookupResult = binder.CheckViability(sym, arity, options, Nothing, useSiteDiagnostics)
 
-                    lookupResult.MergeMembersOfTheSameNamespace(currentResult, sourceModule)
+                    lookupResult.MergeMembersOfTheSameNamespace(currentResult, sourceModule, options)
                 Next
             End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupOptions.vb
@@ -137,6 +137,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' When performing a lookup in interface do NOT lookup in System.Object 
         ''' </summary>
         NoSystemObjectLookupForInterfaces = 1 << 16
+
+        ''' <summary>
+        ''' Ignore duplicate types from the cor library.
+        ''' </summary>
+        IgnoreCorLibraryDuplicatedTypes = 1 << 17
     End Enum
 
     Friend Module LookupOptionExtensions

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -1014,7 +1014,7 @@ BC32042: Too few type arguments to 'C2.cC3(Of U, V)'.
         End Sub
 
         <Fact>
-        Public Sub InacessibleNonGenericType_01()
+        Public Sub InaccessibleNonGenericType_01()
             Dim compilationDef =
 <compilation>
     <file name="a.vb">

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -631,7 +631,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 BinderFlags.UnsafeRegion |
                 BinderFlags.UncheckedRegion |
                 BinderFlags.AllowManagedAddressOf |
-                BinderFlags.AllowAwaitInUnsafeContext);
+                BinderFlags.AllowAwaitInUnsafeContext |
+                BinderFlags.IgnoreCorLibraryDuplicatedTypes);
             var hasImports = !importRecordGroups.IsDefaultOrEmpty;
             var numImportStringGroups = hasImports ? importRecordGroups.Length : 0;
             var currentStringGroup = numImportStringGroups - 1;

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 fullImage,
                 metadataBytes,
                 symReader,
-                includeLocalSignatures);
+                includeLocalSignatures && (fullImage != null));
         }
 
         internal static AssemblyIdentity GetAssemblyIdentity(this MetadataReference reference)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -67,7 +67,7 @@
   <ItemGroup>
     <Compile Include="Binders\EENamedTypeBinder.vb" />
     <Compile Include="Binders\ParametersAndLocalsBinder.vb" />
-    <Compile Include="Binders\SuppressObsoleteDiagnosticsBinder.vb" />
+    <Compile Include="Binders\SuppressDiagnosticsBinder.vb" />
     <Compile Include="CompilationContext.vb" />
     <Compile Include="CompilationExtensions.vb" />
     <Compile Include="VisualBasicInScopeHoistedLocalsByName.vb" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/SuppressDiagnosticsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/SuppressDiagnosticsBinder.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     ''' and <see cref="T:Windows.Foundation.MetadataDeprecatedAttribute"/> 
     ''' to be suppressed.
     ''' </summary>
-    Friend NotInheritable Class SuppressObsoleteDiagnosticsBinder
+    Friend NotInheritable Class SuppressDiagnosticsBinder
 #Enable Warning RS0010
         Inherits Binder
 
@@ -21,6 +21,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Return True
             End Get
         End Property
+
+        Friend Overrides Function BinderSpecificLookupOptions(options As LookupOptions) As LookupOptions
+            Return options Or LookupOptions.IgnoreCorLibraryDuplicatedTypes
+        End Function
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -530,7 +530,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             importRecordGroups As ImmutableArray(Of ImmutableArray(Of ImportRecord))) As Binder
 
             Dim binder = BackstopBinder
-            binder = New SuppressObsoleteDiagnosticsBinder(binder)
+            binder = New SuppressDiagnosticsBinder(binder)
             binder = New IgnoreAccessibilityBinder(binder)
             binder = New SourceModuleBinder(binder, DirectCast(compilation.Assembly.Modules(0), SourceModuleSymbol))
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -386,6 +386,84 @@ End Class"
             End Using
         End Sub
 
+        <WorkItem(1170032)>
+        <Fact>
+        Public Sub DuplicateTypesInMscorlib()
+            Const sourceConsole =
+"Namespace System
+    Public Class Console
+    End Class
+End Namespace"
+            Const sourceObjectModel =
+"Namespace System.Collections.ObjectModel
+    Public Class ReadOnlyDictionary(Of K, V)
+    End Class
+End Namespace"
+            Const source =
+"Class C
+    Shared Sub Main()
+        Dim t = GetType(System.Console)
+        Dim o = DirectCast(Nothing, System.Collections.ObjectModel.ReadOnlyDictionary(Of Object, Object))
+    End Sub
+End Class"
+            Dim systemConsoleComp = CreateCompilationWithMscorlib({sourceConsole}, options:=TestOptions.DebugDll, assemblyName:="System.Console")
+            Dim systemConsoleRef = systemConsoleComp.EmitToImageReference()
+            Dim systemObjectModelComp = CreateCompilationWithMscorlib({sourceObjectModel}, options:=TestOptions.DebugDll, assemblyName:="System.ObjectModel")
+            Dim systemObjectModelRef = systemObjectModelComp.EmitToImageReference()
+            Dim identityObjectModel = systemObjectModelRef.GetAssemblyIdentity()
+
+            ' At runtime System.Runtime.dll contract assembly is replaced
+            ' by mscorlib.dll and System.Runtime.dll facade assemblies;
+            ' System.Console.dll and System.ObjectModel.dll are not replaced.
+
+            ' Test different ordering of modules containing duplicates:
+            ' { System.Console, mscorlib } and { mscorlib, System.ObjectModel }.
+            Dim contractReferences = ImmutableArray.Create(systemConsoleRef, SystemRuntimePP7Ref, systemObjectModelRef)
+            Dim runtimeReferences = ImmutableArray.Create(systemConsoleRef, MscorlibFacadeRef, SystemRuntimeFacadeRef, systemObjectModelRef)
+
+            ' Verify the compiler reports duplicate types with facade assemblies.
+            Dim compilation = CreateCompilationWithReferences(MakeSources(source), references:=runtimeReferences, options:=TestOptions.DebugDll)
+            compilation.VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_AmbiguousInNamespace2, "System.Console").WithArguments("Console", "System").WithLocation(3, 25),
+                Diagnostic(ERRID.ERR_AmbiguousInNamespace2, "System.Collections.ObjectModel.ReadOnlyDictionary(Of Object, Object)").WithArguments("ReadOnlyDictionary", "System.Collections.ObjectModel").WithLocation(4, 37))
+
+            ' EE should not report duplicate type when the original source
+            ' is compiled with contract assemblies and the EE expression
+            ' is compiled with facade assemblies.
+            compilation = CreateCompilationWithReferences(MakeSources(source), references:=contractReferences, options:=TestOptions.DebugDll)
+            Dim reference = compilation.EmitToImageReference()
+
+            Dim modules = runtimeReferences.Add(reference).SelectAsArray(Function(r) r.ToModuleInstance(Nothing, Nothing))
+            Using runtime = CreateRuntimeInstance(modules)
+                Dim context = CreateMethodContext(runtime, "C.Main")
+                Dim errorMessage As String = Nothing
+                ' { System.Console, mscorlib }
+                Dim testData = New CompilationTestData()
+                context.CompileExpression("GetType(System.Console)", errorMessage, testData)
+                Dim methodData = testData.GetMethodData("<>x.<>m0")
+                methodData.VerifyIL(
+"{
+  // Code size       11 (0xb)
+  .maxstack  1
+  IL_0000:  ldtoken    ""System.Console""
+  IL_0005:  call       ""Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type""
+  IL_000a:  ret
+}")
+                ' { mscorlib, System.ObjectModel }
+                testData = New CompilationTestData()
+                context.CompileExpression("DirectCast(Nothing, System.Collections.ObjectModel.ReadOnlyDictionary(Of Object, Object))", errorMessage, testData)
+                methodData = testData.GetMethodData("<>x.<>m0")
+                methodData.VerifyIL(
+"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldnull
+  IL_0001:  ret
+}")
+                Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityObjectModel.GetDisplayName())
+            End Using
+        End Sub
+
         Private Shared Function CreateTypeContextFactory(
             moduleVersionId As Guid,
             typeToken As Integer) As ExpressionCompiler.CreateContextDelegate


### PR DESCRIPTION
Ignore types from the cor library that also exist in the other framework assemblies.
This issue arises in the EE when compiling expressions against the runtime assemblies loaded in the debuggee for CoreCLR.