### PR TITLE
Ensure that calls into EnvDTE.CodeModel work even if the underlying FileCodeModel has not been realized

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractProjectCodeModel.cs
@@ -58,14 +58,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
         }
 
-        public IEnumerable<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>> GetFileCodeModelInstances()
+        public IEnumerable<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>> GetCachedFileCodeModelInstances()
         {
             return GetCodeModelCache().GetFileCodeModelInstances();
         }
 
-        public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>? GetFileCodeModelInstance(string fileName)
+        public bool TryGetCachedFileCodeModel(string fileName, out ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> fileCodeModelHandle)
         {
-            return GetCodeModelCache().GetComHandleForFileCodeModel(fileName);
+            var handle = GetCodeModelCache().GetComHandleForFileCodeModel(fileName);
+
+            fileCodeModelHandle = handle != null
+                ? handle.Value
+                : default(ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>);
+
+            return handle != null;
+        }
+
+        public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> GetOrCreateFileCodeModel(string fileName)
+        {
+            return GetCodeModelCache().GetOrCreateFileCodeModel(fileName);
         }
 
         internal abstract bool CanCreateFileCodeModelThroughProject(string fileName);

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
 
@@ -87,13 +88,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                     return;
                 }
 
-                var fileCodeModel = codeModelProvider.ProjectCodeModel.GetFileCodeModelInstance(filename);
-                if (fileCodeModel == null)
+                ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> fileCodeModelHandle;
+                if (!codeModelProvider.ProjectCodeModel.TryGetCachedFileCodeModel(filename, out fileCodeModelHandle))
                 {
                     return;
                 }
 
-                var codeModel = fileCodeModel.Value.Object;
+                var codeModel = fileCodeModelHandle.Object;
                 _notificationService.RegisterNotification(() => codeModel.FireEvents(), _listener.BeginAsyncOperation("CodeModelEvent"), cancellationToken);
             }
 

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_Events.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_Events.cs
@@ -63,8 +63,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return needMoreTime;
             }
 
-            var comHandleToThis = provider.ProjectCodeModel.GetFileCodeModelInstance(this.Workspace.GetFilePath(GetDocumentId()));
-            if (comHandleToThis == null)
+            ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> fileCodeModelHandle;
+            if (!provider.ProjectCodeModel.TryGetCachedFileCodeModel(this.Workspace.GetFilePath(GetDocumentId()), out fileCodeModelHandle))
             {
                 return needMoreTime;
             }

--- a/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         public void AddProject(AbstractProject project)
         {
             var provider = (IProjectCodeModelProvider)project;
-            IEnumerable<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>> fcms = provider.ProjectCodeModel.GetFileCodeModelInstances();
+            var fcms = provider.ProjectCodeModel.GetCachedFileCodeModelInstances();
 
             foreach (var fcm in fcms)
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
@@ -85,12 +85,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
                 var hostProject = ((VisualStudioWorkspaceImpl)Workspace).ProjectTracker.GetProject(_projectId);
                 var projectCodeModel = ((IProjectCodeModelProvider)hostProject).ProjectCodeModel;
-                return projectCodeModel.GetFileCodeModelInstance(fileName).Value;
+
+                return projectCodeModel.GetOrCreateFileCodeModel(fileName);
             }
-            else
-            {
-                throw Exceptions.ThrowEInvalidArg();
-            }
+
+            throw Exceptions.ThrowEInvalidArg();
         }
 
         public EnvDTE.Project Parent


### PR DESCRIPTION
Fixes issue #2893.

When calling into an EnvDTE.CodeModel API, the caller must pass the file name of the file to be operated on. For example:

var ns = codeModel.AddNamespace("MyFile.cs", "MyNamespace");

However, the implementation EnvDTE.CodeModel would only ever succeed to find the FileCodeModel for "MyFile.cs" if had already been created and cached. If the FileCodeModel wasn't in the cache, the API that was called would throw.

Ultimately, this comes down to a set of APIs with bad names that don't reflect that they only return cached values. This change renames those APIs to give them proper names (e.g. TryGetCachedFileCodeModelInstance) and adds an API that will retrieve a cached FileCodeModel or create a new one if needed.

Testing this is problematic, as it requires Visual Studio to be present. The only way to create an automated test would be through a VS-only integration test, which seems like overkill. To verify, I manually created a VS package containing the repro code in #2893 and verified that works as expected with my change.