### PR TITLE
 Treat .csx/.vbx as regular source files from command-line compilers 

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -50,6 +50,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentOutOfRangeException(nameof(kind));
             }
 
+#if !SCRIPTING
+            if (kind != SourceCodeKind.Regular)
+            {
+                throw new NotSupportedException(kind.ToString());
+            }
+#endif
+
             if (preprocessorSymbols != null)
             {
                 foreach (var preprocessorSymbol in preprocessorSymbols)
@@ -83,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.PreprocessorSymbols = preprocessorSymbols;
         }
 
-        public new CSharpParseOptions WithKind(SourceCodeKind kind)
+        internal new CSharpParseOptions WithKind(SourceCodeKind kind)
         {
             if (kind == this.Kind)
             {
@@ -153,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new CSharpParseOptions(this) { DocumentationMode = documentationMode };
         }
 
-        protected override ParseOptions CommonWithKind(SourceCodeKind kind)
+        internal override ParseOptions CommonWithKind(SourceCodeKind kind)
         {
             return WithKind(kind);
         }

--- a/src/Compilers/CSharp/Portable/PublicAPI.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.txt
@@ -70,7 +70,6 @@ Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Equals(Microsoft.CodeAnalysis.C
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.LanguageVersion.get -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithDocumentationMode(Microsoft.CodeAnalysis.DocumentationMode documentationMode) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithFeatures(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> features) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
-Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion version) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithPreprocessorSymbols(System.Collections.Generic.IEnumerable<string> preprocessorSymbols) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithPreprocessorSymbols(System.Collections.Immutable.ImmutableArray<string> symbols) -> Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
@@ -2491,7 +2490,6 @@ override Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions.Equals(object ob
 override Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions.GetHashCode() -> int
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CommonWithDocumentationMode(Microsoft.CodeAnalysis.DocumentationMode documentationMode) -> Microsoft.CodeAnalysis.ParseOptions
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CommonWithFeatures(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> features) -> Microsoft.CodeAnalysis.ParseOptions
-override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CommonWithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Features.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.GetHashCode() -> int

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7677,6 +7677,36 @@ class C {
 
             CleanupAllGeneratedFiles(src.Path);
         }
+
+        /// <summary>
+        /// Script compilation should be internal only.
+        /// </summary>
+        [WorkItem(1979, "https://github.com/dotnet/roslyn/issues/1979")]
+        [Fact]
+        public void ScriptCompilationInternalOnly()
+        {
+            const string source = @"System.Console.WriteLine();";
+            var dir = Temp.CreateDirectory();
+            var file = dir.CreateFile("c.csx");
+            file.WriteAllText(source);
+
+            // Compiling script file with internal API should be supported.
+            var compilation = CreateCompilationWithMscorlib(
+                source,
+                sourceFileName: file.Path,
+                parseOptions: new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.None, SourceCodeKind.Script, ImmutableArray<string>.Empty),
+                options: new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+            compilation.VerifyDiagnostics();
+
+            // Compiling with command-line compiler, should not treat .csx as script.
+            var compiler = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", file.Path });
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            int exitCode = compiler.Run(outWriter);
+            Assert.Equal(1, exitCode);
+            Assert.True(outWriter.ToString().Contains("(1,25): error CS1022: Type or namespace definition, or end-of-file expected"));
+
+            CleanupAllGeneratedFiles(file.Path);
+        }
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CSharpParseOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CSharpParseOptionsTests.cs
@@ -40,6 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
         [Fact]
         public void ConstructorValidation()
         {
+            Assert.DoesNotThrow(() => new CSharpParseOptions(kind: SourceCodeKind.Regular));
+#if !SCRIPTING
+            Assert.Throws<NotSupportedException>(() => new CSharpParseOptions(kind: SourceCodeKind.Interactive));
+            Assert.Throws<NotSupportedException>(() => new CSharpParseOptions(kind: SourceCodeKind.Script));
+#endif
             Assert.Throws<ArgumentOutOfRangeException>(() => new CSharpParseOptions(kind: (SourceCodeKind)Int32.MaxValue));
             Assert.Throws<ArgumentOutOfRangeException>(() => new CSharpParseOptions(languageVersion: (LanguageVersion)1000));
         }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -771,8 +771,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal CommandLineSourceFile ToCommandLineSourceFile(string resolvedPath)
+        private CommandLineSourceFile ToCommandLineSourceFile(string resolvedPath)
         {
+#if SCRIPTING
             string extension = PathUtilities.GetExtension(resolvedPath);
 
             bool isScriptFile;
@@ -786,6 +787,9 @@ namespace Microsoft.CodeAnalysis
             }
 
             return new CommandLineSourceFile(resolvedPath, isScriptFile);
+#else
+            return new CommandLineSourceFile(resolvedPath, isScript: false);
+#endif
         }
 
         internal IEnumerable<CommandLineSourceFile> ParseFileArgument(string arg, string baseDirectory, IList<Diagnostic> errors)

--- a/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
@@ -34,12 +34,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new options instance with the specified source code kind.
         /// </summary>
-        public ParseOptions WithKind(SourceCodeKind kind)
+        internal ParseOptions WithKind(SourceCodeKind kind)
         {
             return CommonWithKind(kind);
         }
 
-        protected abstract ParseOptions CommonWithKind(SourceCodeKind kind);
+        internal abstract ParseOptions CommonWithKind(SourceCodeKind kind);
 
         /// <summary>
         /// Creates a new options instance with the specified documentation mode.

--- a/src/Compilers/Core/Portable/PublicAPI.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.txt
@@ -752,7 +752,6 @@ Microsoft.CodeAnalysis.ParseOptions.Kind.get -> Microsoft.CodeAnalysis.SourceCod
 Microsoft.CodeAnalysis.ParseOptions.Kind.set -> void
 Microsoft.CodeAnalysis.ParseOptions.WithDocumentationMode(Microsoft.CodeAnalysis.DocumentationMode documentationMode) -> Microsoft.CodeAnalysis.ParseOptions
 Microsoft.CodeAnalysis.ParseOptions.WithFeatures(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> features) -> Microsoft.CodeAnalysis.ParseOptions
-Microsoft.CodeAnalysis.ParseOptions.WithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 Microsoft.CodeAnalysis.Platform
 Microsoft.CodeAnalysis.Platform.AnyCpu = 0 -> Microsoft.CodeAnalysis.Platform
 Microsoft.CodeAnalysis.Platform.AnyCpu32BitPreferred = 4 -> Microsoft.CodeAnalysis.Platform
@@ -1649,7 +1648,6 @@ abstract Microsoft.CodeAnalysis.Metadata.Kind.get -> Microsoft.CodeAnalysis.Meta
 abstract Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveReference(string reference, string baseFilePath, Microsoft.CodeAnalysis.MetadataReferenceProperties properties) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.PortableExecutableReference>
 abstract Microsoft.CodeAnalysis.ParseOptions.CommonWithDocumentationMode(Microsoft.CodeAnalysis.DocumentationMode documentationMode) -> Microsoft.CodeAnalysis.ParseOptions
 abstract Microsoft.CodeAnalysis.ParseOptions.CommonWithFeatures(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> features) -> Microsoft.CodeAnalysis.ParseOptions
-abstract Microsoft.CodeAnalysis.ParseOptions.CommonWithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 abstract Microsoft.CodeAnalysis.ParseOptions.Features.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 abstract Microsoft.CodeAnalysis.ParseOptions.PreprocessorSymbolNames.get -> System.Collections.Generic.IEnumerable<string>
 abstract Microsoft.CodeAnalysis.PortableExecutableReference.CreateDocumentationProvider() -> Microsoft.CodeAnalysis.DocumentationProvider

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -8,14 +8,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
     {
         // Disable documentation comments by default so that we don't need to
         // document every public member of every test input.
-        public static readonly CSharpParseOptions Script = new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.None);
-        public static readonly CSharpParseOptions Interactive = new CSharpParseOptions(kind: SourceCodeKind.Interactive, documentationMode: DocumentationMode.None);
-        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None);
-        public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
+        public static readonly CSharpParseOptions Script = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.None, SourceCodeKind.Script, ImmutableArray<string>.Empty);
+        public static readonly CSharpParseOptions Interactive = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.None, SourceCodeKind.Interactive, ImmutableArray<string>.Empty);
+        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.None, SourceCodeKind.Regular, ImmutableArray<string>.Empty);
+        public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Diagnose, SourceCodeKind.Regular, ImmutableArray<string>.Empty);
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string>(); // no experimental features to enable
         public static readonly CSharpParseOptions ExperimentalParseOptions =
