### PR TITLE
Expand transparent identifier in the (VB) EE

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameKind.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameKind.vb
@@ -17,6 +17,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         StateMachineStateField
         StateMachineHoistedUserVariableField
         StaticLocalField
+        TransparentIdentifier
+        AnonymousTransparentIdentifier
+        AnonymousType
 
         LambdaCacheField
     End Enum
@@ -43,6 +46,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return GeneratedNameKind.StateMachineAwaiterField
             ElseIf name.StartsWith(StringConstants.StateMachineHoistedUserVariablePrefix, StringComparison.Ordinal) Then
                 Return GeneratedNameKind.StateMachineHoistedUserVariableField
+            ElseIf name.StartsWith(AnonymousTypeTemplateNamePrefix, StringComparison.Ordinal) Then
+                Return GeneratedNameKind.AnonymousType
+            ElseIf name.Equals(StringConstants.It, StringComparison.Ordinal) OrElse
+                    name.Equals(StringConstants.It1, StringComparison.Ordinal) OrElse
+                    name.Equals(StringConstants.It2, StringComparison.Ordinal) Then
+                Return GeneratedNameKind.TransparentIdentifier
+            ElseIf name.Equals(StringConstants.ItAnonymous, StringComparison.Ordinal) Then
+                ' We distinguish StringConstants.ItAnonymous, because it won't be an instance
+                ' of an anonymous type.
+                Return GeneratedNameKind.AnonymousTransparentIdentifier
             End If
 
             Return GeneratedNameKind.None

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -151,8 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 var variable = pair.Value;
                 var oldDisplayClassInstance = variable.DisplayClassInstance;
 
-                // Note: the code path for DisplayClassInstanceFromLocal is equivalent to calling 
-                // oldDisplayClassInstance.ToOtherMethod, except that doing that would produce
+                // Note: we don't call ToOtherMethod in the local case because doing so would produce
                 // a new LocalSymbol that would not be ReferenceEquals to the one in this.LocalsForBinding.
                 var oldDisplayClassInstanceFromLocal = oldDisplayClassInstance as DisplayClassInstanceFromLocal;
                 var newDisplayClassInstance = (oldDisplayClassInstanceFromLocal == null) ?

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -2820,7 +2820,6 @@ class C
             testData = new CompilationTestData();
             context.CompileExpression("z", out error, testData);
             Assert.Null(error);
-
             testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
 
             testData = new CompilationTestData();
@@ -2923,7 +2922,6 @@ class C
             testData = new CompilationTestData();
             context.CompileExpression("z", out error, testData);
             Assert.Null(error);
-
             testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
 
             testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
@@ -28,7 +28,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim nameToSymbolMap As New Dictionary(Of String, Symbol)(CaseInsensitiveComparison.Comparer)
 
             For Each parameter In parameters
-                nameToSymbolMap(parameter.Name) = parameter
+                Dim name As String = parameter.Name
+                Dim kind As GeneratedNameKind = GeneratedNames.GetKind(name)
+                If kind = GeneratedNameKind.None OrElse kind = GeneratedNameKind.HoistedMeField Then
+                    nameToSymbolMap(name) = parameter
+                Else
+                    Debug.Assert(kind = GeneratedNameKind.TransparentIdentifier OrElse
+                                 kind = GeneratedNameKind.AnonymousTransparentIdentifier)
+                End If
             Next
 
             For Each local In locals

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -276,7 +276,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     ' Method parameters (except those that have been hoisted).
                     Dim parameterIndex = If(m.IsShared, 0, 1)
                     For Each parameter In m.Parameters
-                        If Not _hoistedParameterNames.Contains(parameter.Name) Then
+                        Dim parameterName As String = parameter.Name
+                        If Not _hoistedParameterNames.Contains(parameterName) AndAlso GeneratedNames.GetKind(parameterName) = GeneratedNameKind.None Then
                             AppendParameterAndMethod(localBuilder, methodBuilder, parameter, container, parameterIndex)
                         End If
 
@@ -1006,12 +1007,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End If
             Next
 
