### PR TITLE
Make MetadataReference.CreateFromAssembly obsolete

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -2281,8 +2281,8 @@ public class Test
             CompileAndVerify(CreateCompilation(
                 text,
                 references: new[] {
-                    MetadataReference.CreateFromAssembly(typeof(object).Assembly),
-                    MetadataReference.CreateFromAssembly(typeof(System.Linq.Enumerable).Assembly)
+                    MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly),
+                    MetadataReference.CreateFromAssemblyInternal(typeof(System.Linq.Enumerable).Assembly)
                 },
                 options: TestOptions.ReleaseExe),
                 expectedOutput: TrimExpectedOutput(expectedOutput));

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             var tree = CSharpSyntaxTree.ParseText("class Program { static void Main() { } }");
             var compilation = CSharpCompilation.Create("Program",
                                                        new[] { tree },
-                                                       new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) },
+                                                       new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) },
                                                        new CSharpCompilationOptions(OutputKind.ConsoleApplication).WithFeatures((new[] { "deterministic" }).AsImmutable()));
             var output = new WriteOnlyStream();
             compilation.Emit(output);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -2696,7 +2696,7 @@ System.Diagnostics.Process.GetCurrentProcess();
             var data = Temp.CreateFile().WriteAllBytes(ProprietaryTestResources.NetFX.v4_0_30319.System_Data).Path;
             var core = Temp.CreateFile().WriteAllBytes(ProprietaryTestResources.NetFX.v4_0_30319.System_Core).Path;
             var system = Temp.CreateFile().WriteAllBytes(ProprietaryTestResources.NetFX.v4_0_30319.System).Path;
-            var mscorlibRef = MetadataReference.CreateFromAssembly(typeof(object).Assembly);
+            var mscorlibRef = MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly);
 
             var trees = new[] {
                     SyntaxFactory.ParseSyntaxTree(@"

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
@@ -28,11 +28,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => MetadataReference.CreateFromFile(null, default(MetadataReferenceProperties)));
             Assert.Throws<ArgumentNullException>(() => MetadataReference.CreateFromStream(null));
 
-            Assert.Throws<ArgumentNullException>(() => MetadataReference.CreateFromAssembly(null));
-            Assert.Throws<ArgumentException>(() => MetadataReference.CreateFromAssembly(typeof(object).Assembly, new MetadataReferenceProperties(MetadataImageKind.Module)));
+            Assert.Throws<ArgumentNullException>(() => MetadataReference.CreateFromAssemblyInternal(null));
+            Assert.Throws<ArgumentException>(() => MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly, new MetadataReferenceProperties(MetadataImageKind.Module)));
 
             var dynamicAssembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName { Name = "Foo" }, System.Reflection.Emit.AssemblyBuilderAccess.Run);
