### PR TITLE
fixed explicit cache bug in solution crawler

### DIFF
--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -149,12 +149,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 private IDisposable EnableCaching(ProjectId projectId)
                 {
-                    if (_cacheService == null)
-                    {
-                        return NullDisposable.Instance;
-                    }
-
-                    return _cacheService.EnableCaching(projectId);
+                    return _cacheService?.EnableCaching(projectId) ?? NullDisposable.Instance;
                 }
 
                 private ProjectDependencyGraph DependencyGraph

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Notification;
@@ -27,6 +28,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 private readonly Registration _registration;
                 private readonly IAsynchronousOperationListener _listener;
                 private readonly IDocumentTrackingService _documentTracker;
+                private readonly IProjectCacheService _cacheService;
+
                 private readonly HighPriorityProcessor _highPriorityProcessor;
                 private readonly NormalPriorityProcessor _normalPriorityProcessor;
                 private readonly LowPriorityProcessor _lowPriorityProcessor;
@@ -43,6 +46,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     _listener = listener;
                     _registration = registration;
+                    _cacheService = registration.GetService<IProjectCacheService>();
 
                     var lazyActiveFileAnalyzers = new Lazy<ImmutableArray<IIncrementalAnalyzer>>(() => GetActiveFileIncrementalAnalyzers(_registration, analyzerProviders));
                     var lazyAllAnalyzers = new Lazy<ImmutableArray<IIncrementalAnalyzer>>(() => GetIncrementalAnalyzers(_registration, analyzerProviders));
@@ -141,6 +145,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         return _registration.CurrentSolution;
                     }
+                }
+
+                private IDisposable EnableCaching(ProjectId projectId)
+                {
+                    if (_cacheService == null)
+                    {
+                        return NullDisposable.Instance;
+                    }
+
+                    return _cacheService.EnableCaching(projectId);
                 }
 
                 private ProjectDependencyGraph DependencyGraph
@@ -310,6 +324,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     _normalPriorityProcessor.WaitUntilCompletion_ForTestingPurposesOnly();
                     _lowPriorityProcessor.WaitUntilCompletion_ForTestingPurposesOnly();
+                }
+
+                private class NullDisposable : IDisposable
+                {
+                    public static readonly IDisposable Instance = new NullDisposable();
+
+                    public void Dispose() { }
                 }
             }
         }

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -144,16 +144,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 if (project != null)
                                 {
                                     var semanticsChanged = workItem.InvocationReasons.Contains(PredefinedInvocationReasons.SemanticChanged) ||
-                                        workItem.InvocationReasons.Contains(PredefinedInvocationReasons.SolutionRemoved);
+                                                           workItem.InvocationReasons.Contains(PredefinedInvocationReasons.SolutionRemoved);
 
-                                    if (project.Solution.Services.CacheService != null)
-                                    {
-                                        using (project.Solution.Services.CacheService.EnableCaching(project.Id))
-                                        {
-                                            await RunAnalyzersAsync(analyzers, project, (a, p, c) => a.AnalyzeProjectAsync(p, semanticsChanged, c), cancellationToken).ConfigureAwait(false);
-                                        }
-                                    }
-                                    else
+                                    using (Processor.EnableCaching(project.Id))
                                     {
                                         await RunAnalyzersAsync(analyzers, project, (a, p, c) => a.AnalyzeProjectAsync(p, semanticsChanged, c), cancellationToken).ConfigureAwait(false);
                                     }

--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -225,12 +225,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     private static void DisposeProjectCache(IDisposable projectCache)
                     {
-                        if (projectCache == null)
-                        {
-                            return;
-                        }
-
-                        projectCache.Dispose();
+                        projectCache?.Dispose();
                     }
 
                     private void DisposeProjectCache()
@@ -296,9 +291,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                                 // remove opened document processed
                                 IDisposable projectCache;
-                                _higherPriorityDocumentsNotProcessed.TryRemove(documentId, out projectCache);
-
-                                DisposeProjectCache(projectCache);
+                                if (_higherPriorityDocumentsNotProcessed.TryRemove(documentId, out projectCache))
+                                {
+                                    DisposeProjectCache(projectCache);
+                                }
 
                                 return true;
                             }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -302,5 +302,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         AnalyzerDependencyCheckingService_LogMissingDependency,
         VirtualMemory_MemoryLow,
         Extension_Exception,
+
+        WorkCoordinator_WaitForHigherPriorityOperationsAsync,
     }
 }


### PR DESCRIPTION
found a bug where we missed caching a project explicitly while doing document analysis.

this is a race so it doesn't happen all the time, but when condition is met, we will re-parse every files in the project to build compilation for every file in the project.

I am not 100% sure since when this bug existed but looks like some recent change caused this to happen more often.

* I hoped this is the reason for VM increase in some of our perf tests
- unfortunately this didn't fix the VM regression. 

but this still fixes an issue we saw from our own perf machine where solution wide diagnostic analysis taking 10 times more time when this race happened

![image](https://cloud.githubusercontent.com/assets/1333179/7877632/88d80fe8-0592-11e5-87b1-bceabb9e7244.png)

circled portion is after the fix.

1,490 seconds vs 107 seconds = about 13 times when the race happened.
