### PR TITLE
Optimize away BoundReferenceAssignment in StackScheduler if the assigned local isn't used.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Rewriter.vb
@@ -97,7 +97,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
                 ' this should not be the last store, why would be created such a variable after all???
                 Debug.Assert(locInfo.localDefs.Any(Function(d) _nodeCounter = d.Start AndAlso _nodeCounter <= d.End))
-                Debug.Assert(Not IsLastAccess(locInfo, _nodeCounter))
+
+                If IsLastAccess(locInfo, _nodeCounter) Then
+                    ' assigned local is not used later => just emit the Right 
+                    Return right
+                End If
 
                 ' assigned local used later - keep assignment. 
                 ' codegen will keep value on stack when sees assignment "stackLocal = expr"

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithBlock.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithBlock.vb
@@ -3392,6 +3392,34 @@ End Namespace
             VerifyDiagnostics()
         End Sub
 
+        <Fact(), WorkItem(2640, "https://github.com/dotnet/roslyn/issues/2640")>
+        Public Sub WithUnusedArrayElement()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Module Module1
+  Private Structure MyStructure
+    Public x As Single
+  End Structure
+  Sub Main()
+    Dim unusedArrayInWith(0) As MyStructure
+    With unusedArrayInWith(GetIndex())
+      System.Console.WriteLine("Hello, World")
+    End With
+  End Sub
+
+  Function GetIndex() as Integer
+    System.Console.WriteLine("GetIndex")
+    Return 0
+  End Function
+End Module
+    </file>
+</compilation>, options:=TestOptions.ReleaseExe, expectedOutput:=<![CDATA[
+GetIndex
+Hello, World
+]]>)
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #2640.

@VSadov, @gafter, @agocke, @jaredpar Please review.   