### PR TITLE
Fix format rule for dot expression after label

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
@@ -255,6 +255,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             ' * [member access dot without expression]
             If previousToken.Kind <> SyntaxKind.OpenParenToken AndAlso FormattingHelpers.IsMemberAccessDotWithoutExpression(currentToken) Then
+
+                ' label:     .X
+                If previousToken.Kind = SyntaxKind.ColonToken AndAlso TypeOf previousToken.Parent Is LabelStatementSyntax Then
+                    Return FormattingOperations.CreateAdjustSpacesOperation(1, AdjustSpacesOption.DynamicSpaceToIndentationIfOnSingleLine)
+                End If
+
                 Return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 
@@ -303,7 +309,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
                 Case SyntaxKind.DotToken
                     Dim space = If(previousToken.Kind = SyntaxKind.CallKeyword OrElse
-                                   previousToken.Kind = SyntaxKind.KeyKeyword, 1, 0)
+                               previousToken.Kind = SyntaxKind.KeyKeyword, 1, 0)
                     Return CreateAdjustSpacesOperation(space, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End Select
 

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4258,5 +4258,31 @@ End Class
             Assert.Equal(expected, actual)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
+        <WorkItem(2822, "https://github.com/dotnet/roslyn/issues/2822")>
+        Public Sub FormatLabelFollowedByDotExpression()
+            Dim code = <Code>
+Module Module1
+    Sub Main()
+        With New List(Of Integer)
+lab: .Capacity = 15
+        End With
+    End Sub
+End Module
+</Code>
+
+            Dim expected = <Code>
+Module Module1
+    Sub Main()
+        With New List(Of Integer)
+lab:        .Capacity = 15
+        End With
+    End Sub
+End Module
+</Code>
+
+            AssertFormatLf2CrLf(code.Value, expected.Value)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #2822 

A catch-all rule for dot expressions (without LHS) was overriding the default rule that would affect spacing/indentation after a label. 

Added check for labels in catch-all rule to continue to produce spacing operation that would allow indentation after label.

@heejaechang @Pilchie please review.
