### PR TITLE
remove rule about no line between attributes

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -54,11 +54,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             If previousToken.Kind = SyntaxKind.GreaterThanToken AndAlso previousToken.Parent IsNot Nothing AndAlso TypeOf previousToken.Parent Is AttributeListSyntax Then
 
-                ' If the attribute is followed by another attribute then there is no line operation
-                'If currentToken.Kind = SyntaxKind.LessThanToken AndAlso currentToken.Parent IsNot Nothing AndAlso TypeOf currentToken.Parent Is AttributeListSyntax Then
-                'Return Nothing
-                'End If
-
                 ' This AttributeList is the last applied attribute
                 ' If this AttributeList belongs to a parameter then apply no line operation
                 If previousToken.Parent.Parent IsNot Nothing AndAlso TypeOf previousToken.Parent.Parent Is ParameterSyntax Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -55,9 +55,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             If previousToken.Kind = SyntaxKind.GreaterThanToken AndAlso previousToken.Parent IsNot Nothing AndAlso TypeOf previousToken.Parent Is AttributeListSyntax Then
 
                 ' If the attribute is followed by another attribute then there is no line operation
-                If currentToken.Kind = SyntaxKind.LessThanToken AndAlso currentToken.Parent IsNot Nothing AndAlso TypeOf currentToken.Parent Is AttributeListSyntax Then
-                    Return Nothing
-                End If
+                'If currentToken.Kind = SyntaxKind.LessThanToken AndAlso currentToken.Parent IsNot Nothing AndAlso TypeOf currentToken.Parent Is AttributeListSyntax Then
+                'Return Nothing
+                'End If
 
                 ' This AttributeList is the last applied attribute
                 ' If this AttributeList belongs to a parameter then apply no line operation

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -1335,7 +1335,7 @@ End Namespace]]></Code>
 
             Dim expected = <Code><![CDATA[Namespace SomeNamespace
     <SomeAttribute()>
-                <SomeAttribute2()>
+    <SomeAttribute2()>
     Class Foo
     End Class
 End Namespace]]></Code>


### PR DESCRIPTION
fixes #2714 

The problem is that without a line operation for the space between the attributes, even a no-op operation, the attribute themselves fall under the default anchor operation for the statement (method declaration statement), which anchors anything without a line operation between the start of the statement (including leading trivia) and the end relative to the indentation of the start of the statement. 

The actual pasting (using mouse selection) causes the initial attribute to be double indented because the cursor is indented already. When formatting later adjusts this, it then too also adjusts anything at the start of a line that doesn't have a overriding line operation. You only see the second attribute adjust because the statement itself has a line operation.

This issue was introduced with http://roslyn.codeplex.com/workitem/423, though the intended fix there was supposed to only relate to attributes before a parameter, somehow a general rule about lines between attributes was introduced too, removing the line operation.

@heejaechang @Pilchie @rchande @dpoeschl please review.

