### PR TITLE
Change pipe checksum to SHA256

### DIFF
--- a/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
+++ b/src/Compilers/Core/VBCSCompiler/BuildProtocol.cs
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// </summary>
         internal static string GetPipeName(string compilerExeDirectory)
         {
-            using (var sha = SHA1.Create())
+            using (var sha = SHA256.Create())
             {
                 var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(compilerExeDirectory));
                 return BitConverter.ToString(bytes).Replace("-", string.Empty);


### PR DESCRIPTION
Change our pipe hashing to SHA256 instead of SHA1.

The use of the SHA1 algorithm in security sensitive situations is
banned.  It is still fine as a simple check summing mechanism for public
data (as we are doing in this case).  But source code scanners can't
understand context and raise warnings whenever it is used at all.  Hence
switching this to SHA256 instead.