### PR TITLE
No conflicts on same-named locals of delegate types

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -101,7 +101,7 @@ class C
     {
         Foo {|DeclConflict:x|} = new Foo(FooMeth);
         int [|$$z|] = 1; // Rename z to x
-        {|unresolve1:x|}({|unresolve2:z|});
+        x({|unresolve2:z|});
     }
 }
                             </Document>
@@ -109,7 +109,6 @@ class C
                     </Workspace>, renameTo:="x")
 
                 result.AssertLabeledSpansAre("DeclConflict", type:=RelatedLocationType.UnresolvedConflict)
-                result.AssertLabeledSpansAre("unresolve1", type:=RelatedLocationType.UnresolvedConflict)
                 result.AssertLabeledSpansAre("unresolve2", "x", type:=RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -317,12 +317,13 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                         var conflictAnnotation = nodeAndAnnotation.Item2;
                         reverseMappedLocations[tokenOrNode.GetLocation()] = baseSyntaxTree.GetLocation(conflictAnnotation.OriginalSpan);
                         var originalLocation = conflictAnnotation.OriginalSpan;
+                        IEnumerable<ISymbol> newReferencedSymbols = null;
 
                         var hasConflict = _renameAnnotations.HasAnnotation(tokenOrNode, RenameInvalidIdentifierAnnotation.Instance);
                         if (!hasConflict)
                         {
                             newDocumentSemanticModel = newDocumentSemanticModel ?? await newDocument.GetSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
-                            var newReferencedSymbols = GetSymbolsInNewSolution(newDocument, newDocumentSemanticModel, conflictAnnotation, tokenOrNode);
+                            newReferencedSymbols = GetSymbolsInNewSolution(newDocument, newDocumentSemanticModel, conflictAnnotation, tokenOrNode);
 
                             // The semantic correctness, after rename, for each token of interest in the rename context is performed by getting the symbol pointed by
                             // each token and obtain the Symbol's First Ordered Location's  Span-Start and check to see if it is the same as before from the base solution.
@@ -333,7 +334,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                         if (!hasConflict && !conflictAnnotation.IsInvocationExpression)
                         {
-                            hasConflict = LocalVariableConflictPerLanguage((SyntaxToken)tokenOrNode, newDocument);
+                            hasConflict = LocalVariableConflictPerLanguage((SyntaxToken)tokenOrNode, newDocument, newReferencedSymbols);
                         }
 
                         if (!hasConflict)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -86,10 +86,10 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             return complexifiedTarget;
         }
 
-        private static bool LocalVariableConflictPerLanguage(SyntaxToken tokenOrNode, Document document)
+        private static bool LocalVariableConflictPerLanguage(SyntaxToken tokenOrNode, Document document, IEnumerable<ISymbol> newReferencedSymbols)
         {
             var renameRewriterService = document.Project.LanguageServices.GetService<IRenameRewriterLanguageService>();
-            var isConflict = renameRewriterService.LocalVariableConflict(tokenOrNode);
+            var isConflict = renameRewriterService.LocalVariableConflict(tokenOrNode, newReferencedSymbols);
             return isConflict;
         }
 

--- a/src/Workspaces/Core/Portable/Rename/IRenameRewriterLanguageService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRenameRewriterLanguageService.cs
@@ -92,9 +92,12 @@ namespace Microsoft.CodeAnalysis.Rename
         /// Identifies potential Conflicts into the inner scope locals. This may give false positives.
         /// </summary>
         /// <param name="token">The Token that may introduce errors else where</param>
+        /// <param name="newReferencedSymbols">The symbols that this token binds to after the rename
+        /// has been applied</param>
         /// <returns>Returns if there is a potential conflict</returns>
         bool LocalVariableConflict(
-            SyntaxToken token);
+            SyntaxToken token,
+            IEnumerable<ISymbol> newReferencedSymbols);
 
         /// <summary>
         /// Used to find if the replacement Identifier is valid

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -627,7 +627,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
 #Region "Declaration Conflicts"
 
         Public Function LocalVariableConflict(
-            token As SyntaxToken
+            token As SyntaxToken,
+            newReferencedSymbols As IEnumerable(Of ISymbol)
             ) As Boolean Implements IRenameRewriterLanguageService.LocalVariableConflict
 
             ' This scenario is not present in VB and only in C#


### PR DESCRIPTION
Fixes #1729

The C# implementation of IRenameRewriterLanguageService.LocalVariableConflict was returning conflicts any time a related invocation expression bound to a local/parameter, but this condition is not indicative of a conflict when the local/parameter is of a delegate type. This change prevents reporting this particular kind of conflict on references to locals & parameters of a delegate type.

Tagging reviewers: @Pilchie @jasonmalinowski @rchande @balajikris @brettfo @jmarolf