### PR TITLE
Extending life time of a sequence scoped local if the local is repres…

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -201,57 +201,52 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             // when a sequence is happened to be a byref receiver
             // we may need to extend the life time of the target until we are done accessing it
-            // {.v ; v = Foo(); v}.Bar()     // v should be released after Bar() is over.
+            // {.v ; v = Foo(); v}.Bar()     // v should be released only after Bar() is done.
             LocalSymbol doNotRelease = null;
             if (tempOpt == null)
             {
-                BoundLocal referencedLocal = DigForLocal(sequence.Value);
-                if (referencedLocal != null)
+                doNotRelease = DigForValueLocal(sequence);
+                if (doNotRelease != null)
                 {
-                    doNotRelease = referencedLocal.LocalSymbol;
+                    tempOpt = GetLocal(doNotRelease);
                 }
             }
 
-            if (hasLocals)
-            {
-                _builder.CloseLocalScope();
-
-                foreach (var local in sequence.Locals)
-                {
-                    if (local != doNotRelease)
-                    {
-                        FreeLocal(local);
-                    }
-                    else
-                    {
-                        tempOpt = GetLocal(doNotRelease);
-                    }
-                }
-            }
-
+            FreeLocals(sequence, doNotRelease);
             return tempOpt;
         }
 
-        private BoundLocal DigForLocal(BoundExpression value)
+        // if sequence value is a local scoped to the sequence, return that local
+        private LocalSymbol DigForValueLocal(BoundSequence topSequence)
+        {
+            return DigForValueLocal(topSequence, topSequence.Value);
+        }
+
+        private LocalSymbol DigForValueLocal(BoundSequence topSequence, BoundExpression value)
         {
             switch (value.Kind)
             {
                 case BoundKind.Local:
                     var local = (BoundLocal)value;
-                    if (local.LocalSymbol.RefKind == RefKind.None)
+                    var symbol = local.LocalSymbol;
+                    if (topSequence.Locals.Contains(symbol))
                     {
-                        return local;
+                        return symbol;
                     }
                     break;
 
                 case BoundKind.Sequence:
-                    return DigForLocal(((BoundSequence)value).Value);
+                    return DigForValueLocal(topSequence, ((BoundSequence)value).Value);
 
                 case BoundKind.FieldAccess:
                     var fieldAccess = (BoundFieldAccess)value;
                     if (!fieldAccess.FieldSymbol.IsStatic)
                     {
-                        return DigForLocal(fieldAccess.ReceiverOpt);
+                        var receiver = fieldAccess.ReceiverOpt;
+                        if (!receiver.Type.IsReferenceType)
+                        {
+                            return DigForValueLocal(topSequence, receiver);
+                        }
                     }
                     break;
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -621,7 +621,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 EmitExpression(sequence.Value, used);
             }
 
-            FreeLocals(sequence);
+            // sequence is used as a value, can release all locals
+            FreeLocals(sequence, doNotRelease: null);
         }
 
         private void DefineLocals(BoundSequence sequence)
@@ -639,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private void FreeLocals(BoundSequence sequence)
+        private void FreeLocals(BoundSequence sequence, LocalSymbol doNotRelease)
         {
             if (sequence.Locals.IsEmpty)
             {
@@ -650,7 +651,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             foreach (var local in sequence.Locals)
             {
-                FreeLocal(local);
+                if ((object)local != doNotRelease)
+                {
+                    FreeLocal(local);
+                }
             }
         }
 
@@ -2032,17 +2036,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         DefineLocals(sequence);
                         EmitSideEffects(sequence);
 
-                        BoundLocal referencedLocal = DigForLocal(sequence.Value);
-                        LocalSymbol doNotRelease = null;
-                        if (referencedLocal != null)
-                        {
-                            doNotRelease = referencedLocal.LocalSymbol;
-                        }
-
                         lhsUsesStack = EmitAssignmentPreamble(assignmentOperator.Update(sequence.Value, assignmentOperator.Right, assignmentOperator.RefKind, assignmentOperator.Type));
 
-                        FreeLocals(sequence);
-                        Debug.Assert(!sequence.Locals.Any(l => l == doNotRelease));
+                        // doNotRelease will be released in EmitStore after we are done with the whole assignment.
+                        var doNotRelease = DigForValueLocal(sequence);
+                        FreeLocals(sequence, doNotRelease);
                     }
                     break;
 
