### PR TITLE
Fix errors reported intermittently when changing the current IP by drag & drop right after edit

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -775,12 +775,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     //    pENC2->ExitBreakState();
                     //    >>> hr = GetCodeContextOfPosition(pTextPos, &pCodeContext, &pProgram, true, true);
                     //    pENC2->EnterBreakState(m_pSession, GetEncBreakReason());
+                    //
+                    // The debugger seem to expect ENC_NOT_MODIFIED in these cases, otherwise errors occur.
 
-                    if (_changesApplied)
+                    if (_changesApplied || _encService.EditSession == null)
                     {
                         _lastEditSessionSummary = ProjectAnalysisSummary.NoChanges;
                     }
-                    else if (_encService.EditSession != null)
+                    else
                     {
                         // Fetch the latest snapshot of the project and get an analysis summary for any changes 
                         // made since the break mode was entered.
@@ -799,6 +801,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                             _projectBeingEmitted = currentProject;
                             _lastEditSessionSummary = GetProjectAnalysisSummary(_projectBeingEmitted);
                         }
+
                         _encService.EditSession.LogBuildState(_lastEditSessionSummary);
                     }
 


### PR DESCRIPTION
When the user starts dragging the IP after edit was made the debugger calls us to apply the change. We do so. Then the debugger exits break mode and enters it again when you drop the IP indicator. For reasons unknown to me the debugger is querying us for the current status of the project (i.e. has there been changes? any compiler edits? any rude edits? etc.) during the time in between exiting and entering the break mode. Although we handled that case before by returning the last state it doesn't seem to be what the debugger expects. Seems like it expects to always get "no change" status back. So we do that now.