### PR TITLE
Fixes a couple of issues around import scope compilation

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             SourceMemberContainerTypeSymbol typeSymbol,
             MethodSymbol scriptCtor,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> fieldInitializers,
-            bool generateDebugInfo,
             DiagnosticBag diagnostics,
             ref ProcessedFieldInitializers processedInitializers) //by ref so that we can store the results of lowering
         {
@@ -33,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImportChain firstImportChain;
 
                 processedInitializers.BoundInitializers = BindFieldInitializers(typeSymbol, scriptCtor, fieldInitializers,
-                    diagsForInstanceInitializers, generateDebugInfo, out firstImportChain);
+                    diagsForInstanceInitializers, out firstImportChain);
 
                 processedInitializers.HasErrors = diagsForInstanceInitializers.HasAnyErrors();
                 processedInitializers.FirstImportChain = firstImportChain;
@@ -50,7 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol scriptCtor,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
             DiagnosticBag diagnostics,
-            bool generateDebugInfo,
             out ImportChain firstImportChain)
         {
             if (initializers.IsEmpty)
@@ -64,11 +62,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)scriptCtor == null)
             {
-                BindRegularCSharpFieldInitializers(compilation, initializers, boundInitializers, diagnostics, generateDebugInfo, out firstImportChain);
+                BindRegularCSharpFieldInitializers(compilation, initializers, boundInitializers, diagnostics, out firstImportChain);
             }
             else
             {
-                BindScriptFieldInitializers(compilation, scriptCtor, initializers, boundInitializers, diagnostics, generateDebugInfo, out firstImportChain);
+                BindScriptFieldInitializers(compilation, scriptCtor, initializers, boundInitializers, diagnostics, out firstImportChain);
             }
 
             return boundInitializers.ToImmutableAndFree();
@@ -83,7 +81,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
             ArrayBuilder<BoundInitializer> boundInitializers,
             DiagnosticBag diagnostics,
-            bool generateDebugInfo,
             out ImportChain firstDebugImports)
         {
             firstDebugImports = null;
@@ -118,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(parentBinder.ContainingMemberOrLambda == fieldSymbol.ContainingType || //should be the binder for the type
                                 fieldSymbol.ContainingType.IsImplicitClass); //however, we also allow fields in namespaces to help support script scenarios
 
-                        if (generateDebugInfo && firstDebugImports == null)
+                        if (firstDebugImports == null)
                         {
                             firstDebugImports = parentBinder.ImportChain;
                         }
@@ -138,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private static void BindScriptFieldInitializers(CSharpCompilation compilation, MethodSymbol scriptCtor,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers, ArrayBuilder<BoundInitializer> boundInitializers, DiagnosticBag diagnostics,
-            bool generateDebugInfo, out ImportChain firstDebugImports)
+            out ImportChain firstDebugImports)
         {
             Debug.Assert((object)scriptCtor != null);
 
@@ -177,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder scriptClassBinder = binderFactory.GetBinder(initializerNode);
                     Debug.Assert(((ImplicitNamedTypeSymbol)scriptClassBinder.ContainingMemberOrLambda).IsScriptClass);
 
-                    if (generateDebugInfo && firstDebugImports == null)
+                    if (firstDebugImports == null)
                     {
                         firstDebugImports = scriptClassBinder.ImportChain;
                     }

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             PEModuleBuilder moduleBuilder,
             DiagnosticBag diagnostics,
             OptimizationLevel optimizations,
-            bool emittingPdbs)
+            bool emittingPdb)
         {
             Debug.Assert((object)method != null);
             Debug.Assert(boundBody != null);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             //   user code that can be stepped thru, or changed during EnC.
             // 
             // This setting only affects generating PDB sequence points, it shall not affect generated IL in any way.
-            _emitPdbSequencePoints = emittingPdbs && method.GenerateDebugInfo;
+            _emitPdbSequencePoints = emittingPdb && method.GenerateDebugInfo;
 
             if (_optimizations == OptimizationLevel.Release)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2322,7 +2322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CommonPEModuleBuilder moduleBuilder,
             Stream win32Resources,
             Stream xmlDocStream,
-            bool generateDebugInfo,
+            bool emittingPdb,
             DiagnosticBag diagnostics,
             Predicate<ISymbol> filterOpt,
             CancellationToken cancellationToken)
