### PR TITLE
Disable Rename Tracking with "var" and "dynamic" in C#

### DIFF
--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -201,6 +201,7 @@
     <Compile Include="QuickInfo\SyntacticQuickInfoProvider.cs" />
     <Compile Include="ReferenceHighlighting\ReferenceHighlightingAdditionalReferenceProvider.cs" />
     <Compile Include="RenameTracking\CSharpRenameTrackingCodeFixProvider.cs" />
+    <Compile Include="RenameTracking\CSharpRenameTrackingLanguageHeuristicsService.cs" />
     <Compile Include="SignatureHelp\AbstractCSharpSignatureHelpProvider.cs" />
     <Compile Include="SignatureHelp\AttributeSignatureHelpProvider.cs" />
     <Compile Include="SignatureHelp\ConstructorInitializerSignatureHelpProvider.cs" />

--- a/src/EditorFeatures/CSharp/RenameTracking/CSharpRenameTrackingLanguageHeuristicsService.cs
+++ b/src/EditorFeatures/CSharp/RenameTracking/CSharpRenameTrackingLanguageHeuristicsService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.RenameTracking
+{
+    [ExportLanguageService(typeof(IRenameTrackingLanguageHeuristicsService), LanguageNames.CSharp), Shared]
+    internal sealed class CSharpRenameTrackingLanguageHeuristicsService : IRenameTrackingLanguageHeuristicsService
+    {
+        public bool IsIdentifierValidForRenameTracking(string name)
+        {
+            return name != "var" && name != "dynamic";
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -586,6 +586,7 @@
     <Compile Include="Implementation\Peek\PeekHelpers.cs" />
     <Compile Include="Implementation\ReferenceHighlighting\WrittenReferenceHighlightTag.cs" />
     <Compile Include="Implementation\ReferenceHighlighting\WrittenReferenceHighlightTagDefinition.cs" />
+    <Compile Include="Implementation\RenameTracking\IRenameTrackingLanguageHeuristicsService.cs" />
     <Compile Include="Implementation\RenameTracking\RenameTrackingCancellationCommandHandler.cs" />
     <Compile Include="Implementation\RenameTracking\RenameTrackingTagDefinition.cs" />
     <Compile Include="Implementation\RenameTracking\RenameTrackingTag.cs" />

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/IRenameTrackingLanguageHeuristicsService.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/IRenameTrackingLanguageHeuristicsService.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
+{
+    internal interface IRenameTrackingLanguageHeuristicsService : ILanguageService
+    {
+        bool IsIdentifierValidForRenameTracking(string name);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -253,8 +253,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 }
 
                 ISyntaxFactsService syntaxFactsService;
-                return TryGetSyntaxFactsService(out syntaxFactsService) &&
-                    trackingSession.CanInvokeRename(syntaxFactsService, isSmartTagCheck, waitForResult, cancellationToken);
+                IRenameTrackingLanguageHeuristicsService languageHeuristicsService;
+                return TryGetSyntaxFactsService(out syntaxFactsService) && TryGetLanguageHeuristicsService(out languageHeuristicsService) &&
+                    trackingSession.CanInvokeRename(syntaxFactsService, languageHeuristicsService, isSmartTagCheck, waitForResult, cancellationToken);
             }
 
             internal async Task<IEnumerable<Diagnostic>> GetDiagnostic(SyntaxTree tree, DiagnosticDescriptor diagnosticDescriptor, CancellationToken cancellationToken)
@@ -330,6 +331,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 }
 
                 return syntaxFactsService != null;
+            }
+
+            private bool TryGetLanguageHeuristicsService(out IRenameTrackingLanguageHeuristicsService languageHeuristicsService)
+            {
+                // Can be called on a background thread
+
+                languageHeuristicsService = null;
+                var document = _buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                if (document != null)
+                {
+                    languageHeuristicsService = document.Project.LanguageServices.GetService<IRenameTrackingLanguageHeuristicsService>();
+                }
+
+                return languageHeuristicsService != null;
             }
 
             public void Connect()

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1090,5 +1090,109 @@ class C
                 state.AssertNoTag();
             }
         }