-            Assert.Throws<NotSupportedException>(() => MetadataReference.CreateFromAssembly(dynamicAssembly));
+            Assert.Throws<NotSupportedException>(() => MetadataReference.CreateFromAssemblyInternal(dynamicAssembly));
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void CreateFromAssembly()
         {
             var assembly = typeof(object).Assembly;
-            var r = (PortableExecutableReference)MetadataReference.CreateFromAssembly(assembly);
+            var r = (PortableExecutableReference)MetadataReference.CreateFromAssemblyInternal(assembly);
             Assert.Equal(assembly.Location, r.FilePath);
             Assert.Equal(assembly.Location, r.Display);
             Assert.Equal(MetadataImageKind.Assembly, r.Properties.Kind);
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var doc = new TestDocumentationProvider();
             var assembly = typeof(object).Assembly;
-            var r = (PortableExecutableReference)MetadataReference.CreateFromAssembly(assembly, new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a", "b"), embedInteropTypes: true), documentation: doc);
+            var r = (PortableExecutableReference)MetadataReference.CreateFromAssemblyInternal(assembly, new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a", "b"), embedInteropTypes: true), documentation: doc);
             Assert.Equal(assembly.Location, r.FilePath);
             Assert.Equal(assembly.Location, r.Display);
             Assert.Equal(MetadataImageKind.Assembly, r.Properties.Kind);

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Reflection.PortableExecutable;
@@ -257,9 +258,16 @@ namespace Microsoft.CodeAnalysis
         /// Reusing <see cref="AssemblyMetadata"/> object allows for sharing data accross these references.
         /// </para>
         /// </remarks>
+        [Obsolete("Use CreateFromFile(assembly.Location) instead", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MetadataReference CreateFromAssembly(Assembly assembly)
         {
-            return CreateFromAssembly(assembly, default(MetadataReferenceProperties));
+            return CreateFromAssemblyInternal(assembly);
+        }
+
+        internal static MetadataReference CreateFromAssemblyInternal(Assembly assembly)
+        {
+            return CreateFromAssemblyInternal(assembly, default(MetadataReferenceProperties));
         }
 
         /// <summary>
@@ -278,7 +286,17 @@ namespace Microsoft.CodeAnalysis
         /// Reusing <see cref="AssemblyMetadata"/> object allows for sharing data accross these references.
         /// </para>
         /// </remarks>
+        [Obsolete("Use CreateFromFile(assembly.Location) instead", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MetadataReference CreateFromAssembly(
+            Assembly assembly,
+            MetadataReferenceProperties properties,
+            DocumentationProvider documentation = null)
+        {
+            return CreateFromAssemblyInternal(assembly, properties, documentation);
+        }
+
+        internal static MetadataReference CreateFromAssemblyInternal(
             Assembly assembly,
             MetadataReferenceProperties properties,
             DocumentationProvider documentation = null)

--- a/src/Diagnostics/FxCop/Test/Usage/CA2214Tests.cs
+++ b/src/Diagnostics/FxCop/Test/Usage/CA2214Tests.cs
@@ -271,8 +271,8 @@ class E : ControlBase
 }
 ";
             var document = CreateDocument(source, LanguageNames.CSharp);
-            var project = document.Project.AddMetadataReference(MetadataReference.CreateFromAssembly(typeof(System.Web.UI.Control).Assembly));
-            project = project.AddMetadataReference(MetadataReference.CreateFromAssembly(typeof(System.Windows.Forms.Control).Assembly));
+            var project = document.Project.AddMetadataReference(MetadataReference.CreateFromAssemblyInternal(typeof(System.Web.UI.Control).Assembly));
+            project = project.AddMetadataReference(MetadataReference.CreateFromAssemblyInternal(typeof(System.Windows.Forms.Control).Assembly));
             var analyzer = GetCSharpDiagnosticAnalyzer();
             GetSortedDiagnostics(analyzer, project.Documents.Single()).Verify(analyzer);
         }
@@ -313,8 +313,8 @@ Class E
 End Class
 ";
             var document = CreateDocument(source, LanguageNames.VisualBasic);
-            var project = document.Project.AddMetadataReference(MetadataReference.CreateFromAssembly(typeof(System.Web.UI.Control).Assembly));
-            project = project.AddMetadataReference(MetadataReference.CreateFromAssembly(typeof(System.Windows.Forms.Control).Assembly));
+            var project = document.Project.AddMetadataReference(MetadataReference.CreateFromAssemblyInternal(typeof(System.Web.UI.Control).Assembly));
+            project = project.AddMetadataReference(MetadataReference.CreateFromAssemblyInternal(typeof(System.Windows.Forms.Control).Assembly));
             var analyzer = GetBasicDiagnosticAnalyzer();
             GetSortedDiagnostics(analyzer, project.Documents.Single()).Verify(analyzer);
         }

--- a/src/Diagnostics/Test/Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Diagnostics/Test/Utilities/DiagnosticAnalyzerTestBase.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public abstract class DiagnosticAnalyzerTestBase
     {
-        private static readonly MetadataReference s_corlibReference = MetadataReference.CreateFromAssembly(typeof(object).Assembly);
-        private static readonly MetadataReference s_systemCoreReference = MetadataReference.CreateFromAssembly(typeof(Enumerable).Assembly);
-        private static readonly MetadataReference s_CSharpSymbolsReference = MetadataReference.CreateFromAssembly(typeof(CSharpCompilation).Assembly);
-        private static readonly MetadataReference s_visualBasicSymbolsReference = MetadataReference.CreateFromAssembly(typeof(VisualBasicCompilation).Assembly);
-        private static readonly MetadataReference s_codeAnalysisReference = MetadataReference.CreateFromAssembly(typeof(Compilation).Assembly);
-        private static readonly MetadataReference s_immutableCollectionsReference = MetadataReference.CreateFromAssembly(typeof(ImmutableArray<int>).Assembly);
+        private static readonly MetadataReference s_corlibReference = MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly);
+        private static readonly MetadataReference s_systemCoreReference = MetadataReference.CreateFromAssemblyInternal(typeof(Enumerable).Assembly);
+        private static readonly MetadataReference s_CSharpSymbolsReference = MetadataReference.CreateFromAssemblyInternal(typeof(CSharpCompilation).Assembly);
+        private static readonly MetadataReference s_visualBasicSymbolsReference = MetadataReference.CreateFromAssemblyInternal(typeof(VisualBasicCompilation).Assembly);
+        private static readonly MetadataReference s_codeAnalysisReference = MetadataReference.CreateFromAssemblyInternal(typeof(Compilation).Assembly);
+        private static readonly MetadataReference s_immutableCollectionsReference = MetadataReference.CreateFromAssemblyInternal(typeof(ImmutableArray<int>).Assembly);
         private static readonly CompilationOptions s_CSharpDefaultOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
         private static readonly CompilationOptions s_visualBasicDefaultOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 

--- a/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             this.Documents = documents ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
             this.AdditionalDocuments = additionalDocuments ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
             _projectReferences = projectReferences != null ? projectReferences.Select(p => new ProjectReference(p.Id)) : SpecializedCollections.EmptyEnumerable<ProjectReference>();
-            _metadataReferences = metadataReferences ?? new MetadataReference[] { MetadataReference.CreateFromAssembly(typeof(int).Assembly) };
+            _metadataReferences = metadataReferences ?? new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib };
             _analyzerReferences = analyzerReferences ?? SpecializedCollections.EmptyEnumerable<AnalyzerReference>();
             _assemblyName = assemblyName ?? "TestProject";
             _version = VersionStamp.Create();

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
             var compilation = CreateCompilation(
                 new[] { source },
                 assemblyName: assemblyName,
-                references: references.Concat(new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) }),
+                references: references.Concat(new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) }),
                 options: fileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? TestOptions.ReleaseExe : TestOptions.ReleaseDll);
 
             var image = compilation.EmitToArray();

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1939,7 +1939,7 @@ class D
         [Fact]
         public void Submissions_EmitToPeStream()
         {
-            var references = new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) };
+            var references = new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) };
 
             CSharpCompilation s0 = CSharpCompilation.CreateSubmission("s0", syntaxTree: SyntaxFactory.ParseSyntaxTree("int a = 1;", options: TestOptions.Interactive), references: references, returnType: typeof(object));
             CSharpCompilation s11 = CSharpCompilation.CreateSubmission("s11", syntaxTree: SyntaxFactory.ParseSyntaxTree("a + 1", options: TestOptions.Interactive), previousSubmission: s0, references: references, returnType: typeof(object));