@@ -2354,12 +2354,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (generateDebugInfo && moduleBeingBuilt != null)
+                if (emittingPdb && !StartSourceChecksumCalculation(moduleBeingBuilt, diagnostics))
                 {
-                    if (!StartSourceChecksumCalculation(moduleBeingBuilt, diagnostics))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
 
                 // Perform initial bind of method bodies in spite of earlier errors. This is the same
@@ -2371,7 +2368,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MethodCompiler.CompileMethodBodies(
                     this,
                     moduleBeingBuilt,
-                    generateDebugInfo,
+                    emittingPdb,
                     hasDeclarationErrors,
                     diagnostics: methodBodyDiagnosticBag,
                     filterOpt: filterOpt,

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 moduleBeingBuilt,
                 win32Resources: null,
                 xmlDocStream: null,
-                generateDebugInfo: true,
+                emittingPdb: true,
                 diagnostics: diagnostics,
                 filterOpt: changes.RequiresCompilation,
                 cancellationToken: cancellationToken))

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         protected sealed override IEnumerable<string> LinkedAssembliesDebugInfo => SpecializedCollections.EmptyEnumerable<string>();
 
         // C# currently doesn't emit compilation level imports (TODO: scripting).
-        protected override ImmutableArray<Cci.UsedNamespaceOrType> GetImports(EmitContext context) => ImmutableArray<Cci.UsedNamespaceOrType>.Empty;
+        protected override ImmutableArray<Cci.UsedNamespaceOrType> GetImports() => ImmutableArray<Cci.UsedNamespaceOrType>.Empty;
 
         // C# doesn't allow to define default namespace for compilation.
         protected override string DefaultNamespace => null;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -12570,7 +12570,7 @@ expectedOutput: "-100");
             var methodBodyCompiler = new MethodCompiler(
                 compilation: compilation,
                 moduleBeingBuiltOpt: module,
-                generateDebugInfo: false,
+                emittingPdb: false,
                 hasDeclarationErrors: false,
                 diagnostics: diagnostics,
                 filterOpt: null,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
@@ -293,16 +293,9 @@ class C
                     scriptCtor: null,
                     initializers: initializers,
                     diagnostics: diagnostics,
-                    generateDebugInfo: false,
                     firstImportChain: out unused);
 
-                var filteredDiag = diagnostics.AsEnumerable();
-                foreach (var diagnostic in filteredDiag)
-                {
-                    Console.WriteLine(diagnostic);
-                }
-
-                Assert.True(filteredDiag.IsEmpty());
+                diagnostics.Verify();
 
                 return boundInitializers;
             }

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1250,7 +1250,7 @@ namespace Microsoft.CodeAnalysis
             CommonPEModuleBuilder moduleBuilder,
             Stream win32Resources,
             Stream xmlDocStream,
-            bool generateDebugInfo,
+            bool emittingPdb,
             DiagnosticBag diagnostics,
             Predicate<ISymbol> filterOpt,
             CancellationToken cancellationToken);
@@ -1259,7 +1259,7 @@ namespace Microsoft.CodeAnalysis
             CommonPEModuleBuilder moduleBuilder,
             Stream win32Resources,
             Stream xmlDocStream,
-            bool generateDebugInfo,
+            bool emittingPdb,
             DiagnosticBag diagnostics,
             Predicate<ISymbol> filterOpt,
             CancellationToken cancellationToken)
@@ -1270,7 +1270,7 @@ namespace Microsoft.CodeAnalysis
                     moduleBuilder,
                     win32Resources,
                     xmlDocStream,
-                    generateDebugInfo,
+                    emittingPdb,
                     diagnostics,
                     filterOpt,
                     cancellationToken);
@@ -1303,7 +1303,7 @@ namespace Microsoft.CodeAnalysis
                             moduleBeingBuilt,
                             win32Resources: null,
                             xmlDocStream: null,
