### PR TITLE
Fix deadlock in AliasSymbol.GetAliasTarget

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // lazy binding
         private readonly NameSyntax _aliasTargetName;
         private readonly bool _isExtern;
-        private ImmutableArray<Diagnostic> _aliasTargetDiagnostics;
+        private DiagnosticBag _aliasTargetDiagnostics;
 
         private AliasSymbol(InContainerBinder binder, NamespaceOrTypeSymbol target, SyntaxToken aliasName, ImmutableArray<Location> locations)
         {
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if ((object)Interlocked.CompareExchange(ref _aliasTarget, symbol, null) == null)
                 {
-                    bool won = ImmutableInterlocked.InterlockedInitialize(ref _aliasTargetDiagnostics, newDiagnostics.ToReadOnlyAndFree());
+                    bool won = Interlocked.Exchange(ref _aliasTargetDiagnostics, newDiagnostics) == null;
                     Debug.Assert(won, "Only one thread can win the alias target CompareExchange");
 
                     _state.NotePartComplete(CompletionPart.AliasTarget);
@@ -266,12 +266,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _aliasTarget;
         }
 
-        internal ImmutableArray<Diagnostic> AliasTargetDiagnostics
+        internal DiagnosticBag AliasTargetDiagnostics
         {
             get
             {
                 GetAliasTarget(null);
-                Debug.Assert(!_aliasTargetDiagnostics.IsDefault);
+                Debug.Assert(_aliasTargetDiagnostics != null);
                 return _aliasTargetDiagnostics;
             }
         }


### PR DESCRIPTION
The following line inside GetAliasTarget was causing a deadlock in the
compiler:

```
bool won = ImmutableInterlocked.InterlockedInitialize(ref
_aliasTargetDiagnostics, newDiagnostics.ToReadOnlyAndFree());
```

The ToReadOnlyAndFree call caused any lazy diagnostics present in the
DiagnosticsBag to be promptly evaluated.  As a part of evaluation the
diagnostics could call back into other compiler code including
AliasSymbol.GetAliasTarget.  If that happened on the same AliasSymbol
instance the compiler would enter a deadlock as _aliasTarget had already
been set to a non-null value.

The CompareExchange of _aliasTarget is effectively a lock statement
ToReadOnlyAndFree is calling out to untrusted code.  The fix is to stop
doing this by just saving the DiagnosticBag directly vs. calling
ToReadOnlyAndFree.

This resolves DevDiv 1161400