+
+        [Fact]
+        [WorkItem(2605, "https://github.com/dotnet/roslyn/issues/2605")]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_CannotRenameToVarInCSharp()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        C$$ c;
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.InsertText("va");
+
+                state.AssertTag("C", "va");
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+
+                state.EditorOperations.InsertText("r");
+                state.AssertNoTag();
+                Assert.Empty(state.GetDocumentDiagnostics());
+
+                state.EditorOperations.InsertText("p");
+                state.AssertTag("C", "varp");
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+            }
+        }
+
+        [Fact]
+        [WorkItem(2605, "https://github.com/dotnet/roslyn/issues/2605")]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_CannotRenameFromVarInCSharp()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        var$$ c = new C();
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.AssertNoTag();
+                Assert.Empty(state.GetDocumentDiagnostics());
+            }
+        }
+
+        [Fact]
+        [WorkItem(2605, "https://github.com/dotnet/roslyn/issues/2605")]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_CanRenameToVarInVisualBasic()
+        {
+            var code = @"
+Class C
+    Sub M()
+        Dim x as C$$
+    End Sub
+End Class";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.InsertText("var");
+
+                state.AssertTag("C", "var");
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+            }
+        }
+
+        [Fact]
+        [WorkItem(2605, "https://github.com/dotnet/roslyn/issues/2605")]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public void RenameTracking_CannotRenameToDynamicInCSharp()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        C$$ c;
+    }
+}";
+            using (var state = new RenameTrackingTestState(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.InsertText("dynami");
+
+                state.AssertTag("C", "dynami");
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+
+                state.EditorOperations.InsertText("c");
+                state.AssertNoTag();
+                Assert.Empty(state.GetDocumentDiagnostics());
+
+                state.EditorOperations.InsertText("s");
+                state.AssertTag("C", "dynamics");
+                Assert.NotEmpty(state.GetDocumentDiagnostics());
+            }
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
@@ -216,6 +216,7 @@
     <Compile Include="Outlining\VisualBasicOutliningService.vb" />
     <Compile Include="QuickInfo\SemanticQuickInfoProvider.vb" />
     <Compile Include="ReferenceHighlighting\ReferenceHighlightingAdditionalReferenceProvider.vb" />
+    <Compile Include="RenameTracking\BasicRenameTrackingLanguageHeuristicsService.vb" />
     <Compile Include="RenameTracking\RenameTrackingCodeFixProvider.vb" />
     <Compile Include="SignatureHelp\AbstractIntrinsicOperatorSignatureHelpProvider.vb" />
     <Compile Include="SignatureHelp\AbstractSignatureHelpProvider.vb" />

--- a/src/EditorFeatures/VisualBasic/RenameTracking/BasicRenameTrackingLanguageHeuristicsService.vb
+++ b/src/EditorFeatures/VisualBasic/RenameTracking/BasicRenameTrackingLanguageHeuristicsService.vb
@@ -1,0 +1,16 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.RenameTracking
+    <ExportLanguageService(GetType(IRenameTrackingLanguageHeuristicsService), LanguageNames.VisualBasic), [Shared]>
+    Friend NotInheritable Class BasicRenameTrackingLanguageHeuristicsService
+        Implements IRenameTrackingLanguageHeuristicsService
+
+        Public Function IsIdentifierValidForRenameTracking(name As String) As Boolean Implements IRenameTrackingLanguageHeuristicsService.IsIdentifierValidForRenameTracking
+            Return True
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Fixes #2605 "Lightbulb suggests renaming a type to 'var'"

This change disables using Rename Tracking to rename to/from "var" and "dynamic" in C#.

Tagging reviewers: @Pilchie @jasonmalinowski @balajikris @rchande @brettfo @jmarolf  