-                            generateDebugInfo: false,
+                            emittingPdb: false,
                             diagnostics: discardedDiagnostics,
                             filterOpt: null,
                             cancellationToken: cancellationToken);
@@ -1576,7 +1576,7 @@ namespace Microsoft.CodeAnalysis
                 moduleBeingBuilt,
                 win32Resources,
                 xmlDocumentationStream,
-                generateDebugInfo: pdbStreamProvider != null,
+                emittingPdb: pdbStreamProvider != null,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: cancellationToken))

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Emit.NoPia;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Emit
         internal abstract CommonModuleCompilationState CommonModuleCompilationState { get; }
         internal abstract void CompilationFinished();
         internal abstract ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> GetSynthesizedMembers();
+        internal abstract CommonEmbeddedTypesManager CommonEmbeddedTypesManagerOpt { get; }
     }
 
     /// <summary>
@@ -237,54 +239,16 @@ namespace Microsoft.CodeAnalysis.Emit
             return Translate((TTypeSymbol)symbol, (TSyntaxNode)syntaxNodeOpt, diagnostics);
         }
 
-        internal OutputKind OutputKind
-        {
-            get
-            {
-                return _outputKind;
-            }
-        }
+        internal OutputKind OutputKind => _outputKind;
+        internal TSourceModuleSymbol SourceModule => _sourceModule;
+        internal TCompilation Compilation => _compilation;
 
-        internal TSourceModuleSymbol SourceModule
-        {
-            get
-            {
-                return _sourceModule;
-            }
-        }
-
-        internal TCompilation Compilation
-        {
-            get
-            {
-                return _compilation;
-            }
-        }
-
-        internal override Compilation CommonCompilation
-        {
-            get
-            {
-                return _compilation;
-            }
-        }
-
-        internal override CommonModuleCompilationState CommonModuleCompilationState
-        {
-            get
-            {
-                return this.CompilationState;
-            }
-        }
+        internal sealed override Compilation CommonCompilation => _compilation;
+        internal sealed override CommonModuleCompilationState CommonModuleCompilationState => CompilationState;
+        internal sealed override CommonEmbeddedTypesManager CommonEmbeddedTypesManagerOpt => EmbeddedTypesManagerOpt;
 
         // General entry point method. May be a PE entry point or a submission entry point.
