### PR TITLE
Don't cache DeclaredSymbolInfos for generated files.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToSymbolFinder.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
@@ -14,14 +14,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 {
     internal static class NavigateToSymbolFinder
     {
-        private static readonly char[] s_dotArray = new char[] { '.' };
-
         internal static async Task<IEnumerable<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>> FindNavigableDeclaredSymbolInfos(Project project, string pattern, CancellationToken cancellationToken)
         {
+            var generatedCodeRecognitionService = project.LanguageServices.WorkspaceServices.GetService<IGeneratedCodeRecognitionService>();
             var patternMatcher = new PatternMatcher(pattern);
 
             var result = new List<ValueTuple<DeclaredSymbolInfo, Document, IEnumerable<PatternMatch>>>();
-            foreach (var document in project.Documents)
+            foreach (var document in project.Documents.Where(d => !generatedCodeRecognitionService?.IsGeneratedCode(d) ?? true))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var declaredSymbolInfos = await document.GetDeclaredSymbolInfosAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
@@ -159,8 +159,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             containsElementAccess = containsElementAccess || syntaxFacts.IsElementAccessExpression(node);
                             containsIndexerMemberCref = containsIndexerMemberCref || syntaxFacts.IsIndexerMemberCRef(node);
 
+                            // We've received a number of error reports where DeclaredSymbolInfo.GetSymbolAsync() will
+                            // crash because the document's syntax root doesn't contain the span of the node returned
+                            // by TryGetDeclaredSymbolInfo().  There are two possibilities for this crash:
+                            //   1) syntaxFacts.TryGetDeclaredSymbolInfo() is returning a bad span, or
+                            //   2) Document.GetSyntaxRootAsync() (called from DeclaredSymbolInfo.GetSymbolAsync) is
+                            //      returning a bad syntax root that doesn't represent the original parsed document.
+                            // By adding the `root.FullSpan.Contains()` check below, if we get similar crash reports in
+                            // the future then we know the problem lies in (2).  If, however, the problem is really in
+                            // TryGetDeclaredSymbolInfo, then this will at least prevent us from returning bad spans
+                            // and will prevent the crash from occuring.
                             DeclaredSymbolInfo declaredSymbolInfo;
-                            if (syntaxFacts.TryGetDeclaredSymbolInfo(node, out declaredSymbolInfo))
+                            if (syntaxFacts.TryGetDeclaredSymbolInfo(node, out declaredSymbolInfo) &&
+                                root.FullSpan.Contains(declaredSymbolInfo.Span))
                             {
                                 declaredSymbolInfos.Add(declaredSymbolInfo);
                             }


### PR DESCRIPTION
*Fixes internal bug 1174255.*

**Customer Scenario**
VS can crash when NavigateTo tries to resolve a symbol from code generated by the XAML compiler.

**Fix Description**
Don't let NavigateTo see generated files.  This also brings the behavior inline with Dev12 which also doesn't show items in generated code in NavigateTo.

**Detailed Description of the Problem**
I was unable to repro this locally but all of the crash dumps analyzed had the same pattern: NavigateTo tried to resolve a symbol from the `XamlTypeInfoProvider` class which is generated by the XAML compiler, but the span of the expected identifier is out of range of the current (at the time of the navigation) document.  Preventing the gathering of `DeclaredSymbolInfo` items on generated code prevents this from happening.

**Testing Done**
Ran standard unit/integration tests + targeted manual testing.

Tagging @Pilchie for review for inclusion in stabilization branch.