### PR TITLE
Ensure anonymous types are always defined in a Global namespace.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Public Overrides ReadOnly Property ContainingSymbol As Symbol
                 Get
-                    Return Me.Manager.ContainingModule.RootNamespace
+                    Return Me.Manager.ContainingModule.GlobalNamespace
                 End Get
             End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Public Overrides ReadOnly Property ContainingSymbol As Symbol
                 Get
-                    Return Me.Manager.ContainingModule.RootNamespace
+                    Return Me.Manager.ContainingModule.GlobalNamespace
                 End Get
             End Property
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
@@ -465,5 +465,37 @@ VB$AnonymousDelegate_6`2[System.Int64,System.Int64]
 ]]>)
         End Sub
 
+        <Fact>
+        <WorkItem(2928, "https://github.com/dotnet/roslyn/issues/2928")>
+        Public Sub ContainingSymbol()
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Module Test
+    Sub Main()
+        Dim x = Function(y) y + 1
+        System.Console.WriteLine(x)
+    End Sub
+End Module
+    </file>
+</compilation>, options:=TestOptions.DebugExe.WithRootNamespace("Ns1.Ns2"))
+
+            Dim tree As SyntaxTree = comp.SyntaxTrees.Single()
+            Dim semanticModel = comp.GetSemanticModel(tree)
+            Dim x = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(n) n.Identifier.ValueText = "x").Single()
+
+            Dim type = semanticModel.GetTypeInfo(x).Type
+            Assert.Equal("Function <generated method>(y As System.Object) As System.Object", type.ToTestDisplayString())
+            Assert.True(type.ContainingNamespace.IsGlobalNamespace)
+
+            Dim validator As Action(Of ModuleSymbol) =
+                Sub(m As ModuleSymbol)
+                    Dim anonDelegate = (From sym In m.GlobalNamespace.GetMembers()
+                                        Where sym.Name.Contains("AnonymousDelegate")).Single()
+                End Sub
+
+            CompileAndVerify(comp, symbolValidator:=validator, expectedOutput:="VB$AnonymousDelegate_0`2[System.Object,System.Object]")
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #2928.

@VSadov, @gafter, @agocke, @jaredpar Please review  