### PR TITLE
Numeric literals (binary and digit separators)

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8829,6 +8829,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to binary literals.
+        /// </summary>
+        internal static string IDS_FeatureBinaryLiteral {
+            get {
+                return ResourceManager.GetString("IDS_FeatureBinaryLiteral", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to collection initializer.
         /// </summary>
         internal static string IDS_FeatureCollectionInitializer {
@@ -8861,6 +8870,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureDictionaryInitializer {
             get {
                 return ResourceManager.GetString("IDS_FeatureDictionaryInitializer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to digit separators.
+        /// </summary>
+        internal static string IDS_FeatureDigitSeparator {
+            get {
+                return ResourceManager.GetString("IDS_FeatureDigitSeparator", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4599,6 +4599,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_AwaitInCatchAndFinally" xml:space="preserve">
     <value>await in catch blocks and finally blocks</value>
   </data>
+  <data name="IDS_FeatureBinaryLiteral" xml:space="preserve">
+    <value>binary literals</value>
+  </data>
+  <data name="IDS_FeatureDigitSeparator" xml:space="preserve">
+    <value>digit separators</value>
+  </data>
   <data name="ERR_UnescapedCurly" xml:space="preserve">
     <value>A '{0}' character must be escaped (by doubling) in an interpolated string.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -111,6 +111,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureInterpolatedStrings = MessageBase + 12702,
         IDS_OperationCausedStackOverflow = MessageBase + 12703,
         IDS_AwaitInCatchAndFinally = MessageBase + 12704,
+
+        IDS_FeatureBinaryLiteral = MessageBase + 12705,
+        IDS_FeatureDigitSeparator = MessageBase + 12706,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -144,10 +147,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalizableErrorArgument(id);
         }
 
+        // Returns the string to be used in the /features flag switch to enable the MessageID feature.
+        // Always call this before RequiredVersion:
+        //   If this method returns null, call RequiredVersion and use that.
+        //   If this method returns non-null, use that.
+        // Features should be mutually exclusive between RequiredFeature and RequiredVersion.
+        //   (hence the above rule - RequiredVersion throws when RequiredFeature returns non-null)
         internal static string RequiredFeature(this MessageID feature)
         {
             switch (feature)
             {
+                case MessageID.IDS_FeatureBinaryLiteral:
+                    return "binaryLiterals";
+                case MessageID.IDS_FeatureDigitSeparator:
+                    return "digitSeparators";
+
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Parser/CharacterInfo.cs
+++ b/src/Compilers/CSharp/Portable/Parser/CharacterInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>true if the character is a binary digit.</returns>
         internal static bool IsBinaryDigit(char c)
         {
-            return c == '0' || c == '1';
+            return c == '0' | c == '1';
         }
 
         /// <summary>
@@ -50,6 +50,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(IsHexDigit(c));
             return (c >= '0' && c <= '9') ? c - '0' : (c & 0xdf) - 'A' + 10;
+        }
+
+        /// <summary>
+        /// Returns the value of a binary Unicode character.
+        /// </summary>
+        /// <param name="c">The Unicode character.</param>
+        internal static int BinaryValue(char c)
+        {
+            Debug.Assert(IsBinaryDigit(c));
+            return c - '0';
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Parser/CharacterInfo.cs
+++ b/src/Compilers/CSharp/Portable/Parser/CharacterInfo.cs
@@ -23,6 +23,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Returns true if the Unicode character is a binary (0-1) digit.
+        /// </summary>
+        /// <param name="c">The Unicode character.</param>
+        /// <returns>true if the character is a binary digit.</returns>
+        internal static bool IsBinaryDigit(char c)
+        {
+            return c == '0' || c == '1';
+        }
+
+        /// <summary>
         /// Returns true if the Unicode character is a decimal digit.
         /// </summary>
         /// <param name="c">The Unicode character.</param>

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -925,6 +925,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             int start = TextWindow.Position;
             char ch;
             bool isHex = false;
+            bool isBinary = false;
             bool hasDecimal = false;
             bool hasExponent = false;
             info.Text = null;
@@ -934,20 +935,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             bool hasLSuffix = false;
 
             ch = TextWindow.PeekChar();
-            if (ch == '0' && ((ch = TextWindow.PeekChar(1)) == 'x' || ch == 'X'))
+            if (ch == '0')
             {
-                TextWindow.AdvanceChar(2);
-                isHex = true;
+                ch = TextWindow.PeekChar(1);
+                if (ch == 'x' || ch == 'X')
+                {
+                    TextWindow.AdvanceChar(2);
+                    isHex = true;
+                }
+                else if (ch == 'b' || ch == 'B')
+                {
+                    TextWindow.AdvanceChar(2);
+                    isBinary = true;
+                }
             }
 
-            if (isHex)
+            if (isHex || isBinary)
             {
                 // It's OK if it has no digits after the '0x' -- we'll catch it in ScanNumericLiteral
                 // and give a proper error then.
-                while (SyntaxFacts.IsHexDigit(ch = TextWindow.PeekChar()))
+                if (isHex)
                 {
-                    _builder.Append(ch);
-                    TextWindow.AdvanceChar();
+                    while (SyntaxFacts.IsHexDigit(ch = TextWindow.PeekChar()))
+                    {
+                        _builder.Append(ch);
+                        TextWindow.AdvanceChar();
+                    }
+                }
+                else if (isBinary)
+                {
+                    while (SyntaxFacts.IsBinaryDigit(ch = TextWindow.PeekChar()))
+                    {
+                        _builder.Append(ch);
+                        TextWindow.AdvanceChar();
+                    }
                 }
 
                 if ((ch = TextWindow.PeekChar()) == 'L' || ch == 'l')
@@ -1124,7 +1145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     }
                     else
                     {
-                        val = this.GetValueUInt64(valueText, isHex);
+                        val = this.GetValueUInt64(valueText, isHex, isBinary);
                     }
 
                     // 2.4.4.2 Integer literals
@@ -1220,6 +1241,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return true;
         }
 
+        // TODO: Change to Int64.TryParse when it supports NumberStyles.AllowBinarySpecifier (inline this method into GetValueUInt32/64)
+        private bool TryParseBinaryUInt64(string text, out ulong value)
+        {
+            value = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                // if uppermost bit is set, then the next bitshift will overflow
+                if ((value & 0x8000000000000000) != 0)
+                {
+                    return false;
+                }
+                if (!SyntaxFacts.IsBinaryDigit(text[i]))
+                {
+                    return false;
+                }
+                var bit = (ulong)SyntaxFacts.DecValue(text[i]);
+                value = (value << 1) | bit;
+            }
+            return true;
+        }
+
         //used in directives
         private int GetValueInt32(string text, bool isHex)
         {
@@ -1234,10 +1276,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         //used for all non-directive integer literals (cast to desired type afterward)
-        private ulong GetValueUInt64(string text, bool isHex)
+        private ulong GetValueUInt64(string text, bool isHex, bool isBinary)
         {
             ulong result;
-            if (!UInt64.TryParse(text, isHex ? NumberStyles.AllowHexSpecifier : NumberStyles.None, CultureInfo.InvariantCulture, out result))
+            if (isBinary)
+            {
+                if (!TryParseBinaryUInt64(text, out result))
+                {
+                    this.AddError(MakeError(ErrorCode.ERR_IntOverflow));
+                }
+            }
+            else if (!UInt64.TryParse(text, isHex ? NumberStyles.AllowHexSpecifier : NumberStyles.None, CultureInfo.InvariantCulture, out result))
             {
                 //we've already lexed the literal, so the error must be from overflow
                 this.AddError(MakeError(ErrorCode.ERR_IntOverflow));
@@ -1766,7 +1815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         goto Fail;
                     }
                     // Parse hex value to check for overflow.
-                    this.GetValueUInt64(valueText, isHex: true);
+                    this.GetValueUInt64(valueText, isHex: true, isBinary: false);
                 }
 
                 return true;

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -1046,7 +1046,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
 
             var featureName = feature.Localize();
-            var requiredVersion = feature.RequiredVersion();
 
             if (feature.RequiredFeature() != null)
             {
@@ -1060,6 +1059,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             else
             {
+                var requiredVersion = feature.RequiredVersion();
+
                 if (forceWarning)
                 {
                     SyntaxDiagnosticInfo rawInfo = new SyntaxDiagnosticInfo(availableVersion.GetErrorCode(), featureName, requiredVersion.Localize());

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -1916,6 +1916,109 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithUnsignedAndLongSpecifier()
+        {
+            var value = 0x123ul;
+            var text = "0b100100011ul";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+
+            text = "0b100100011lu";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithUpperUnsignedAndLongSpecifier()
+        {
+            var value = 0x123Ul;
+            var text = "0b100100011Ul";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+
+            text = "0b100100011lU";
+            token = LexToken(text);
+            errors = token.Errors();
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithUnsignedAndUpperLongSpecifier()
+        {
+            var value = 0x123uL;
+            var text = "0b100100011uL";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+
+            text = "0b100100011Lu";
+            token = LexToken(text);
+            errors = token.Errors();
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithUpperUnsignedAndUpperLongSpecifier()
+        {
+            var value = 0x123UL;
+            var text = "0b100100011UL";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+
+            text = "0b100100011LU";
+            token = LexToken(text);
+            errors = token.Errors();
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
         public void TestNumericLiteralMaxInt32()
         {
             var text = Int32.MaxValue.ToString();
@@ -2209,6 +2312,182 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
             Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteral()
+        {
+            var value = 0x123;
+            var text = "0b100100011";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithUnsignedSpecifier()
+        {
+            var value = 0x123u;
+            var text = "0b100100011u";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericBinaryLiteralWithLongSpecifier()
+        {
+            var value = 0x123L;
+            var text = "0b100100011L";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric8DigitBinaryLiteral()
+        {
+            var value = 0xAA;
+            var text = "0b10101010";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric8DigitMaxBinaryLiteral()
+        {
+            var value = 0x7FFFFFFF;
+            var text = "0b1111111111111111111111111111111";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric8DigitMaxUnsignedBinaryLiteral()
+        {
+            var value = 0xFFFFFFFF;
+            var text = "0b11111111111111111111111111111111";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric8DigitMaxUnsignedBinaryLiteralWithUnsignedSpecifier()
+        {
+            var value = 0xFFFFFFFFu;
+            var text = "0b11111111111111111111111111111111u";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric16DigitMaxBinaryLiteral()
+        {
+            var value = 0x7FFFFFFFFFFFFFFF;
+            var text = "0b111111111111111111111111111111111111111111111111111111111111111";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumeric16DigitMaxUnsignedBinaryLiteral()
+        {
+            var value = 0xFFFFFFFFFFFFFFFF;
+            var text = "0b1111111111111111111111111111111111111111111111111111111111111111";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(value, token.Value);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericOverflowBinaryLiteral()
+        {
+            var text = "0b10000000000000000000000000000000000000000000000000000000000000000";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_IntOverflow, errors[0].Code);
+            Assert.Equal("error CS1021: Integral constant is too large", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericEmptyBinaryLiteral()
+        {
+            var text = "0b";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -2492,6 +2492,200 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [Trait("Feature", "Literals")]
+        public void TestNumericWithUnderscores()
+        {
+            var text = "1_000";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(1000, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "1___0_0___0";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(1000, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "1_000.000_1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(1000.0001, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "1_01__0.0__10_1f";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(1010.0101f, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "1_01__0.0__10_1e0_1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(1010.0101e01, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "0xA_A";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(0xAA, token.Value);
+            Assert.Equal(text, token.Text);
+
+            text = "0b1_1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+            Assert.Equal(3, token.Value);
+            Assert.Equal(text, token.Text);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
+        public void TestNumericWithBadUnderscores()
+        {
+            var text = "_1000";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
+            Assert.Equal(0, token.Errors().Length);
+
+            text = "1000_";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            var errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "1000_.0";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            // parses as Int32.Member, where Member is _0
+            // TODO: Check for that it does parse as a field access
+            // text = "1000._0";
+
+            text = "1000.0_";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "1000.0_e1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "1000.0e_1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "1000.0e1_";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "0x_A";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "0xA_";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "0b_1";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+
+            text = "0b1_";
+            token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
+            errors = token.Errors();
+            Assert.Equal(1, errors.Length);
+            Assert.Equal((int)ErrorCode.ERR_InvalidNumber, errors[0].Code);
+            Assert.Equal("error CS1013: Invalid number", errors[0].ToString(EnsureEnglishUICulture.PreferredOrNull));
+            Assert.Equal(text, token.Text);
+        }
+
+        [Fact]
+        [Trait("Feature", "Literals")]
         public void TestNumericWithTrailingDot()
         {
             var value = 3;

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1935,5 +1935,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_GlobalNamespace
         FEATURE_NullPropagatingOperator
         FEATURE_NameOfExpressions
+        FEATURE_DigitSeparators
+        FEATURE_BinaryLiterals
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -5998,36 +5998,19 @@ checkNullable:
         ''' of the parser.  If it is not available a diagnostic will be added to the returned value.
         ''' </summary>
         Private Function CheckFeatureAvailability(Of TNode As VisualBasicSyntaxNode)(feature As Feature, node As TNode) As TNode
-            Dim languageVersion = _scanner.Options.LanguageVersion
-            If CheckFeatureAvailability(languageVersion, feature) Then
+            If _scanner.CheckFeatureAvailability(feature) Then
                 Return node
             End If
 
             If feature = Feature.InterpolatedStrings Then
                 ' Bug: It is too late in the release cycle to update localized strings.  As a short term measure we will output 
                 ' an unlocalized string and fix this to be localized in the next release.
-                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), "interpolated strings")
+                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, _scanner.Options.LanguageVersion.GetErrorName(), "interpolated strings")
             Else
                 Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
-                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), featureName)
+                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, _scanner.Options.LanguageVersion.GetErrorName(), featureName)
             End If
         End Function
-
-        Private Function CheckFeatureAvailability(feature As Feature) As Boolean
-            Return CheckFeatureAvailability(_scanner.Options.LanguageVersion, feature)
-        End Function
-
-        Private Shared Function CheckFeatureAvailability(languageVersion As LanguageVersion, feature As Feature) As Boolean
-            Dim required = feature.GetLanguageVersion()
-            Return CInt(required) <= CInt(languageVersion)
-        End Function
-
-        Friend Shared Sub CheckFeatureAvailability(diagnostics As DiagnosticBag, location As Location, languageVersion As LanguageVersion, feature As Feature)
-            If Not CheckFeatureAvailability(languageVersion, feature) Then
-                Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
-                diagnostics.Add(ERRID.ERR_LanguageVersion, location, languageVersion.GetErrorName(), featureName)
-            End If
-        End Sub
 
     End Class
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -18,12 +18,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         NullPropagatingOperator
         NameOfExpressions
         InterpolatedStrings
+        DigitSeparators
+        BinaryLiterals
     End Enum
 
     Friend Module FeatureExtensions
         <Extension>
         Friend Function GetFeatureFlag(feature As Feature) As String
             Select Case feature
+                Case Feature.DigitSeparators
+                    Return "digitSeparators"
+
+                Case Feature.BinaryLiterals
+                    Return "binaryLiterals"
 
                 Case Else
                     Return Nothing
@@ -86,6 +93,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ERRID.FEATURE_NullPropagatingOperator
                 Case Feature.NameOfExpressions
                     Return ERRID.FEATURE_NameOfExpressions
+                Case Feature.DigitSeparators
+                    Return ERRID.FEATURE_DigitSeparators
+                Case Feature.BinaryLiterals
+                    Return ERRID.FEATURE_BinaryLiterals
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)
             End Select

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.txt
@@ -1207,6 +1207,7 @@ Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase.Decimal = 0 -> Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase.Hexadecimal = 1 -> Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase.Octal = 2 -> Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase
+Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase.Binary = 3 -> Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralBase
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralExpressionSyntax
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralExpressionSyntax.Token() -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralExpressionSyntax.Update(kind As Microsoft.CodeAnalysis.VisualBasic.SyntaxKind, token As Microsoft.CodeAnalysis.SyntaxToken) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralExpressionSyntax

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -91,6 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Const FULLWIDTH_QUOTATION_MARK As Char = ChrW(s_fullwidth + AscW(""""c))        REM ＂
 
         Friend Const FULLWIDTH_DIGIT_ZERO As Char = ChrW(s_fullwidth + AscW("0"c))             REM ０
+        Friend Const FULLWIDTH_DIGIT_ONE As Char = ChrW(s_fullwidth + AscW("1"c))              REM １
         Friend Const FULLWIDTH_DIGIT_SEVEN As Char = ChrW(s_fullwidth + AscW("7"c))            REM ７
         Friend Const FULLWIDTH_DIGIT_NINE As Char = ChrW(s_fullwidth + AscW("9"c))             REM ９
 
@@ -116,6 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Const FULLWIDTH_COMMA As Char = ChrW(s_fullwidth + AscW(","c))                  REM ，
         Friend Const FULLWIDTH_PERCENT_SIGN As Char = ChrW(s_fullwidth + AscW("%"c))           REM ％
 
+        Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_B As Char = ChrW(s_fullwidth + AscW("B"c)) REM Ｂ
         Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_H As Char = ChrW(s_fullwidth + AscW("H"c)) REM Ｈ
         Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_O As Char = ChrW(s_fullwidth + AscW("O"c)) REM Ｏ
         Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_E As Char = ChrW(s_fullwidth + AscW("E"c)) REM Ｅ
@@ -125,6 +127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_P As Char = ChrW(s_fullwidth + AscW("P"c)) REM Ｐ
         Friend Const FULLWIDTH_LATIN_CAPITAL_LETTER_M As Char = ChrW(s_fullwidth + AscW("M"c)) REM Ｍ
 
+        Friend Const FULLWIDTH_LATIN_SMALL_LETTER_B As Char = ChrW(s_fullwidth + AscW("b"c))   REM ｂ
         Friend Const FULLWIDTH_LATIN_SMALL_LETTER_H As Char = ChrW(s_fullwidth + AscW("h"c))   REM ｈ
         Friend Const FULLWIDTH_LATIN_SMALL_LETTER_O As Char = ChrW(s_fullwidth + AscW("o"c))   REM ｏ
         Friend Const FULLWIDTH_LATIN_SMALL_LETTER_E As Char = ChrW(s_fullwidth + AscW("e"c))   REM ｅ
@@ -253,8 +256,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Shared Function BeginsBaseLiteral(c As Char) As Boolean
-            Return (c = "H"c Or c = "O"c Or c = "h"c Or c = "o"c) OrElse
-                    (IsFullWidth(c) AndAlso (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_O))
+            Return (c = "H"c Or c = "O"c Or c = "B"c Or c = "h"c Or c = "o"c Or c = "b"c) OrElse
+                    (IsFullWidth(c) AndAlso (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_O Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_B))
         End Function
 
         Private Shared ReadOnly s_isIDChar As Boolean() =
@@ -379,6 +382,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function BeginsExponent(c As Char) As Boolean
             Return c = "E"c Or c = "e"c Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_E Or c = FULLWIDTH_LATIN_SMALL_LETTER_E
+        End Function
+
+        Friend Shared Function IsBinaryDigit(c As Char) As Boolean
+            Return (c >= "0"c And c <= "1"c) Or
+                   (c >= FULLWIDTH_DIGIT_ZERO And c <= FULLWIDTH_DIGIT_ONE)
         End Function
 
         Friend Shared Function IsOctalDigit(c As Char) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -1554,6 +1554,7 @@ FullWidthRepeat:
 
             Dim Here As Integer = 0
             Dim IntegerLiteralStart As Integer
+            Dim UnderscoreInWrongPlace As Boolean
 
             Dim Base As LiteralBase = LiteralBase.Decimal
             Dim literalKind As NumericLiteralKind = NumericLiteralKind.Integral
@@ -1576,39 +1577,45 @@ FullWidthRepeat:
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Hexadecimal
 
+                        UnderscoreInWrongPlace = Peek(Here) = "_"c
                         While CanGet(Here)
                             ch = Peek(Here)
-                            If Not IsHexDigit(ch) Then
+                            If Not IsHexDigit(ch) AndAlso ch <> "_"c Then
                                 Exit While
                             End If
                             Here += 1
                         End While
+                        UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
 
                     Case "B"c, "b"c
                         Here += 1
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Binary
 
+                        UnderscoreInWrongPlace = Peek(Here) = "_"c
                         While CanGet(Here)
                             ch = Peek(Here)
-                            If Not IsBinaryDigit(ch) Then
+                            If Not IsBinaryDigit(ch) AndAlso ch <> "_"c Then
                                 Exit While
                             End If
                             Here += 1
                         End While
+                        UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
 
                     Case "O"c, "o"c
                         Here += 1
                         IntegerLiteralStart = Here
                         Base = LiteralBase.Octal
 
+                        UnderscoreInWrongPlace = Peek(Here) = "_"c
                         While CanGet(Here)
                             ch = Peek(Here)
-                            If Not IsOctalDigit(ch) Then
+                            If Not IsOctalDigit(ch) AndAlso ch <> "_"c Then
                                 Exit While
                             End If
                             Here += 1
                         End While
+                        UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
 
                     Case Else
                         If IsFullWidth(ch) Then
@@ -1621,13 +1628,17 @@ FullWidthRepeat:
             Else
                 ' no base specifier - just go through decimal digits.
                 IntegerLiteralStart = Here
+                UnderscoreInWrongPlace = Peek(Here) = "_"c
                 While CanGet(Here)
                     ch = Peek(Here)
-                    If Not IsDecimalDigit(ch) Then
+                    If Not IsDecimalDigit(ch) AndAlso ch <> "_"c Then
                         Exit While
                     End If
                     Here += 1
                 End While
+                If Here <> IntegerLiteralStart Then
+                    UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
+                End If
             End If
 
             ' we may have a dot, and then it is a float, but if this is an integral, then we have seen it all.
@@ -1647,11 +1658,12 @@ FullWidthRepeat:
                     ' all following decimal digits belong to the literal (fractional part)
                     While CanGet(Here)
                         ch = Peek(Here)
-                        If Not IsDecimalDigit(ch) Then
+                        If Not IsDecimalDigit(ch) AndAlso ch <> "_"c Then
                             Exit While
                         End If
                         Here += 1
                     End While
+                    UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
                     literalKind = NumericLiteralKind.Float
                 End If
 
@@ -1672,11 +1684,12 @@ FullWidthRepeat:
                         Here += 1
                         While CanGet(Here)
                             ch = Peek(Here)
-                            If Not IsDecimalDigit(ch) Then
+                            If Not IsDecimalDigit(ch) AndAlso ch <> "_"c Then
                                 Exit While
                             End If
                             Here += 1
                         End While
+                        UnderscoreInWrongPlace = UnderscoreInWrongPlace Or (Peek(Here - 1) = "_"c)
                     Else
                         Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_InvalidLiteralExponent)
                     End If
@@ -1819,12 +1832,16 @@ FullWidthRepeat2:
                 If IntegerLiteralStart = IntegerLiteralEnd Then
                     Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_Syntax)
                 Else
-                    IntegralValue = IntegralLiteralCharacterValue(Peek(IntegerLiteralStart))
+                    IntegralValue = 0
 
                     If Base = LiteralBase.Decimal Then
                         ' Init For loop
-                        For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1
-                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(Peek(LiteralCharacter))
+                        For LiteralCharacter As Integer = IntegerLiteralStart To IntegerLiteralEnd - 1
+                            Dim LiteralCharacterValue As Char = Peek(LiteralCharacter)
+                            If LiteralCharacterValue = "_"c Then
+                                Continue For
+                            End If
+                            Dim NextCharacterValue As UInteger = IntegralLiteralCharacterValue(LiteralCharacterValue)
 
                             If IntegralValue < 1844674407370955161UL OrElse
                               (IntegralValue = 1844674407370955161UL AndAlso NextCharacterValue <= 5UI) Then
@@ -1844,12 +1861,17 @@ FullWidthRepeat2:
                         Dim OverflowMask As UInt64 = If(Base = LiteralBase.Hexadecimal, &HF000000000000000UL, If(Base = LiteralBase.Octal, &HE000000000000000UL, &H8000000000000000UL))
 
                         ' Init For loop
-                        For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1
+                        For LiteralCharacter As Integer = IntegerLiteralStart To IntegerLiteralEnd - 1
+                            Dim LiteralCharacterValue As Char = Peek(LiteralCharacter)
+                            If LiteralCharacterValue = "_"c Then
+                                Continue For
+                            End If
+
                             If (IntegralValue And OverflowMask) <> 0 Then
                                 Overflows = True
                             End If
 
-                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(Peek(LiteralCharacter))
+                            IntegralValue = (IntegralValue << Shift) + IntegralLiteralCharacterValue(LiteralCharacterValue)
                         Next
                     End If
 
@@ -1892,7 +1914,9 @@ FullWidthRepeat2:
                 Dim scratch = GetScratch()
                 For i = 0 To literalWithoutTypeChar - 1
                     Dim curCh = Peek(i)
-                    scratch.Append(If(IsFullWidth(curCh), MakeHalfWidth(curCh), curCh))
+                    If curCh <> "_"c Then
+                        scratch.Append(If(IsFullWidth(curCh), MakeHalfWidth(curCh), curCh))
+                    End If
                 Next
                 Dim LiteralSpelling = GetScratchTextInterned(scratch)
 
@@ -1920,17 +1944,19 @@ FullWidthRepeat2:
             Dim result As SyntaxToken
             Select Case literalKind
                 Case NumericLiteralKind.Integral
-                    result = MakeIntegerLiteralToken(precedingTrivia, Base, TypeCharacter, If(Overflows, 0UL, IntegralValue), Here)
+                    result = MakeIntegerLiteralToken(precedingTrivia, Base, TypeCharacter, If(Overflows Or UnderscoreInWrongPlace, 0UL, IntegralValue), Here)
                 Case NumericLiteralKind.Float
-                    result = MakeFloatingLiteralToken(precedingTrivia, TypeCharacter, If(Overflows, 0.0F, FloatingValue), Here)
+                    result = MakeFloatingLiteralToken(precedingTrivia, TypeCharacter, If(Overflows Or UnderscoreInWrongPlace, 0.0F, FloatingValue), Here)
                 Case NumericLiteralKind.Decimal
-                    result = MakeDecimalLiteralToken(precedingTrivia, TypeCharacter, If(Overflows, 0D, DecimalValue), Here)
+                    result = MakeDecimalLiteralToken(precedingTrivia, TypeCharacter, If(Overflows Or UnderscoreInWrongPlace, 0D, DecimalValue), Here)
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(literalKind)
             End Select
 
             If Overflows Then
                 result = DirectCast(result.AddError(ErrorFactory.ErrorInfo(ERRID.ERR_Overflow)), SyntaxToken)
+            ElseIf UnderscoreInWrongPlace Then
+                result = DirectCast(result.AddError(ErrorFactory.ErrorInfo(ERRID.ERR_Syntax)), SyntaxToken)
             End If
 
             Return result

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -1584,6 +1584,19 @@ FullWidthRepeat:
                             Here += 1
                         End While
 
+                    Case "B"c, "b"c
+                        Here += 1
+                        IntegerLiteralStart = Here
+                        Base = LiteralBase.Binary
+
+                        While CanGet(Here)
+                            ch = Peek(Here)
+                            If Not IsBinaryDigit(ch) Then
+                                Exit While
+                            End If
+                            Here += 1
+                        End While
+
                     Case "O"c, "o"c
                         Here += 1
                         IntegerLiteralStart = Here
@@ -1827,8 +1840,8 @@ FullWidthRepeat2:
                             Overflows = True
                         End If
                     Else
-                        Dim Shift As Integer = If(Base = LiteralBase.Hexadecimal, 4, 3)
-                        Dim OverflowMask As UInt64 = If(Base = LiteralBase.Hexadecimal, &HF000000000000000UL, &HE000000000000000UL)
+                        Dim Shift As Integer = If(Base = LiteralBase.Hexadecimal, 4, If(Base = LiteralBase.Octal, 3, 1))
+                        Dim OverflowMask As UInt64 = If(Base = LiteralBase.Hexadecimal, &HF000000000000000UL, If(Base = LiteralBase.Octal, &HE000000000000000UL, &H8000000000000000UL))
 
                         ' Init For loop
                         For LiteralCharacter As Integer = IntegerLiteralStart + 1 To IntegerLiteralEnd - 1

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxLiterals.vb
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         ''' <summary>
-        ''' Whether the token was specified in base 10, 16, or 8.
+        ''' Whether the token was specified in base 10, 16, 8, or 2.
         ''' </summary>
         Friend ReadOnly Property Base As LiteralBase
             Get

--- a/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
@@ -8915,7 +8915,7 @@ Unify Enum declarations with other block type declarations.
       </node-kind>
 
       <field name="Base" type="LiteralBase">
-        <description>Whether the token was specified in base 10, 16 or 8.</description>
+        <description>Whether the token was specified in base 10, 16, 8 or 2.</description>
       </field>
 
       <field name="TypeSuffix" type="TypeCharacter">
@@ -9042,7 +9042,7 @@ Unify Enum declarations with other block type declarations.
 
     <enumeration name="LiteralBase">
       <description>
-        The three possible number bases that a literal can be written in.
+        The four possible number bases that a literal can be written in.
       </description>
       <native-equiv name="LiteralBase"></native-equiv>
 
@@ -9050,6 +9050,7 @@ Unify Enum declarations with other block type declarations.
         <enumerator name="Decimal" />
         <enumerator name="Hexadecimal" />
         <enumerator name="Octal" />
+        <enumerator name="Binary" />
       </enumerators>
     </enumeration>
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -222,7 +222,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="value">The 4-byte signed integer value to be represented by the returned token.</param> 
         ''' <param name="trailing">A list of trivia immediately following the token.</param>
         Public Shared Function Literal(leading As SyntaxTriviaList, text As String, value As Integer, trailing As SyntaxTriviaList) As SyntaxToken
-            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, LiteralBase.Decimal)), If(text.EndsWith("I", StringComparison.OrdinalIgnoreCase), TypeCharacter.IntegerLiteral, TypeCharacter.None), CULng(value),
+            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, If(text.StartsWith("&B", StringComparison.OrdinalIgnoreCase), LiteralBase.Binary, LiteralBase.Decimal))), If(text.EndsWith("I", StringComparison.OrdinalIgnoreCase), TypeCharacter.IntegerLiteral, TypeCharacter.None), CULng(value),
                         DirectCast(leading.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailing.Node, InternalSyntax.VisualBasicSyntaxNode)), SyntaxToken)
         End Function
 
@@ -246,7 +246,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="value">The 4-byte unsigned integer value to be represented by the returned token.</param>
         ''' <param name="trailing">A list of trivia immediately following the token.</param>
         Public Shared Function Literal(leading As SyntaxTriviaList, text As String, value As UInteger, trailing As SyntaxTriviaList) As SyntaxToken
-            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, LiteralBase.Decimal)), If(text.EndsWith("UI", StringComparison.OrdinalIgnoreCase), TypeCharacter.UIntegerLiteral, TypeCharacter.None), value,
+            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, If(text.StartsWith("&B", StringComparison.OrdinalIgnoreCase), LiteralBase.Binary, LiteralBase.Decimal))), If(text.EndsWith("UI", StringComparison.OrdinalIgnoreCase), TypeCharacter.UIntegerLiteral, TypeCharacter.None), value,
                     DirectCast(leading.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailing.Node, InternalSyntax.VisualBasicSyntaxNode)), SyntaxToken)
         End Function
 
@@ -269,7 +269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="value">The 8-byte signed integer value to be represented by the returned token.</param>
         ''' <param name="trailing">A list of trivia immediately following the token.</param>
         Public Shared Function Literal(leading As SyntaxTriviaList, text As String, value As Long, trailing As SyntaxTriviaList) As SyntaxToken
-            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, LiteralBase.Decimal)), If(text.EndsWith("L", StringComparison.OrdinalIgnoreCase), TypeCharacter.LongLiteral, TypeCharacter.None), CULng(value),
+            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, If(text.StartsWith("&B", StringComparison.OrdinalIgnoreCase), LiteralBase.Binary, LiteralBase.Decimal))), If(text.EndsWith("L", StringComparison.OrdinalIgnoreCase), TypeCharacter.LongLiteral, TypeCharacter.None), CULng(value),
                     DirectCast(leading.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailing.Node, InternalSyntax.VisualBasicSyntaxNode)), SyntaxToken)
         End Function
 
@@ -292,7 +292,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="value">The 8-byte unsigned integer value to be represented by the returned token.</param>
         ''' <param name="trailing">A list of trivia immediately following the token.</param>
         Public Shared Function Literal(leading As SyntaxTriviaList, text As String, value As ULong, trailing As SyntaxTriviaList) As SyntaxToken
-            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, LiteralBase.Decimal)), If(text.EndsWith("UL", StringComparison.OrdinalIgnoreCase), TypeCharacter.ULongLiteral, TypeCharacter.None), value,
+            Return CType(InternalSyntax.SyntaxFactory.IntegerLiteralToken(text, If(text.StartsWith("&H", StringComparison.OrdinalIgnoreCase), LiteralBase.Hexadecimal, If(text.StartsWith("&O", StringComparison.OrdinalIgnoreCase), LiteralBase.Octal, If(text.StartsWith("&B", StringComparison.OrdinalIgnoreCase), LiteralBase.Binary, LiteralBase.Decimal))), If(text.EndsWith("UL", StringComparison.OrdinalIgnoreCase), TypeCharacter.ULongLiteral, TypeCharacter.None), value,
                     DirectCast(leading.Node, InternalSyntax.VisualBasicSyntaxNode), DirectCast(trailing.Node, InternalSyntax.VisualBasicSyntaxNode)), SyntaxToken)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -11605,6 +11605,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to binary literals.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_BinaryLiterals() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_BinaryLiterals", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to variance.
         '''</summary>
         Friend ReadOnly Property FEATURE_CoContraVariance() As String
@@ -11619,6 +11628,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property FEATURE_CollectionInitializers() As String
             Get
                 Return ResourceManager.GetString("FEATURE_CollectionInitializers", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to digit separators.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_DigitSeparators() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_DigitSeparators", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5295,4 +5295,10 @@
   <data name="FEATURE_NameOfExpressions" xml:space="preserve">
     <value>'nameof' expressions</value>
   </data>
+  <data name="FEATURE_DigitSeparators" xml:space="preserve">
+    <value>digit separators</value>
+  </data>
+  <data name="FEATURE_BinaryLiterals" xml:space="preserve">
+    <value>binary literals</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -99,6 +99,7 @@ Public Class ParseExpressionTest
     Public Sub ParseIntegerLiteralTest()
         ParseExpression("&H1")
         ParseExpression("&O1")
+        ParseExpression("&B1")
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -99,7 +99,6 @@ Public Class ParseExpressionTest
     Public Sub ParseIntegerLiteralTest()
         ParseExpression("&H1")
         ParseExpression("&O1")
-        ParseExpression("&B1")
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
@@ -707,6 +707,13 @@ End If]]>.Value,
         Assert.Equal(LiteralBase.Hexadecimal, tks(1).GetBase())
         Assert.Equal(&H42L, tks(1).Value)
         Assert.Equal(TypeCharacter.Long, tks(1).GetTypeCharacter())
+
+        Str = " &B1010L "
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(LiteralBase.Binary, tk.GetBase())
+        Assert.Equal(&HAL, tk.Value)
+        Assert.Equal(" &B1010L ", tk.ToFullString())
     End Sub
 
     <Fact>
@@ -821,6 +828,22 @@ End If]]>.Value,
         Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
         Assert.Equal(30036, tk.GetSyntaxErrorsNoTree()(0).Code)
         Assert.Equal(0, CInt(tk.Value))
+
+        Str = "&B111111111111111111111111111111111I"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(30036, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
+
+        Str = "&B11111111111111111111111111111111UI"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(&HFFFFFFFFUI, CUInt(tk.Value))
+
+        Str = "&B1111111111111111111111111111111I"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(&H7FFFFFFFI, CInt(tk.Value))
 
         Str = "1.7976931348623157E+308d"
         tk = ScanOnce(Str)

--- a/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
@@ -700,6 +700,7 @@ End If]]>.Value,
         Assert.Equal(LiteralBase.Decimal, tk.GetBase())
         Assert.Equal(42, tk.Value)
         Assert.Equal(" 4_2 ", tk.ToFullString())
+        Assert.Equal("error BC36716: Visual Basic 14.0 does not support digit separators.", tk.Errors().Single().ToString())
 
         Str = " &H42L "
         tk = ScanOnce(Str)
@@ -728,6 +729,7 @@ End If]]>.Value,
         Assert.Equal(LiteralBase.Binary, tk.GetBase())
         Assert.Equal(&HAL, tk.Value)
         Assert.Equal(" &B1010L ", tk.ToFullString())
+        Assert.Equal("error BC36716: Visual Basic 14.0 does not support binary literals.", tk.Errors().Single().ToString())
 
         Str = " &B1_0_1_0L "
         tk = ScanOnce(Str)
@@ -735,6 +737,9 @@ End If]]>.Value,
         Assert.Equal(LiteralBase.Binary, tk.GetBase())
         Assert.Equal(&HAL, tk.Value)
         Assert.Equal(" &B1_0_1_0L ", tk.ToFullString())
+        Assert.Equal(2, tk.Errors().Count)
+        Assert.Equal("error BC36716: Visual Basic 14.0 does not support digit separators.", tk.Errors()(0).ToString())
+        Assert.Equal("error BC36716: Visual Basic 14.0 does not support binary literals.", tk.Errors()(1).ToString())
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
@@ -694,12 +694,26 @@ End If]]>.Value,
         Assert.Equal(42, tk.Value)
         Assert.Equal(" 42 ", tk.ToFullString())
 
+        Str = " 4_2 "
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(LiteralBase.Decimal, tk.GetBase())
+        Assert.Equal(42, tk.Value)
+        Assert.Equal(" 4_2 ", tk.ToFullString())
+
         Str = " &H42L "
         tk = ScanOnce(Str)
         Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
         Assert.Equal(LiteralBase.Hexadecimal, tk.GetBase())
         Assert.Equal(&H42L, tk.Value)
         Assert.Equal(" &H42L ", tk.ToFullString())
+
+        Str = " &H4_2L "
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(LiteralBase.Hexadecimal, tk.GetBase())
+        Assert.Equal(&H42L, tk.Value)
+        Assert.Equal(" &H4_2L ", tk.ToFullString())
 
         Str = " &H42L &H42& "
         Dim tks = ScanAllCheckDw(Str)
@@ -714,6 +728,13 @@ End If]]>.Value,
         Assert.Equal(LiteralBase.Binary, tk.GetBase())
         Assert.Equal(&HAL, tk.Value)
         Assert.Equal(" &B1010L ", tk.ToFullString())
+
+        Str = " &B1_0_1_0L "
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(LiteralBase.Binary, tk.GetBase())
+        Assert.Equal(&HAL, tk.Value)
+        Assert.Equal(" &B1_0_1_0L ", tk.ToFullString())
     End Sub
 
     <Fact>
@@ -729,6 +750,13 @@ End If]]>.Value,
         Assert.Equal(0.42, tk.Value)
         Assert.IsType(Of Double)(tk.Value)
         Assert.Equal(" 0.42 ", tk.ToFullString())
+
+        Str = " 0_0.4_2 "
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.FloatingLiteralToken, tk.Kind)
+        Assert.Equal(0.42, tk.Value)
+        Assert.IsType(Of Double)(tk.Value)
+        Assert.Equal(" 0_0.4_2 ", tk.ToFullString())
 
         Str = " 0.42# "
         tk = ScanOnce(Str)
@@ -856,6 +884,44 @@ End If]]>.Value,
         Assert.Equal(SyntaxKind.FloatingLiteralToken, tk.Kind)
         Assert.Equal(30036, tk.GetSyntaxErrorsNoTree()(0).Code)
         Assert.Equal(0.0F, tk.Value)
+    End Sub
+
+    <Fact>
+    Public Sub Scanner_UnderscoreWrongLocation()
+        Dim Str = "_1"
+        Dim tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IdentifierToken, tk.Kind)
+        Assert.Equal(0, tk.GetSyntaxErrorsNoTree().Count())
+
+        Str = "1_"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(30035, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
+
+        Str = "&H_1"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(30035, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
+
+        Str = "&H1_"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.IntegerLiteralToken, tk.Kind)
+        Assert.Equal(30035, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
+
+        Str = "1_.1"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.FloatingLiteralToken, tk.Kind)
+        Assert.Equal(30035, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
+
+        Str = "1.1_"
+        tk = ScanOnce(Str)
+        Assert.Equal(SyntaxKind.FloatingLiteralToken, tk.Kind)
+        Assert.Equal(30035, tk.GetSyntaxErrorsNoTree()(0).Code)
+        Assert.Equal(0, CInt(tk.Value))
     End Sub
 
     <Fact>


### PR DESCRIPTION
This PR implements binary literals for C# and VB, as well as digit separators (underscores) for both C# and VB. It also implements a feature check and two /features flags for binary literals and digit separators, again for both C# and VB.

This implements proposals #215 and #216

Original PR [here](https://github.com/dotnet/roslyn/pull/2730), closed due to branching reorganization.

@gafter @jaredpar @VSadov @AlekseyTs @agocke Please review