+            For Each parameter As ParameterSymbol In method.Parameters
+                If GeneratedNames.GetKind(parameter.Name) = GeneratedNameKind.TransparentIdentifier Then
+                    Dim instance As New DisplayClassInstanceFromParameter(parameter)
+                    displayClassTypes.Add(instance.Type)
+                    displayClassInstances.Add(New DisplayClassInstanceAndFields(instance))
+                End If
+            Next
+
             Dim containingType = method.ContainingType
             Dim isIteratorOrAsyncMethod = False
             If containingType.IsClosureOrStateMachineType() Then
                 If Not method.IsShared Then
                     ' Add "Me" display class instance.
-                    Dim instance As New DisplayClassInstanceFromMe(method.MeParameter)
+                    Dim instance As New DisplayClassInstanceFromParameter(method.MeParameter)
                     displayClassTypes.Add(instance.Type)
                     displayClassInstances.Add(New DisplayClassInstanceAndFields(instance))
                 End If
@@ -1104,6 +1113,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 name.StartsWith(StringConstants.HoistedSpecialVariablePrefix & StringConstants.DisplayClassPrefix, StringComparison.Ordinal) ' Async lambda case
         End Function
 
+        Private Shared Function IsTransparentIdentifierField(field As FieldSymbol) As Boolean
+            Dim fieldName = field.Name
+
+            Dim unmangledName As String = Nothing
+            If GeneratedNames.TryParseHoistedUserVariableName(fieldName, unmangledName) Then
+                fieldName = unmangledName
+            ElseIf field.IsAnonymousTypeField(unmangledName) Then
+                fieldName = unmangledName
+            End If
+
+            Return GeneratedNames.GetKind(fieldName) = GeneratedNameKind.TransparentIdentifier
+        End Function
+
         Private Shared Function IsGeneratedLocalName(name As String) As Boolean
             Debug.Assert(name IsNot Nothing) ' Verified by caller.
             ' If a local's name contains "$", then it is a generated local.
@@ -1157,7 +1179,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Dim field = DirectCast(member, FieldSymbol)
                 Dim fieldType = field.Type
                 Dim fieldName As String = field.Name
-                If IsDisplayClassInstanceFieldName(fieldName) Then
+                If IsDisplayClassInstanceFieldName(fieldName) OrElse
+                    IsTransparentIdentifierField(field) Then
                     Debug.Assert(Not field.IsShared)
                     ' A local that is itself a display class instance.
                     If displayClassTypes.Add(DirectCast(fieldType, NamedTypeSymbol)) Then
@@ -1187,6 +1210,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Dim field = DirectCast(member, FieldSymbol)
                 Dim fieldName = field.Name
 
+                Dim unmangledName As String = Nothing
+                If field.IsAnonymousTypeField(unmangledName) Then
+                    fieldName = unmangledName
+                End If
+
                 Dim variableKind As DisplayClassVariableKind
                 Dim variableName As String
 
@@ -1212,6 +1240,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     variableKind = DisplayClassVariableKind.Me
                     variableName = fieldName ' As in C#, we retain the mangled name.  It shouldn't be used, other than as a dictionary key.
                 ElseIf fieldName.StartsWith(StringConstants.LambdaCacheFieldPrefix, StringComparison.Ordinal) Then
+                    Continue For
+                ElseIf GeneratedNames.GetKind(fieldName) = GeneratedNameKind.TransparentIdentifier
+                    ' A transparent identifier (field) in an anonymous type synthesized for a transparent identifier.
+                    Debug.Assert(Not field.IsShared)
                     Continue For
                 Else
                     variableKind = DisplayClassVariableKind.Local
@@ -1393,7 +1425,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Friend Sub New(instance As DisplayClassInstance)
                 MyClass.New(instance, ConsList(Of FieldSymbol).Empty)
-                Debug.Assert(instance.Type.IsClosureOrStateMachineType())
+                Debug.Assert(instance.Type.IsClosureOrStateMachineType() OrElse
+                             GeneratedNames.GetKind(instance.Type.Name) = GeneratedNameKind.AnonymousType)
             End Sub
 
             Private Sub New(instance As DisplayClassInstance, fields As ConsList(Of FieldSymbol))
