### PR TITLE
Update the VS AnalyzerDependencyChecker

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyChecker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyChecker.cs
@@ -11,59 +11,82 @@ using System.Security;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
+using System.Reflection;
+using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal sealed class AnalyzerDependencyChecker
     {
-        private readonly ImmutableHashSet<string> _analyzerFilePaths;
+        private readonly HashSet<string> _analyzerFilePaths;
+        private readonly HashSet<AssemblyIdentity> _assemblyWhiteList;
 
-        private readonly SortedSet<string> _examinedFilePaths = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-        private readonly SortedSet<string> _filePathsToExamine = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        private readonly Dictionary<string, string> _dependencyPathToAnalyzerPathMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-        public AnalyzerDependencyChecker(IEnumerable<string> analyzerFilePaths)
+        public AnalyzerDependencyChecker(IEnumerable<string> analyzerFilePaths, IEnumerable<AssemblyIdentity> assemblyWhiteList)
         {
-            _analyzerFilePaths = analyzerFilePaths.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            Debug.Assert(analyzerFilePaths != null);
+            Debug.Assert(assemblyWhiteList != null);
+
+            _analyzerFilePaths = new HashSet<string>(analyzerFilePaths, StringComparer.OrdinalIgnoreCase);
+            _assemblyWhiteList = new HashSet<AssemblyIdentity>(assemblyWhiteList);
         }
 
-        public ImmutableArray<AnalyzerDependencyConflict> Run(CancellationToken cancellationToken = default(CancellationToken))
+        public AnalyzerDependencyResults Run(CancellationToken cancellationToken = default(CancellationToken))
         {
+            List<AnalyzerInfo> analyzerInfos = new List<AnalyzerInfo>();
+
             foreach (var analyzerFilePath in _analyzerFilePaths)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (File.Exists(analyzerFilePath))
+                AnalyzerInfo info = TryReadAnalyzerInfo(analyzerFilePath);
+
+                if (info != null)
                 {
-                    AddDependenciesToWorkList(analyzerFilePath, analyzerFilePath);
+                    analyzerInfos.Add(info);
                 }
             }
 
-            List<DependencyInfo> dependencies = new List<DependencyInfo>();
+            _assemblyWhiteList.UnionWith(analyzerInfos.Select(info => info.Identity));
 
-            while (_filePathsToExamine.Count > 0)
+            // First check for analyzers with the same identity but different
+            // contents (that is, different MVIDs).
+
+            ImmutableArray<AnalyzerDependencyConflict> conflicts = FindConflictingAnalyzers(analyzerInfos, cancellationToken);
+
+            // Then check for missing references.
+
+            ImmutableArray<MissingAnalyzerDependency> missingDependencies = FindMissingDependencies(analyzerInfos, cancellationToken);
+
+            return new AnalyzerDependencyResults(conflicts, missingDependencies);
+        }
+
+        private ImmutableArray<MissingAnalyzerDependency> FindMissingDependencies(List<AnalyzerInfo> analyzerInfos, CancellationToken cancellationToken)
+        {
+            ImmutableArray<MissingAnalyzerDependency>.Builder builder = ImmutableArray.CreateBuilder<MissingAnalyzerDependency>();
+
+            foreach (var analyzerInfo in analyzerInfos)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                string filePath = _filePathsToExamine.Min;
-                _filePathsToExamine.Remove(filePath);
-                _examinedFilePaths.Add(filePath);
-
-                AssemblyIdentity assemblyIdentity = TryReadAssemblyIdentity(filePath);
-                if (assemblyIdentity != null)
+                foreach (var reference in analyzerInfo.References)
                 {
-                    var analyzerPath = _dependencyPathToAnalyzerPathMap[filePath];
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                    dependencies.Add(new DependencyInfo(filePath, assemblyIdentity, analyzerPath));
-
-                    AddDependenciesToWorkList(analyzerPath, filePath);
+                    if (!_assemblyWhiteList.Contains(reference))
+                    {
+                        builder.Add(new MissingAnalyzerDependency(
+                            analyzerInfo.Path,
+                            reference));
+                    }
                 }
             }
 
-            ImmutableArray<AnalyzerDependencyConflict>.Builder conflicts = ImmutableArray.CreateBuilder<AnalyzerDependencyConflict>();
+            return builder.ToImmutable();
+        }
 
