### PR TITLE
Dont auto-format some keys when smart indent is off

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -65,6 +65,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                 return false;
             }
 
+            // don't auto format after these keys if smart indenting is not on.
+            if  ((ch == '#' || ch == 'n') && optionsService.GetOption(FormattingOptions.SmartIndent, document.Project.Language) != FormattingOptions.IndentStyle.Smart)
+            {
+                return false;
+            }
+
             return _supportedChars.Contains(ch);
         }
 


### PR DESCRIPTION
Fixes #2907 

This change makes it so smart-indenting (via formatting) for 'n' and '#' is not enabled unless smart indenting feature is enabled.

If you cut & paste the same text that did not get smart-indented, the formatter will still adjust the indentation.

@Pilchie @heejaechang please review
