### PR TITLE
Import parameter's default constant value from metadata even if parameter is not optional.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -685,7 +685,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private TypedConstant GetDefaultValueArgument(ParameterSymbol parameter, AttributeSyntax syntax, DiagnosticBag diagnostics)
         {
             var parameterType = parameter.Type;
-            ConstantValue defaultConstantValue = parameter.ExplicitDefaultConstantValue;
+            ConstantValue defaultConstantValue = parameter.IsOptional ? parameter.ExplicitDefaultConstantValue : ConstantValue.NotAvailable;
 
             TypedConstantKind kind;
             object defaultValue = null;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -868,6 +868,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to pass this information, and this might be a big task. We should consider doing this when the time permits.
 
             TypeSymbol parameterType = parameter.Type;
+            Debug.Assert(parameter.IsOptional);
             ConstantValue defaultConstantValue = parameter.ExplicitDefaultConstantValue;
             BoundExpression defaultValue;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -1985,13 +1985,15 @@ public class C
                 Assert.False(parameters[4].IsOptional);
                 Assert.False(parameters[4].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[4].ExplicitDefaultValue);
-                Assert.Equal(isFromSource ? ConstantValue.Create(0) : null, parameters[4].ExplicitDefaultConstantValue); // not imported for non-optional parameter
+                Assert.True(parameters[4].HasMetadataConstantValue);
+                Assert.Equal(ConstantValue.Create(0), parameters[4].ExplicitDefaultConstantValue); 
                 Assert.Equal(isFromSource ? 1 : 0, parameters[4].GetAttributes().Length);
 
                 Assert.False(parameters[5].IsOptional);
                 Assert.False(parameters[5].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[5].ExplicitDefaultValue);
-                Assert.Equal(isFromSource ? ConstantValue.Create(1) : null, parameters[5].ExplicitDefaultConstantValue); // not imported for non-optional parameter
+                Assert.True(parameters[5].HasMetadataConstantValue);
+                Assert.Equal(ConstantValue.Create(1), parameters[5].ExplicitDefaultConstantValue);
                 Assert.Equal(isFromSource ? 1 : 0, parameters[5].GetAttributes().Length);
 
                 Assert.True(parameters[6].IsOptional);
@@ -2116,19 +2118,21 @@ public class C
                 Assert.False(parameters[4].IsOptional);
                 Assert.False(parameters[4].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[4].ExplicitDefaultValue);
-                Assert.Equal(isFromSource ? ConstantValue.Null : null, parameters[4].ExplicitDefaultConstantValue); // not imported for non-optional parameter
+                Assert.True(parameters[4].HasMetadataConstantValue);
+                Assert.Equal(ConstantValue.Null, parameters[4].ExplicitDefaultConstantValue); 
                 Assert.Equal(isFromSource ? 1 : 0, parameters[4].GetAttributes().Length);
 
                 Assert.True(parameters[5].IsOptional);
                 Assert.True(parameters[5].HasExplicitDefaultValue);
                 Assert.Null(parameters[5].ExplicitDefaultValue);
-                Assert.Equal(ConstantValue.Null, parameters[5].ExplicitDefaultConstantValue); // not imported for non-optional parameter
+                Assert.Equal(ConstantValue.Null, parameters[5].ExplicitDefaultConstantValue); 
                 Assert.Equal(isFromSource ? 2 : 0, parameters[5].GetAttributes().Length);
 
                 Assert.False(parameters[6].IsOptional);
                 Assert.False(parameters[6].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[6].ExplicitDefaultValue);
-                Assert.Equal(isFromSource ? ConstantValue.Create("A") : null, parameters[6].ExplicitDefaultConstantValue); // not imported for non-optional parameter
+                Assert.True(parameters[6].HasMetadataConstantValue);
+                Assert.Equal(ConstantValue.Create("A"), parameters[6].ExplicitDefaultConstantValue); 
                 Assert.Equal(isFromSource ? 1 : 0, parameters[6].GetAttributes().Length);
 
                 Assert.True(parameters[7].IsOptional);
@@ -2197,12 +2201,14 @@ public class C
                 Assert.False(parameters[4].IsOptional);
                 Assert.False(parameters[4].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[4].ExplicitDefaultValue);
+                Assert.False(parameters[4].HasMetadataConstantValue);
                 Assert.Equal(isFromSource ? ConstantValue.Create(0M) : null, parameters[4].ExplicitDefaultConstantValue); // not imported for non-optional parameter
                 Assert.Equal(1, parameters[4].GetAttributes().Length); // DecimalConstantAttribute
 
                 Assert.False(parameters[5].IsOptional);
                 Assert.False(parameters[5].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[5].ExplicitDefaultValue);
+                Assert.False(parameters[5].HasMetadataConstantValue);
                 Assert.Equal(isFromSource ? ConstantValue.Create(1M) : null, parameters[5].ExplicitDefaultConstantValue); // not imported for non-optional parameter
                 Assert.Equal(1, parameters[5].GetAttributes().Length); // DecimalConstantAttribute
 
@@ -2271,12 +2277,14 @@ public class C
                 Assert.False(parameters[3].IsOptional);
                 Assert.False(parameters[3].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[3].ExplicitDefaultValue);
+                Assert.False(parameters[3].HasMetadataConstantValue);
                 Assert.Equal(isFromSource ? ConstantValue.Create(new DateTime(0)) : null, parameters[3].ExplicitDefaultConstantValue); // not imported for non-optional parameter
                 Assert.Equal(1, parameters[3].GetAttributes().Length); // DateTimeConstant
 
                 Assert.False(parameters[4].IsOptional);
                 Assert.False(parameters[4].HasExplicitDefaultValue);
                 Assert.Throws<InvalidOperationException>(() => parameters[4].ExplicitDefaultValue);
+                Assert.False(parameters[4].HasMetadataConstantValue);
                 Assert.Equal(isFromSource ? ConstantValue.Create(new DateTime(1)) : null, parameters[4].ExplicitDefaultConstantValue); // not imported for non-optional parameter
                 Assert.Equal(1, parameters[4].GetAttributes().Length); // DateTimeConstant
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -3021,7 +3021,7 @@ ProduceBoundNode:
 
             ' See Section 3 of §11.8.2 Applicable Methods
             ' Deal with Optional arguments. HasDefaultValue is true if the parameter is optional and has a default value.
-            Dim defaultConstantValue As ConstantValue = param.ExplicitDefaultConstantValue(DefaultParametersInProgress)
+            Dim defaultConstantValue As ConstantValue = If(param.IsOptional, param.ExplicitDefaultConstantValue(DefaultParametersInProgress), Nothing)
             If defaultConstantValue IsNot Nothing Then
 
                 If callerInfoOpt IsNot Nothing AndAlso

--- a/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Function GetMetadataConstantValue(context As EmitContext) As IMetadataConstant
             If Me.HasMetadataConstantValue Then
-                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(Me.Type, Me.ExplicitDefaultValue, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(Me.Type, Me.ExplicitDefaultConstantValue.Value, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
             Else
                 Return Nothing
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEParameterSymbol.vb
@@ -203,19 +203,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
                     Dim defaultValue As ConstantValue = ConstantValue.NotAvailable
 
-                    If IsOptional Then
-                        Dim peModule = Me.PEModule
-                        Dim handle = Me._handle
+                    Dim peModule = Me.PEModule
+                    Dim handle = Me._handle
 
-                        If (_flags And ParameterAttributes.HasDefault) <> 0 Then
-                            defaultValue = peModule.GetParamDefaultValue(handle)
-                        Else
-                            ' Dev10 behavior just checks for Decimal then DateTime.  If both are specified, DateTime wins
-                            ' regardless of the parameter's type.
+                    If (_flags And ParameterAttributes.HasDefault) <> 0 Then
+                        defaultValue = peModule.GetParamDefaultValue(handle)
+                    ElseIf IsOptional
+                        ' Dev10 behavior just checks for Decimal then DateTime.  If both are specified, DateTime wins
+                        ' regardless of the parameter's type.
 
-                            If Not peModule.HasDateTimeConstantAttribute(handle, defaultValue) Then
-                                peModule.HasDecimalConstantAttribute(handle, defaultValue)
-                            End If
+                        If Not peModule.HasDateTimeConstantAttribute(handle, defaultValue) Then
+                            peModule.HasDecimalConstantAttribute(handle, defaultValue)
                         End If
                     End If
 


### PR DESCRIPTION
Fixes #2793.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.    