-            foreach (var identityGroup in dependencies.GroupBy(di => di.Identity))
+        private static ImmutableArray<AnalyzerDependencyConflict> FindConflictingAnalyzers(List<AnalyzerInfo> analyzerInfos, CancellationToken cancellationToken)
+        {
+            ImmutableArray<AnalyzerDependencyConflict>.Builder builder = ImmutableArray.CreateBuilder<AnalyzerDependencyConflict>();
+
+            foreach (var identityGroup in analyzerInfos.GroupBy(di => di.Identity))
             {
                 var identityGroupArray = identityGroup.ToImmutableArray();
 
@@ -73,81 +96,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        byte[] hash1;
-                        byte[] hash2;
-                        if ((hash1 = identityGroupArray[i].TryGetFileHash()) != null &&
-                            (hash2 = identityGroupArray[j].TryGetFileHash()) != null &&
-                            !HashesAreEqual(hash1, hash2))
+                        if (identityGroupArray[i].MVID != identityGroupArray[j].MVID)
                         {
-                            conflicts.Add(new AnalyzerDependencyConflict(
-                                identityGroupArray[i].DependencyFilePath,
-                                identityGroupArray[j].DependencyFilePath,
-                                identityGroupArray[i].AnalyzerFilePath,
-                                identityGroupArray[j].AnalyzerFilePath));
+                            builder.Add(new AnalyzerDependencyConflict(
+                                identityGroup.Key,
+                                identityGroupArray[i].Path,
+                                identityGroupArray[j].Path));
                         }
                     }
                 }
             }
 
-            return conflicts.ToImmutable();
+            return builder.ToImmutable();
         }
 