@@ -1414,7 +1447,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Property
 
             Friend Function FromField(field As FieldSymbol) As DisplayClassInstanceAndFields
-                Debug.Assert(field.Type.IsClosureOrStateMachineType())
+                Debug.Assert(field.Type.IsClosureOrStateMachineType() OrElse
+                             GeneratedNames.GetKind(field.Type.Name) = GeneratedNameKind.AnonymousType)
                 Return New DisplayClassInstanceAndFields(Me.Instance, Me.Fields.Prepend(field))
             End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -122,12 +122,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Private Function RewriteParameter(syntax As VisualBasicSyntaxNode, symbol As ParameterSymbol, node As BoundExpression) As BoundExpression
-            Dim variable = Me.GetVariable(symbol.Name)
+            Dim name As String = symbol.Name
+            Dim variable = Me.GetVariable(name)
             If variable Is Nothing Then
                 ' The state machine case is for async lambdas.  The state machine
                 ' will have a hoisted "me" field if it needs access to the containing
                 ' display class, but the display class may not have a "me" field.
-                If symbol.Type.IsClosureOrStateMachineType() Then
+                If symbol.Type.IsClosureOrStateMachineType() AndAlso
+                    GeneratedNames.GetKind(name) <> GeneratedNameKind.TransparentIdentifier Then
+
                     ReportMissingMe(syntax)
                 End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Immutable
 Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
@@ -69,6 +70,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             method.ContainingType.GetAllTypeParameters(builder)
             builder.AddRange(method.TypeParameters)
             Return builder.ToImmutableAndFree()
+        End Function
+
+        <Extension>
+        Friend Function IsAnonymousTypeField(field As FieldSymbol, <Out> ByRef unmangledName As String) As Boolean
+            If GeneratedNames.GetKind(field.ContainingType.Name) <> GeneratedNameKind.AnonymousType Then
+                unmangledName = Nothing
+                Return False
+            End If
+
+            unmangledName = field.Name
+            If unmangledName(0) = "$"c Then
+                unmangledName = unmangledName.Substring(1)
+            End If
+
+            Return True
         End Function
     End Module
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/DisplayClassVariable.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/DisplayClassVariable.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Shared Function SubstituteField(field As FieldSymbol, typeMap As TypeSubstitution) As FieldSymbol
             Debug.Assert(Not field.IsShared)
-            Debug.Assert(Not field.IsReadOnly)
+            Debug.Assert(Not field.IsReadOnly OrElse field.IsAnonymousTypeField(Nothing))
             Debug.Assert(field.CustomModifiers.Length = 0)
             Debug.Assert(Not field.HasConstantValue)
             Return New EEDisplayClassFieldSymbol(typeMap.SubstituteNamedType(field.ContainingType), field.Name, typeMap.SubstituteType(field.Type), field.DeclaredAccessibility)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -132,23 +132,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Me.LocalsForBinding = localsBuilder.ToImmutableAndFree()
 
             ' Create a map from variable name to display class field.
-            Dim displayClassVariables = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
-            For Each pair In sourceDisplayClassVariables
-                Dim variable = pair.Value
-                Dim displayClassInstanceFromLocal = TryCast(variable.DisplayClassInstance, DisplayClassInstanceFromLocal)
-                Dim displayClassInstance = If(displayClassInstanceFromLocal Is Nothing,
-                    DirectCast(New DisplayClassInstanceFromMe(Me.Parameters(0)), DisplayClassInstance),
-                    New DisplayClassInstanceFromLocal(DirectCast(localsMap(displayClassInstanceFromLocal.Local), EELocalSymbol)))
-                variable = variable.SubstituteFields(displayClassInstance, Me.TypeMap)
-                displayClassVariables.Add(pair.Key, variable)
-            Next
-
-            _displayClassVariables = displayClassVariables.ToImmutableDictionary()
-            displayClassVariables.Free()
+            _displayClassVariables = SubstituteDisplayClassVariables(sourceDisplayClassVariables, localsMap, Me, Me.TypeMap)
             localsMap.Free()
 
             _generateMethodBody = generateMethodBody
         End Sub
