### PR TITLE
Ensure BoundLValueToRValueWrapper nodes are marked as compiler generated.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundLValuePlaceholderBase.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundLValuePlaceholderBase.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Protected NotOverridable Overrides Function MakeRValueImpl() As BoundExpression
-            Return New BoundLValueToRValueWrapper(Me.Syntax, Me, Me.Type)
+            Return New BoundLValueToRValueWrapper(Me.Syntax, Me, Me.Type).MakeCompilerGenerated() ' This is a compiler generated node
         End Function
 
     End Class


### PR DESCRIPTION
Fixes #2662.

@VSadov, @gafter, @agocke, @jaredpar Please review.   