### PR TITLE
Dont offer cast simplification fixes for explicit reference conversions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3598,10 +3598,11 @@ namespace ConsoleApplication23
         }
 
         [WorkItem(844482)]
+        [WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public void RemoveCastFromDerivedToBaseWithImplicitRefernce()
+        public void DontRemoveCastFromBaseToDerivedWithExplicitReference()
         {
-            Test(
+            TestMissing(
 @"class Program
 {
     static void Main(string[] args)
@@ -3620,29 +3621,7 @@ class C
 class D : C
 {
 
-}",
-
-@"class Program
-{
-    static void Main(string[] args)
-    {
-        C x = null;
-        C y = null;
-        y = x;
-    }
-}
-
-class C
-{
-
-}
-
-class D : C
-{
-
-}",
-            index: 0,
-            compareTokens: false);
+}");
         }
     }
 }

--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -1969,8 +1969,10 @@ class C
         End Sub
 
         <WorkItem(530083)>
+        <WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub Csharp_Remove_InsideThrowStatement2()
+        Public Sub CSharp_Remove_InsideThrowStatement2()
+            ' We can't remove cast from base to derived, as we cannot be sure that the cast will succeed at runtime.
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1998,7 +2000,7 @@ class C
 	public static void Main()
 	{
 		Exception ex = new ArgumentException();
-		throw ex;
+		throw (ArgumentException)ex;
 	}
 }
 </code>
@@ -4528,8 +4530,10 @@ End Class
         End Sub
 
         <WorkItem(530083)>
+        <WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub VisualBasic_Remove_InsideThrowStatement2()
+        Public Sub VisualBasic_DontRemove_InsideThrowStatement2()
+            ' We can't remove cast from base to derived, as we cannot be sure that the cast will succeed at runtime.
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -4551,7 +4555,7 @@ Imports System
 Class C
     Shared Sub Main()
         Dim ex As Exception = New ArgumentException()
-        Throw ex
+        Throw DirectCast(ex, ArgumentException)
     End Sub
 End Class
 </code>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -2636,5 +2636,27 @@ End Module
             Test(markup, expected, compareTokens:=False)
         End Sub
 
+        <WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        Public Sub DontRemoveCastFromBaseToDerivedWithNarrowingReference()
+            Dim markup =
+<File>
+Module Module1
+    Private Function NewMethod(base As Base) As Base
+        Return If([|TryCast(base, Derived1)|], New Derived1())
+    End Function
+End Module
+
+Class Base
+End Class
+
+Class Derived1 : Inherits Base
+End Class
+
+Class Derived2 : Inherits Base
+End Class
+</File>
+            TestMissing(markup)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -350,6 +350,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 return true;
             }
+            else if (expressionToCastType.IsExplicit && expressionToCastType.IsReference)
+            {
+                // Explicit reference conversions can cause an exception or data loss, hence can never be removed.
+                return false;
+            }
 
             if (parentIsOrAsExpression)
             {
@@ -491,16 +496,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                             !speculationAnalyzer.ReplacementChangesSemanticsOfUnchangedLambda(cast.Expression, speculationAnalyzer.ReplacedExpression);
                     }
 
-                    return true;
-                }
-
-                // case :
-                // 4. baseType x;
-                //    baseType y = (DerivedType)x;
-                if (expressionToOuterType.IsIdentity &&
-                    castToOuterType.IsImplicit &&
-                    castToOuterType.IsReference)
-                {
                     return true;
                 }
             }

--- a/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
@@ -214,10 +214,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
             Dim expressionToCastType = _semanticModel.ClassifyConversion(_castNode.SpanStart, _castExpressionNode, castType)
 
-            ' Simple case: If the conversion from the inner expression to the cast type is identity,
-            ' the cast can be removed.
             If expressionToCastType.IsIdentity Then
+                ' Simple case: If the conversion from the inner expression to the cast type is identity,
+                ' the cast can be removed.
                 Return True
+            ElseIf expressionToCastType.IsNarrowing AndAlso expressionToCastType.IsReference
+                ' If the conversion from the inner expression to the cast type is narrowing reference conversion,
+                ' the cast cannot be removed.
+                Return False
             End If
 
             Dim outerType = GetOuterCastType(_castNode, castTypeInfo, _semanticModel, _cancellationToken)
@@ -311,7 +315,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 If expressionToOuterType.IsIdentity AndAlso
                         castToOuterType.IsWidening AndAlso
                         castToOuterType.IsReference Then
-                    Return Not (expressionToCastType.IsNarrowing AndAlso expressionToCastType.IsReference)
+                    Debug.Assert(Not (expressionToCastType.IsNarrowing AndAlso expressionToCastType.IsReference))
+                    Return True
                 End If
             End If
 


### PR DESCRIPTION
For code snippets such as below: `Base M(Base b) => (Derived)b;`, we currently offer cast removal for cast to derived. However, this involves an explicit/narrowing conversion and hence can lead to an exception or data loss. The only way to detect such redundant casts is via flow analysis, which is not currently in our scope.

Fix is to bail out early for such cast expressions. I have also fixed incorrect tests that were added to ensure the current behavior.

Fixes #2761 