-        internal sealed override Cci.IMethodReference EntryPoint
-        {
-            get
-            {
-                return _entryPoint;
-            }
-        }
+        internal sealed override Cci.IMethodReference EntryPoint => _entryPoint;
 
         internal void SetEntryPoint(TMethodSymbol value)
         {
@@ -778,8 +742,8 @@ namespace Microsoft.CodeAnalysis.Emit
         IEnumerable<string> Cci.IModule.LinkedAssembliesDebugInfo => LinkedAssembliesDebugInfo;
         protected abstract IEnumerable<string> LinkedAssembliesDebugInfo { get; }
 
-        ImmutableArray<Cci.UsedNamespaceOrType> Cci.IModule.GetImports(EmitContext context) => GetImports(context);
-        protected abstract ImmutableArray<Cci.UsedNamespaceOrType> GetImports(EmitContext context);
+        ImmutableArray<Cci.UsedNamespaceOrType> Cci.IModule.GetImports() => GetImports();
+        protected abstract ImmutableArray<Cci.UsedNamespaceOrType> GetImports();
 
         string Cci.IModule.DefaultNamespace => DefaultNamespace;
         protected abstract string DefaultNamespace { get; }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Cci
             // NOTE: This is an attempt to match Dev10's apparent behavior.  For iterator methods (i.e. the method
             // that appears in source, not the synthesized ones), Dev10 only emits the ForwardIterator and IteratorLocal
             // custom debug info (e.g. there will be no information about the usings that were in scope).
-            if (!isIterator)
+            if (!isIterator && methodBody.ImportScope != null)
             {
                 IMethodDefinition forwardToMethod;
                 if (customDebugInfoWriter.ShouldForwardNamespaceScopes(Context, methodBody, methodToken, out forwardToMethod))
@@ -375,7 +375,7 @@ namespace Microsoft.Cci
             {
                 for (var scope = namespaceScopes; scope != null; scope = scope.Parent)
                 {
-                    foreach (var import in scope.GetUsedNamespaces(Context))
+                    foreach (var import in scope.GetUsedNamespaces())
                     {
                         if (import.TargetNamespaceOpt == null && import.TargetTypeOpt == null)
                         {
@@ -396,7 +396,7 @@ namespace Microsoft.Cci
             // file and namespace level
             for (IImportScope scope = namespaceScopes; scope != null; scope = scope.Parent)
             {
-                foreach (UsedNamespaceOrType import in scope.GetUsedNamespaces(Context))
+                foreach (UsedNamespaceOrType import in scope.GetUsedNamespaces())
                 {
                     var importString = TryEncodeImport(import, lazyDeclaredExternAliases, isProjectLevel: false);
                     if (importString != null)
@@ -424,7 +424,7 @@ namespace Microsoft.Cci
                     UsingNamespace("&" + assemblyName, module);
                 }
 
-                foreach (UsedNamespaceOrType import in module.GetImports(Context))
+                foreach (UsedNamespaceOrType import in module.GetImports())
                 {
                     var importString = TryEncodeImport(import, null, isProjectLevel: true);
                     if (importString != null)

--- a/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Cci
         /// </summary>
         public bool ShouldForwardNamespaceScopes(EmitContext context, IMethodBody methodBody, uint methodToken, out IMethodDefinition forwardToMethod)
         {
-            if (ShouldForwardToPreviousMethodWithUsingInfo(context, methodBody) || methodBody.ImportScope == null)
+            if (ShouldForwardToPreviousMethodWithUsingInfo(context, methodBody))
             {
                 // SerializeNamespaceScopeMetadata will do the actual forwarding in case this is a CSharp method.
                 // VB on the other hand adds a "@methodtoken" to the scopes instead.
@@ -351,7 +351,7 @@ namespace Microsoft.Cci
             BinaryWriter cmw = new BinaryWriter(customMetadata);
             for (IImportScope scope = methodBody.ImportScope; scope != null; scope = scope.Parent)
             {
-                usingCounts.Add((ushort)scope.GetUsedNamespaces(context).Length);
+                usingCounts.Add((ushort)scope.GetUsedNamespaces().Length);
             }
 
             // ACASEY: This originally wrote (uint)12, (ushort)1, (ushort)0 in the
@@ -414,7 +414,7 @@ namespace Microsoft.Cci
             var s2 = previousScopes;
             while (s1 != null && s2 != null)
             {
-                if (!s1.GetUsedNamespaces(context).SequenceEqual(s2.GetUsedNamespaces(context)))
+                if (!s1.GetUsedNamespaces().SequenceEqual(s2.GetUsedNamespaces()))
                 {
                     return false;
                 }

--- a/src/Compilers/Core/Portable/PEWriter/IImportScope.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IImportScope.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.Cci
 {
@@ -13,7 +12,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// Zero or more used namespaces. These correspond to using directives in C# or Imports syntax in VB.
         /// </summary>
-        ImmutableArray<UsedNamespaceOrType> GetUsedNamespaces(EmitContext context);
+        ImmutableArray<UsedNamespaceOrType> GetUsedNamespaces();
 
         /// <summary>
         /// Parent import scope, or null.

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Cci
                 this.Visit(module.GetResources(Context));
             }
 
-            VisitImports(module.GetImports(Context));
+            VisitImports(module.GetImports());
         }
 
         public void VisitMethodBodyReference(IReference reference)
@@ -101,7 +101,7 @@ namespace Microsoft.Cci
                     {
                         if (_alreadySeenScopes.Add(scope))
                         {
-                            VisitImports(scope.GetUsedNamespaces(Context));
+                            VisitImports(scope.GetUsedNamespaces());
                         }
                         else
                         {

--- a/src/Compilers/Core/Portable/PEWriter/Units.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Units.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// Project level imports (VB only, TODO: C# scripts).
         /// </summary>
-        ImmutableArray<UsedNamespaceOrType> GetImports(EmitContext context);
+        ImmutableArray<UsedNamespaceOrType> GetImports();
 
         /// <summary>
         /// Default namespace (VB only).

--- a/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                        moduleBuilder As PEModuleBuilder,
                        diagnostics As DiagnosticBag,
                        optimizations As OptimizationLevel,
-                       emittingPdbs As Boolean)
+                       emittingPdb As Boolean)
 
             Debug.Assert(method IsNot Nothing)
             Debug.Assert(boundBody IsNot Nothing)
@@ -55,14 +55,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Debug.Assert(moduleBuilder IsNot Nothing)
             Debug.Assert(diagnostics IsNot Nothing)
 
-            Me._method = method
-            Me._block = boundBody
-            Me._builder = builder
-            Me._module = moduleBuilder
-            Me._diagnostics = diagnostics
+            _method = method
+            _block = boundBody
+            _builder = builder
+            _module = moduleBuilder
+            _diagnostics = diagnostics
 
             ' Always optimize synthesized methods that don't contain user code.
-            Me._optimizations = If(method.GenerateDebugInfo, optimizations, OptimizationLevel.Release)
+            _optimizations = If(method.GenerateDebugInfo, optimizations, OptimizationLevel.Release)
 
             ' Emit sequence points unless
             ' - the PDBs are not being generated
@@ -70,14 +70,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             '   user code that can be stepped thru, or changed during EnC.
             ' 
             ' This setting only affects generating PDB sequence points, it shall Not affect generated IL in any way.
-            Me._emitPdbSequencePoints = emittingPdbs AndAlso method.GenerateDebugInfo
+            _emitPdbSequencePoints = emittingPdb AndAlso method.GenerateDebugInfo
 
-            If Me._optimizations = OptimizationLevel.Release Then
-                Me._block = Optimizer.Optimize(method, boundBody, Me._stackLocals)
+            If _optimizations = OptimizationLevel.Release Then
+                _block = Optimizer.Optimize(method, boundBody, _stackLocals)
             End If
 
-            Me._checkCallsForUnsafeJITOptimization = (Me._method.ImplementationAttributes And MethodSymbol.DisableJITOptimizationFlags) <> MethodSymbol.DisableJITOptimizationFlags
-            Debug.Assert(Not Me._module.JITOptimizationIsDisabled(Me._method))
+            _checkCallsForUnsafeJITOptimization = (_method.ImplementationAttributes And MethodSymbol.DisableJITOptimizationFlags) <> MethodSymbol.DisableJITOptimizationFlags
+            Debug.Assert(Not _module.JITOptimizationIsDisabled(_method))
         End Sub
 
         Public Sub Generate()

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -63,7 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             If compilation.Compile(moduleBeingBuilt,
                                    win32Resources:=Nothing,
                                    xmlDocStream:=Nothing,
-                                   generateDebugInfo:=True,
+                                   emittingPdb:=True,
                                    diagnostics:=diagnostics,
                                    filterOpt:=AddressOf changes.RequiresCompilation,
                                    cancellationToken:=cancellationToken) Then

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private ReadOnly _metadataName As String
 
         Private _lazyExportedTypes As ImmutableArray(Of TypeExport(Of NamedTypeSymbol))
-        Private _lazyImports As ImmutableArray(Of Cci.UsedNamespaceOrType)
+        Private _lazyTranslatedImports As ImmutableArray(Of Cci.UsedNamespaceOrType)
         Private _lazyDefaultNamespace As String
 
         ' These fields will only be set when running tests.  They allow realized IL for a given method to be looked up by method display name.
@@ -99,15 +99,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Protected NotOverridable Overrides Function GetImports(context As EmitContext) As ImmutableArray(Of Cci.UsedNamespaceOrType)
-            If _lazyImports.IsDefault Then
-                ImmutableInterlocked.InterlockedInitialize(
-                    _lazyImports,
-                    NamespaceScopeBuilder.BuildNamespaceScope(context, SourceModule.XmlNamespaces, SourceModule.AliasImports, SourceModule.MemberImports))
-            End If
-
-            Return _lazyImports
+        Protected NotOverridable Overrides Function GetImports() As ImmutableArray(Of Cci.UsedNamespaceOrType)
+            ' Imports should have been translated in code gen phase.
+            Debug.Assert(Not _lazyTranslatedImports.IsDefault)
+            Return _lazyTranslatedImports
         End Function
+
+        Public Sub TranslateImports(diagnostics As DiagnosticBag)
+            If _lazyTranslatedImports.IsDefault Then
+                ImmutableInterlocked.InterlockedInitialize(
+                    _lazyTranslatedImports,
+                    NamespaceScopeBuilder.BuildNamespaceScope(Me, SourceModule.XmlNamespaces, SourceModule.AliasImports, SourceModule.MemberImports, diagnostics))
+            End If
+        End Sub
 
         Protected NotOverridable Overrides ReadOnly Property DefaultNamespace As String
             Get

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 module,
                 win32Resources: null,
                 xmlDocStream: null,
-                generateDebugInfo: false,
+                emittingPdb: false,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: CancellationToken.None);
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 module,
                 win32Resources: null,
                 xmlDocStream: null,
-                generateDebugInfo: false,
+                emittingPdb: false,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: CancellationToken.None);
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 module,
                 win32Resources: null,
                 xmlDocStream: null,
-                generateDebugInfo: false,
+                emittingPdb: false,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: CancellationToken.None);

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 moduleBuilder,
                 win32Resources:=Nothing,
                 xmlDocStream:=Nothing,
-                generateDebugInfo:=False,
+                emittingPdb:=False,
                 diagnostics:=diagnostics,
                 filterOpt:=Nothing,
                 cancellationToken:=CancellationToken.None)
@@ -250,15 +250,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         ' "Me" for non-shared methods that are not display class methods
                         ' or display class methods where the display class contains "$VB$Me".
                         If Not m.IsShared AndAlso (Not m.ContainingType.IsClosureOrStateMachineType() OrElse _displayClassVariables.ContainsKey(GeneratedNames.MakeStateMachineCapturedMeName())) Then
-                                Dim methodName = GetNextMethodName(methodBuilder)
-                                Dim method = Me.GetMeMethod(container, methodName)
-                                localBuilder.Add(New VisualBasicLocalAndMethod("Me", "Me", methodName, DkmClrCompilationResultFlags.None)) ' NOTE: writable in Dev11.
-                                methodBuilder.Add(method)
-                            End If
+                            Dim methodName = GetNextMethodName(methodBuilder)
+                            Dim method = Me.GetMeMethod(container, methodName)
+                            localBuilder.Add(New VisualBasicLocalAndMethod("Me", "Me", methodName, DkmClrCompilationResultFlags.None)) ' NOTE: writable in Dev11.
+                            methodBuilder.Add(method)
                         End If
+                    End If
 
-                        ' Hoisted method parameters (represented as locals in the EE).
-                        If Not _hoistedParameterNames.IsEmpty Then
+                    ' Hoisted method parameters (represented as locals in the EE).
+                    If Not _hoistedParameterNames.IsEmpty Then
                         Dim localIndex As Integer = 0
 
                         For Each local In _localsForBinding
@@ -327,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 moduleBuilder,
                 win32Resources:=Nothing,
                 xmlDocStream:=Nothing,
-                generateDebugInfo:=False,
+                emittingPdb:=False,
                 diagnostics:=diagnostics,
                 filterOpt:=Nothing,
                 cancellationToken:=CancellationToken.None)

--- a/src/Scripting/Core/Emit/CommonCompilationExtensions.cs
+++ b/src/Scripting/Core/Emit/CommonCompilationExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Emit
                 moduleBeingBuilt,
                 win32Resources: null,
                 xmlDocStream: null,
-                generateDebugInfo: false,
+                emittingPdb: false,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: cancellationToken))

--- a/src/Test/Utilities/AssertXml.cs
+++ b/src/Test/Utilities/AssertXml.cs
@@ -84,7 +84,7 @@ namespace Roslyn.Test.Utilities
             string expectedString = expectedIsXmlLiteral ? expected.Replace(" />\r\n", "/>\r\n") : string.Format("@\"{0}\"", expected.Replace("\"", "\"\""));
 
             string link;
-            if (AssertEx.TryGenerateExpectedSourceFielAndGetDiffLink(actualString, expectedString.Count(c => c == '\n') + 1, expectedValueSourcePath, expectedValueSourceLine, out link))
+            if (AssertEx.TryGenerateExpectedSourceFileAndGetDiffLink(actualString, expectedString.Count(c => c == '\n') + 1, expectedValueSourcePath, expectedValueSourceLine, out link))
             {
                 assertText.AppendLine(link);
             }

--- a/src/Test/Utilities/CompilationExtensions.cs
+++ b/src/Test/Utilities/CompilationExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 getHostDiagnostics: null,
                 cancellationToken: default(CancellationToken));
 
-            Assert.True(emitResult.Success, "Diagnostics:\r\n" + string.Join("\r\n, ", emitResult.Diagnostics.Select(d => d.ToString())));
+            Assert.True(emitResult.Success, "Diagnostics:\r\n" + string.Join("\r\n", emitResult.Diagnostics.Select(d => d.ToString())));
 
             if (expectedWarnings != null)
             {

--- a/src/Test/Utilities/SharedCompilationUtils.cs
+++ b/src/Test/Utilities/SharedCompilationUtils.cs
@@ -8,12 +8,14 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
+using PDB::Roslyn.Test.MetadataUtilities;
 using PDB::Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -54,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             return methodData;
         }
-
+        
         internal static void VerifyIL(
             this CompilationTestData.MethodData method,
             string expectedIL,
@@ -192,6 +194,39 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var actualPath = Encoding.UTF8.GetString(pathBlob);
             Assert.Equal(pdbPath, actualPath);
             Assert.Equal(0, reader.ReadByte());
+        }
+
+        public static void VerifyMetadataEqualModuloMvid(Stream peStream1, Stream peStream2)
+        {
+            peStream1.Position = 0;
+            peStream2.Position = 0;
+
+            var peReader1 = new PEReader(peStream1);
+            var peReader2 = new PEReader(peStream2);
+
+            var md1 = peReader1.GetMetadata().GetContent();
+            var md2 = peReader2.GetMetadata().GetContent();
+
+            var mdReader1 = peReader1.GetMetadataReader();
+            var mdReader2 = peReader2.GetMetadataReader();
+
+            var mvidIndex1 = mdReader1.GetModuleDefinition().Mvid;
+            var mvidIndex2 = mdReader2.GetModuleDefinition().Mvid;
+
+            var mvidOffset1 = mdReader1.GetHeapMetadataOffset(HeapIndex.Guid) + 16 * (MetadataTokens.GetHeapOffset(mvidIndex1) - 1);
+            var mvidOffset2 = mdReader2.GetHeapMetadataOffset(HeapIndex.Guid) + 16 * (MetadataTokens.GetHeapOffset(mvidIndex2) - 1);
+
+            if (!md1.RemoveRange(mvidOffset1, 16).SequenceEqual(md1.RemoveRange(mvidOffset2, 16)))
+            {
+                var mdw1 = new StringWriter();
+                var mdw2 = new StringWriter();
+                new MetadataVisualizer(mdReader1, mdw1).Visualize();
+                new MetadataVisualizer(mdReader2, mdw2).Visualize();
+                mdw1.Flush();
+                mdw2.Flush();
+
+                AssertEx.AssertResultsEqual(mdw1.ToString(), mdw2.ToString());
+            }
         }
 
         internal static string GetMethodIL(this CompilationTestData.MethodData method)


### PR DESCRIPTION
First off, we translated symbols in import scopes too late (while generating PDBs), which was the root cause of a crash while emitting imports of NoPia types (internal bug 1167563). They need to be translated before emit starts. Even with the proper translation in place we don't quite have an infrastructure to handle imports of NoPia types without possibly introducing breaking changes when importing a type from linked assembly that can't be embedded. The change skips emitting aliased NoPia type imports, which results in slightly degraded experience: the alias is not available. A simple workaround is to use the qualified type name. We can revisit and enable this scenario later.

Second off, emitting imports for a constructor that includes initializers in some cases resulted in different metadata depending on whether the compilation was given PDB stream or not, which is not desirable.