-            new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None, languageVersion: LanguageVersion.CSharp6).WithFeatures(s_experimentalFeatures);
+            Regular.WithFeatures(s_experimentalFeatures);
 
         public static readonly CSharpCompilationOptions ReleaseDll = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Release).WithExtendedCustomDebugInformation(true);
         public static readonly CSharpCompilationOptions ReleaseExe = new CSharpCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel: OptimizationLevel.Release).WithExtendedCustomDebugInformation(true);

--- a/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
@@ -1,11 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Runtime.CompilerServices
 
 Public Class TestOptions
-    Public Shared ReadOnly Script As New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
-    Public Shared ReadOnly Interactive As New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive)
-    Public Shared ReadOnly Regular As New VisualBasicParseOptions(kind:=SourceCodeKind.Regular)
+    Public Shared ReadOnly Script As New VisualBasicParseOptions(LanguageVersion.VisualBasic14, DocumentationMode.Parse, SourceCodeKind.Script, ImmutableArray(Of KeyValuePair(Of String, Object)).Empty)
+    Public Shared ReadOnly Interactive As New VisualBasicParseOptions(LanguageVersion.VisualBasic14, DocumentationMode.Parse, SourceCodeKind.Interactive, ImmutableArray(Of KeyValuePair(Of String, Object)).Empty)
+    Public Shared ReadOnly Regular As New VisualBasicParseOptions(LanguageVersion.VisualBasic14, DocumentationMode.Parse, SourceCodeKind.Regular, ImmutableArray(Of KeyValuePair(Of String, Object)).Empty)
 
     Public Shared ReadOnly ReleaseDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release).WithExtendedCustomDebugInformation(True)
     Public Shared ReadOnly ReleaseExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Release).WithExtendedCustomDebugInformation(True)
@@ -13,7 +14,7 @@ Public Class TestOptions
     Private Shared ReadOnly s_features As New Dictionary(Of String, String) ' No experimental features to enable at this time
     Public Shared ReadOnly ExperimentalReleaseExe As New VisualBasicCompilationOptions(OutputKind.ConsoleApplication,
                                                                                        optimizationLevel:=OptimizationLevel.Release,
-                                                                                       parseOptions:=New VisualBasicParseOptions(kind:=SourceCodeKind.Regular).WithFeatures(s_features))
+                                                                                       parseOptions:=Regular.WithFeatures(s_features))
 
     Public Shared ReadOnly DebugDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Debug).WithExtendedCustomDebugInformation(True)
     Public Shared ReadOnly DebugExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Debug).WithExtendedCustomDebugInformation(True)

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.txt
@@ -3231,7 +3231,6 @@ Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.LanguageVersion() -> 
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.New(languageVersion As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion = Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14, documentationMode As Microsoft.CodeAnalysis.DocumentationMode = Microsoft.CodeAnalysis.DocumentationMode.Parse, kind As Microsoft.CodeAnalysis.SourceCodeKind = Microsoft.CodeAnalysis.SourceCodeKind.Regular, preprocessorSymbols As System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of String, Object)) = Nothing) -> Void
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.PreprocessorSymbols() -> System.Collections.Immutable.ImmutableArray(Of System.Collections.Generic.KeyValuePair(Of String, Object))
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.WithFeatures(features As System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of String, String))) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
-Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.WithKind(kind As Microsoft.CodeAnalysis.SourceCodeKind) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.WithLanguageVersion(version As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.WithPreprocessorSymbols(ParamArray symbols As System.Collections.Generic.KeyValuePair(Of String, Object)()) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.WithPreprocessorSymbols(symbols As System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of String, Object))) -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
@@ -4415,7 +4414,6 @@ Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions.Equal
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions.GetHashCode() -> Integer
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.CommonWithDocumentationMode(documentationMode As Microsoft.CodeAnalysis.DocumentationMode) -> Microsoft.CodeAnalysis.ParseOptions
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.CommonWithFeatures(features As System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of String, String))) -> Microsoft.CodeAnalysis.ParseOptions
-Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.CommonWithKind(kind As Microsoft.CodeAnalysis.SourceCodeKind) -> Microsoft.CodeAnalysis.ParseOptions
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.Equals(obj As Object) -> Boolean
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.Features() -> System.Collections.Generic.IReadOnlyDictionary(Of String, String)
 Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.GetHashCode() -> Integer

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -45,6 +45,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentOutOfRangeException(NameOf(kind))
             End If
 
+#If Not SCRIPTING Then
+            If kind <> SourceCodeKind.Regular Then
+                Throw New NotSupportedException(kind.ToString())
+            End If
+#End If
+
             ValidatePreprocessorSymbols(preprocessorSymbols, NameOf(preprocessorSymbols))
         End Sub
 