@@ -1955,7 +1955,7 @@ class D
         [Fact]
         public void Submissions_ExecutionOrder3()
         {
-            var references = new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) };
+            var references = new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) };
 
             CSharpCompilation s0 = CSharpCompilation.CreateSubmission("s0.dll", syntaxTree: SyntaxFactory.ParseSyntaxTree("int a = \"x\";", options: TestOptions.Interactive), references: references, returnType: typeof(object));
 
@@ -2012,7 +2012,7 @@ class D
         private CSharpCompilation CreateSubmission(string code, CSharpParseOptions options, int expectedErrorCount = 0)
         {
             var submission = CSharpCompilation.CreateSubmission("sub",
-                references: new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) },
+                references: new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) },
                 syntaxTree: Parse(code, options: options));
 
             Assert.Equal(expectedErrorCount, submission.GetDiagnostics(CompilationStage.Declare, true, CancellationToken.None).Count());
@@ -3584,7 +3584,7 @@ static int Baz = w;
                 references: new[]
                 {
                     MscorlibRef,
-                    MetadataReference.CreateFromAssembly(typeof(InteractiveSessionTests).Assembly)
+                    MetadataReference.CreateFromAssemblyInternal(typeof(InteractiveSessionTests).Assembly)
                 },
                 hostObjectType: typeof(B));
 

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -1334,7 +1334,7 @@ End Class
             var compilation = VB.VisualBasicCompilation.Create(
                 "foo",
                 new[] { VB.VisualBasicSyntaxTree.ParseText(source) },
-                new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) },
+                new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly) },
                 new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug));
 
             Assembly a;

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
             if (this.GlobalsType != null)
             {
-                var globalsTypeAssembly = MetadataReference.CreateFromAssembly(this.GlobalsType.Assembly);
+                var globalsTypeAssembly = MetadataReference.CreateFromAssemblyInternal(this.GlobalsType.Assembly);
                 if (!references.Contains(globalsTypeAssembly))
                 {
                     references = references.Add(globalsTypeAssembly);

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             }
             else
             {
-                return WithReferences(assemblies.Select(MetadataReference.CreateFromAssembly));
+                return WithReferences(assemblies.Select(MetadataReference.CreateFromAssemblyInternal));
             }
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             }
             else
             {
-                return AddReferences(assemblies.Select(MetadataReference.CreateFromAssembly));
+                return AddReferences(assemblies.Select(MetadataReference.CreateFromAssemblyInternal));
             }
         }
 

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -308,7 +308,7 @@ End If
         Private Function CreateSubmission(code As String, options As VisualBasicParseOptions, Optional expectedErrorCount As Integer = 0) As VisualBasicCompilation
             Dim submission = VisualBasicCompilation.CreateSubmission(
                 "sub",
-                references:={MetadataReference.CreateFromAssembly(GetType(Object).Assembly)},
+                references:={MetadataReference.CreateFromAssemblyInternal(GetType(Object).Assembly)},
                 syntaxTree:=Parse(code, options:=options))
 
             Assert.Equal(expectedErrorCount, submission.GetDiagnostics(CompilationStage.Declare, True).Length())

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -124,9 +125,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                     "System.Core"
                 };
 