@@ -2188,6 +2186,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     {
                         var sequence = (BoundSequence)expression;
                         EmitStore(assignment.Update(sequence.Value, assignment.Right, assignment.RefKind, assignment.Type));
+
+                        var notReleased = DigForValueLocal(sequence);
+                        if (notReleased != null)
+                        {
+                            FreeLocal(notReleased);
+                        }
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -518,7 +518,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             DefineLocals(sequence);
             EmitSideEffects(sequence);
             EmitCondBranch(sequence.Value, ref dest, sense);
-            FreeLocals(sequence);
+
+            // sequence is used as a value, can release all locals
+            FreeLocals(sequence, doNotRelease: null);
         }
 
         private void EmitLabelStatement(BoundLabelStatement boundLabelStatement)
@@ -1115,7 +1117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             if (sequence != null)
             {
-                FreeLocals(sequence);
+                FreeLocals(sequence, doNotRelease: null);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1509,6 +1509,135 @@ struct S
         }
 
         [Fact]
+        public void InitTemp001a()
+        {
+            string source = @"
+
+using System;
+ 
+struct S1
+{
+    public int x;
+}
+
+struct S
+{
+    public S1 x;
+
+    
+ 
+    static void Main()
+    {
+        Console.WriteLine(new S { x = new S1{x=0} }.x.Equals(new S { x = new S1{x=1} }));
+    }
+}
+
+";
+
+            var compilation = CompileAndVerify(source, expectedOutput: "False");
+
+            compilation.VerifyIL("S.Main",
+@"
+{
+  // Code size       94 (0x5e)
+  .maxstack  4
+  .locals init (S V_0,
+                S1 V_1,
+                S V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  initobj    ""S1""
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  ldc.i4.0
+  IL_0015:  stfld      ""int S1.x""
+  IL_001a:  ldloc.1
+  IL_001b:  stfld      ""S1 S.x""
+  IL_0020:  ldloca.s   V_0
+  IL_0022:  ldflda     ""S1 S.x""
+  IL_0027:  ldloca.s   V_2
+  IL_0029:  initobj    ""S""
+  IL_002f:  ldloca.s   V_2
+  IL_0031:  ldloca.s   V_1
+  IL_0033:  initobj    ""S1""
+  IL_0039:  ldloca.s   V_1
+  IL_003b:  ldc.i4.1
+  IL_003c:  stfld      ""int S1.x""
+  IL_0041:  ldloc.1
+  IL_0042:  stfld      ""S1 S.x""
+  IL_0047:  ldloc.2
+  IL_0048:  box        ""S""
+  IL_004d:  constrained. ""S1""
+  IL_0053:  callvirt   ""bool object.Equals(object)""
+  IL_0058:  call       ""void System.Console.WriteLine(bool)""
+  IL_005d:  ret
+}
+");
+        }
+
+        [Fact]
+        public void InitTemp001b()
+        {
+            string source = @"
+
+using System;
+ 
+class S1
+{
+    public int x;
+}
+
+struct S
+{
+    public S1 x;
+
+    
+ 
+    static void Main()
+    {
+        Console.WriteLine(new S { x = new S1{x=0} }.x.Equals(new S { x = new S1{x=1} }));
+    }
+}
+
+";
+
+            var compilation = CompileAndVerify(source, expectedOutput: "False");
+
+            compilation.VerifyIL("S.Main",
+@"
+{
+  // Code size       77 (0x4d)
+  .maxstack  5
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  newobj     ""S1..ctor()""
+  IL_000f:  dup
+  IL_0010:  ldc.i4.0
+  IL_0011:  stfld      ""int S1.x""
+  IL_0016:  stfld      ""S1 S.x""
+  IL_001b:  ldloc.0
+  IL_001c:  ldfld      ""S1 S.x""
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  initobj    ""S""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  newobj     ""S1..ctor()""
+  IL_0030:  dup
+  IL_0031:  ldc.i4.1
+  IL_0032:  stfld      ""int S1.x""
+  IL_0037:  stfld      ""S1 S.x""
+  IL_003c:  ldloc.0
+  IL_003d:  box        ""S""
+  IL_0042:  callvirt   ""bool object.Equals(object)""
+  IL_0047:  call       ""void System.Console.WriteLine(bool)""
+  IL_004c:  ret
+}
+");
+        }
+
+        [Fact]
         public void InitTemp002()
         {
             string source = @"


### PR DESCRIPTION
…ented by the sequence and is used as a target of an assignment.

We would need to extend the life time of such local for the same reasons that we do it in a case when sequence is a target of an invocation. - We need to access that local in the outer expression, so it must still be in scope.

I could not create an actual scenario where we would have sequence as a target of an assignment and would need to keep the local until the assignment is done. I still think that is possible in theory and more robust support for this scenario shared with similar support for calls is a good idea.

* refactored the logic that digs out the local so that it could be used in other places.
* made it not optional to specify doNotRelease local to ensure we are not releasing locals by accident
* added comments to the cases where releasing all sequence locals at once is ok.

Fixes #2889