### PR TITLE
Rationalize Code Model "member node" logic

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/NamespaceCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/NamespaceCollection.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             nodesBuilder.AddRange(CodeModelService.GetOptionNodes(node));
             nodesBuilder.AddRange(CodeModelService.GetImportNodes(node));
             nodesBuilder.AddRange(CodeModelService.GetAttributeNodes(node));
-            nodesBuilder.AddRange(CodeModelService.GetFlattenedMemberNodes(node));
+            nodesBuilder.AddRange(CodeModelService.GetLogicalSupportedMemberNodes(node));
 
             return new NodeSnapshot(this.State, _fileCodeModel, node, parentElement, nodesBuilder.ToImmutable());
         }
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             currentIndex += attributeNodeCount;
 
             // Members
-            var memberNodes = CodeModelService.GetFlattenedMemberNodes(node);
+            var memberNodes = CodeModelService.GetLogicalSupportedMemberNodes(node);
             var memberNodeCount = memberNodes.Count();
             if (index < currentIndex + memberNodeCount)
             {
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             }
 
             // Members
-            foreach (var child in CodeModelService.GetFlattenedMemberNodes(node))
+            foreach (var child in CodeModelService.GetLogicalSupportedMemberNodes(node))
             {
                 var childName = CodeModelService.GetName(child);
                 if (childName == name)
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
                     CodeModelService.GetOptionNodes(node).Count() +
                     CodeModelService.GetImportNodes(node).Count() +
                     CodeModelService.GetAttributeNodes(node).Count() +
-                    CodeModelService.GetFlattenedMemberNodes(node).Count();
+                    CodeModelService.GetLogicalSupportedMemberNodes(node).Count();
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/TypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/TypeCollection.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             var parentElement = (AbstractCodeElement)this.Parent;
 
             var nodesBuilder = ImmutableArray.CreateBuilder<SyntaxNode>();
-            nodesBuilder.AddRange(CodeModelService.GetFlattenedMemberNodes(node));
+            nodesBuilder.AddRange(CodeModelService.GetLogicalSupportedMemberNodes(node));
 
             return new NodeSnapshot(this.State, _fileCodeModel, node, parentElement, nodesBuilder.ToImmutable());
         }
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
         {
             var node = LookupNode();
 
-            var memberNodes = CodeModelService.GetFlattenedMemberNodes(node);
+            var memberNodes = CodeModelService.GetLogicalSupportedMemberNodes(node);
             if (index >= 0 && index < memberNodes.Count())
             {
                 var child = memberNodes.ElementAt(index);
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
         {
             var node = LookupNode();
 
-            foreach (var child in CodeModelService.GetFlattenedMemberNodes(node))
+            foreach (var child in CodeModelService.GetLogicalSupportedMemberNodes(node))
             {
                 var childName = CodeModelService.GetName(child);
                 if (childName == name)
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             get
             {
                 var node = LookupNode();
-                return CodeModelService.GetFlattenedMemberNodes(node).Count();
+                return CodeModelService.GetLogicalSupportedMemberNodes(node).Count();
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -46,11 +46,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         IEnumerable<SyntaxNode> GetImplementsNodes(SyntaxNode parent);
 
         /// <summary>
-        /// Retrieves the logical members of a given node, flattening the declarators
-        /// in field declarations. For example, if a class contains the field "int foo, bar", 
-        /// two nodes are returned -- one for "foo" and one for "bar".
+        /// Retrieves the members of a specified <paramref name="container"/> node. The members that are
+        /// returned can be controlled by passing various parameters.
         /// </summary>
-        IEnumerable<SyntaxNode> GetFlattenedMemberNodes(SyntaxNode parent);
+        /// <param name="container">The <see cref="SyntaxNode"/> from which to retrieve members.</param>
+        /// <param name="includeSelf">If true, the container is returned as well.</param>
+        /// <param name="recursive">If true, members are recursed to return descendent members as well
+        /// as immediate children. For example, a namespace would return the namespaces and types within.
+        /// However, if <paramref name="recursive"/> is true, members with the namespaces and types would
+        /// also be returned.</param>
+        /// <param name="logicalFields">If true, field declarations are broken into their respecitive declarators.
+        /// For example, the field "int x, y" would return two declarators, one for x and one for y in place
+        /// of the field.</param>
+        /// <param name="onlySuportedNodes">If true, only members supported by Code Model are returned.</param>
+        IEnumerable<SyntaxNode> GetMemberNodes(SyntaxNode container, bool includeSelf, bool recursive, bool logicalFields, bool onlySuportedNodes);
+
+        IEnumerable<SyntaxNode> GetLogicalSupportedMemberNodes(SyntaxNode container);
 
         SyntaxNodeKey GetNodeKey(SyntaxNode node);
         SyntaxNodeKey TryGetNodeKey(SyntaxNode node);

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -1947,6 +1947,33 @@ class C
             TestAddFunction(code, expected, New FunctionData With {.Name = "C", .Kind = EnvDTE.vsCMFunction.vsCMFunctionDestructor, .Type = "void", .Access = EnvDTE.vsCMAccess.vsCMAccessPublic})
         End Sub
 
+        <WorkItem(1172038)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddFunction_AfterIncompleteMember()
+            Dim code =
+<Code>
+class $$C
+{
+    private void M1()
+    private void
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    private void M1()
+    private void private void M2()
+    {
+
+    }
+}
+</Code>
+
+            TestAddFunction(code, expected, New FunctionData With {.Name = "M2", .Type = "void", .Position = -1, .Access = EnvDTE.vsCMAccess.vsCMAccessPrivate})
+        End Sub
+
 #End Region
 
 #Region "AddImplementedInterface tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -853,6 +853,35 @@ End Class
                 End Sub)
         End Sub
 
+        <WorkItem(1172038)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddFunction_AfterIncompleteMember()
+            Dim code =
+<Code>
+Class $$C
+    Private Sub M1()
+    End Sub
+
+    Private Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Private Sub M1()
+    End Sub
+
+    Private Sub
+Private Sub M2()
+
+    End Sub
+End Class
+</Code>
+
+            TestAddFunction(code, expected, New FunctionData With {.Name = "M2", .Type = "void", .Position = -1, .Access = EnvDTE.vsCMAccess.vsCMAccessPrivate})
+        End Sub
+
 #End Region
 
 #Region "AddProperty tests"


### PR DESCRIPTION
Code Model has several ways of looking at the member nodes of a particular container. Sometimes it does so recursively, flattening all nested members into a single list. Sometimes, it looks for "logical" nodes, i.e. breaking up field declarations into their component declarators. Sometimes only supported nodes (that is, nodes that can be properly represented in Code Mode) are expected.

Unfortunately, the internal APIs for these searches grew up organically and have become quite a mess. There were several places where the wrong search was being used, resulting in strange bugs.

These concepts are now consolidated into a single GetMemberNodes() method and all callsites have been reviewed and updated.

Note: The particular bug that this change addresses is about inserting a node into a container that contains an incomplete member. In that case, the code used a "flattened" list to find the index where the node was to be inserted. What it really wanted was a "logical" list, but that was conflated with "flattening".