### PR TITLE
Fix nulls in AnalyzerDependencyChecker

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyCheckingService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private readonly BindingRedirectionService _bindingRedirectionService;
 
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private Task<AnalyzerDependencyResults> _task = Task.FromResult((AnalyzerDependencyResults)null);
+        private Task<AnalyzerDependencyResults> _task = Task.FromResult(AnalyzerDependencyResults.Empty);
         private ImmutableHashSet<string> _analyzerPaths = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
 
         [ImportingConstructor]
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 results = await GetConflictsAsync().ConfigureAwait(continueOnCapturedContext: true);
             }
-            catch (OperationCanceledException)
+            catch
             {
                 return;
             }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyResults.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyResults.cs
@@ -7,6 +7,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal sealed class AnalyzerDependencyResults
     {
+        public static readonly AnalyzerDependencyResults Empty = new AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict>.Empty, ImmutableArray<MissingAnalyzerDependency>.Empty);
+
         public AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict> conflicts, ImmutableArray<MissingAnalyzerDependency> missingDependencies)
         {
             Debug.Assert(conflicts != default(ImmutableArray<AnalyzerDependencyConflict>));


### PR DESCRIPTION
Currently we use a `Task.FromResult(null)` as a sentinel task before a
real dependency check has been queued up. This works fine until we try
to access the results of this task, and things blow up.

Instead, we should create an AnalyzerDependecyResults.Empty singleton,
and create a task from that.

Also, this change catches all exceptions coming out of
`AnalyzerDependencyChecker`, to avoid bringing down VS.

@heejaechang @srivatsn @mavasani @ManishJayaswal @jmarolf @shyamnamboodiripad Could you take a look, please?