### PR TITLE
Fix couple of cast simplification bugs in unsafe and unchecked context

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -1943,6 +1943,132 @@ unsafe class C
 ");
         }
 
+        [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
+        [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveNecessaryCastBeforePointerDereference3()
+        {
+            // Conservatively disable cast simplifications for casts involving pointer conversions.
+            // https://github.com/dotnet/roslyn/issues/2987 tracks improving cast simplification for this scenario.
+
+            TestMissing(
+            @"
+class C
+{
+    public unsafe float ReadSingle(byte* ptr)
+    {
+        return *[|(float*)ptr|];
+    }
+}
+");
+        }
+
+        [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
+        [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveNumericCastInUncheckedExpression()
+        {
+            // Conservatively disable cast simplifications within explicit checked/unchecked expressions.
+            // https://github.com/dotnet/roslyn/issues/2987 tracks improving cast simplification for this scenario.
+
+            TestMissing(
+            @"
+class C
+{
+    private unsafe readonly byte* _endPointer;
+    private unsafe byte* _currentPointer;
+
+    private unsafe void CheckBounds(int byteCount)
+    {
+        if (unchecked([|(uint)byteCount)|] > (_endPointer - _currentPointer))
+        {
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
+        [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveNumericCastInUncheckedStatement()
+        {
+            // Conservatively disable cast simplifications within explicit checked/unchecked statements.
+            // https://github.com/dotnet/roslyn/issues/2987 tracks improving cast simplification for this scenario.
+
+            TestMissing(
+            @"
+class C
+{
+    private unsafe readonly byte* _endPointer;
+    private unsafe byte* _currentPointer;
+
+    private unsafe void CheckBounds(int byteCount)
+    {
+        unchecked
+        {
+            if (([|(uint)byteCount)|] > (_endPointer - _currentPointer))
+            {
+            }
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
+        [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveNumericCastInCheckedExpression()
+        {
+            // Conservatively disable cast simplifications within explicit checked/unchecked expressions.
+            // https://github.com/dotnet/roslyn/issues/2987 tracks improving cast simplification for this scenario.
+
+            TestMissing(
+            @"
+class C
+{
+    private unsafe readonly byte* _endPointer;
+    private unsafe byte* _currentPointer;
+
+    private unsafe void CheckBounds(int byteCount)
+    {
+        if (checked([|(uint)byteCount)|] > (_endPointer - _currentPointer))
+        {
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
+        [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveNumericCastInCheckedStatement()
+        {
+            // Conservatively disable cast simplifications within explicit checked/unchecked statements.
+            // https://github.com/dotnet/roslyn/issues/2987 tracks improving cast simplification for this scenario.
+
+            TestMissing(
+            @"
+class C
+{
+    private unsafe readonly byte* _endPointer;
+    private unsafe byte* _currentPointer;
+
+    private unsafe void CheckBounds(int byteCount)
+    {
+        checked
+        {
+            if (([|(uint)byteCount)|] > (_endPointer - _currentPointer))
+            {
+            }
+        }
+    }
+}
+");
+        }
+
         [WorkItem(545894)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInAttribute()

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return semanticModel.GetTypeInfo(castExpression).Type;
             }
 
+            if (parentNode.IsKind(SyntaxKind.PointerIndirectionExpression))
+            {
+                return semanticModel.GetTypeInfo(expression).Type;
+            }
+
             if (parentNode.IsKind(SyntaxKind.IsExpression) ||
                 parentNode.IsKind(SyntaxKind.AsExpression))
             {
@@ -355,6 +360,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 // Explicit reference conversions can cause an exception or data loss, hence can never be removed.
                 return false;
             }
+            else if (expressionToCastType.IsExplicit && expressionToCastType.IsNumeric && IsInExplicitCheckedOrUncheckedContext(cast))
+            {
+                // Don't remove any explicit numeric casts in explicit checked/unchecked context.
+                // https://github.com/dotnet/roslyn/issues/2987 tracks improving on this conservative approach.
+                return false;
+            }
+            else if (expressionToCastType.IsPointer)
+            {
+                // Don't remove any non-identity pointer conversions.
+                // https://github.com/dotnet/roslyn/issues/2987 tracks improving on this conservative approach.
+                return expressionType != null && expressionType.Equals(outerType);
+            }
 
             if (parentIsOrAsExpression)
             {
@@ -539,6 +556,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 default:
                     return false;
             }
+        }
+
+        private static bool IsInExplicitCheckedOrUncheckedContext(CastExpressionSyntax cast)
+        {
+            SyntaxNode currentNode = cast;
+
+            do
+            {
+                switch(currentNode.Kind())
+                {
+                    case SyntaxKind.UncheckedExpression:
+                    case SyntaxKind.UncheckedStatement:
+                    case SyntaxKind.CheckedExpression:
+                    case SyntaxKind.CheckedStatement:
+                        return true;
+                }
+
+                currentNode = currentNode.Parent;
+            } while (currentNode is ExpressionSyntax || currentNode is StatementSyntax);
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fix cast simplification to not offer cast removals for following cases:

1) Explicit numeric casts in unchecked context
2) Non-identity pointer-to-pointer conversions.

Fixes #2691

Description: Fix is to bail out early for these cases. As we are now more conservative, we cannot regress in offering any additional incorrect cast removals.

Testing Done: Existing cast simplification tests.

/cc @ManishJayaswal @Srivatsn: Please let me know if the PR will correctly go into the stabilization branch.