### PR TITLE
only show directly inherited types in the InheritedBy progression query

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/InheritedByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/InheritedByGraphQuery.cs
@@ -3,7 +3,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 if (namedType.TypeKind == TypeKind.Class)
                 {
-                    var derivedTypes = await namedType.FindTypesImmediatelyDerivedFromClassesAsync(solution, cancellationToken).ConfigureAwait(false);
+                    var derivedTypes = await DependentTypeFinder.GetTypesImmediatelyDerivedFromClassesAsync(namedType, solution, cancellationToken).ConfigureAwait(false);
                     foreach (var derivedType in derivedTypes)
                     {
                         var symbolNode = await graphBuilder.AddNodeForSymbolAsync(derivedType, relatedNode: node).ConfigureAwait(false);
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 }
                 else if (namedType.TypeKind == TypeKind.Interface)
                 {
-                    var derivedTypes = await namedType.FindTypesImmediatelyDerivedFromInterfacesAsync(solution, cancellationToken).ConfigureAwait(false);
+                    var derivedTypes = await DependentTypeFinder.GetTypesImmediatelyDerivedFromInterfacesAsync(namedType, solution, cancellationToken).ConfigureAwait(false);
                     foreach (var derivedType in derivedTypes)
                     {
                         var symbolNode = await graphBuilder.AddNodeForSymbolAsync(derivedType, relatedNode: node).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/InheritedByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/InheritedByGraphQuery.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 {
@@ -31,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 if (namedType.TypeKind == TypeKind.Class)
                 {
-                    var derivedTypes = await namedType.FindDerivedClassesAsync(solution, cancellationToken).ConfigureAwait(false);
+                    var derivedTypes = await namedType.FindTypesImmediatelyDerivedFromClassesAsync(solution, cancellationToken).ConfigureAwait(false);
                     foreach (var derivedType in derivedTypes)
                     {
                         var symbolNode = await graphBuilder.AddNodeForSymbolAsync(derivedType, relatedNode: node).ConfigureAwait(false);
@@ -40,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 }
                 else if (namedType.TypeKind == TypeKind.Interface)
                 {
-                    var derivedTypes = await namedType.FindDerivedInterfacesAsync(solution, cancellationToken).ConfigureAwait(false);
+                    var derivedTypes = await namedType.FindTypesImmediatelyDerivedFromInterfacesAsync(solution, cancellationToken).ConfigureAwait(false);
                     foreach (var derivedType in derivedTypes)
                     {
                         var symbolNode = await graphBuilder.AddNodeForSymbolAsync(derivedType, relatedNode: node).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Test/Progression/InheritedByGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/InheritedByGraphQueryTests.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
 
     Public Class InheritedByGraphQueryTests
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
-        Public Sub TestInheritedByClasses()
+        Public Sub TestInheritedByClassesCSharp()
             Using testState = New ProgressionTestState(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
@@ -69,7 +69,7 @@ class ReallyDerived : Foo // should not be shown as inherited by Base
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
-        Public Sub TestInheritedByInterfaces()
+        Public Sub TestInheritedByInterfacesCSharp()
             Using testState = New ProgressionTestState(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
@@ -80,7 +80,7 @@ public interface $$I { }
 
 public class C : I { } // should appear as being derived from (implementing) I
 
-public class C2 : C { } // should not appear as being derived from (implementing ) I
+public class C2 : C { } // should not appear as being derived from (implementing) I
 
 interface I2 : I, IComparable
 {
@@ -111,6 +111,119 @@ interface I3 : I2 // should not be shown as inherited by I
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
+                        </IdentifierAliases>
+                    </DirectedGraph>)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Sub TestInheritedByClassesVisualBasic()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true" FilePath="Z:\Project.vbproj">
+                            <Document FilePath="Z:\Project.vb">
+Imports System
+
+Interface IBlah
+End Interface
+
+MustInherit Class $$Base
+    Public MustOverride Function CompareTo(obj As Object) As Integer
+End Class
+
+Class Foo
+    Inherits Base
+    Implements IComparable, IBlah
+    Public Overrides Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        Throw New NotImplementedException()
+    End Function
+End Class
+
+Class Foo2
+    Inherits Base
+    Implements IBlah
+    Public Overrides Function CompareTo(obj As Object) As Integer
+        Throw New NotImplementedException()
+    End Function
+End Class
+
+Class ReallyDerived ' should not be shown as inherited by Base
+    Inherits Foo
+End Class
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim inputGraph = testState.GetGraphWithMarkedSymbolNode()
+                Dim outputContext = testState.GetGraphContextAfterQuery(inputGraph, New InheritedByGraphQuery(), GraphContextDirection.Target)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes>
+                            <Node Id="(@1 Type=Base)" Category="CodeSchema_Class" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsInternal="True" CommonLabel="Base" Icon="Microsoft.VisualStudio.Class.Internal" Label="Base"/>
+                            <Node Id="(@1 Type=Foo)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Foo" Icon="Microsoft.VisualStudio.Class.Internal" Label="Foo"/>
+                            <Node Id="(@1 Type=Foo2)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Foo2" Icon="Microsoft.VisualStudio.Class.Internal" Label="Foo2"/>
+                        </Nodes>
+                        <Links>
+                            <Link Source="(@1 Type=Foo)" Target="(@1 Type=Base)" Category="InheritsFrom"/>
+                            <Link Source="(@1 Type=Foo2)" Target="(@1 Type=Base)" Category="InheritsFrom"/>
+                        </Links>
+                        <IdentifierAliases>
+                            <Alias n="1" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
+                        </IdentifierAliases>
+                    </DirectedGraph>)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Sub TestInheritedByInterfacesVisualBasic()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true" FilePath="Z:\Project.vbproj">
+                            <Document FilePath="Z:\Project.vb">
+Imports System
+
+Public Interface $$I
+End Interface
+
+Public Class C ' should appear as being derived from (implementing) I
+    Implements I
+End Class
+
+Public Class C2 ' should not appear as being derived from (implementing) I
+    Inherits C
+End Class
+
+Interface I2
+    Inherits I, IComparable
+    Sub M()
+End Interface
+
+Interface I3 ' should not be shown as inherited by I
+    Inherits I2
+End Interface
+                         </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim inputGraph = testState.GetGraphWithMarkedSymbolNode()
+                Dim outputContext = testState.GetGraphContextAfterQuery(inputGraph, New InheritedByGraphQuery(), GraphContextDirection.Target)
+
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes>
+                            <Node Id="(@1 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsPublic="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Public" Label="C"/>
+                            <Node Id="(@1 Type=I)" Category="CodeSchema_Interface" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="I" Icon="Microsoft.VisualStudio.Interface.Public" Label="I"/>
+                            <Node Id="(@1 Type=I2)" Category="CodeSchema_Interface" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsInternal="True" CommonLabel="I2" Icon="Microsoft.VisualStudio.Interface.Internal" Label="I2"/>
+                        </Nodes>
+                        <Links>
+                            <Link Source="(@1 Type=C)" Target="(@1 Type=I)" Category="InheritsFrom"/>
+                            <Link Source="(@1 Type=I2)" Target="(@1 Type=I)" Category="InheritsFrom"/>
+                        </Links>
+                        <IdentifierAliases>
+                            <Alias n="1" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using

--- a/src/VisualStudio/Core/Test/Progression/InheritedByGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/InheritedByGraphQueryTests.vb
@@ -38,6 +38,10 @@ class Foo2 : Base, IBlah
         throw new NotImplementedException();
     }
 }
+
+class ReallyDerived : Foo // should not be shown as inherited by Base
+{
+}
                          </Document>
                         </Project>
                     </Workspace>)
@@ -74,9 +78,17 @@ using System;
 
 public interface $$I { }
 
+public class C : I { } // should appear as being derived from (implementing) I
+
+public class C2 : C { } // should not appear as being derived from (implementing ) I
+
 interface I2 : I, IComparable
 {
     void M();
+}
+
+interface I3 : I2 // should not be shown as inherited by I
+{
 }
                          </Document>
                         </Project>
@@ -89,10 +101,12 @@ interface I2 : I, IComparable
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsPublic="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Public" Label="C"/>
                             <Node Id="(@1 Type=I)" Category="CodeSchema_Interface" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="I" Icon="Microsoft.VisualStudio.Interface.Public" Label="I"/>
                             <Node Id="(@1 Type=I2)" Category="CodeSchema_Interface" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsInternal="True" CommonLabel="I2" Icon="Microsoft.VisualStudio.Interface.Internal" Label="I2"/>
                         </Nodes>
                         <Links>
+                            <Link Source="(@1 Type=C)" Target="(@1 Type=I)" Category="InheritsFrom"/>
                             <Link Source="(@1 Type=I2)" Target="(@1 Type=I)" Category="InheritsFrom"/>
                         </Links>
                         <IdentifierAliases>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return SpecializedTasks.EmptyEnumerable<INamedTypeSymbol>();
         }
 
-        internal static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromClassesAsync(
+        public static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromClassesAsync(
             INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return SpecializedTasks.EmptyEnumerable<INamedTypeSymbol>();
         }
 
-        internal static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromInterfacesAsync(
+        public static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromInterfacesAsync(
             INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -166,6 +166,45 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return SpecializedTasks.EmptyEnumerable<INamedTypeSymbol>();
         }
 
+        internal static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromClassesAsync(
+            INamedTypeSymbol type,
+            Solution solution,
+            CancellationToken cancellationToken)
+        {
+            if (type != null && type.TypeKind == TypeKind.Class)
+            {
+                return GetDependentTypesAsync(
+                    type,
+                    solution,
+                    null,
+                    (t1, t2) => t1.BaseType == t2,
+                    s_derivedClassesCache,
+                    cancellationToken);
+            }
+
+            return SpecializedTasks.EmptyEnumerable<INamedTypeSymbol>();
+        }
+
+        internal static Task<IEnumerable<INamedTypeSymbol>> GetTypesImmediatelyDerivedFromInterfacesAsync(
+            INamedTypeSymbol type,
+            Solution solution,
+            CancellationToken cancellationToken)
+        {
+            if (type != null && type.TypeKind == TypeKind.Interface)
+            {
+                type = type.OriginalDefinition;
+                return GetDependentTypesAsync(
+                    type,
+                    solution,
+                    null,
+                    (i1, i2) => i1.Interfaces.Contains(i2),
+                    s_derivedInterfacesCache,
+                    cancellationToken);
+            }
+
+            return SpecializedTasks.EmptyEnumerable<INamedTypeSymbol>();
+        }
+
         private static async Task<IEnumerable<INamedTypeSymbol>> GetDependentTypesAsync(
             INamedTypeSymbol type,
             Solution solution,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -25,12 +25,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
-        public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedClassesAsync(
+        public static Task<IEnumerable<INamedTypeSymbol>> FindTypesImmediatelyDerivedFromClassesAsync(
             this INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)
         {
-            return FindDerivedClassesAsync(type, solution, null, cancellationToken);
+            return DependentTypeFinder.GetTypesImmediatelyDerivedFromClassesAsync(type, solution, cancellationToken);
         }
 
         public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedClassesAsync(
@@ -42,12 +42,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return DependentTypeFinder.FindDerivedClassesAsync(type, solution, projects, cancellationToken);
         }
 
-        public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedInterfacesAsync(
+        public static Task<IEnumerable<INamedTypeSymbol>> FindTypesImmediatelyDerivedFromInterfacesAsync(
             this INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)
         {
-            return FindDerivedInterfacesAsync(type, solution, null, cancellationToken);
+            return DependentTypeFinder.GetTypesImmediatelyDerivedFromInterfacesAsync(type, solution, cancellationToken);
         }
 
         public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedInterfacesAsync(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -25,14 +25,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
-        public static Task<IEnumerable<INamedTypeSymbol>> FindTypesImmediatelyDerivedFromClassesAsync(
-            this INamedTypeSymbol type,
-            Solution solution,
-            CancellationToken cancellationToken)
-        {
-            return DependentTypeFinder.GetTypesImmediatelyDerivedFromClassesAsync(type, solution, cancellationToken);
-        }
-
         public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedClassesAsync(
             this INamedTypeSymbol type,
             Solution solution,
@@ -40,23 +32,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             CancellationToken cancellationToken)
         {
             return DependentTypeFinder.FindDerivedClassesAsync(type, solution, projects, cancellationToken);
-        }
-
-        public static Task<IEnumerable<INamedTypeSymbol>> FindTypesImmediatelyDerivedFromInterfacesAsync(
-            this INamedTypeSymbol type,
-            Solution solution,
-            CancellationToken cancellationToken)
-        {
-            return DependentTypeFinder.GetTypesImmediatelyDerivedFromInterfacesAsync(type, solution, cancellationToken);
-        }
-
-        public static Task<IEnumerable<INamedTypeSymbol>> FindDerivedInterfacesAsync(
-            this INamedTypeSymbol type,
-            Solution solution,
-            IImmutableSet<Project> projects,
-            CancellationToken cancellationToken)
-        {
-            return DependentTypeFinder.FindDerivedInterfacesAsync(type, solution, projects, cancellationToken);
         }
 
         public static Task<IEnumerable<INamedTypeSymbol>> FindImplementingTypesAsync(


### PR DESCRIPTION
Fixes internal bug 747965.

When showing the derived types in a progression query in the Solution Explorer, only the types that immediately derive from the selected type should be shown, not everything down the chain (because the tree view will take care of that).  This takes the behavior back to how it was in Dev12.