### PR TITLE
Fix Code Model bug with adding attributes in presence of XML doc comments

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
+++ b/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
@@ -180,6 +180,7 @@
     <Compile Include="CodeModel\ParameterFlags.cs" />
     <Compile Include="CodeModel\ParameterFlagsExtensions.cs" />
     <Compile Include="CodeModel\SyntaxListExtensions.cs" />
+    <Compile Include="CodeModel\SyntaxNodeExtensions.cs" />
     <Compile Include="Debugging\BreakpointResolver.cs" />
     <Compile Include="Debugging\CSharpBreakpointResolutionService.cs" />
     <Compile Include="Debugging\CSharpLanguageDebugInfoService.cs" />

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -125,20 +125,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 }
             }
 
-            private SyntaxToken GetFirstTokenAfterAttributes(BaseTypeDeclarationSyntax node)
-            {
-                return node.AttributeLists.Count != 0
-                    ? node.AttributeLists.Last().GetLastToken().GetNextToken()
-                    : node.GetFirstToken();
-            }
-
-            private SyntaxToken GetFirstTokenAfterAttributes(BaseMethodDeclarationSyntax node)
-            {
-                return node.AttributeLists.Count != 0
-                    ? node.AttributeLists.Last().GetLastToken().GetNextToken()
-                    : node.GetFirstToken();
-            }
-
             private VirtualTreePoint GetBodyStartPoint(SourceText text, SyntaxToken openBrace)
             {
                 Debug.Assert(!openBrace.IsMissing);
@@ -302,7 +288,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         throw Exceptions.ThrowENotImpl();
 
                     case EnvDTE.vsCMPart.vsCMPartHeader:
-                        startPosition = GetFirstTokenAfterAttributes(node).SpanStart;
+                        startPosition = node.GetFirstTokenAfterAttributes().SpanStart;
                         break;
 
                     case EnvDTE.vsCMPart.vsCMPartAttributesWithDelimiter:
@@ -350,7 +336,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         throw Exceptions.ThrowENotImpl();
 
                     case EnvDTE.vsCMPart.vsCMPartHeader:
-                        startPosition = GetFirstTokenAfterAttributes(node).SpanStart;
+                        startPosition = node.GetFirstTokenAfterAttributes().SpanStart;
                         break;
 
                     case EnvDTE.vsCMPart.vsCMPartAttributesWithDelimiter:
@@ -393,7 +379,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                                     startPosition = ((OperatorDeclarationSyntax)node).OperatorToken.SpanStart;
                                     break;
                                 default:
-                                    startPosition = GetFirstTokenAfterAttributes(node).SpanStart;
+                                    startPosition = node.GetFirstTokenAfterAttributes().SpanStart;
                                     break;
                             }
                         }
@@ -929,7 +915,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                                     endPosition = ((OperatorDeclarationSyntax)node).OperatorToken.Span.End;
                                     break;
                                 default:
-                                    endPosition = GetFirstTokenAfterAttributes(node).Span.End;
+                                    endPosition = node.GetFirstTokenAfterAttributes().Span.End;
                                     break;
                             }
                         }

