### PR TITLE
[Proof of Concept] Refine hoisted local scopes

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -118,6 +118,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundStatement rewrittenBody = (BoundStatement)Visit(body);
 
+            ImmutableArray<StateMachineFieldSymbol> rootScopeHoistedLocals;
+            F.TryUnwrapBoundStateMachineScope(ref rewrittenBody, out rootScopeHoistedLocals);
+
             var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
 
             bodyBuilder.Add(F.HiddenSequencePoint());
@@ -187,18 +190,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             bodyBuilder.Add(F.Label(_exitLabel));
             bodyBuilder.Add(F.Return());
 
-            var newBody = bodyBuilder.ToImmutableAndFree();
+            var newStatements = bodyBuilder.ToImmutableAndFree();
 
             var locals = ArrayBuilder<LocalSymbol>.GetInstance();
             locals.Add(cachedState);
             if ((object)_exprRetValue != null) locals.Add(_exprRetValue);
 
-            F.CloseMethod(
+            var newBody =
                 F.SequencePoint(
-                    body.Syntax,
+                    body.Syntax, 
                     F.Block(
-                        locals.ToImmutableAndFree(),
-                        newBody)));
+						locals.ToImmutableAndFree(), 
+						newStatements));
+
+            if (rootScopeHoistedLocals.Length > 0)
+            {
+                newBody = F.StateMachineScope(rootScopeHoistedLocals, newBody);
+            }
+            
+            F.CloseMethod(newBody);
         }
 
         protected override BoundStatement GenerateReturn(bool finished)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // wrap the node in an iterator scope for debugging
             if (hoistedLocalsWithDebugScopes.Count != 0)
             {
-                translatedStatement = F.Block(new BoundStateMachineScope(F.Syntax, hoistedLocalsWithDebugScopes.ToImmutable(), translatedStatement));
+                translatedStatement = F.StateMachineScope(hoistedLocalsWithDebugScopes.ToImmutable(), translatedStatement);
             }
 
             hoistedLocalsWithDebugScopes.Free();


### PR DESCRIPTION
Old: Scopes followed the bound tree, so the outermost scope was within the
try-catch block synthesized in async MovedNext methods.

New: If the entire try block would be a hoisted local scope, we remove the
marker node (```BoundStateMachineScope```) and insert a new one around the
entire method body.

Upshot: hoisted locals are still in scope when stopped on method closing
braces.

Alternatives:
1. Give the StateMachineMethodRewriter knowledge of which node is the root
and let it pass out information about hoisted locals that would have had
that scope.
2. Something better that I haven't thought of.

TODO: VB
TODO: Update test baselines.