### PR TITLE
Fix #2790 where multiple compiler servers were starting for the same path

### DIFF
--- a/src/Compilers/Core/MSBuildTask/BuildClient.cs
+++ b/src/Compilers/Core/MSBuildTask/BuildClient.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             out string newPipeName)
         {
             string basePipeName = pipeName;
-            for (int counter = 1; File.Exists(pipeName); counter++)
+            for (int counter = 1; File.Exists($@"\\.\pipe\{pipeName}"); counter++)
             {
                 NamedPipeClientStream pipe;
                 if (null != (pipe = TryConnectToProcess(pipeName, timeoutMs, cancellationToken)))

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -2022,5 +2022,15 @@ class Program
             Assert.Equal(1, result.ExitCode);
             Assert.Equal("", result.Output);
         }
+
+        [Fact]
+        public void OnlyStartsOneServer()
+        {
+            var result = ProcessLauncher.Run(_csharpCompilerClientExecutable, "");
+            Assert.Equal(1, GetProcessesByFullPath(_compilerServerExecutable).Count);
+
+            result = ProcessLauncher.Run(_csharpCompilerClientExecutable, "");
+            Assert.Equal(1, GetProcessesByFullPath(_compilerServerExecutable).Count);
+        }
     }
 }


### PR DESCRIPTION
@pharring @jaredpar @gafter @VSadov @AlekseyTs

Bad bug, simple fix. Please review ASAP.