### PR TITLE
Use a ConditionalWeakTable for SyntaxContext cache

### DIFF
--- a/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         // PERF: Many CompletionProviders derive AbstractSymbolCompletionProvider and therefore
         // compute identical contexts. This actually shows up on the 2-core typing test.
         // Cache the most recent document/position/computed SyntaxContext to reduce repeat computation.
-        private static readonly Dictionary<Document, Task<AbstractSyntaxContext>> s_cachedDocuments = new Dictionary<Document, Task<AbstractSyntaxContext>>();
+        private static readonly ConditionalWeakTable<Document, Task<AbstractSyntaxContext>> s_cachedDocuments = new ConditionalWeakTable<Document, Task<AbstractSyntaxContext>>();
         private static int s_cachedPosition;
         private static readonly object s_cacheGate = new object();
 
@@ -184,14 +185,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 // Invalidate the cache if it's for a different position or a different set of Documents.
                 // It's fairly likely that we'll only have to check the first document, unless someone
                 // specially constructed a Solution with mismatched linked files.
+                Task<AbstractSyntaxContext> value;
                 if (s_cachedPosition != position ||
-                    !relatedDocuments.All(s_cachedDocuments.ContainsKey))
+                    !relatedDocuments.All((Document d) => s_cachedDocuments.TryGetValue(d, out value)))
                 {
                     s_cachedPosition = position;
-                    s_cachedDocuments.Clear();
                     foreach (var related in relatedDocuments)
                     {
-                        s_cachedDocuments.Add(related, null);
+                        s_cachedDocuments.Remove(document);
                     }
                 }
             }
@@ -297,18 +298,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             lock (s_cacheGate)
             {
-                Task<AbstractSyntaxContext> cachedContext;
-                if (s_cachedDocuments.TryGetValue(document, out cachedContext) && cachedContext != null)
-                {
-                    return cachedContext;
-                }
-            }
-
-            var context = CreateContext(document, position, cancellationToken);
-            lock (s_cacheGate)
-            {
-                s_cachedDocuments[document] = context;
-                return context;
+                return s_cachedDocuments.GetValue(document, d => CreateContext(d, position, cancellationToken));
             }
         }
 


### PR DESCRIPTION
This should prevent this cache from leaking Documents.

Can you take a look? @heejaechang @pharring 