### PR TITLE
Guard against concurrent callbacks into analyzers in IDE

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/AnalyzerDriver/AnalyzerExecutor.cs
@@ -26,9 +26,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Action<Exception, DiagnosticAnalyzer, Diagnostic> _onAnalyzerException;
         private readonly AnalyzerManager _analyzerManager;
         private readonly Func<DiagnosticAnalyzer, bool> _isCompilerAnalyzer;
-        private readonly ImmutableDictionary<DiagnosticAnalyzer, object> _singleThreadedAnalyzerToGateMap;
+        private readonly Func<DiagnosticAnalyzer, object> _getAnalyzerGateOpt;
         private readonly ConcurrentDictionary<DiagnosticAnalyzer, TimeSpan> _analyzerExecutionTimeMapOpt;
-        
+
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -44,8 +44,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="isCompilerAnalyzer">Delegate to determine if the given analyzer is compiler analyzer. 
         /// We need to special case the compiler analyzer at few places for performance reasons.</param>
         /// <param name="analyzerManager">Analyzer manager to fetch supported diagnostics.</param>
-        /// <param name="singleThreadedAnalyzerToGateMap">Map from non-thread safe analyzers to unique gate objects. 
-        /// All analyzer callbacks for these analyzers will be guarded with a lock on the gate.
+        /// <param name="getAnalyzerGate">
+        /// Delegate to fetch the gate object to guard all callbacks into the analyzer.
+        /// It should return a unique gate object for the given analyzer instance for non-concurrent analyzers, and null otherwise.
+        /// All analyzer callbacks for non-concurrent analyzers will be guarded with a lock on the gate.
         /// </param>
         /// <param name="logExecutionTime">Flag indicating whether we need to log analyzer execution time.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
@@ -56,11 +58,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
             Func<DiagnosticAnalyzer, bool> isCompilerAnalyzer,
             AnalyzerManager analyzerManager,
-            ImmutableDictionary<DiagnosticAnalyzer, object> singleThreadedAnalyzerToGateMap = default(ImmutableDictionary<DiagnosticAnalyzer, object>),
+            Func<DiagnosticAnalyzer, object> getAnalyzerGate,
             bool logExecutionTime = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return new AnalyzerExecutor(compilation, analyzerOptions, addDiagnostic, onAnalyzerException, isCompilerAnalyzer, analyzerManager, singleThreadedAnalyzerToGateMap, logExecutionTime, cancellationToken);
+            return new AnalyzerExecutor(compilation, analyzerOptions, addDiagnostic, onAnalyzerException, isCompilerAnalyzer, analyzerManager, getAnalyzerGate, logExecutionTime, cancellationToken);
         }
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 analyzerOptions: null,
                 addDiagnostic: null,
                 isCompilerAnalyzer: null,
-                singleThreadedAnalyzerToGateMap: ImmutableDictionary<DiagnosticAnalyzer, object>.Empty,
+                getAnalyzerGateOpt: null,
                 onAnalyzerException: onAnalyzerException,
                 analyzerManager: analyzerManager,
                 logExecutionTime: logExecutionTime,
@@ -98,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
             Func<DiagnosticAnalyzer, bool> isCompilerAnalyzer,
             AnalyzerManager analyzerManager,
-            ImmutableDictionary<DiagnosticAnalyzer, object> singleThreadedAnalyzerToGateMap,
+            Func<DiagnosticAnalyzer, object> getAnalyzerGateOpt,
             bool logExecutionTime,
             CancellationToken cancellationToken)
         {
@@ -108,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _onAnalyzerException = onAnalyzerException;
             _isCompilerAnalyzer = isCompilerAnalyzer;
             _analyzerManager = analyzerManager;
-            _singleThreadedAnalyzerToGateMap = singleThreadedAnalyzerToGateMap ?? ImmutableDictionary<DiagnosticAnalyzer, object>.Empty;
+            _getAnalyzerGateOpt = getAnalyzerGateOpt;
             _analyzerExecutionTimeMapOpt = logExecutionTime ? new ConcurrentDictionary<DiagnosticAnalyzer, TimeSpan>() : null;
             _cancellationToken = cancellationToken;
         }
