### PR TITLE
Refine hoisted local scopes in async methods

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -462,7 +462,7 @@ namespace ConsoleApplication1
       <customDebugInfo>
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0x11e"" />
+          <slot startOffset=""0x0"" endOffset=""0x14e"" />
           <slot startOffset=""0x0"" endOffset=""0x0"" />
           <slot startOffset=""0x0"" endOffset=""0x0"" />
           <slot startOffset=""0x41"" endOffset=""0xed"" />
@@ -848,7 +848,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0xe0"" />
+          <slot startOffset=""0x0"" endOffset=""0x10d"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -945,7 +945,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0xa"" endOffset=""0xc0"" />
+          <slot startOffset=""0x0"" endOffset=""0xeb"" />
         </hoistedLocalScopes>
       </customDebugInfo>
       <sequencePoints>
@@ -1034,7 +1034,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0xcf"" />
+          <slot startOffset=""0x0"" endOffset=""0xfc"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1127,7 +1127,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0xe"" endOffset=""0xdc"" />
+          <slot startOffset=""0x0"" endOffset=""0x109"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1290,7 +1290,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x11"" endOffset=""0xdc"" />
+          <slot startOffset=""0x0"" endOffset=""0x109"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1587,7 +1587,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0xe"" endOffset=""0xed"" />
+          <slot startOffset=""0x0"" endOffset=""0x11d"" />
           <slot startOffset=""0x29"" endOffset=""0x32"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -441,10 +441,8 @@ End Class
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x13a">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
-                <scope startOffset="0x11" endOffset="0xfd">
-                    <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x11" il_end="0xfd" attributes="0"/>
-                    <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x11" il_end="0xfd" attributes="0"/>
-                </scope>
+                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x13a" attributes="0"/>
+                <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x0" il_end="0x13a" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_Lambda"/>
@@ -506,9 +504,7 @@ End Class
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10f">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
-                <scope startOffset="0xa" endOffset="0xd6">
-                    <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0xa" il_end="0xd6" attributes="0"/>
-                </scope>
+                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x10f" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_Lambda"/>
@@ -579,10 +575,8 @@ End Class
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>
-                <scope startOffset="0xe" endOffset="0xba">
-                    <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0xe" il_end="0xba" attributes="0"/>
-                    <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0xe" il_end="0xba" attributes="0"/>
-                </scope>
+                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0x0" il_end="0xf7" attributes="0"/>
+                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0x0" il_end="0xf7" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_NoLambda"/>
@@ -643,10 +637,8 @@ End Class
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>
-                <scope startOffset="0xa" endOffset="0xaa">
-                    <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0xa" il_end="0xaa" attributes="0"/>
-                    <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0xa" il_end="0xaa" attributes="0"/>
-                </scope>
+                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0x0" il_end="0xe3" attributes="0"/>
+                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0x0" il_end="0xe3" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_NoLambda"/>


### PR DESCRIPTION
Old: Scopes followed the bound tree, so the outermost scope was within the
try-catch block synthesized in async MovedNext methods.

New: If the entire try block would be a hoisted local scope, we remove the
marker node (BoundStateMachineScope) and insert a new one around the
entire method body.

Upshot: hoisted locals are still in scope when stopped on method closing
braces.

Fixes #2336 