+
+        Private Shared Function SubstituteDisplayClassVariables(
+            oldDisplayClassVariables As ImmutableDictionary(Of String, DisplayClassVariable),
+            localsMap As Dictionary(Of LocalSymbol, LocalSymbol),
+            otherMethod As MethodSymbol,
+            typeMap As TypeSubstitution) As ImmutableDictionary(Of String, DisplayClassVariable)
+
+            ' Create a map from variable name to display class field.
+            Dim newDisplayClassVariables = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
+            For Each pair In oldDisplayClassVariables
+                Dim variable = pair.Value
+                Dim oldDisplayClassInstance = variable.DisplayClassInstance
+
+                ' Note: we don't call ToOtherMethod in the local case because doing so would produce
+                ' a new LocalSymbol that would not be ReferenceEquals to the one in this.LocalsForBinding.
+                Dim oldDisplayClassInstanceFromLocal = TryCast(oldDisplayClassInstance, DisplayClassInstanceFromLocal)
+                Dim newDisplayClassInstance = If(oldDisplayClassInstanceFromLocal Is Nothing,
+                    oldDisplayClassInstance.ToOtherMethod(otherMethod, typeMap),
+                    New DisplayClassInstanceFromLocal(DirectCast(localsMap(oldDisplayClassInstanceFromLocal.Local), EELocalSymbol)))
+
+                variable = variable.SubstituteFields(newDisplayClassInstance, typeMap)
+                newDisplayClassVariables.Add(pair.Key, variable)
+            Next
+
+            Dim result = newDisplayClassVariables.ToImmutableDictionary()
+            newDisplayClassVariables.Free()
+            Return result
+        End Function
 
         Private Function MakeParameterSymbol(ordinal As Integer, name As String, sourceParameter As ParameterSymbol) As ParameterSymbol
             Return New SynthesizedParameterSymbolWithCustomModifiers(
@@ -510,25 +526,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             '       is triggered by overriding PreserveOriginalLocals to return "True".
 
             ' Create a map from variable name to display class field.
-            Dim displayClassVariables = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
-            For Each pair In _displayClassVariables
-                Dim variable = pair.Value
-                Dim displayClassInstanceFromLocal = TryCast(variable.DisplayClassInstance, DisplayClassInstanceFromLocal)
-                Dim displayClassInstance = If(displayClassInstanceFromLocal Is Nothing,
-                        DirectCast(New DisplayClassInstanceFromMe(Me.Parameters(0)), DisplayClassInstance),
-                        New DisplayClassInstanceFromLocal(DirectCast(localMap(displayClassInstanceFromLocal.Local), EELocalSymbol)))
-                variable = New DisplayClassVariable(variable.Name, variable.Kind, displayClassInstance, variable.DisplayClassFields)
-                displayClassVariables.Add(pair.Key, variable)
-            Next
+            Dim displayClassVariables = SubstituteDisplayClassVariables(_displayClassVariables, localMap, Me, Me.TypeMap)
 
             ' Rewrite references to "Me" to refer to this method's "Me" parameter.
             ' Rewrite variables within body to reference existing display classes.
             newBody = DirectCast(CapturedVariableRewriter.Rewrite(
                 If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
-                displayClassVariables.ToImmutableDictionary(),
+                displayClassVariables,
                 newBody,
                 diagnostics), BoundBlock)
-            displayClassVariables.Free()
 
             If diagnostics.HasAnyErrors() Then
                 Return newBody


### PR DESCRIPTION
...the same way we expand display classes and state machines.  If we see a
local or parameter with a transparent identifier generated/mangled name,
we should instead include the properties of its (anonymous) type in our
list of bindable symbols.

This is a port of ec4d462d57a7224d07067b18d4c99ef99a368639

There is one notable difference between C# and VB: whereas C# has a
single mangled name for transparent identifiers, VB has four - $VB$It,
$VB$It1, $VB$It2, and $VB$ItAnonymous.  Fortunately, the differences are
not interesting to the EE - they're only to prevent name collisions
(except $VB$ItAnonymous which is used when the value is not an anonymous
type and does not need to be expanded).