-        private bool HashesAreEqual(byte[] hash1, byte[] hash2)
-        {
-            for (int i = 0; i < hash1.Length; i++)
-            {
-                if (hash1[i] != hash2[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private void AddDependenciesToWorkList(string analyzerFilePath, string assemblyPath)
-        {
-            ImmutableArray<string> referencedAssemblyNames = GetReferencedAssemblyNames(assemblyPath);
-            foreach (var reference in referencedAssemblyNames)
-            {
-                string referenceFilePath = Path.Combine(Path.GetDirectoryName(analyzerFilePath), reference + ".dll");
-
-                if (!_examinedFilePaths.Contains(referenceFilePath) &&
-                    File.Exists(referenceFilePath))
-                {
-                    _filePathsToExamine.Add(referenceFilePath);
-
-                    _dependencyPathToAnalyzerPathMap[referenceFilePath] = analyzerFilePath;
-                }
-            }
-        }
-
-        private ImmutableArray<string> GetReferencedAssemblyNames(string assemblyPath)
-        {
-            try
-            {
-                using (var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-                using (var peReader = new PEReader(stream))
-                {
-                    var metadataReader = peReader.GetMetadataReader();
-
-                    var builder = ImmutableArray.CreateBuilder<string>();
-                    foreach (var referenceHandle in metadataReader.AssemblyReferences)
-                    {
-                        var reference = metadataReader.GetAssemblyReference(referenceHandle);
-
-                        builder.Add(metadataReader.GetString(reference.Name));
-                    }
-
-                    return builder.ToImmutable();
-                }
-            }
-            catch { }
-
-            return ImmutableArray<string>.Empty;
-        }
-
-        private AssemblyIdentity TryReadAssemblyIdentity(string filePath)
+        private static AnalyzerInfo TryReadAnalyzerInfo(string filePath)
         {
             try
             {
@@ -156,18 +119,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     var metadataReader = peReader.GetMetadataReader();
 
-                    string name;
-                    Version version;
-                    string cultureName;
-                    ImmutableArray<byte> publicKeyToken;
+                    Guid mvid = ReadMvid(metadataReader);
+                    AssemblyIdentity identity = ReadAssemblyIdentity(metadataReader);
+                    ImmutableArray<AssemblyIdentity> references = ReadReferences(metadataReader);
 
-                    var assemblyDefinition = metadataReader.GetAssemblyDefinition();
-                    name = metadataReader.GetString(assemblyDefinition.Name);
-                    version = assemblyDefinition.Version;
-                    cultureName = metadataReader.GetString(assemblyDefinition.Culture);
-                    publicKeyToken = metadataReader.GetBlobContent(assemblyDefinition.PublicKey);
-
-                    return new AssemblyIdentity(name, version, cultureName, publicKeyToken, hasPublicKey: false);
+                    return new AnalyzerInfo(filePath, identity, mvid, references);
                 }
             }
             catch { }
@@ -175,50 +131,64 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return null;
         }
 
-        private sealed class DependencyInfo
+        private static ImmutableArray<AssemblyIdentity> ReadReferences(MetadataReader metadataReader)
         {
-            private byte[] _lazyFileHash;
-            private bool _triedToComputeFileHash = false;
-
-            public DependencyInfo(string dependencyFilePath, AssemblyIdentity identity, string analyzerFilePath)
+            var builder = ImmutableArray.CreateBuilder<AssemblyIdentity>();
+            foreach (var referenceHandle in metadataReader.AssemblyReferences)
             {
-                DependencyFilePath = dependencyFilePath;
-                Identity = identity;
-                AnalyzerFilePath = analyzerFilePath;
+                var reference = metadataReader.GetAssemblyReference(referenceHandle);
+
+                string refname = metadataReader.GetString(reference.Name);
+                Version refversion = reference.Version;
+                string refcultureName = metadataReader.GetString(reference.Culture);
+                ImmutableArray<byte> refpublicKeyOrToken = metadataReader.GetBlobContent(reference.PublicKeyOrToken);
+                AssemblyFlags refflags = reference.Flags;
+                bool refhasPublicKey = (refflags & AssemblyFlags.PublicKey) != 0;
+
+                builder.Add(new AssemblyIdentity(refname, refversion, refcultureName, refpublicKeyOrToken, hasPublicKey: refhasPublicKey));
             }
 
-            public string AnalyzerFilePath { get; }
+            return builder.ToImmutable();
+        }
 
-            public string DependencyFilePath { get; }
+        private static AssemblyIdentity ReadAssemblyIdentity(MetadataReader metadataReader)
+        {
+            var assemblyDefinition = metadataReader.GetAssemblyDefinition();
+            string name = metadataReader.GetString(assemblyDefinition.Name);
+            Version version = assemblyDefinition.Version;
+            string cultureName = metadataReader.GetString(assemblyDefinition.Culture);
+            ImmutableArray<byte> publicKeyOrToken = metadataReader.GetBlobContent(assemblyDefinition.PublicKey);
+            AssemblyFlags flags = assemblyDefinition.Flags;
+            bool hasPublicKey = (flags & AssemblyFlags.PublicKey) != 0;
+
+            return new AssemblyIdentity(name, version, cultureName, publicKeyOrToken, hasPublicKey: hasPublicKey);
+        }
+
+        private static Guid ReadMvid(MetadataReader metadataReader)
+        {
+            var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
+            return metadataReader.GetGuid(mvidHandle);
+        }
+
+        private sealed class AnalyzerInfo
+        {
+            public AnalyzerInfo(string filePath, AssemblyIdentity identity, Guid mvid, ImmutableArray<AssemblyIdentity> references)
+            {
+                Path = filePath;
+                Identity = identity;
+                MVID = mvid;
+                References = references;
+            }
+
+            public string Path { get; }
 
             public AssemblyIdentity Identity { get; }
 
-            public byte[] TryGetFileHash()
-            {
-                if (!_triedToComputeFileHash)
-                {
-                    _triedToComputeFileHash = true;
+            public Guid MVID { get; }
 
-                    _lazyFileHash = TryComputeFileHash(DependencyFilePath);
-                }
-
-                return _lazyFileHash;
-            }
-
-            private byte[] TryComputeFileHash(string filePath)
-            {
-                try
-                {
-                    using (var cryptoProvider = new SHA1CryptoServiceProvider())
-                    using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-                    {
-                        return cryptoProvider.ComputeHash(stream);
-                    }
-                }
-                catch { }
-
-                return null;
-            }
+            public ImmutableArray<AssemblyIdentity> References { get; }
         }
     }
+
+
 }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyConflict.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyConflict.cs
@@ -1,20 +1,25 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis;
+using System.Diagnostics;
+
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal sealed class AnalyzerDependencyConflict
     {
-        public AnalyzerDependencyConflict(string dependencyFilePath1, string dependencyFilePath2, string analyzerFilePath1, string analyzerFilePath2)
+        public AnalyzerDependencyConflict(AssemblyIdentity identity, string analyzerFilePath1, string analyzerFilePath2)
         {
-            DependencyFilePath1 = dependencyFilePath1;
-            DependencyFilePath2 = dependencyFilePath2;
+            Debug.Assert(identity != null);
+            Debug.Assert(analyzerFilePath1 != null);
+            Debug.Assert(analyzerFilePath2 != null);
+
+            Identity = identity;
             AnalyzerFilePath1 = analyzerFilePath1;
             AnalyzerFilePath2 = analyzerFilePath2;
         }
 
-        public string DependencyFilePath1 { get; }
-        public string DependencyFilePath2 { get; }
         public string AnalyzerFilePath1 { get; }
         public string AnalyzerFilePath2 { get; }
+        public AssemblyIdentity Identity { get; }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyResults.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyResults.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class AnalyzerDependencyResults
+    {
+        public AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict> conflicts, ImmutableArray<MissingAnalyzerDependency> missingDependencies)
+        {
+            Debug.Assert(conflicts != default(ImmutableArray<AnalyzerDependencyConflict>));
+            Debug.Assert(missingDependencies != default(ImmutableArray<MissingAnalyzerDependency>));
+
+            Conflicts = conflicts;
+            MissingDependencies = missingDependencies;
+        }
+
+        public ImmutableArray<AnalyzerDependencyConflict> Conflicts { get; }
+        public ImmutableArray<MissingAnalyzerDependency> MissingDependencies { get; }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/IBindingRedirectionService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IBindingRedirectionService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal interface IBindingRedirectionService
+    {
+        AssemblyIdentity ApplyBindingRedirects(AssemblyIdentity originalIdentity);
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/MissingAnalyzerDependency.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MissingAnalyzerDependency.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class MissingAnalyzerDependency
+    {
+        public MissingAnalyzerDependency(string analyzerPath, AssemblyIdentity dependencyIdentity)
+        {
+            Debug.Assert(analyzerPath != null);
+            Debug.Assert(dependencyIdentity != null);
+
+            AnalyzerPath = analyzerPath;
+            DependencyIdentity = dependencyIdentity;
+        }
+
+        public string AnalyzerPath { get; }
+        public AssemblyIdentity DependencyIdentity { get; }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
@@ -51,7 +52,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // Also, all remaining project adds need to immediately pushed as well, since we're now "interactive"
             _solutionLoadComplete = true;
 
+            // Check that the set of analyzers is complete and consistent.
+            GetAnalyzerDependencyCheckingService().CheckForConflictsAsync();
+
             return VSConstants.S_OK;
+        }
+
+        private AnalyzerDependencyCheckingService GetAnalyzerDependencyCheckingService()
+        {
+            var componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
+
+            return componentModel.GetService<AnalyzerDependencyCheckingService>();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _solutionLoadComplete = true;
 
             // Check that the set of analyzers is complete and consistent.
-            GetAnalyzerDependencyCheckingService().CheckForConflictsAsync();
+            GetAnalyzerDependencyCheckingService()?.CheckForConflictsAsync();
 
             return VSConstants.S_OK;
         }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1102,11 +1102,29 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assembly &apos;{0}&apos; used by analyzer &apos;{1}&apos; and assembly &apos;{2}&apos; used by analyzer &apos;{3}&apos; have the same identity but different contents. These analyzers may not run correctly..
+        ///   Looks up a localized string similar to Analyzer assemblies &apos;{0}&apos; and &apos;{1}&apos; both have identity &apos;{2}&apos; but different contents. Only one will be loaded and analyzers using these assemblies may not run correctly..
         /// </summary>
         internal static string WRN_AnalyzerDependencyConflictMessage {
             get {
                 return ResourceManager.GetString("WRN_AnalyzerDependencyConflictMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MissingAnalyzerReference.
+        /// </summary>
+        internal static string WRN_MissingAnalyzerReferenceId {
+            get {
+                return ResourceManager.GetString("WRN_MissingAnalyzerReferenceId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzer assembly &apos;{0}&apos; depends on &apos;{1}&apos; but it was not found. Analyzers may not run correctly..
+        /// </summary>
+        internal static string WRN_MissingAnalyzerReferenceMessage {
+            get {
+                return ResourceManager.GetString("WRN_MissingAnalyzerReferenceMessage", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -445,7 +445,7 @@ Use the dropdown to view and switch to other projects this file may belong to.</
     <value>AnalyzerDependencyConflict</value>
   </data>
   <data name="WRN_AnalyzerDependencyConflictMessage" xml:space="preserve">
-    <value>Assembly '{0}' used by analyzer '{1}' and assembly '{2}' used by analyzer '{3}' have the same identity but different contents. These analyzers may not run correctly.</value>
+    <value>Analyzer assemblies '{0}' and '{1}' both have identity '{2}' but different contents. Only one will be loaded and analyzers using these assemblies may not run correctly.</value>
   </data>
   <data name="ReferenceCountPlural" xml:space="preserve">
     <value>{0} references</value>
@@ -479,5 +479,11 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   </data>
   <data name="WorkspaceOutputPaneTitle" xml:space="preserve">
     <value>IntelliSense</value>
+  </data>
+  <data name="WRN_MissingAnalyzerReferenceId" xml:space="preserve">
+    <value>MissingAnalyzerReference</value>
+  </data>
+  <data name="WRN_MissingAnalyzerReferenceMessage" xml:space="preserve">
+    <value>Analyzer assembly '{0}' depends on '{1}' but it was not found. Analyzers may not run correctly.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\..\..\Compilers\Helpers\ShadowCopyAnalyzerAssemblyLoader.cs">
       <Link>InternalUtilities\ShadowCopyAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="Implementation\AnalyzerDependencyResults.cs" />
     <Compile Include="IAnalyzerNodeSetup.cs" />
     <Compile Include="Implementation\AnalyzerDependencyChecker.cs" />
     <Compile Include="Implementation\AnalyzerDependencyCheckingService.cs" />
@@ -39,6 +40,7 @@
     <Compile Include="Implementation\Library\FindResults\TreeItems\MetadataDefinitionTreeItem.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\SourceDefinitionTreeItem.cs" />
     <Compile Include="Implementation\Log\VisualStudioErrorLogger.cs" />
+    <Compile Include="Implementation\MissingAnalyzerDependency.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.MetadataReferenceChange.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.AnalyzerReferenceChange.cs" />
     <Compile Include="Implementation\Preview\ReferenceChange.ProjectReferenceChange.cs" />
@@ -85,6 +87,11 @@
     <Compile Include="Implementation\Workspace\VisualStudioErrorReportingService.cs" />
     <Compile Include="IRoslynTelemetrySetup.cs" />
     <Compile Include="RoslynPackage.cs" />
+    <Compile Include="ServicesVSResources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ServicesVSResources.resx</DependentUpon>
+    </Compile>
     <Compile Include="SolutionEventMonitor.cs" />
     <Compile Include="Utilities\VSCodeAnalysisColors.cs" />
     <Compile Include="Implementation\WorkspaceCacheService.cs" />
@@ -662,11 +669,6 @@
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="Progression\GraphNodeCreation.cs" />
     <Compile Include="RoslynDocumentProvider.cs" />
-    <Compile Include="ServicesVSResources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>ServicesVSResources.resx</DependentUpon>
-    </Compile>
     <Compile Include="Utilities\SpanExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
     <Compile Include="Implementation\EditAndContinue\Interop\NativeMethods.cs" />
+    <Compile Include="Implementation\IBindingRedirectionService.cs" />
     <Compile Include="Implementation\LanguageService\AbstractLanguageService`2.IVsLanguageBlock.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\MetadataDefinitionTreeItem.cs" />

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -298,7 +298,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Tagger_Diagnostics_Updated,
         SuggestedActions_HasSuggestedActionsAsync,
         SuggestedActions_GetSuggestedActions,
-        AnalyzerDependencyCheckingService_CheckForConflictsAsync,
+        AnalyzerDependencyCheckingService_LogConflict,
+        AnalyzerDependencyCheckingService_LogMissingDependency,
         VirtualMemory_MemoryLow,
         Extension_Exception,
     }


### PR DESCRIPTION
This commit updates the `AnalyzerDependencyChecker` type to reflect the
recent changes to require all analyzers and dependencies to be
specified, and the changes in how we load analyzer assemblies.

Now that we require all analyzers and dependencies to be specified, we
no longer look next to the specified analyzers to optimistically locate
dependencies. Instead, we only consider the list of passed-in analyzers
*plus* the assemblies already loaded into the `AppDomain`. The latter
avoids unhelpful warnings in the event that the analyzer assembly
includes a code fix that take a dependency on a Visual Studio assembly,
which of course can't be included in the list of analyzers. We now
create a warning when we identify a missing dependency.

We now also check analyzers themselves for conflicts (i.e., assemblies
at different paths with the same identity but different contents)
instead of just their dependencies.

Fixes #2684.
Fixes #2728.
Fixes #2738.

@mavasani @srivatsn @heejaechang @jmarolf @shyamnamboodiripad @ManishJayaswal Could you take a look, please?