### PR TITLE
Use assembly name for analyzer ID

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -148,6 +148,33 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(2781, "https://github.com/dotnet/roslyn/issues/2781")]
+        [WorkItem(2782, "https://github.com/dotnet/roslyn/issues/2782")]
+        public void ValidAnalyzerReference_Id()
+        {
+            var directory = Temp.CreateDirectory();
+            var alphaDll = directory.CreateFile("Alpha.dll").WriteAllBytes(TestResources.AssemblyLoadTests.AssemblyLoadTests.Alpha);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(alphaDll.Path);
+
+            AssemblyIdentity expectedIdentity = null;
+            AssemblyIdentity.TryParseDisplayName("Alpha, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", out expectedIdentity);
+
+            Assert.Equal(expected: expectedIdentity, actual: reference.Id);
+        }
+
+        [Fact]
+        [WorkItem(2781, "https://github.com/dotnet/roslyn/issues/2781")]
+        [WorkItem(2782, "https://github.com/dotnet/roslyn/issues/2782")]
+        public void BadAnalyzerReference_Id()
+        {
+            var directory = Temp.CreateDirectory();
+            var textFile = directory.CreateFile("Foo.txt").WriteAllText("I am the very model of a modern major general.");
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile.Path);
+
+            Assert.Equal(expected: "Foo", actual: reference.Id);
+        }
+
+        [Fact]
         [WorkItem(1032909)]
         public void TestFailedLoadDoesntCauseNoAnalyzersWarning()
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly string _fullPath;
         private readonly IAnalyzerAssemblyLoader _assemblyLoader;
 
-        private string _lazyDisplayName;
-        private string _lazyId;
+        private string _lazyDisplay;
+        private object _lazyIdentity;
         private ImmutableArray<DiagnosticAnalyzer> _lazyAllAnalyzers;
         private ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> _lazyAnalyzersPerLanguage;
         private Assembly _lazyAssembly;
@@ -117,12 +117,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             get
             {
-                if (_lazyDisplayName == null)
+                if (_lazyDisplay == null)
                 {
-                    _lazyDisplayName = Path.GetFileNameWithoutExtension(this.FullPath);
+                    InitializeDisplayAndId();
                 }
 
-                return _lazyDisplayName;
+                return _lazyDisplay;
             }
         }
 
@@ -130,12 +130,33 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             get
             {
-                if (_lazyId == null)
+                if (_lazyIdentity == null)
                 {
-                    _lazyId = Path.GetFileName(this.FullPath).ToLower();
+                    InitializeDisplayAndId();
                 }
-                
-                return _lazyId;
+
+                return _lazyIdentity;
+            }
+        }
+
+        private void InitializeDisplayAndId()
+        {
+            try
+            {
+                // AssemblyName.GetAssemblyName(path) is not available on CoreCLR.
+                // Use our metadata reader to do the equivalent thing.
+                using (var reader = new PEReader(FileUtilities.OpenRead(_fullPath)))
+                {
+                    var metadataReader = reader.GetMetadataReader();
+                    var assemblyIdentity = metadataReader.ReadAssemblyIdentityOrThrow();
+                    _lazyDisplay = assemblyIdentity.Name;
+                    _lazyIdentity = assemblyIdentity;
+                }
+            }
+            catch
+            {
+                _lazyDisplay = Path.GetFileNameWithoutExtension(_fullPath);
+                _lazyIdentity = _lazyDisplay;
             }
         }
 


### PR DESCRIPTION
Use the actual assembly name for `AnalyzerFileReference.Id`, instead of
a lowercase version of the file name.

There are places we are currently using `AnalyzerReference.Id` when what
we may want is `AnalyzerReference.DisplayName`. Notably, in the rule set
editor. This means that after my recent change to simply return the
lowercase version of the analyzer assembly's file name, the rule set
editor started showing "microsoft.codeanalysis.analyzers.dll" instead of
"Microsoft.CodeAnalysis.Analyzers".

The "right" solution would probably involve an API to map from an ID
back to an `AnalyzerReference`, and then using the `DisplayName` in the
rule set editor instead of the `Id`. At this stage in the release cycle,
however, I'm going with a simpler solution: make `AnalyzerFileReference`
return the same value for `Id` and `DisplayName`, and get that value by
reading the assembly name from the file itself, like we used to.

Fixes #2781 and #2782.

@srivatsn @mavasani @shyamnamboodiripad @jmarolf @ManishJayaswal @heejaechang Could you take a look, please?