### PR TITLE
remove disposal logic from recoverable tree and text

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -124,10 +124,7 @@ namespace Microsoft.CodeAnalysis.Host
 
                 using (var stream = await _storage.ReadStreamAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    var retVal = RecoverRoot(stream, cancellationToken);
-                    _storage.Dispose();
-                    _storage = null;
-                    return retVal;
+                    return RecoverRoot(stream, cancellationToken);
                 }
             }
 
@@ -137,10 +134,7 @@ namespace Microsoft.CodeAnalysis.Host
 
                 using (var stream = _storage.ReadStream(cancellationToken))
                 {
-                    var retVal = RecoverRoot(stream, cancellationToken);
-                    _storage.Dispose();
-                    _storage = null;
-                    return retVal;
+                    return RecoverRoot(stream, cancellationToken);
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
@@ -127,10 +127,7 @@ namespace Microsoft.CodeAnalysis
 
                 using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverTextAsync, _parent._filePath, cancellationToken))
                 {
-                    var retVal = await _storage.ReadTextAsync(cancellationToken).ConfigureAwait(false);
-                    _storage.Dispose();
-                    _storage = null;
-                    return retVal;
+                    return await _storage.ReadTextAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -140,10 +137,7 @@ namespace Microsoft.CodeAnalysis
 
                 using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverText, _parent._filePath, cancellationToken))
                 {
-                    var retVal = _storage.ReadText(cancellationToken);
-                    _storage.Dispose();
-                    _storage = null;
-                    return retVal;
+                    return _storage.ReadText(cancellationToken);
                 }
             }
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -734,17 +734,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var observed = GetObservedText(sol, did, text);
             StopObservingAndWaitForReferenceToGo(observed);
 
-            Persistence.TestTemporaryStorageService.TextStorage.s_DisposalCount = 0;
-
             // get it async and force it to recover from temporary storage
             var doc = sol.GetDocument(did);
             var docText = doc.GetTextAsync().Result;
 
             Assert.NotNull(docText);
-            Assert.Equal(text, docText.ToString());
-
-            // Ensure that the temporary storage was disposed
-            Assert.Equal(1, Persistence.TestTemporaryStorageService.TextStorage.s_DisposalCount);
+            Assert.Equal(text, docText.ToString());            
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -1073,8 +1068,6 @@ End Class";
             var observed2 = GetObservedSyntaxTreeRootAsync(doc2.Project.Solution, did);
             StopObservingAndWaitForReferenceToGo(observed2);
 
-            Persistence.TestTemporaryStorageService.StreamStorage.s_DisposalCount = 0;
-
             // access the tree & root again (recover it)
             var tree2 = doc2.GetSyntaxTreeAsync().Result;
 
@@ -1083,9 +1076,6 @@ End Class";
 
             // prove that the new root is correctly associated with the tree
             Assert.Equal(tree2, root2.SyntaxTree);
-
-            // Ensure that the temporary storage was disposed
-            Assert.Equal(1, Persistence.TestTemporaryStorageService.StreamStorage.s_DisposalCount);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Fixes #2832 

Customer Scenario:  Keeps VS from crashing almost certainly, always.
Description: remove errant dispose logic. see https://github.com/dotnet/roslyn/pull/2919
Testing: normal -- do not observe crashing anymore.

@Pilchie this is for you.
