### PR TITLE
Port2966

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -2165,7 +2165,7 @@ public class D { }
     <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
         <Document><![CDATA[
         [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(null)]
-        internal class A
+        internal class {|Definition:$$A|}
         {
         }]]>
         </Document>
@@ -2174,9 +2174,8 @@ public class D { }
     <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
         <ProjectReference>ClassLibrary1</ProjectReference>
         <Document><![CDATA[
-        public class B
+        public class B : A
         {
-            [$$A] _a;
         }]]>
         </Document>
     </Project>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -2156,5 +2156,35 @@ public class D { }
 
             Test(input)
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(1174256)>
+        Public Sub TestFarWithInternalsVisibleToNull()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+        <Document><![CDATA[
+        [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(null)]
+        internal class A
+        {
+        }]]>
+        </Document>
+    </Project>
+
+    <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
+        <ProjectReference>ClassLibrary1</ProjectReference>
+        <Document><![CDATA[
+        public class B
+        {
+            [$$A] _a;
+        }]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(input)
+
+        End Sub
+
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     }
 
                     var value = (string)typeNameConstant.Value;
-                    if (string.IsNullOrWhiteSpace(value))
+                    if (value == null)
                     {
                         continue;
                     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -364,6 +364,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     }
 
                     var value = (string)typeNameConstant.Value;
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        continue;
+                    }
+
                     var commaIndex = value.IndexOf(',');
                     var assemblyName = commaIndex >= 0 ? value.Substring(0, commaIndex).Trim() : value;
 


### PR DESCRIPTION
**Customer scenario:**
A Watson crash (NullReferenceException) caused by an incomplete InternalsVisibleTo specification can occur when working with VB or C# code.

**Testing**
Verified by adding a new unit test and manual testing.

**Ask Mode**
Tenet affecting: Reliability

See original PR #2966
See Watson bug in TFS: 1174256