### PR TITLE
Use correct count in ReplaceSeparator

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SeparatedSyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SeparatedSyntaxListTests.cs
@@ -285,5 +285,28 @@ c,b", insertAfterEOL.ToFullString());
             Assert.Equal(-1, list.IndexOf(SyntaxKind.WhereClause));
             Assert.False(list.Any(SyntaxKind.WhereClause));
         }
+
+        [Fact]
+        [WorkItem(2630, "https://github.com/dotnet/roslyn/issues/2630")]
+        public void ReplaceSeparator()
+        {
+            var list = SyntaxFactory.SeparatedList<SyntaxNode>(
+                new[] {
+                    SyntaxFactory.IdentifierName("A"),
+                    SyntaxFactory.IdentifierName("B"),
+                    SyntaxFactory.IdentifierName("C"),
+                });
+
+            var newComma = SyntaxFactory.Token(
+                SyntaxFactory.TriviaList(SyntaxFactory.Space),
+                SyntaxKind.CommaToken,
+                SyntaxFactory.TriviaList());
+            var newList = list.ReplaceSeparator(
+                list.GetSeparator(1),
+                newComma);
+            Assert.Equal(3, newList.Count);
+            Assert.Equal(2, newList.SeparatorCount);
+            Assert.Equal(1, newList.GetSeparator(1).GetLeadingTrivia().Count);
     }
+}
 }

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis
         {
             var nodesWithSeps = this.GetWithSeparators();
             var index = nodesWithSeps.IndexOf(separatorToken);
-            if (index < 0 || index >= this.Count)
+            if (index < 0)
             {
                 throw new ArgumentException("separatorToken");
             }


### PR DESCRIPTION
The bounds checking code for the existing separator has no need to do an
upper bound check on `index`.  The IndexOf method will return -1 or a
valid index into nodesWithSeps.  Hence the comparison with `this.Count`
here was both unnecessary and incorrect (should have been
`nodesWithSeps.Count`).

closes #2630