### PR TITLE
Harden access to MetadataReader

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using System.Reflection.PortableExecutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -2121,8 +2122,9 @@ public class Source
                 Diagnostic(ErrorCode.FTL_MetadataCantOpenFile).WithArguments(@"NativeApp.exe", CodeAnalysisResources.PEImageDoesntContainManagedMetadata));
         }
 
-        [Fact, WorkItem(2988, "https://github.com/dotnet/roslyn/issues/2988")]
-        public void EmptyReference()
+        [WorkItem(2988, "https://github.com/dotnet/roslyn/issues/2988")]
+        [ClrOnlyFact(ClrOnlyReason.Signing)]
+        public void EmptyReference1()
         {
             var source = "class C { public static void Main() { } }";
 
@@ -2131,7 +2133,8 @@ public class Source
                 Diagnostic(ErrorCode.FTL_MetadataCantOpenFile).WithArguments(@"Empty.dll", CodeAnalysisResources.PEImageDoesntContainManagedMetadata));
         }
 
-        [Fact, WorkItem(2992, "https://github.com/dotnet/roslyn/issues/2992")]
+        [WorkItem(2992, "https://github.com/dotnet/roslyn/issues/2992")]
+        [ClrOnlyFact(ClrOnlyReason.Signing)]
         public void MetadataDisposed()
         {
             var md = AssemblyMetadata.CreateFromImage(TestResources.NetFX.Minimal.mincorlib);

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -130,5 +130,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ObjectDisposedException>(() => copy1.Module);
             Assert.Throws<ObjectDisposedException>(() => copy2.Module);
         }
+
+        [Fact, WorkItem(2988, "https://github.com/dotnet/roslyn/issues/2988")]
+        public void EmptyStream()
+        {
+            ModuleMetadata.CreateFromStream(new MemoryStream(), PEStreamOptions.Default);
+            Assert.Throws<BadImageFormatException>(() => ModuleMetadata.CreateFromStream(new MemoryStream(), PEStreamOptions.PrefetchMetadata));
+            Assert.Throws<BadImageFormatException>(() => ModuleMetadata.CreateFromStream(new MemoryStream(), PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(_peReaderOpt != null);
 
                 // Checking for an empty image is a workaround for https://github.com/dotnet/corefx/issues/1815: 
-                if (_peReaderOpt.GetEntireImage().Length == 0 || !_peReaderOpt.HasMetadata)
+                if (_peReaderOpt.IsEntireImageAvailable && _peReaderOpt.GetEntireImage().Length == 0 || !_peReaderOpt.HasMetadata)
                 {
                     throw new BadImageFormatException(CodeAnalysisResources.PEImageDoesntContainManagedMetadata);
                 }

--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -167,6 +167,13 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.StreamMustSupportReadAndSeek, nameof(peStream));
             }
 
+            // Workaround of issue https://github.com/dotnet/corefx/issues/1815: 
+            if (peStream.Length == 0 && (options & PEStreamOptions.PrefetchEntireImage) != 0 && (options & PEStreamOptions.PrefetchMetadata) != 0)
+            {
+                // throws BadImageFormatException:
+                new PEHeaders(peStream);
+            }
+
             // ownership of the stream is passed on PEReader:
             return new ModuleMetadata(new PEReader(peStream, options));
         }


### PR DESCRIPTION
Fixes #2992 and #2988. Both are crashes.

**Scenarios**
1) When a referenced metadata image is empty the compiler should report an error and not crash. 
2) When ModuleMetadata is disposed the compiler should throw ObjectDisposedException and not AV. The primary benefit is that ObjectDisposedException clearly identifies what went wrong (so the code that disposed the metadata object can be blamed) while AV just means some memory is read that shouldn't and usually results in blaming the MetadataReader, which is not in fault. This was also reported by a customer (https://github.com/dotnet/roslyn/pull/25) and also happened in XAML designer in VS.

**Fix**
Add a couple of additional checks to PEModule.MetadataReader property. As described in https://github.com/dotnet/roslyn/pull/25 we don't guarantee (2), it would be too much work and it might negatively impact perf. However we can do a very cheap check that avoids AV i 99% cases (when there is not a race between a thread that disposes the metadata and the thread accessing PE symbols).

The root cause of 1) is in System.Reflection.Metadata and is being fixed (dotnet/corefx#1815). To avoid a bigger change of updating the nuget package for RTM we can do a simple check in Roslyn to avoid hitting the PE reader issue.

**Testing**
Added unit tests for both languages.

@ManishJayaswal 