@@ -154,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="kind">The parser source code kind.</param>
         ''' <returns>A new instance of VisualBasicParseOptions if source code kind is different; otherwise current instance.</returns>
-        Public Shadows Function WithKind(kind As SourceCodeKind) As VisualBasicParseOptions
+        Friend Shadows Function WithKind(kind As SourceCodeKind) As VisualBasicParseOptions
             If kind = Me.Kind Then
                 Return Me
             End If
@@ -225,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="kind">The parser source code kind.</param>
         ''' <returns>A new instance of ParseOptions.</returns>
-        Protected Overrides Function CommonWithKind(kind As SourceCodeKind) As ParseOptions
+        Friend Overrides Function CommonWithKind(kind As SourceCodeKind) As ParseOptions
             Return WithKind(kind)
         End Function
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7135,6 +7135,35 @@ End Class
             Assert.Contains(CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader, output, StringComparison.Ordinal)
             CleanupAllGeneratedFiles(source)
         End Sub
+
+        ''' <summary>
+        ''' Script compilation should be internal only.
+        ''' </summary>
+        <WorkItem(1979, "https://github.com/dotnet/roslyn/issues/1979")>
+        <Fact>
+        Public Sub ScriptCompilationInternalOnly()
+            Dim source = "System.Console.WriteLine()"
+            Dim dir = Temp.CreateDirectory()
+            Dim file = dir.CreateFile("b.vbx")
+            file.WriteAllText(source)
+
+            ' Compiling script file with internal API should be supported.
+            Dim compilation = CreateCompilationWithMscorlib(
+                <compilation>
+                    <file name="b.vbx"><%= source %></file>
+                </compilation>,
+                parseOptions:=New VisualBasicParseOptions(LanguageVersion.VisualBasic14, DocumentationMode.Parse, SourceCodeKind.Script, ImmutableArray(Of KeyValuePair(Of String, Object)).Empty),
+                options:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+            compilation.VerifyDiagnostics()
+
+            ' Compiling with command-line compiler, should not treat .vbx as script.
+            Dim cmd = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/nologo", "/preferreduilang:en", file.Path})
+            Dim output As StringWriter = New StringWriter()
+            cmd.Run(output, Nothing)
+            Assert.True(output.ToString().Contains("error BC30689: Statement cannot appear outside of a method body."))
+
+            CleanupAllGeneratedFiles(file.Path)
+        End Sub
     End Class
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
@@ -57,8 +57,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             TestProperty(Function(old, value) old.WithOptionExplicit(value), Function(opt) opt.OptionExplicit, False)
             TestProperty(Function(old, value) old.WithOptionCompareText(value), Function(opt) opt.OptionCompareText, True)
 
+#If SCRIPTING Then
             TestProperty(Function(old, value) old.WithParseOptions(value), Function(opt) opt.ParseOptions,
                          New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive))
+#End If
 
             TestProperty(Function(old, value) old.WithEmbedVbCoreRuntime(value), Function(opt) opt.EmbedVbCoreRuntime, True)
             TestProperty(Function(old, value) old.WithOptimizationLevel(value), Function(opt) opt.OptimizationLevel, OptimizationLevel.Release)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -47,6 +47,11 @@ Public Class VisualBasicParseOptionsTests
 
     <Fact>
     Public Sub ConstructorValidation()
+        Assert.DoesNotThrow(Function() New VisualBasicParseOptions(kind:=SourceCodeKind.Regular))
+#If Not SCRIPTING Then
+        Assert.Throws(Of NotSupportedException)(Function() New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive))
+        Assert.Throws(Of NotSupportedException)(Function() New VisualBasicParseOptions(kind:=SourceCodeKind.Script))
+#End If
         Assert.Throws(Of ArgumentOutOfRangeException)(Function() New VisualBasicParseOptions(kind:=DirectCast(Int32.MaxValue, SourceCodeKind)))
         Assert.Throws(Of ArgumentOutOfRangeException)(Function() New VisualBasicParseOptions(languageVersion:=DirectCast(1000, LanguageVersion)))
     End Sub

--- a/src/EditorFeatures/CSharpTest/Classification/AbstractCSharpClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/AbstractCSharpClassifierTests.cs
@@ -32,6 +32,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
            Tuple<string, string>[] expected,
            CSharpParseOptions options = null)
         {
+#if SCRIPTING
+            if ((options != null) && (options.Kind != SourceCodeKind.Script))
+            {
+                return;
+            }
+#endif
             var start = allCode.IndexOf(code, StringComparison.Ordinal);
             var length = code.Length;
             var span = new TextSpan(start, length);
@@ -88,7 +94,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             params Tuple<string, string>[] expected)
         {
             Test(code, code, expected);
+#if SCRIPTING
             Test(code, code, expected, Options.Script);
+#endif
         }
 
         protected void Test(
@@ -107,7 +115,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
         {
             var allCode = "namespace N {\r\n" + code + "\r\n}";
             Test(code, allCode, expected);
+#if SCRIPTING
             Test(code, allCode, expected, Options.Script);
+#endif
         }
 
         protected void TestInClass(
@@ -118,7 +128,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             var allCode = "class " + className + " {\r\n    " +
                 code + "\r\n}";
             Test(code, allCode, expected);
+#if SCRIPTING
             Test(code, allCode, expected, Options.Script);
+#endif
         }
 
         protected void TestInClass(
@@ -137,7 +149,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             var allCode = "class " + className + " {\r\n    void " + methodName + "() {\r\n        " +
                 code + "\r\n    \r\n}\r\n}";
             Test(code, allCode, expected);
+#if SCRIPTING
             Test(code, allCode, expected, Options.Script);
+#endif
         }
 
         protected void TestInMethod(
@@ -185,7 +199,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             var allCode = "class C {\r\n    void M() {\r\n        var q = \r\n        " +
                 code + "\r\n    ;\r\n    }\r\n}";
             Test(code, allCode, expected);
+#if SCRIPTING
             Test(code, allCode, expected, Options.Script);
+#endif
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -749,7 +749,7 @@ class C
                 Class("C"));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.Classification)]
         public void InteractiveNAQSameFileClass()
         {
             var code = @"class C { static void M() { global::Script.C.M(); } }";
@@ -990,7 +990,7 @@ class ObsoleteAttribute : Attribute { }",
                 Class("Program"));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.Classification)]
         public void InteractiveNestedTypeCantHaveSameNameAsParentTypeWithGlobalNamespaceAlias()
         {
             var code = @"class Program

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -698,7 +698,9 @@ public class SomeClass : Base
             MarkupTestFile.GetPosition(markup, out code, out position);
 
             BaseVerifyWorker(code, position, "@class()", "void Base.@class()", SourceCodeKind.Regular, false, false, null);
+#if SCRIPTING
             BaseVerifyWorker(code, position, "@class()", "void Base.@class()", SourceCodeKind.Script, false, false, null);
+#endif
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -719,7 +721,9 @@ public class SomeClass : Base
             MarkupTestFile.GetPosition(markup, out code, out position);
 
             BaseVerifyWorker(code, position, "@class", "int Base.@class { get; set; }", SourceCodeKind.Regular, false, false, null);
+#if SCRIPTING
             BaseVerifyWorker(code, position, "@class", "int Base.@class { get; set; }", SourceCodeKind.Script, false, false, null);
+#endif
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -791,9 +795,9 @@ class Derived<X> : CFoo
             VerifyItemIsAbsent(markup, "Something<X>(X arg)");
         }
 
-        #endregion
+#endregion
 
-        #region "Commit tests"
+#region "Commit tests"
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void CommitInEmptyClass()
@@ -2152,9 +2156,9 @@ End Class
             }
         }
 
-        #endregion
+#endregion
 
-        #region "Commit: With Trivia"
+#region "Commit: With Trivia"
 
         [WorkItem(529199)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2201,8 +2205,8 @@ class Derived : Base
 class Derived : Base
 {
 override $$
-    #if true
-    #endif
+#if true
+#endif
 }";
 
             var expectedCodeAfterCommit = @"class Base
@@ -2471,9 +2475,9 @@ int bar;
             }
         }
 
-        #endregion
+#endregion
 
-        #region "EditorBrowsable should be ignored"
+#region "EditorBrowsable should be ignored"
 
         [Fact]
         [WorkItem(545678)]
@@ -2501,7 +2505,7 @@ public class B
                 referencedLanguage: LanguageNames.CSharp);
         }
 
-        #endregion
+#endregion
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void DuplicateMember()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -477,7 +477,7 @@ compareTokens: false);
         }
 
         [WorkItem(539853)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void BugFix5950()
         {
             Test(
@@ -698,7 +698,7 @@ class Program
 compareTokens: false);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestWithReferenceDirective()
         {
             // TODO: avoid using real file

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -306,7 +306,7 @@ index: 1);
         }
 
         [WorkItem(539853)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void BugFix5950()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -898,7 +898,7 @@ index: 0);
         }
 
         [WorkItem(537929)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInScript1()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -1080,7 +1080,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         [WorkItem(539783)]
         public void RegressionFor5867ErrorToleranceTopLevel()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -655,7 +655,7 @@ index: 1);
         }
 
         [WorkItem(539738)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoScript()
         {
             Test(
@@ -1074,7 +1074,7 @@ compareTokens: false);
         }
 
         [WorkItem(540595)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInScript()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -1412,7 +1412,7 @@ index: 0);
         }
 
         [WorkItem(541748)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnErrorInInteractive()
         {
             TestMissing(
@@ -2027,7 +2027,7 @@ class A
 @"using N ; namespace N { class Color { public static void Foo ( ) { } public void Bar ( ) { } } } class Program { Color Color ; void Main ( ) { [|Color . Foo |]( ) ; } } ");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestAliasQualifiedType()
         {
             var source =

--- a/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/AbstractContextTests.cs
+++ b/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/AbstractContextTests.cs
@@ -112,21 +112,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.Completion
         {
             // run the verification in both context(normal and script)
             VerifyWorker(text, validLocation: true);
+#if SCRIPTING
             VerifyWorker(text, validLocation: true, options: Options.Script);
+#endif
         }
 
         protected void VerifyOnlyInScript(string text)
         {
             // run the verification in both context(normal and script)
             VerifyWorker(text, validLocation: false);
+#if SCRIPTING
             VerifyWorker(text, validLocation: true, options: Options.Script);
+#endif
         }
 
         protected void VerifyFalse(string text)
         {
             // run the verification in both context(normal and script)
             VerifyWorker(text, validLocation: false);
+#if SCRIPTING
             VerifyWorker(text, validLocation: false, options: Options.Script);
+#endif
         }
 
         protected string AddInsideMethod(string text)

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -1154,7 +1154,7 @@ class Test
             }
 
             [WorkItem(545503)]
-            [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+            [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.ExtractMethod)]
             public void MethodBodyInScript()
             {
                 var code = @"#r ""System.Management""

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -8793,7 +8793,7 @@ struct Foo
         }
 
         [WorkItem(542632)]
-        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void ExtractMethodInInteractive1()
         {
             var code = @"int i; [|i = 2|]; i = 3;";
@@ -9160,7 +9160,7 @@ class Node<K, T> where T : new()
         }
 
         [WorkItem(542708)]
-        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void InteractiveArgumentException()
         {
             var code = @"using System;
@@ -9521,7 +9521,7 @@ class Program
         }
 
         [WorkItem(530609)]
-        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void NoCrashInteractive()
         {
             var code = @"[|if (true)

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -1305,7 +1305,7 @@ class Program
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void AfterIfWithSingleStatementInTopLevelMethod_Bug7291_1()
         {
@@ -1322,7 +1322,7 @@ class Program
                 options: Options.Script);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void AfterIfWithSingleStatementInTopLevelMethod_Bug7291_2()
         {
@@ -2376,11 +2376,7 @@ class Program
 
         private static void AssertSmartIndentInProjection(string markup, int expectedIndentation, CSharpParseOptions options = null)
         {
-            var optionsSet = options != null
-                    ? new[] { options }
-                    : new[] { Options.Regular, Options.Script };
-
-            foreach (var option in optionsSet)
+            foreach (var option in GetOptions(options))
             {
                 using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromLines(new string[] { markup }, parseOptions: option))
                 {
@@ -2411,17 +2407,26 @@ class Program
             int? expectedIndentation,
             CSharpParseOptions options = null)
         {
-            var optionsSet = options != null
-                ? new[] { options }
-                : new[] { Options.Regular, Options.Script };
-
-            foreach (var option in optionsSet)
+            foreach (var option in GetOptions(options))
             {
                 using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(code, parseOptions: option))
                 {
                     TestIndentation(indentationLine, expectedIndentation, workspace);
                 }
             }
+        }
+
+        private static CSharpParseOptions[] GetOptions(CSharpParseOptions options)
+        {
+            if (options != null)
+            {
+                return new[] { options };
+            }
+#if SCRIPTING
+            return new[] { Options.Regular, Options.Script };
+#else
+            return new[] { Options.Regular };
+#endif
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
             return producer.ProduceTagsAsync(document, buffer.CurrentSnapshot, position, CancellationToken.None).Result;
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public void TestCurlies()
         {
             var code = new string[] { "public class C {", "} " };
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public void TestTouchingItems()
         {
             var code = new string[] { "public class C {", "  public void Foo(){}", "}" };
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public void TestAngles()
         {
             var code = new string[] { "/// <summary>Foo</summary>", "public class C<T> {", "  void Foo() {", "    bool a = b < c;", "    bool d = e > f;", "  }", "} " };
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public void TestSwitch()
         {
             var code = @"

--- a/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
@@ -15,7 +15,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
 
         protected void Test(string initial, string expected, int index = 0, bool compareTokens = true)
         {
+#if SCRIPTING
             Test(initial, expected, Options.Script, index, compareTokens);
+#endif
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             return workspace;
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void NoItemsForEmptyFile()
         {
             using (var workspace = SetupWorkspace())
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindClass()
         {
             using (var workspace = SetupWorkspace("class Foo { }"))
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindNestedClass()
         {
             using (var workspace = SetupWorkspace("class Foo { class Bar { internal class DogBed { } } }"))
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindMemberInANestedClass()
         {
             using (var workspace = SetupWorkspace("class Foo { class Bar { class DogBed { public void Method() { } } } }"))
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindGenericClassWithConstraints()
         {
             using (var workspace = SetupWorkspace("using System.Collections; class Foo<T> where T : IEnumerable { }"))
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindGenericMethodWithConstraints()
         {
             using (var workspace = SetupWorkspace("using System; class Foo<U> { public void Bar<T>(T item) where T:IComparable<T> {} }"))
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindPartialClass()
         {
             using (var workspace = SetupWorkspace("public partial class Foo { int a; } partial class Foo { int b; }"))
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindTypesInMetadata()
         {
             using (var workspace = SetupWorkspace("using System; Class Program {FileStyleUriParser f;}"))
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindClassInNamespace()
         {
             using (var workspace = SetupWorkspace("namespace Bar { class Foo { } }"))
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindStruct()
         {
             using (var workspace = SetupWorkspace("struct Bar { }"))
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindEnum()
         {
             using (var workspace = SetupWorkspace("enum Colors {Red, Green, Blue}"))
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindEnumMember()
         {
             using (var workspace = SetupWorkspace("enum Colors {Red, Green, Blue}"))
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindConstField()
         {
             using (var workspace = SetupWorkspace("class Foo { const int bar = 7;}"))
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindVerbatimIdentifier()
         {
             using (var workspace = SetupWorkspace("class Foo { string @string; }"))
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindIndexer()
         {
             var program = @"class Foo { int[] arr; public int this[int i] { get { return arr[i]; } set { arr[i] = value; } } }";
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindEvent()
         {
             var program = "class Foo { public event EventHandler ChangedEventHandler; }";
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindAutoProperty()
         {
             using (var workspace = SetupWorkspace("class Foo { int Bar { get; set; } }"))
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindMethod()
         {
             using (var workspace = SetupWorkspace("class Foo { void DoSomething(); }"))
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindParameterizedMethod()
         {
             using (var workspace = SetupWorkspace("class Foo { void DoSomething(int a, string b) {} }"))
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindConstructor()
         {
             using (var workspace = SetupWorkspace("class Foo { public Foo(){} }"))
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindParameterizedConstructor()
         {
             using (var workspace = SetupWorkspace("class Foo { public Foo(int i){} }"))
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindStaticConstructor()
         {
             using (var workspace = SetupWorkspace("class Foo { static Foo(){} }"))
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindPartialMethods()
         {
             using (var workspace = SetupWorkspace("partial class Foo { partial void Bar(); } partial class Foo { partial void Bar() { Console.Write(\"hello\"); } }"))
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindPartialMethodDefinitionOnly()
         {
             using (var workspace = SetupWorkspace("partial class Foo { partial void Bar(); }"))
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindOverriddenMembers()
         {
             var program = "class Foo { public virtual string Name { get; set; } } class DogBed : Foo { public override string Name { get { return base.Name; } set {} } }";
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindInterface()
         {
             using (var workspace = SetupWorkspace("public interface IFoo { }"))
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindDelegateInNamespace()
         {
             using (var workspace = SetupWorkspace("namespace Foo { delegate void DoStuff(); }"))
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void FindLambdaExpression()
         {
             using (var workspace = SetupWorkspace("using System; class Foo { Func<int, int> sqr = x => x*x; }"))
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void OrderingOfConstructorsAndTypes()
         {
             using (var workspace = SetupWorkspace(@"
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void StartStopSanity()
         {
             // Verify that multiple calls to start/stop and dispose don't blow up
@@ -419,7 +419,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void DescriptionItems()
         {
             var code = new string[] { "public", "class", "Foo", "{ }" };
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest1()
         {
             var source = "class SyllableBreaking {int GetKeyWord; int get_key_word; string get_keyword; int getkeyword; int wake;}";
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest2()
         {
             var source = "class SyllableBreaking {int GetKeyWord; int get_key_word; string get_keyword; int getkeyword; int wake;}";
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest3()
         {
             var source = "class SyllableBreaking {int GetKeyWord; int get_key_word; string get_keyword; int getkeyword; int wake;}";
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest4()
         {
             var source = "class SyllableBreaking {int GetKeyWord; int get_key_word; string get_keyword; int getkeyword; int wake;}";
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest5()
         {
             var source = "class SyllableBreaking {int GetKeyWord; int get_key_word; string get_keyword; int getkeyword; int wake;}";
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest7()
         {
             ////Diff from dev10
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             }
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public void TermSplittingTest8()
         {
             ////Diff from dev10

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/AbstractCSharpKeywordHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/AbstractCSharpKeywordHighlighterTests.cs
@@ -18,7 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         protected override IEnumerable<ParseOptions> GetOptions()
         {
             yield return Options.Regular;
+#if SCRIPTING
             yield return Options.Script;
+#endif
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
@@ -525,7 +525,9 @@ class Program
         private void AssertTagsOnBracesOrSemicolons(string contents, params int[] tokenIndices)
         {
             AssertTagsOnBracesOrSemicolonsTokens(contents, tokenIndices);
+#if SCRIPTING
             AssertTagsOnBracesOrSemicolonsTokens(contents, tokenIndices, Options.Script);
+#endif
         }
 
         private void AssertTagsOnBracesOrSemicolonsTokens(string contents, int[] tokenIndices, CSharpParseOptions options = null)

--- a/src/EditorFeatures/CSharpTest/Organizing/AbstractOrganizerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/AbstractOrganizerTests.cs
@@ -17,13 +17,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Organizing
         protected void Check(string initial, string final)
         {
             CheckResult(initial, final);
+#if SCRIPTING
             CheckResult(initial, final, Options.Script);
+#endif
         }
 
         protected void Check(string initial, string final, bool specialCaseSystem)
         {
             CheckResult(initial, final, specialCaseSystem);
+#if SCRIPTING
             CheckResult(initial, final, specialCaseSystem, Options.Script);
+#endif
         }
 
         protected void CheckResult(string initial, string final, bool specialCaseSystem, CSharpParseOptions options = null)

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -133,7 +133,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.QuickInfo
         protected override void Test(string markup, params Action<object>[] expectedResults)
         {
             TestWithOptions(Options.Regular, markup, expectedResults);
+#if SCRIPTING
             TestWithOptions(Options.Script, markup, expectedResults);
+#endif
         }
 
         protected void TestWithUsings(string markup, params Action<object>[] expectedResults)

--- a/src/EditorFeatures/CSharpTest/Recommendations/FromKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/FromKeywordRecommenderTests.cs
@@ -216,7 +216,7 @@ class C
         var c = new C { x = 2, y = 3, $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public void NotAfterOutInArgument()
         {
             var experimentalFeatures = new System.Collections.Generic.Dictionary<string, string>(); // no experimental features to enable

--- a/src/EditorFeatures/CSharpTest/Recommendations/IsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/IsKeywordRecommenderTests.cs
@@ -122,7 +122,7 @@ $$");
 @"for (var $$"));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public void NotAfterVarInOutArgument()
         {
             var experimentalFeatures = new System.Collections.Generic.Dictionary<string, string>(); // no experimental features to enable

--- a/src/EditorFeatures/CSharpTest/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/RecommenderTests.cs
@@ -164,7 +164,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         {
             // run the verification in both context(normal and script)
             VerifyWorker(text, absent: false, options: options);
+#if SCRIPTING
             VerifyWorker(text, absent: false, options: scriptOptions ?? Options.Script);
+#endif
         }
 
         protected void VerifyKeyword(SourceCodeKind kind, string text)
@@ -174,12 +176,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 case SourceCodeKind.Regular:
                     VerifyWorker(text, absent: false);
                     break;
+#if SCRIPTING
                 case SourceCodeKind.Script:
                     VerifyWorker(text, absent: false, options: Options.Script);
                     break;
                 case SourceCodeKind.Interactive:
                     VerifyWorker(text, absent: false, options: Options.Interactive);
                     break;
+#endif
             }
         }
 
@@ -187,7 +191,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         {
             // run the verification in both context(normal and script)
             VerifyWorker(text, absent: true, options: options);
+#if SCRIPTING
             VerifyWorker(text, absent: true, options: scriptOptions ?? Options.Script);
+#endif
         }
 
         protected void VerifyAbsence(SourceCodeKind kind, string text)
@@ -197,12 +203,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 case SourceCodeKind.Regular:
                     VerifyWorker(text, absent: true);
                     break;
+#if SCRIPTING
                 case SourceCodeKind.Script:
                     VerifyWorker(text, absent: true, options: Options.Script);
                     break;
                 case SourceCodeKind.Interactive:
                     VerifyWorker(text, absent: true, options: Options.Interactive);
                     break;
+#endif
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
@@ -347,7 +347,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
         private static void AssertExtent(string code, int pos, bool isSignificant, int start, int length)
         {
             AssertExtent(code, pos, isSignificant, start, length, null);
+#if SCRIPTING
             AssertExtent(code, pos, isSignificant, start, length, Options.Script);
+#endif
         }
 
         private static void AssertExtent(string code, int pos, bool isSignificant, int start, int length, CSharpParseOptions options)
@@ -380,7 +382,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
             int endLength)
         {
             TestNavigator(code, func, startPosition, startLength, endPosition, endLength, null);
+#if SCRIPTING
             TestNavigator(code, func, startPosition, startLength, endPosition, endLength, Options.Script);
+#endif
         }
 
         private static void TestNavigator(

--- a/src/EditorFeatures/CSharpTest/Utilities/Options.cs
+++ b/src/EditorFeatures/CSharpTest/Utilities/Options.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests
 {
     internal static class Options
     {
-        internal static readonly CSharpParseOptions Script = new CSharpParseOptions(kind: SourceCodeKind.Script);
-        internal static readonly CSharpParseOptions Interactive = new CSharpParseOptions(kind: SourceCodeKind.Interactive);
-        internal static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular);
+        internal static CSharpParseOptions Script { get { return new CSharpParseOptions(kind: SourceCodeKind.Script); } }
+        internal static CSharpParseOptions Interactive { get { return new CSharpParseOptions(kind: SourceCodeKind.Interactive); } }
+        internal static CSharpParseOptions Regular { get { return new CSharpParseOptions(kind: SourceCodeKind.Regular); } }
     }
 }

--- a/src/EditorFeatures/Test/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/Test/CodeActions/AbstractCodeActionTest.cs
@@ -32,7 +32,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             Func<dynamic, dynamic> nodeLocator = null)
         {
             TestMissing(initial, null, nodeLocator);
+#if SCRIPTING
             TestMissing(initial, GetScriptOptions(), nodeLocator);
+#endif
         }
 
         protected virtual void TestMissing(
@@ -65,7 +67,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             IDictionary<OptionKey, object> options = null)
         {
             Test(initial, expected, null, index, compareTokens, nodeLocator, options);
+#if SCRIPTING
             Test(initial, expected, GetScriptOptions(), index, compareTokens, nodeLocator, options);
+#endif
         }
 
         protected void Test(
@@ -361,7 +365,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             bool compareTokens = true)
         {
             TestAddDocument(initial, expected, index, expectedContainers, expectedDocumentName, null, null, compareTokens);
+#if SCRIPTING
             TestAddDocument(initial, expected, index, expectedContainers, expectedDocumentName, GetScriptOptions(), null, compareTokens);
+#endif
         }
 
         private void TestAddDocument(

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -101,6 +101,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private void Verify(string markup, string expectedItemOrNull, string expectedDescriptionOrNull, SourceCodeKind sourceCodeKind, bool usePreviousCharAsTrigger, bool checkForAbsence, bool experimental, int? glyph)
         {
+#if !SCRIPTING
+            if (sourceCodeKind != SourceCodeKind.Regular)
+            {
+                return;
+            }
+#endif
+
             string code;
             int position;
             MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out code, out position);
@@ -122,8 +129,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             {
                 VerifyCustomCommitProviderWorker(code, position, itemToCommit, expectedCodeAfterCommit, SourceCodeKind.Regular, commitChar);
                 VerifyCustomCommitProviderWorker(code, position, itemToCommit, expectedCodeAfterCommit, SourceCodeKind.Script, commitChar);
-            }
         }
+    }
 
         protected void VerifyProviderCommit(string markupBeforeCommit, string itemToCommit, string expectedCodeAfterCommit,
             char? commitChar, string textTypedSoFar, SourceCodeKind? sourceCodeKind = null)
@@ -251,6 +258,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>
         protected virtual void VerifyCustomCommitProviderWorker(string codeBeforeCommit, int position, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind sourceCodeKind, char? commitChar = null)
         {
+#if !SCRIPTING
+            if (sourceCodeKind != SourceCodeKind.Regular)
+            {
+                return;
+            }
+#endif
+
             var document1 = workspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
             VerifyCustomCommitProviderCheckResults(document1, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
 
@@ -317,6 +331,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected virtual void VerifyProviderCommitWorker(string codeBeforeCommit, int position, string itemToCommit, string expectedCodeAfterCommit,
             char? commitChar, string textTypedSoFar, SourceCodeKind sourceCodeKind)
         {
+#if !SCRIPTING
+            if (sourceCodeKind != SourceCodeKind.Regular)
+            {
+                return;
+            }
+#endif
+
             var document1 = workspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
             VerifyProviderCommitCheckResults(document1, position, itemToCommit, expectedCodeAfterCommit, commitChar, textTypedSoFar);
 

--- a/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -31,7 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         protected virtual void TestMissing(string initial, IDictionary<OptionKey, object> options = null, string fixAllActionEquivalenceKey = null)
         {
             TestMissing(initial, null, options, fixAllActionEquivalenceKey);
+#if SCRIPTING
             TestMissing(initial, GetScriptOptions(), options, fixAllActionEquivalenceKey);
+#endif
         }
 
         protected virtual void TestMissing(string initial, ParseOptions parseOptions, IDictionary<OptionKey, object> options = null, string fixAllActionEquivalenceKey = null)
@@ -64,7 +66,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             string fixAllActionEquivalenceKey = null)
         {
             Test(initial, expected, null, index, compareTokens, isLine, options, isAddedDocument, fixAllActionEquivalenceKey);
+#if SCRIPTING
             Test(initial, expected, GetScriptOptions(), index, compareTokens, isLine, options, isAddedDocument, fixAllActionEquivalenceKey);
+#endif
         }
 
         protected void Test(
@@ -457,7 +461,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             bool isLine = true)
         {
             TestAddDocument(initial, expected, index, expectedContainers, expectedDocumentName, null, null, compareTokens, isLine);
+#if SCRIPTING
             TestAddDocument(initial, expected, index, expectedContainers, expectedDocumentName, GetScriptOptions(), null, compareTokens, isLine);
+#endif
         }
 
         private void TestAddDocument(

--- a/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -50,7 +50,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             else
             {
                 TestSignatureHelpWorker(markup, SourceCodeKind.Regular, experimental, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+#if SCRIPTING
                 TestSignatureHelpWorker(markup, SourceCodeKind.Script, experimental, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+#endif
             }
         }
 
@@ -121,7 +123,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             else
             {
                 VerifyTriggerCharactersWorker(expectedTriggerCharacters, unexpectedTriggerCharacters, SourceCodeKind.Regular);
+#if SCRIPTING
                 VerifyTriggerCharactersWorker(expectedTriggerCharacters, unexpectedTriggerCharacters, SourceCodeKind.Script);
+#endif
             }
         }
 
@@ -149,7 +153,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             else
             {
                 VerifyCurrentParameterNameWorker(markup, expectedParameterName, SourceCodeKind.Regular);
+#if SCRIPTING
                 VerifyCurrentParameterNameWorker(markup, expectedParameterName, SourceCodeKind.Script);
+#endif
             }
         }
 

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
@@ -186,7 +186,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 var compilationFactory = languageServices.GetService<ICompilationFactoryService>();
                 var compilationOptions = compilationFactory.GetDefaultCompilationOptions().WithOutputKind(OutputKind.DynamicallyLinkedLibrary);
 
-                var parseOptions = syntaxFactory.GetDefaultParseOptions().WithKind(SourceCodeKind.Interactive);
+                var parseOptions = syntaxFactory.GetDefaultParseOptions();
+#if SCRIPTING
+                parseOptions = parseOptions.WithKind(SourceCodeKind.Interactive);
+#else
+                if (parseOptions.Kind != SourceCodeKind.Interactive)
+                {
+                    throw new NotSupportedException();
+                }
+#endif
 
                 var references = CreateCommonReferences(workspace, submissionElement);
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.RangeVariableSymbol.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.RangeVariableSymbol.vb
@@ -52,7 +52,7 @@ class C
         End Sub
 
         <WorkItem(542161)>
-        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Sub TestCSharpRangeVariableInSubmission1()
             Dim input =
 <Workspace>
@@ -66,7 +66,7 @@ var q = from $${|Definition:x|} in new int[] { 1, 2, 3, 4 } select [|x|];
         End Sub
 
         <WorkItem(542161)>
-        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Sub TestCSharpRangeVariableInSubmission2()
             Dim input =
 <Workspace>

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -771,7 +771,7 @@ class C
 
 #Region "CSharp Script Tests"
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGoToDefinition()
             Dim workspace =
 <Workspace>
@@ -787,7 +787,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGoToDefinitionSameClass()
             Dim workspace =
 <Workspace>
@@ -802,7 +802,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGoToDefinitionNestedClass()
             Dim workspace =
 <Workspace>
@@ -824,7 +824,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionDifferentFiles()
             Dim workspace =
 <Workspace>
@@ -847,7 +847,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionPartialClasses()
             Dim workspace =
 <Workspace>
@@ -874,7 +874,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionMethod()
             Dim workspace =
 <Workspace>
@@ -899,7 +899,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionOnMethodCall1()
             Dim workspace =
 <Workspace>
@@ -925,7 +925,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionOnMethodCall2()
             Dim workspace =
 <Workspace>
@@ -950,7 +950,8 @@ class C
 
             Test(workspace)
         End Sub
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionOnMethodCall3()
             Dim workspace =
 <Workspace>
@@ -976,7 +977,7 @@ class C
             Test(workspace)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub CSharpScriptGotoDefinitionOnMethodCall4()
             Dim workspace =
 <Workspace>

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 </Workspace>)
         End Sub
 
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888")>
         <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
         Public Sub VerifyHighlightsForScriptReference()
             VerifyHighlights(

--- a/src/EditorFeatures/Test2/Rename/CSharp/InteractiveTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/InteractiveTests.vb
@@ -2,7 +2,7 @@
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class InteractiveTests
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingTopLevelMethodsSupported()
             Using result = RenameEngineResult.Create(

--- a/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
@@ -363,7 +363,7 @@ class Program
         End Sub
 
         <WorkItem(543969)>
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CannotRenameElementFromPreviousSubmission()
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1054,10 +1054,12 @@ NewLines("Module Program \n Sub Main() \n With """" \n Dim x = [|.GetHashCode|] 
 NewLines("Module Program \n Sub Main() \n With """" \n Dim {|Rename:getHashCode|} As Integer = .GetHashCode \n Dim x = getHashCode Xor &H7F3E ' Introduce Local \n End With \n End Sub \n End Module"),
 parseOptions:=Nothing)
 
+#If SCRIPTING Then
             Test(
 NewLines("Module Program \n Sub Main() \n With """" \n Dim x = [|.GetHashCode|] Xor &H7F3E ' Introduce Local \n End With \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n With """" \n Dim {|Rename:getHashCode1|} As Integer = .GetHashCode \n Dim x = getHashCode1 Xor &H7F3E ' Introduce Local \n End With \n End Sub \n End Module"),
 parseOptions:=GetScriptOptions())
+#End If
         End Sub
 
         <WorkItem(545702)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -402,7 +402,7 @@ NewLines("Class Program \n Implements IFoo \n Public Function Bip(i As Integer) 
         End Sub
 
         <WorkItem(537929)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInScript1()
             Test(
 NewLines("Imports System \n Shared Sub Main ( args As String() ) \n [|Foo|] ( ) \n End Sub"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -517,7 +517,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(666189)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInScript()
             Test(
 <Text>Dim x As Integer
@@ -528,8 +528,9 @@ x = Foo</Text>.Value.Replace(vbLf, vbCrLf),
 parseOptions:=New VisualBasicParseOptions(kind:=SourceCodeKind.Script),
 compareTokens:=False)
         End Sub
+
         <WorkItem(666189)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInScript()
             Test(
 <Text>Dim x As Integer

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -799,7 +799,7 @@ End Structure")
         NewLines("<[|Global.Module|]> ' Simplify \n Class Module \n Inherits Attribute \n End Class"))
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestAlisedType()
             Dim source =
         NewLines("Class Program \n Sub Foo() \n Dim x As New [|Global.Program|] \n End Sub \n End Class")

--- a/src/Interactive/HostTest/CommandLineTests.cs
+++ b/src/Interactive/HostTest/CommandLineTests.cs
@@ -24,7 +24,7 @@ namespace Roslyn.Interactive.CommandLine.UnitTests
             _baseDirectory = Temp.CreateDirectory();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888")]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void InteractiveCompilerCS()
         {
@@ -52,7 +52,7 @@ namespace Roslyn.Interactive.CommandLine.UnitTests
 ", 1);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888")]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void BadUsings()
         {
@@ -75,7 +75,7 @@ error CS0246: The type or namespace name 'Foo' could not be found (are you missi
                 equalityComparer);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/2888")]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void InteractiveCompilerVB()
         {

--- a/src/Scripting/CSharp/CSharpScript.cs
+++ b/src/Scripting/CSharp/CSharpScript.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -133,8 +134,8 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
         }
 
         #region Compilation
-        private static readonly CSharpParseOptions s_defaultInteractive = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Interactive);
-        private static readonly CSharpParseOptions s_defaultScript = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script);
+        private static readonly CSharpParseOptions s_defaultInteractive = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Interactive, documentationMode: DocumentationMode.Parse, preprocessorSymbols: ImmutableArray<string>.Empty);
+        private static readonly CSharpParseOptions s_defaultScript = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script, documentationMode: DocumentationMode.Parse, preprocessorSymbols: ImmutableArray<string>.Empty);
 
         protected override Compilation CreateCompilation()
         {

--- a/src/Scripting/VisualBasic/VisualBasicScript.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScript.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Globalization
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -88,8 +89,8 @@ Namespace Microsoft.CodeAnalysis.Scripting.VisualBasic
         End Function
 
 #Region "Compilation"
-        Private Shared ReadOnly s_defaultInteractive As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Interactive)
-        Private Shared ReadOnly s_defaultScript As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script)
+        Private Shared ReadOnly s_defaultInteractive As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Interactive, documentationMode:=DocumentationMode.Parse, preprocessorSymbols:=ImmutableArray(Of KeyValuePair(Of String, Object)).Empty)
+        Private Shared ReadOnly s_defaultScript As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script, documentationMode:=DocumentationMode.Parse, preprocessorSymbols:=ImmutableArray(Of KeyValuePair(Of String, Object)).Empty)
 
         Protected Overrides Function CreateCompilation() As Compilation
 

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
@@ -63,9 +63,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 return;
             }
 
+#if SCRIPTING
             var sourceCodeKind = extension.Equals(".csx", StringComparison.OrdinalIgnoreCase)
                 ? SourceCodeKind.Script
                 : SourceCodeKind.Regular;
+#else
+            var sourceCodeKind = SourceCodeKind.Regular;
+#endif
 
             IVsHierarchy foundHierarchy;
             uint itemId;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -236,10 +236,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 var parseOptions = languageInformation.ParseOptions;
 
+#if SCRIPTING
                 if (Path.GetExtension(moniker) == languageInformation.ScriptExtension)
                 {
                     parseOptions = parseOptions.WithKind(SourceCodeKind.Script);
                 }
+#endif
 
                 // First, create the project
                 var hostProject = new HostProject(this, CurrentSolution.Id, languageInformation.LanguageName, parseOptions, _metadataReferences);

--- a/src/VisualStudio/Core/Test/Progression/ContainsGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/ContainsGraphQueryTests.vb
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
             End Using
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/2888"), Trait(Traits.Feature, Traits.Features.Progression)>
         Public Sub MembersContainedInCSharpScriptDocument()
             Using testState = New ProgressionTestState(
                     <Workspace>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -247,7 +247,11 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
+#if SCRIPTING
             return this.SetParseOptions(this.ParseOptions.WithKind(kind));
+#else
+            throw new NotSupportedException(kind.ToString());
+#endif
         }
 
         public DocumentState UpdateFolders(IList<string> folders)


### PR DESCRIPTION
 Treat .csx/.vbx as regular source files from command-line compilers

As a result, a significant number of unit tests are now skipped. (Search for SCRIPTING define and https://github.com/dotnet/roslyn/issues/2888.)