@@ -486,10 +488,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal void ExecuteAndCatchIfThrows(DiagnosticAnalyzer analyzer, Action analyze)
         {
-            object gate;
-            if (_singleThreadedAnalyzerToGateMap.TryGetValue(analyzer, out gate))
+            object gate = _getAnalyzerGateOpt?.Invoke(analyzer);
+            if (gate != null)
             {
-                lock(gate)
+                lock (gate)
                 {
                     ExecuteAndCatchIfThrows_NoLock(analyzer, analyze);
                 }

--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
@@ -15,6 +16,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 {
     internal class DiagnosticAnalyzerDriver
     {
+        /// <summary>
+        /// Map containing unique gate objects per-analyzer instance.
+        /// We need to guard against concurrent callbacks into analyzers from different diagnostic clients.
+        /// Additionally, certain diagnostic clients, such as FixAll occurrences, may request diagnostics for multiple documents in parallel.
+        /// </summary>
+        private static readonly ConditionalWeakTable<DiagnosticAnalyzer, object> s_analyzerGateMap =
+            new ConditionalWeakTable<DiagnosticAnalyzer, object>();
+
         private readonly Document _document;
 
         // The root of the document.  May be null for documents without a root.
@@ -40,12 +49,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private readonly AnalyzerOptions _analyzerOptions;
 
         public DiagnosticAnalyzerDriver(
-            Document document, 
-            TextSpan? span, 
+            Document document,
+            TextSpan? span,
             SyntaxNode root,
             BaseDiagnosticIncrementalAnalyzer owner,
             CancellationToken cancellationToken)
-            : this (document.Project, owner, cancellationToken)
+            : this(document.Project, owner, cancellationToken)
         {
             _document = document;
             _span = span;
@@ -280,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         internal void OnAnalyzerException(Exception ex, DiagnosticAnalyzer analyzer, Compilation compilation)
         {
             var exceptionDiagnostic = AnalyzerExecutor.GetAnalyzerExceptionDiagnostic(analyzer, ex);
-            
+
             if (compilation != null)
             {
                 exceptionDiagnostic = CompilationWithAnalyzers.GetEffectiveDiagnostics(ImmutableArray.Create(exceptionDiagnostic), compilation).SingleOrDefault();
@@ -291,7 +300,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private AnalyzerExecutor GetAnalyzerExecutor(DiagnosticAnalyzer analyzer, Compilation compilation, Action<Diagnostic> addDiagnostic)
         {
-            return AnalyzerExecutor.Create(compilation, _analyzerOptions, addDiagnostic, _onAnalyzerException, AnalyzerHelper.IsCompilerAnalyzer, AnalyzerManager.Instance, cancellationToken: _cancellationToken);
+            return AnalyzerExecutor.Create(compilation, _analyzerOptions, addDiagnostic, _onAnalyzerException, AnalyzerHelper.IsCompilerAnalyzer, AnalyzerManager.Instance, s_analyzerGateMap.GetOrCreateValue, cancellationToken: _cancellationToken);
         }
 
         public async Task<AnalyzerActions> GetAnalyzerActionsAsync(DiagnosticAnalyzer analyzer)


### PR DESCRIPTION
**Customer scenario:** We need to do so for couple of scenarios:

1. Different diagnostic clients might end up requesting diagnostics at the same time and hence end up attempting to invoke into the same analyzer simultaneously.

2. FixAll occurrences computes diagnostics in parallel, hence can causes concurrent callbacks.

If the analyzer hasn't been written in a thread-safe way, then concurrent callbacks into it can cause analyzers to produce incorrect/misleading/duplicate diagnostics or the analyzer itself might throw and never execute again in the VS session.

**Fixes #2410**

**Testing:** There is no functional change here, so existing tests provide adequate coverage. I manually verified that FixAll performance is acceptable for simplify name/remove unnecessary usings across projects/solution in Roslyn.sln

/cc @srivatsn @ManishJayaswal Note that this is an identical change as #2833 (which was in the main repot). This one is directly in the stabilization branch. I already have couple of signoffs on #2833, so I just need your approval.