--- a/src/VisualStudio/CSharp/Impl/CodeModel/SyntaxNodeExtensions.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/SyntaxNodeExtensions.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
+{
+    internal static class SyntaxNodeExtensions
+    {
+        public static bool TryGetAttributeLists(this SyntaxNode node, out SyntaxList<AttributeListSyntax> attributeLists)
+        {
+            if (node is CompilationUnitSyntax)
+            {
+                attributeLists = ((CompilationUnitSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is BaseTypeDeclarationSyntax)
+            {
+                attributeLists = ((BaseTypeDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is BaseMethodDeclarationSyntax)
+            {
+                attributeLists = ((BaseMethodDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is BasePropertyDeclarationSyntax)
+            {
+                attributeLists = ((BasePropertyDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is BaseFieldDeclarationSyntax)
+            {
+                attributeLists = ((BaseFieldDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is DelegateDeclarationSyntax)
+            {
+                attributeLists = ((DelegateDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is EnumMemberDeclarationSyntax)
+            {
+                attributeLists = ((EnumMemberDeclarationSyntax)node).AttributeLists;
+                return true;
+            }
+            else if (node is ParameterSyntax)
+            {
+                attributeLists = ((ParameterSyntax)node).AttributeLists;
+                return true;
+            }
+
+            attributeLists = default(SyntaxList<AttributeListSyntax>);
+            return false;
+        }
+
+        public static SyntaxToken GetFirstTokenAfterAttributes(this SyntaxNode node)
+        {
+            SyntaxList<AttributeListSyntax> attributeLists;
+            if (node.TryGetAttributeLists(out attributeLists) && attributeLists.Count > 0)
+            {
+                return attributeLists.Last().GetLastToken().GetNextToken();
+            }
+
+            return node.GetFirstToken();
+        }
+    }
+}

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
@@ -68,6 +68,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Return codeElement.Parameters
         End Function
 
+        Protected Overrides Function AddAttribute(codeElement As EnvDTE80.CodeDelegate2, data As AttributeData) As EnvDTE.CodeAttribute
+            Return codeElement.AddAttribute(data.Name, data.Value, data.Position)
+        End Function
+
         Protected Overrides Sub RemoveChild(codeElement As EnvDTE80.CodeDelegate2, child As Object)
             codeElement.RemoveParameter(child)
         End Sub

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -1566,6 +1566,7 @@ partial class C
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -1599,6 +1600,76 @@ class $$C { }
 <Code>
 using System;
 
+[Serializable]
+[CLSCompliant(true)]
+class C { }
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment1()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+class $$C { }
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[CLSCompliant(true)]
+class C { }
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment2()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[Serializable]
+class $$C { }
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[CLSCompliant(true)]
+[Serializable]
+class C { }
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment3()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[Serializable]
+class $$C { }
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
 [Serializable]
 [CLSCompliant(true)]
 class C { }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
@@ -302,6 +302,71 @@ public delegate int $$M(int @int, string @string);
 
 #End Region
 
+#Region "AddAttribute tests"
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute1()
+            Dim code =
+<Code>
+using System;
+
+delegate void $$D();
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+[Serializable()]
+delegate void D();
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute2()
+            Dim code =
+<Code>
+using System;
+
+[Serializable]
+delegate void $$D();
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+[Serializable]
+[CLSCompliant(true)]
+delegate void D();
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+delegate void $$D();
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[CLSCompliant(true)]
+delegate void D();
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
@@ -1,8 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -256,6 +254,36 @@ enum E
 }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+enum $$E
+{
+    Foo = 1,
+    Bar
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[Flags()]
+enum E
+{
+    Foo = 1,
+    Bar
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Flags"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
@@ -1,8 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -802,6 +800,89 @@ class C
 </Code>
 
             TestSetTypeProp(code, expected, "System.ConsoleCancelEventHandler")
+        End Sub
+
+#End Region
+
+#Region "AddAttribute tests"
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute1()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    public event EventHandler $$E;
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable()]
+    public event EventHandler E;
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute2()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    public event EventHandler $$E;
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    [CLSCompliant(true)]
+    public event EventHandler E;
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    public event EventHandler $$E;
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    [CLSCompliant(true)]
+    public event EventHandler E;
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -2439,6 +2439,89 @@ public class C
 
 #End Region
 
+#Region "AddAttribute tests"
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute1()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    void $$M() { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable()]
+    void M() { }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute2()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    void $$M() { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    [CLSCompliant(true)]
+    void M() { }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    void $$M() { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    [CLSCompliant(true)]
+    void M() { }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+#End Region
+
         Private Function GetExtensionMethodExtender(codeElement As EnvDTE80.CodeFunction2) As ICSExtensionMethodExtender
             Return CType(codeElement.Extender(ExtenderNames.ExtensionMethod), ICSExtensionMethodExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
@@ -141,7 +141,7 @@ partial interface I
 <Code>
 using System;
 
-interface $$C { }
+interface $$I { }
 </Code>
 
             Dim expected =
@@ -149,7 +149,7 @@ interface $$C { }
 using System;
 
 [Serializable()]
-interface C { }
+interface I { }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
         End Sub
@@ -161,7 +161,7 @@ interface C { }
 using System;
 
 [Serializable]
-interface $$C { }
+interface $$I { }
 </Code>
 
             Dim expected =
@@ -170,9 +170,31 @@ using System;
 
 [Serializable]
 [CLSCompliant(true)]
-interface C { }
+interface I { }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+interface $$I { }
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[CLSCompliant(true)]
+interface I { }
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -9,6 +9,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
         Inherits AbstractCodeParameterTests
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -1342,6 +1342,114 @@ class Program
 
 #End Region
 
+#Region "AddAttribute tests"
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute1()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    public int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable()]
+    public int P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute2()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    public int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    [Serializable]
+    [CLSCompliant(true)]
+    public int P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    public int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    [CLSCompliant(true)]
+    public int P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+#End Region
+
         Private Function GetAutoImplementedPropertyExtender(codeElement As EnvDTE80.CodeProperty2) As ICSAutoImplementedPropertyExtender
             Return CType(codeElement.Extender(ExtenderNames.AutoImplementedProperty), ICSAutoImplementedPropertyExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
@@ -301,7 +301,7 @@ partial struct S
 <Code>
 using System;
 
-struct $$C { }
+struct $$S { }
 </Code>
 
             Dim expected =
@@ -309,7 +309,7 @@ struct $$C { }
 using System;
 
 [Serializable()]
-struct C { }
+struct S { }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
         End Sub
@@ -321,7 +321,7 @@ struct C { }
 using System;
 
 [Serializable]
-struct $$C { }
+struct $$S { }
 </Code>
 
             Dim expected =
@@ -330,10 +330,33 @@ using System;
 
 [Serializable]
 [CLSCompliant(true)]
-struct C { }
+struct S { }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
         End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+struct $$S { }
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+/// &lt;summary&gt;&lt;/summary&gt;
+[CLSCompliant(true)]
+struct S { }
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
 #End Region
 
 #Region "AddFunction tests"

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
@@ -306,6 +306,7 @@ class C
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -314,7 +315,7 @@ using System;
 
 class C
 {
-    int $$Foo;
+    int $$F;
 }
 </Code>
 
@@ -325,7 +326,7 @@ using System;
 class C
 {
     [Serializable()]
-    int Foo;
+    int F;
 }
 </Code>
 
@@ -341,7 +342,7 @@ using System;
 class C
 {
     [Serializable]
-    int $$Foo;
+    int $$F;
 }
 </Code>
 
@@ -353,10 +354,38 @@ class C
 {
     [Serializable]
     [CLSCompliant(true)]
-    int Foo;
+    int F;
 }
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    int $$F;
+}
+</Code>
+
+            Dim expected =
+<Code>
+using System;
+
+class C
+{
+    /// &lt;summary&gt;&lt;/summary&gt;
+    [CLSCompliant(true)]
+    int F;
+}
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -171,7 +171,8 @@ class C { }
 [assembly: System.Reflection.AssemblyCompany("Microsoft")]
 [assembly: System.CLSCompliant(true)]
 
-class C { }</Code>
+class C { }
+</Code>
 
             TestAddAttribute(code, expected, New AttributeData With {.Name = "System.CLSCompliant", .Value = "true", .Position = -1})
         End Sub
@@ -192,9 +193,28 @@ class C { }
 [assembly: System.Reflection.AssemblyCopyright("2012")]
 [assembly: System.CLSCompliant(true)]
 
-class C { }</Code>
+class C { }
+</Code>
 
             TestAddAttribute(code, expected, New AttributeData With {.Name = "System.CLSCompliant", .Value = "true", .Position = -1})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute6()
+            Dim code =
+<Code>
+/// &lt;summary&gt;&lt;/summary&gt;
+class $$C { }
+</Code>
+
+            Dim expected =
+<Code>
+[assembly: System.CLSCompliant(true)]
+/// &lt;summary&gt;&lt;/summary&gt;
+class C { }
+</Code>
+
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "System.CLSCompliant", .Value = "true"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -1552,6 +1552,7 @@ End Class
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -1588,6 +1589,82 @@ End Class
 <Code>
 Imports System
 
+&lt;Serializable&gt;
+&lt;CLSCompliant(True)&gt;
+Class C
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment1()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Class $$C
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;CLSCompliant(True)&gt;
+Class C
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment2()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;Serializable&gt;
+Class $$C
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;CLSCompliant(True)&gt;
+&lt;Serializable&gt;
+Class C
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment3()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;Serializable&gt;
+Class $$C
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
 &lt;Serializable&gt;
 &lt;CLSCompliant(True)&gt;
 Class C

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeDelegateTests.vb
@@ -521,6 +521,72 @@ Delegate Sub $$D([integer] as Integer, [string] as String)
 
 #End Region
 
+#Region "AddAttribute tests"
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute1()
+            Dim code =
+<Code>
+Imports System
+
+Delegate Sub $$M()
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+&lt;Serializable()&gt;
+Delegate Sub M()
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute2()
+            Dim code =
+<Code>
+Imports System
+
+&lt;Serializable&gt;
+Delegate Sub $$M()
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+&lt;Serializable&gt;
+&lt;CLSCompliant(true)&gt;
+Delegate Sub M()
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Delegate Sub $$M()
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;CLSCompliant(true)&gt;
+Delegate Sub M()
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+#End Region
+
         Private Function GetGenericExtender(codeElement As EnvDTE80.CodeDelegate2) As IVBGenericExtender
             Return CType(codeElement.Extender(ExtenderNames.VBGenericExtender), IVBGenericExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEnumTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEnumTests.vb
@@ -158,6 +158,7 @@ Public Enum $$E : End Enum
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -208,6 +209,34 @@ Enum E
 End Enum
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Enum $$E
+    Foo = 1,
+    Bar
+End Enum
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;Flags()&gt;
+Enum E
+    Foo = 1,
+    Bar
+End Enum
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Flags"})
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeEventTests.vb
@@ -707,6 +707,72 @@ End Class
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
         End Sub
 
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_SimpleEvent_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Public Event $$E()
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;CLSCompliant(true)&gt;
+    Public Event E()
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_CustomEvent_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Public Custom Event $$E As EventHandler
+        AddHandler(ByVal value As EventHandler)
+        End AddHandler
+        RemoveHandler(ByVal value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
+     End Event
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;CLSCompliant(true)&gt;
+    Public Custom Event E As EventHandler
+        AddHandler(ByVal value As EventHandler)
+        End AddHandler
+        RemoveHandler(ByVal value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
+     End Event
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "true"})
+        End Sub
+
 #End Region
 
 #Region "Set IsShared tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeFunctionTests.vb
@@ -1029,6 +1029,7 @@ End Class
 #End Region
 
 #Region "Kind tests"
+
         <WorkItem(2355, "https://github.com/dotnet/roslyn/issues/2355")>
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub DeclareSubKind()
@@ -1519,6 +1520,250 @@ End Class
 Imports System
 
 Class C
+    &lt;Serializable()&gt;
+    Public Shared Operator Widening CType(x As Integer) As C
+    End Operator
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Sub_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Sub $$M()
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Sub M()
+    End Sub
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Function_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Function $$M() As integer
+    End Function
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Function M() As integer
+    End Function
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Sub_MustOverride_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+MustInherit Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    MustOverride Sub $$M()
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+MustInherit Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    MustOverride Sub M()
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Function_MustOverride_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+MustInherit Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    MustOverride Function $$M() As integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+MustInherit Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    MustOverride Function M() As integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_DeclareSub_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Declare Sub $$M() Lib "MyDll.dll"
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Declare Sub M() Lib "MyDll.dll"
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_DeclareFunction_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Declare Function $$M() Lib "MyDll.dll" As Integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Declare Function M() Lib "MyDll.dll" As Integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Constructor_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Sub $$New()
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Sub New()
+    End Sub
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Operator_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Public Shared Operator $$+(x As C, y As C) As C
+    End Operator
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Public Shared Operator +(x As C, y As C) As C
+    End Operator
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_Conversion_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Public Shared Operator Widening $$CType(x As Integer) As C
+    End Operator
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
     &lt;Serializable()&gt;
     Public Shared Operator Widening CType(x As Integer) As C
     End Operator

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeInterfaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeInterfaceTests.vb
@@ -83,13 +83,14 @@ End Interface
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
 <Code>
 Imports System
 
-Interface $$C
+Interface $$I
 End Interface
 </Code>
 
@@ -98,7 +99,7 @@ End Interface
 Imports System
 
 &lt;Serializable()&gt;
-Interface C
+Interface I
 End Interface
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
@@ -111,7 +112,7 @@ End Interface
 Imports System
 
 &lt;Serializable&gt;
-Interface $$C
+Interface $$I
 End Interface
 </Code>
 
@@ -121,10 +122,34 @@ Imports System
 
 &lt;Serializable&gt;
 &lt;CLSCompliant(True)&gt;
-Interface C
+Interface I
 End Interface
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True", .Position = 1})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Interface $$I
+End Interface
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;CLSCompliant(True)&gt;
+Interface I
+End Interface
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True"})
         End Sub
 
 #End Region
@@ -250,6 +275,7 @@ End Interface
 #End Region
 
 #Region "Set Name tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub SetName1()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
@@ -436,6 +436,7 @@ End Class
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -475,6 +476,29 @@ End Class
 ]]></Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Foo"})
         End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute3()
+            Dim code =
+<Code><![CDATA[
+Class C
+    Sub Foo(s As String, ' Comment after implicit line continuation
+            $$i As Integer)
+    End Sub
+End Class
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+Class C
+    Sub Foo(s As String, ' Comment after implicit line continuation
+            <Out()> i As Integer)
+    End Sub
+End Class
+]]></Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Out"})
+        End Sub
+
 #End Region
 
 #Region "FullName tests"
@@ -702,6 +726,7 @@ End Class
 #End Region
 
 #Region "Parent tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub Parent()
             Dim code =
@@ -714,6 +739,7 @@ End Class
 
             TestParent(code, IsElement("M", kind:=EnvDTE.vsCMElement.vsCMElementFunction))
         End Sub
+
 #End Region
 
 #Region "Type tests"
@@ -757,6 +783,7 @@ End Class
 #End Region
 
 #Region "DefaultValue tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub DefaultValue()
             Dim code =
@@ -769,9 +796,11 @@ End Class
 
             TestDefaultValue(code, """Foo""")
         End Sub
+
 #End Region
 
 #Region "Set ParameterKind tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub SetParameterKind_In()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -917,6 +917,68 @@ End Class
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
         End Sub
 
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_NormalProperty_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Property P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_AutoProperty_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Property $$P As Integer
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    &lt;Serializable()&gt;
+    Property P As Integer
+End Class
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
+        End Sub
+
 #End Region
 
 #Region "AddParameter tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeStructTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeStructTests.vb
@@ -49,13 +49,14 @@ End Structure
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
 <Code>
 Imports System
 
-Structure $$C
+Structure $$S
 End Structure
 </Code>
 
@@ -64,7 +65,7 @@ End Structure
 Imports System
 
 &lt;Serializable()&gt;
-Structure C
+Structure S
 End Structure
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "Serializable"})
@@ -77,7 +78,7 @@ End Structure
 Imports System
 
 &lt;Serializable&gt;
-Structure $$C
+Structure $$S
 End Structure
 </Code>
 
@@ -87,11 +88,36 @@ Imports System
 
 &lt;Serializable&gt;
 &lt;CLSCompliant(True)&gt;
-Structure C
+Structure S
 End Structure
 </Code>
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True", .Position = 1})
         End Sub
+
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Structure $$S
+End Structure
+</Code>
+
+            Dim expected =
+<Code>
+Imports System
+
+''' &lt;summary&gt;&lt;/summary&gt;
+&lt;CLSCompliant(True)&gt;
+Structure S
+End Structure
+</Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True"})
+        End Sub
+
 #End Region
 
 #Region "AddImplementedInterface tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeVariableTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeVariableTests.vb
@@ -838,6 +838,7 @@ End Class
 #End Region
 
 #Region "AddAttribute tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttribute1()
             Dim code =
@@ -887,9 +888,36 @@ End Class
             TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True", .Position = 1})
         End Sub
 
+        <WorkItem(2825, "https://github.com/dotnet/roslyn/issues/2825")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute_BelowDocComment()
+            Dim code =
+<Code><![CDATA[
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    Dim $$foo As Integer
+End Class
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+Imports System
+
+Class C
+    ''' &lt;summary&gt;&lt;/summary&gt;
+    <CLSCompliant(True)>
+    Dim foo As Integer
+End Class
+]]></Code>
+            TestAddAttribute(code, expected, New AttributeData With {.Name = "CLSCompliant", .Value = "True"})
+        End Sub
+
 #End Region
 
 #Region "Set Access tests"
+
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub SetEnumAccess1()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -307,6 +307,27 @@ End Class</Code>
             TestAddAttributeWithSimplification(code, expected, New AttributeData With {.Name = "System.CLSCompliant", .Value = "True", .Position = -1}, "System.CLSCompliant", "CLSCompliant")
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttribute6()
+            Dim code =
+<Code>
+''' &lt;summary&gt;&lt;/summary&gt;
+Class $$C
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+&lt;Assembly: CLSCompliant(True)&gt;
+
+''' &lt;summary&gt;&lt;/summary&gt;
+Class C
+End Class
+</Code>
+
+            TestAddAttributeWithSimplification(code, expected, New AttributeData With {.Name = "System.CLSCompliant", .Value = "True"}, "System.CLSCompliant", "CLSCompliant")
+        End Sub
+
 #End Region
 
 #Region "AddClass tests"


### PR DESCRIPTION
Addresses issue #2825.

Code Model must insert attributes below XML doc comments. Otherwise, this can change the intent of the user's code.

* In C#, it's bad. If an attribute appears above an XML doc comment for a member, the attribute is attached to the member but the XML doc comment will not be emitted.
* In VB, it's worse. If an attribute appears above an XML doc comment for a member, the attribute isn't actually attached to the member!

The approach taken is pretty simple: if an attribute is being inserted at the front of the list, just copy the existing leading trivia to it. In addition, extra care is taken in VB to ensure that the attribute has a trailing line break.

Unit tests have been added to handle every potential CodeElement that may encounter this situation. These also uncovered several other bugs, including lack of support for C# event fields and VB delegate statements.