+            var metadataService  = workspace.Services.GetService<IMetadataService>();
+
             var referenceAssemblies = Thread.GetDomain().GetAssemblies()
                 .Where(x => references.Contains(x.GetName(true).Name, StringComparer.OrdinalIgnoreCase))
-                .Select(MetadataReference.CreateFromAssembly);
+                .Select(a => metadataService.GetReference(a.Location, MetadataReferenceProperties.Assembly));
 
             project = project.WithMetadataReferences(referenceAssemblies);
 

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -2593,7 +2593,7 @@ class C { }";
                 var solution = ws.OpenSolutionAsync(GetSolutionFileName("TestSolution.sln")).Result;
                 var project = solution.Projects.First();
 
-                var mref = MetadataReference.CreateFromAssembly(typeof(System.Xaml.XamlObjectReader).Assembly);
+                var mref = MetadataReference.CreateFromFile(typeof(System.Xaml.XamlObjectReader).Assembly.Location);
 
                 // add reference to System.Xaml
                 ws.TryApplyChanges(project.AddMetadataReference(mref).Solution);


### PR DESCRIPTION
Fixes #2911.

**Scenario**
The functionality that this method relies on is not available on CoreCLR and although we can implement an alternative it's not clear what the cost is. The method currently throws ```PlatformNotSupportedException```. It was decided that we should not have such APIs in the compiler.

**Fix**
Make the method obsolete. There is only one place in the RTM shipping code where this method is used: in VS formatting options preview. Replaces this usage with a call to IMetadataService.

**Testing**
Verified that VS formatting options preview works.

@ManishJayaswal
@jaredpar 