### PR TITLE
Generate relative paths correctly

### DIFF
--- a/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
+++ b/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
@@ -73,7 +73,7 @@ namespace Roslyn.Utilities
                 string directorySeparator = Path.DirectorySeparatorChar.ToString();
                 for (int i = 0; i < remainingParts; i++)
                 {
-                    relativePath += relativePath + ".." + directorySeparator;
+                    relativePath = relativePath + ".." + directorySeparator;
                 }
             }
 

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="CodeCleanup\NormalizeModifiersOrOperatorsTests.cs" />
     <Compile Include="CodeCleanup\ReduceTokenTests.cs" />
     <Compile Include="CodeCleanup\RemoveUnnecessaryLineContinuationTests.cs" />
+    <Compile Include="UtilityTest\FilePathUtilitiesTests.cs" />
     <Compile Include="WorkspaceTests\CommandLineProjectTests.cs" />
     <Compile Include="WorkspaceTests\AdhocWorkspaceTests.cs" />
     <Compile Include="Differencing\MatchTests.cs" />

--- a/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"Doc.txt", actual: result);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"Delta\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"Delta\Doc.txt", actual: result);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"Delta\Epsilon\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"Delta\Epsilon\Doc.txt", actual: result);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"..\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"..\Doc.txt", actual: result);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"..\..\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"..\..\Doc.txt", actual: result);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"..\..\Phi\Omega\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"..\..\Phi\Omega\Doc.txt", actual: result);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
-            Assert.Equal(expected: @"D:\Alpha\Beta\Gamma\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expected: @"D:\Alpha\Beta\Gamma\Doc.txt", actual: result);
         }
     }
 }

--- a/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public sealed class FilePathUtilitiesTests
+    {
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_SameDirectory()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Beta\Gamma\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_NestedOneLevelDown()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Beta\Gamma\Delta\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"Delta\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_NestedTwoLevelsDown()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Beta\Gamma\Delta\Epsilon\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"Delta\Epsilon\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_UpOneLevel()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Beta\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"..\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_UpTwoLevels()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"..\..\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_UpTwoLevelsAndThenDown()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"C:\Alpha\Phi\Omega\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"..\..\Phi\Omega\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [WorkItem(1579, "https://github.com/dotnet/roslyn/issues/1579")]
+        public void GetRelativePath_OnADifferentDrive()
+        {
+            string baseDirectory = @"C:\Alpha\Beta\Gamma";
+            string fullPath = @"D:\Alpha\Beta\Gamma\Doc.txt";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"D:\Alpha\Beta\Gamma\Doc.txt", actual: result, comparer: StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
**Bug:** Fixes #1579.

**Customer Scenario:**
The customer wishes to use a shared rule set file in their project to control their diagnostics. The .ruleset file is at the root of their solution, so the customer adds it to their project as a linked file. They then set it as the active rule set by right-clicking on the file in Solution Explorer and selecting "Set as Active Rule Set".

The file should become the active rule set for the project, turning various diagnostics on or off or altering their severity. Instead the customer gets an error in the Error List: "The file '..\\..\\..\\Rule.ruleset' cannot be found" and the rule set has no effect.

**Fix:**
When adding `..` to the relative path to backup to higher-level directories, we effectively add each one multiple times. The fix is to stop doing that.

**Testing:**
I manually tested the following variation on the original scenario:

* Rule set file in the same directory as the project file
* Rule set file one level above the project file
* Rule set file two levels above the project file
* Rule set file up two levels and then down in a subdirectory
* Rule set file one level below the project file
* Rule set file two levels below the project file
* Rule set file on a different directory

and verified that in each case the project file ends up with the correct path, and that the rule set takes effect as expected.

I also added unit tests to exercise the affected code.

@srivatsn @mavasani @shyamnamboodiripad @heejaechang @jmarolf @ManishJayaswal Could you take a look, please? This is a pull request against the stabilization branch.