### PR TITLE
Check EnvDTE.Configuration.Properties for null

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/RuleSetEventHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/RuleSetEventHandler.cs
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.R
             EnvDTE.Properties properties = config.Properties;
             try
             {
-                EnvDTE.Property codeAnalysisRuleSetFileProperty = properties.Item("CodeAnalysisRuleSet");
+                EnvDTE.Property codeAnalysisRuleSetFileProperty = properties?.Item("CodeAnalysisRuleSet");
 
                 if (codeAnalysisRuleSetFileProperty != null)
                 {

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -521,7 +521,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
                 try
                 {
-                    EnvDTE.Property codeAnalysisRuleSetFileProperty = properties.Item("CodeAnalysisRuleSet");
+                    EnvDTE.Property codeAnalysisRuleSetFileProperty = properties?.Item("CodeAnalysisRuleSet");
 
                     if (codeAnalysisRuleSetFileProperty != null)
                     {


### PR DESCRIPTION
We access the Properties collection of the EnvDTE.Configuration type to
check and update the "CodeAnalysisRuleSet" property. However, sometimes
the Properties collection will be null, leading to a
`NullReferenceException`. For example, the Properties collection always
seems to be null in PowerShell projects.

This change adds the necessary checks to avoid the
`NullReferenceException`.

Related to #2524.

@srivatsn @mavasani @ManishJayaswal @heejaechang @shyamnamboodiripad @jmarolf Could you take a look, please? It's a very short review.