### PR TITLE
Guard visitors against stack overflow exceptions

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         //  2. A modified version of the parser was run on the Roslyn source base and the maximum depth 
         //     discovered was 7.  Having 20 as a minimum seems reasonable in that context 
         //
-        private const int MaxUncheckedRecursionDepth = 20;
+        internal const int MaxUncheckedRecursionDepth = 20;
 
         // list pools - allocators for lists that are used to build sequences of nodes. The lists
         // can be reused (hence pooled) since the syntax factory methods don't keep references to

--- a/src/Compilers/CSharp/Portable/PublicAPI.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.txt
@@ -2522,6 +2522,7 @@ override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ReplaceTriviaInListCore(
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.SerializeTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.SyntaxTreeCore.get -> Microsoft.CodeAnalysis.SyntaxTree
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.WriteTo(System.IO.TextWriter writer) -> void
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(Microsoft.CodeAnalysis.SyntaxNode node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitAccessorDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitAccessorList(Microsoft.CodeAnalysis.CSharp.Syntax.AccessorListSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitAliasQualifiedName(Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Compilers/CSharp/Portable/PublicAPI.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.txt
@@ -2727,6 +2727,7 @@ override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.OptionsCore.get -> Micro
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.TryGetRootCore(out Microsoft.CodeAnalysis.SyntaxNode root) -> bool
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.WithChangedText(Microsoft.CodeAnalysis.Text.SourceText newText) -> Microsoft.CodeAnalysis.SyntaxTree
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxWalker.DefaultVisit(Microsoft.CodeAnalysis.SyntaxNode node) -> void
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxWalker.Visit(Microsoft.CodeAnalysis.SyntaxNode node) -> void
 override Microsoft.CodeAnalysis.CSharp.Conversion.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.CSharp.Conversion.GetHashCode() -> int
 override Microsoft.CodeAnalysis.CSharp.Conversion.ToString() -> string

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return _visitIntoStructuredTrivia; }
         }
 
-        private const int MaxUncheckedRecursionDepth = Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth;
         private int _recursionDepth;
 
         public override SyntaxNode Visit(SyntaxNode node)
@@ -35,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node != null)
             {
                 _recursionDepth++;
-                if (_recursionDepth > MaxUncheckedRecursionDepth)
+                if (_recursionDepth > Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth)
                 {
                     PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
                 }

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxVisitor.cs
@@ -17,23 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </typeparam>
     public abstract partial class CSharpSyntaxVisitor<TResult>
     {
-        private const int MaxUncheckedRecursionDepth = Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth;
-        private int _recursionDepth;
-
         public virtual TResult Visit(SyntaxNode node)
         {
             if (node != null)
             {
-                _recursionDepth++;
-                if (_recursionDepth > MaxUncheckedRecursionDepth)
-                {
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-                }
-
-                var result = ((CSharpSyntaxNode)node).Accept(this);
-
-                _recursionDepth--;
-                return result;
+                return ((CSharpSyntaxNode)node).Accept(this);
             }
 
             // should not come here too often so we will put this at the end of the method.
@@ -52,22 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     public abstract partial class CSharpSyntaxVisitor
     {
-        private const int MaxUncheckedRecursionDepth = Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth;
-        private int _recursionDepth;
-
         public virtual void Visit(SyntaxNode node)
         {
             if (node != null)
             {
-                _recursionDepth++;
-                if (_recursionDepth > MaxUncheckedRecursionDepth)
-                {
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-                }
-
                 ((CSharpSyntaxNode)node).Accept(this);
-
-                _recursionDepth--;
             }
         }
 

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -930,6 +930,7 @@
     <Compile Include="Syntax\LambdaUtilities.vb" />
     <Compile Include="Syntax\TypeBlockSyntax.vb" />
     <Compile Include="Syntax\TypeStatementSyntax.vb" />
+    <Compile Include="Syntax\VisualBasicSyntaxVisitor.vb" />
     <Compile Include="Syntax\VisualBasicWarningStateMap.vb" />
     <Compile Include="Syntax\VisualBasicLineDirectiveMap.vb" />
     <Compile Include="Syntax\VisualBasicSyntaxNode.vb" />

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Try
                 _recursionDepth += 1
-                If _recursionDepth >= _maxUncheckedRecursionDepth Then
+                If _recursionDepth >= MaxUncheckedRecursionDepth Then
                     PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Enum
 
         ' Keep this value in sync with C# LanguageParser
-        Private Const _maxUncheckedRecursionDepth As Integer = 30
+        Friend Const MaxUncheckedRecursionDepth As Integer = 20
 
         Private _allowLeadingMultilineTrivia As Boolean = True
         Private _hadImplicitLineContinuation As Boolean = False
@@ -856,7 +856,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Try
                 _recursionDepth += 1
-                If _recursionDepth >= _maxUncheckedRecursionDepth Then
+                If _recursionDepth >= MaxUncheckedRecursionDepth Then
                     PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.txt
@@ -4697,6 +4697,7 @@ Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.OptionsCore()
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.TryGetRootCore(ByRef root As Microsoft.CodeAnalysis.SyntaxNode) -> Boolean
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.WithChangedText(newText As Microsoft.CodeAnalysis.Text.SourceText) -> Microsoft.CodeAnalysis.SyntaxTree
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxWalker.DefaultVisit(node As Microsoft.CodeAnalysis.SyntaxNode) -> Void
+Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxWalker.Visit(node As Microsoft.CodeAnalysis.SyntaxNode) -> Void
 ReadOnly Microsoft.CodeAnalysis.VisualBasic.AggregateClauseSymbolInfo.Select1 -> Microsoft.CodeAnalysis.SymbolInfo
 ReadOnly Microsoft.CodeAnalysis.VisualBasic.AggregateClauseSymbolInfo.Select2 -> Microsoft.CodeAnalysis.SymbolInfo
 ReadOnly Microsoft.CodeAnalysis.VisualBasic.CollectionRangeVariableSymbolInfo.AsClauseConversion -> Microsoft.CodeAnalysis.SymbolInfo

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.txt
@@ -4437,6 +4437,7 @@ Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode.ReplaceTrivia
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode.SerializeTo(stream As System.IO.Stream, cancellationToken As System.Threading.CancellationToken = Nothing) -> Void
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode.SyntaxTreeCore() -> Microsoft.CodeAnalysis.SyntaxTree
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode.WriteTo(writer As System.IO.TextWriter) -> Void
+Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter.Visit(node As Microsoft.CodeAnalysis.SyntaxNode) -> Microsoft.CodeAnalysis.SyntaxNode
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter.VisitAccessorBlock(node As Microsoft.CodeAnalysis.VisualBasic.Syntax.AccessorBlockSyntax) -> Microsoft.CodeAnalysis.SyntaxNode
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter.VisitAccessorStatement(node As Microsoft.CodeAnalysis.VisualBasic.Syntax.AccessorStatementSyntax) -> Microsoft.CodeAnalysis.SyntaxNode
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter.VisitAddRemoveHandlerStatement(node As Microsoft.CodeAnalysis.VisualBasic.Syntax.AddRemoveHandlerStatementSyntax) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
@@ -29,14 +29,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
         Private _recursionDepth As Integer
 
         Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
             If node IsNot Nothing Then
                 _recursionDepth += 1
 
-                If _recursionDepth > MaxUncheckedRecursionDepth Then
+                If _recursionDepth > Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth Then
                     PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
@@ -29,6 +29,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
+        Private _recursionDepth As Integer
+
+        Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
+            If node IsNot Nothing Then
+                _recursionDepth += 1
+
+                If _recursionDepth > MaxUncheckedRecursionDepth Then
+                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
+                End If
+
+                Dim result = DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
+
+                _recursionDepth -= 1
+                Return result
+            Else
+                Return node
+            End If
+        End Function
+
         Public Overridable Function VisitToken(token As SyntaxToken) As SyntaxToken
             Dim leading = Me.VisitList(token.LeadingTrivia)
             Dim trailing = Me.VisitList(token.TrailingTrivia)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxVisitor.vb
@@ -1,0 +1,68 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic
+    ''' <summary>
+    ''' Represents a <see cref="SyntaxNode"/> visitor that visits only the single SyntaxNode
+    ''' passed into its <see cref="Visit(SyntaxNode)"/> method.
+    ''' </summary>
+    Partial Public MustInherit Class VisualBasicSyntaxVisitor
+        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
+        Private _recursionDepth As Integer
+
+        Public Overridable Sub Visit(ByVal node As SyntaxNode)
+            If node IsNot Nothing Then
+                _recursionDepth += 1
+
+                If _recursionDepth > MaxUncheckedRecursionDepth Then
+                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
+                End If
+
+                DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
+
+                _recursionDepth -= 1
+            End If
+        End Sub
+
+        Public Overridable Sub DefaultVisit(ByVal node As SyntaxNode)
+        End Sub
+    End Class
+
+    ''' <summary>
+    ''' Represents a <see cref="SyntaxNode"/> visitor that visits only the single SyntaxNode
+    ''' passed into its <see cref="Visit(SyntaxNode)"/> method and produces 
+    ''' a value of the type specified by the <typeparamref name="TResult"/> parameter.
+    ''' </summary>
+    ''' <typeparam name="TResult">
+    ''' The type of the return value of this visitor's Visit method.
+    ''' </typeparam>
+    Partial Public MustInherit Class VisualBasicSyntaxVisitor(Of TResult)
+        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
+        Private _recursionDepth As Integer
+
+        Public Overridable Function Visit(ByVal node As SyntaxNode) As TResult
+            If node IsNot Nothing Then
+                _recursionDepth += 1
+
+                If _recursionDepth > MaxUncheckedRecursionDepth Then
+                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
+                End If
+
+                Dim result = DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
+
+                _recursionDepth -= 1
+
+                Return result
+            End If
+
+            Return Nothing
+        End Function
+
+        Public Overridable Function DefaultVisit(ByVal node As SyntaxNode) As TResult
+            Return Nothing
+        End Function
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxVisitor.vb
@@ -10,20 +10,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' passed into its <see cref="Visit(SyntaxNode)"/> method.
     ''' </summary>
     Partial Public MustInherit Class VisualBasicSyntaxVisitor
-        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
-        Private _recursionDepth As Integer
 
         Public Overridable Sub Visit(ByVal node As SyntaxNode)
             If node IsNot Nothing Then
-                _recursionDepth += 1
-
-                If _recursionDepth > MaxUncheckedRecursionDepth Then
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
-                End If
-
                 DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
-
-                _recursionDepth -= 1
             End If
         End Sub
 
@@ -40,22 +30,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' The type of the return value of this visitor's Visit method.
     ''' </typeparam>
     Partial Public MustInherit Class VisualBasicSyntaxVisitor(Of TResult)
-        Private Const MaxUncheckedRecursionDepth As Integer = Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth
-        Private _recursionDepth As Integer
 
         Public Overridable Function Visit(ByVal node As SyntaxNode) As TResult
             If node IsNot Nothing Then
-                _recursionDepth += 1
-
-                If _recursionDepth > MaxUncheckedRecursionDepth Then
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
-                End If
-
-                Dim result = DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
-
-                _recursionDepth -= 1
-
-                Return result
+                Return DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
             End If
 
             Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
@@ -70,22 +70,4 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
     End Class
-
-    ''' <summary>
-    ''' Represents a <see cref="SyntaxNode"/> visitor that visits only the single SyntaxNode
-    ''' passed into its <see cref="Visit(SyntaxNode)"/> method.
-    ''' </summary>
-    Partial Public MustInherit Class VisualBasicSyntaxVisitor
-    End Class
-
-    ''' <summary>
-    ''' Represents a <see cref="SyntaxNode"/> visitor that visits only the single SyntaxNode
-    ''' passed into its <see cref="Visit(SyntaxNode)"/> method and produces 
-    ''' a value of the type specified by the <typeparamref name="TResult"/> parameter.
-    ''' </summary>
-    ''' <typeparam name="TResult">
-    ''' The type of the return value this visitor's Visit method.
-    ''' </typeparam>
-    Partial Public MustInherit Class VisualBasicSyntaxVisitor(Of TResult)
-    End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
@@ -18,6 +18,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Me.Depth = depth
         End Sub
 
+        Private _recursionDepth As Integer
+
+        Public Overrides Sub Visit(node As SyntaxNode)
+            If node IsNot Nothing Then
+                _recursionDepth += 1
+
+                If _recursionDepth > Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth Then
+                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
+                End If
+
+                DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
+
+                _recursionDepth -= 1
+            End If
+        End Sub
+
         Public Overrides Sub DefaultVisit(node As SyntaxNode)
             Dim list = node.ChildNodesAndTokens()
             Dim childCnt = list.Count

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/RedNodes/RedNodeWriter.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/RedNodes/RedNodeWriter.vb
@@ -1032,22 +1032,6 @@ Friend Class RedNodeWriter
     Private Sub GenerateVisitorClass(withResult As Boolean)
         _writer.WriteLine("    Public MustInherit Class {0}{1}", Ident(_parseTree.VisitorName), If(withResult, "(Of TResult)", ""))
 
-        ' Basic Visit method that dispatches.
-        _writer.WriteLine("        Public Overridable {0} Visit(ByVal node As SyntaxNode){1}",
-                          If(withResult, "Function", "Sub"),
-                          If(withResult, " As TResult", ""))
-        _writer.WriteLine("            If node Is Nothing")
-        _writer.WriteLine("                Return{0}", If(withResult, " Nothing", ""))
-        _writer.WriteLine("            End If")
-        _writer.WriteLine("")
-        _writer.WriteLine("            {0}DirectCast(node, VisualBasicSyntaxNode).Accept(Me){1}", If(withResult, "Return ", ""), If(withResult, "", ": Return"))
-        _writer.WriteLine("        End {0}", If(withResult, "Function", "Sub"))
-
-        _writer.WriteLine("        Public Overridable {0} DefaultVisit(ByVal node As SyntaxNode){1}",
-                          If(withResult, "Function", "Sub"),
-                          If(withResult, " As TResult", ""))
-        _writer.WriteLine("        End {0}", If(withResult, "Function", "Sub"))
-
         For Each nodeStructure In _parseTree.NodeStructures.Values
             If Not nodeStructure.Abstract Then
                 GenerateVisitorMethod(nodeStructure, withResult)


### PR DESCRIPTION
Avoid causing actual stack overflow exceptions when using syntax visitors.  This change adds the same stack check we use in the parsers to the visitor classes.  The visitor will still throw, but it will throw a catchable exception.

@Pilchie @jaredpar  please review