### PR TITLE
Correct the copyright header on four files.

### DIFF
--- a/src/Tools/Source/DebuggerVisualizers/IL/ILDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/IL/ILDebuggerVisualizer.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.EditAndContinue;

--- a/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaDebuggerVisualizer.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Tools/Source/DebuggerVisualizers/PDB/PdbDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/PDB/PdbDebuggerVisualizer.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using System.Diagnostics;
 using System.Linq;
 using System.Text;

--- a/src/Tools/Source/DebuggerVisualizers/UI/TextViewer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/UI/TextViewer.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using System.Windows.Forms;
 
 namespace Roslyn.DebuggerVisualizers.UI


### PR DESCRIPTION
Four of our files have remnants from when we were selecting a license. Corrected herein to have only the correct, final license header.

@tmat Please review.