### PR TITLE
Improve rename conflicts in nameof

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -2969,6 +2969,50 @@ End Namespace
                     </Workspace>, renameTo:="N2")
                 End Using
             End Sub
+
+            <WorkItem(1195, "https://github.com/dotnet/roslyn/issues/1195")>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub NameOfReferenceNoConflict()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class C
+    Sub [|T$$|](x As Integer)
+    End Sub
+
+    Sub Test()
+        Dim x = NameOf(Test)
+    End Sub
+End Class
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Test")
+                End Using
+            End Sub
+
+            <WorkItem(1195, "https://github.com/dotnet/roslyn/issues/1195")>
+            <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub NameOfReferenceWithConflict()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class C
+    Sub Test()
+        Dim [|T$$|] As Integer
+        Dim x = NameOf({|conflict:Test|})
+    End Sub
+End Class
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Test")
+
+                    result.AssertLabeledSpansAre("conflict", "Test", RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -6768,29 +6768,6 @@ class C
 
             End Using
         End Sub
-
-        <WorkItem(446, "https://github.com/dotnet/roslyn/issues/446")>
-        <Fact>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub RenameWithNameOfInAttribute()
-            Using result = RenameEngineResult.Create(
-                   <Workspace>
-                       <Project Language="C#" CommonReferences="true">
-                           <Document>
-class C
-{
-    // Rename F to Fail
-    static void [|F|]$$(int x) { }
-
-    [System.Obsolete(nameof({|conflict:Fail|}))]
-    static void Fail() { }
-}
-                            </Document>
-                       </Project>
-                   </Workspace>, renameTo:="Fail")
-                result.AssertLabeledSpansAre("conflict", type:=RelatedLocationType.UnresolvedConflict)
-            End Using
-        End Sub
 #End Region
 
     End Class

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/Annotations/RenameActionAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/Annotations/RenameActionAnnotation.cs
@@ -51,6 +51,11 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         public readonly bool IsNamespaceDeclarationReference;
 
         /// <summary>
+        /// States if this token is a member group reference, typically found in NameOf expressions
+        /// </summary>
+        public readonly bool IsMemberGroupReference;
+
+        /// <summary>
         /// States if this token is annotated as a part of the Invocation Expression that needs to be checked for the Conflicts
         /// </summary>
         public readonly bool IsInvocationExpression;
@@ -63,7 +68,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             bool isOriginalTextLocation,
             RenameDeclarationLocationReference[] renameDeclarationLocations,
             bool isNamespaceDeclarationReference,
-            bool isInvocationExpression)
+            bool isInvocationExpression,
+            bool isMemberGroupReference)
         {
             this.OriginalSpan = originalSpan;
             this.IsRenameLocation = isRenameLocation;
@@ -73,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             this.IsOriginalTextLocation = isOriginalTextLocation;
             this.IsNamespaceDeclarationReference = isNamespaceDeclarationReference;
             this.IsInvocationExpression = isInvocationExpression;
+            this.IsMemberGroupReference = isMemberGroupReference;
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -58,6 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
             Private ReadOnly _annotatedIdentifierTokens As New HashSet(Of SyntaxToken)
             Private ReadOnly _invocationExpressionsNeedingConflictChecks As New HashSet(Of InvocationExpressionSyntax)
             Private ReadOnly _syntaxFactsService As ISyntaxFactsService
+            Private ReadOnly _semanticFactsService As ISemanticFactsService
             Private ReadOnly _renameAnnotations As AnnotationTable(Of RenameAnnotation)
 
             Private ReadOnly Property AnnotateForComplexification As Boolean
@@ -104,6 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 Me._renamableDeclarationLocation = Me._renamedSymbol.Locations.Where(Function(loc) loc.IsInSource AndAlso loc.SourceTree Is _semanticModel.SyntaxTree).FirstOrDefault()
                 Me._simplificationService = parameters.Document.Project.LanguageServices.GetService(Of ISimplificationService)()
                 Me._syntaxFactsService = parameters.Document.Project.LanguageServices.GetService(Of ISyntaxFactsService)()
+                Me._semanticFactsService = parameters.Document.Project.LanguageServices.GetService(Of ISemanticFactsService)()
                 Me._isVerbatim = Me._syntaxFactsService.IsVerbatimIdentifier(_replacementText)
                 Me._renameAnnotations = parameters.RenameAnnotations
             End Sub
@@ -318,6 +320,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                     isNamespaceDeclarationReference = True
                 End If
 
+                Dim isMemberGroupReference = _semanticFactsService.IsNameOfContext(_semanticModel, token.Span.Start, _cancellationToken)
+
                 Dim renameAnnotation = New RenameActionAnnotation(
                                     token.Span,
                                     isRenameLocation,
@@ -326,7 +330,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                                     isOldText,
                                     renameDeclarationLocations,
                                     isNamespaceDeclarationReference,
-                                    isInvocationExpression:=False)
+                                    isInvocationExpression:=False,
+                                    isMemberGroupReference:=isMemberGroupReference)
 
                 _annotatedIdentifierTokens.Add(token)
                 newToken = Me._renameAnnotations.WithAdditionalAnnotations(newToken, renameAnnotation, New RenameTokenSimplificationAnnotation() With {.OriginalTextSpan = token.Span})
@@ -453,7 +458,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                                             renameDeclarationLocations:=renameDeclarationLocations,
                                             isOriginalTextLocation:=False,
                                             isNamespaceDeclarationReference:=False,
-                                            isInvocationExpression:=True)
+                                            isInvocationExpression:=True,
+                                            isMemberGroupReference:=False)
 
                     Return renameAnnotation
                 End If


### PR DESCRIPTION
Fixes #1195 "Renaming a member to a name used within a nameof is a
conflict"

When a nameof expression is involved in a rename, conflicts are only
introduced if the nameof previously referenced a non-empty set of
symbols and the post-rename set of referenced symbols contains none of
the previously referenced symbols. This allows overloads to join or exit
the set of references without conflicts, but a conflict is still offered
if the nameof switches from referencing a method to referencing a local
(or similar).

Potential reviewers: @Pilchie @jasonmalinowski @rchande @balajikris @brettfo @jmarolf 