### PR TITLE
Handle analyzers which have enabled rules, but no registered actions.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -1070,12 +1070,39 @@ namespace ConsoleApplication1
     }
 }";
 
-            var analyzers = new DiagnosticAnalyzer[] { new CSharpGenericNameAnalyzer() };
+            TestGenericNameCore(source, new CSharpGenericNameAnalyzer());
+        }
 
+        private void TestGenericNameCore(string source, params DiagnosticAnalyzer[] analyzers)
+        {
             // Verify, no duplicate diagnostics on generic name.
             CreateCompilationWithMscorlib45(source)
                 .VerifyAnalyzerDiagnostics(analyzers, null, null, logAnalyzerExceptionAsDiagnostics: false,
                     expected: Diagnostic(CSharpGenericNameAnalyzer.DiagnosticId, @"Nullable<int>").WithLocation(9, 17));
+        }
+
+        [Fact, WorkItem(2980, "https://github.com/dotnet/roslyn/issues/2980")]
+        public void TestAnalyzerWithNoActions()
+        {
+            var source = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        private Nullable<int> myVar = 5;
+        void Method()
+        {
+
+        }
+    }
+}";
+
+            // Ensure that adding a dummy analyzer with no actions doesn't bring down entire analysis.
+            // See https://github.com/dotnet/roslyn/issues/2980 for details.
+            TestGenericNameCore(source, new AnalyzerWithNoActions(), new CSharpGenericNameAnalyzer());
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -92,11 +92,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // create the primary driver task.
                 cancellationToken.ThrowIfCancellationRequested();
                 _primaryTask = Task.Run(async () =>
-                {
-                    await initializeTask.ConfigureAwait(false);
+                    {
+                        await initializeTask.ConfigureAwait(false);
 
-                    await ProcessCompilationEventsAsync(cancellationToken).ConfigureAwait(false);
-                }, cancellationToken)
+                        await ProcessCompilationEventsAsync(cancellationToken).ConfigureAwait(false);
+                    }, cancellationToken)
                     .ContinueWith(c => DiagnosticQueue.TryComplete(), cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
             finally
@@ -335,13 +335,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             for (int i = 0; i < _workerCount; i++)
             {
                 workerTasks[i] = Task.Run(async () =>
-                {
-                    var result = await ProcessCompilationEventsCoreAsync(cancellationToken).ConfigureAwait(false);
-                    if (result != null)
                     {
-                        completedEvent = result;
-                    }
-                }, cancellationToken);
+                        var result = await ProcessCompilationEventsCoreAsync(cancellationToken).ConfigureAwait(false);
+                        if (result != null)
+                        {
+                            completedEvent = result;
+                        }
+                    }, cancellationToken);
             }
 
             // Kick off tasks to execute syntax tree actions.
@@ -634,7 +634,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor))
                     {
                         var analyzerActions = await analyzerManager.GetAnalyzerActionsAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
-                        allAnalyzerActions = allAnalyzerActions.Append(analyzerActions);
+                        if (analyzerActions != null)
+                        {
+                            allAnalyzerActions = allAnalyzerActions.Append(analyzerActions);
+                        }
                     }
                 }
 

--- a/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
@@ -269,5 +269,20 @@ namespace Microsoft.CodeAnalysis
                 context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class AnalyzerWithNoActions : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor DummyRule = new DiagnosticDescriptor(
+                "ID1",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DummyRule);
+            public override void Initialize(AnalysisContext context) { }
+        }
     }
 }


### PR DESCRIPTION
Customer scenario: Analyzer author writes a bolier plate analyzer that defines the rule that it intends to implement in future, but registers no analyzer actions for analysis. Adding such an analyzer to your analyzer assembly brings down the entire analysis, and no analyzers execute during command line build. The issue was reported for StyleCopAnalyzers package which has many such to-be-implemented analyzers.

Fixes #2980

Fix description: Add a null check around the place we compute set of all registered actions for analyzers.

Testing: Added regression tests + existing tests.

/cc @ManishJayaswal @srivatsn This is for 1.0 milestone.