### PR TITLE
NavBar: Guard against symbol navigation on non-symbol items

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -235,6 +235,8 @@
     <Compile Include="Extensibility\Highlighting\IHighlighter.cs" />
     <Compile Include="Extensibility\NavigationBar\AbstractNavigationBarItemService.cs" />
     <Compile Include="Extensibility\NavigationBar\NavigationBarAutomationStrings.cs" />
+    <Compile Include="Extensibility\NavigationBar\NavigationBarActionlessItem.cs" />
+    <Compile Include="Extensibility\NavigationBar\NavigationBarPresentedItem.cs" />
     <Compile Include="Extensibility\NavigationBar\NavigationBarSymbolItem.cs" />
     <Compile Include="Extensibility\Navigation\INavigableItem.cs" />
     <Compile Include="Extensibility\Navigation\NavigableItemFactory.cs" />

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarActionlessItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarActionlessItem.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    /// <summary>
+    /// An item that is displayed and can be chosen but which has no action.
+    /// </summary>
+    internal class NavigationBarActionlessItem : NavigationBarItem
+    {
+        public NavigationBarActionlessItem(
+            string text,
+            Glyph glyph,
+            IList<TextSpan> spans,
+            IList<NavigationBarItem> childItems = null,
+            int indent = 0,
+            bool bolded = false,
+            bool grayed = false)
+            : base(
+                text,
+                glyph,
+                spans,
+                childItems,
+                indent,
+                bolded,
+                grayed)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
@@ -10,7 +10,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
-    internal class NavigationBarItem
+    internal abstract class NavigationBarItem
     {
         public string Text { get; }
         public Glyph Glyph { get; }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    /// <summary>
+    /// The items that are displayed in the Navigation Bar when it is not expanded. They are never
+    /// indented and cannot be used as the target of navigation.
+    /// </summary>
+    internal class NavigationBarPresentedItem : NavigationBarItem
+    {
+        public NavigationBarPresentedItem(
+            string text,
+            Glyph glyph,
+            IList<TextSpan> spans,
+            IList<NavigationBarItem> childItems = null,
+            bool bolded = false,
+            bool grayed = false)
+            : base(
+                  text,
+                  glyph,
+                  spans,
+                  childItems,
+                  indent: 0,
+                  bolded: bolded,
+                  grayed: grayed)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -322,14 +322,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             if (oldRight != null)
             {
-                newRight = new NavigationBarItem(oldRight.Text, oldRight.Glyph, oldRight.Spans, oldRight.ChildItems, 0, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed);
+                newRight = new NavigationBarPresentedItem(oldRight.Text, oldRight.Glyph, oldRight.Spans, oldRight.ChildItems, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed);
                 newRight.TrackingSpans = oldRight.TrackingSpans;
                 listOfRight.Add(newRight);
             }
 
             if (oldLeft != null)
             {
-                newLeft = new NavigationBarItem(oldLeft.Text, oldLeft.Glyph, oldLeft.Spans, listOfRight, 0, oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed);
+                newLeft = new NavigationBarPresentedItem(oldLeft.Text, oldLeft.Glyph, oldLeft.Spans, listOfRight, oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed);
                 newLeft.TrackingSpans = oldLeft.TrackingSpans;
                 listOfLeft.Add(newLeft);
             }
@@ -366,6 +366,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         private void ProcessItemSelectionSynchronously(NavigationBarItem item, CancellationToken cancellationToken)
         {
             AssertIsForeground();
+
+            var presentedItem = item as NavigationBarPresentedItem;
+            if (presentedItem != null)
+            {
+                // Presented items are not navigable, but they may be selected due to a race
+                // documented in Bug #1174848. Protect all INavigationBarItemService implementers
+                // from this by ignoring these selections here.
+                return;
+            }
 
             var projectItem = item as NavigationBarProjectItem;
             if (projectItem != null)

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -354,14 +354,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Next
 
             If eventContainer IsNot Nothing Then
-                Return New NavigationBarItem(
+                Return New NavigationBarActionlessItem(
                     eventContainer.Name,
                     eventContainer.GetGlyph(),
                     indent:=1,
                     spans:=allMethodSpans,
                     childItems:=rightHandMemberItems)
             Else
-                Return New NavigationBarItem(
+                Return New NavigationBarActionlessItem(
                     String.Format(VBEditorResources.Events, containingType.Name),
                     Glyph.EventPublic,
                     indent:=1,


### PR DESCRIPTION
Fixes internal TFS bug #1174848

When a Navigation Bar item is chosen, like the NavigationBarSymbolItem
representing a particular member, we present the set of chosen items
(for project, type, and member) as base NavigationBarItems with the text
display properties & tracking spans *copied* out of the real
NavigationBarSymbolItem to remove any display indentation and to make
sure the Navigation Bar does not hold on to old symbols, etc.
When the Navigation Bar is expanded, we present real
NavigationBarSymbolItems again and when they are chosen we perform the
appropriate symbolic navigation.

However, there is a moment after an item is chosen where we have
replaced the real NavigationBarSymbolItem with its NavigationBarItem
copy, but the Navigation Bar is still allowing clicks to the item to
count as navigation (rather than expansion of the collapsed list). When
this happens, we see NavigateToItem called on a base NavigationBarItem
and crash because we believe it will be a NavigationBarSymbolItem.

The base NavigationBarItem was being used for multiple purposes, so this
change makes it abstract and introduces NavigationBarPresentedItem for the
purposes described above and NavigationBarActionlessItem which can be used
for items that legitimately produce no action when selected (used in some
VB event scenarios). The NavigationBarController now rejects any attempts
to select a NavigationBarPresentedItem so that the
INavigationBarItemService implementers will not have to deal with them.

Potential Reviewers: @Pilchie @jasonmalinowski @rchande @balajikris @brettfo @jmarolf 