### PR TITLE
Improve handling of My.InternalXmlHelper

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -551,7 +551,6 @@ namespace System
             {
                 switch (wkt)
                 {
-                    case WellKnownType.My_InternalXmlHelper:
                     case WellKnownType.Microsoft_VisualBasic_Embedded:
                     case WellKnownType.Microsoft_VisualBasic_CompilerServices_EmbeddedOperators:
                         // Not applicable in C#.
@@ -592,7 +591,6 @@ namespace System
                     case WellKnownMember.Count:
                         // Not a real value;
                         continue;
-                    case WellKnownMember.My_InternalXmlHelper__Value:
                     case WellKnownMember.Microsoft_VisualBasic_Embedded__ctor:
                     case WellKnownMember.Microsoft_VisualBasic_CompilerServices_EmbeddedOperators__CompareStringStringStringBoolean:
                         // C# can't embed VB core.

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -306,8 +306,6 @@ namespace Microsoft.CodeAnalysis
         Microsoft_VisualBasic_Information__VbTypeName,
         Microsoft_VisualBasic_Interaction__CallByName,
 
-        My_InternalXmlHelper__Value,
-
         System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext,
         System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine,
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2220,17 +2220,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.Microsoft_VisualBasic_CallType,
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
 
-                // My_InternalXmlHelper__Value
-                (byte)(MemberFlags.Property | MemberFlags.Static),                                                          // Flags
-                (byte)WellKnownType.My_InternalXmlHelper,                                                                   // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
-                    (byte)SignatureTypeCode.GenericTypeInstance,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
-                    1,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Xml_Linq_XElement,
-
                 // System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext
                 (byte)(MemberFlags.Method | MemberFlags.Virtual),                                                           // Flags
                 (byte)WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine,                                     // DeclaringTypeId
@@ -2799,7 +2788,6 @@ namespace Microsoft.CodeAnalysis
                 "TypeName",                                 // Microsoft_VisualBasic_Information__TypeName
                 "VbTypeName",                               // Microsoft_VisualBasic_Information__VbTypeName
                 "CallByName",                               // Microsoft_VisualBasic_Interaction__CallByName
-                "Value",                                    // My_InternalXmlHelper__Value
                 "MoveNext",                                 // System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext
                 "SetStateMachine",                          // System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine
                 "SetException",                             // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -101,8 +101,6 @@ namespace Microsoft.CodeAnalysis
         Microsoft_VisualBasic_Information,
         Microsoft_VisualBasic_Interaction,
 
-        My_InternalXmlHelper,
-
         // standard Func delegates - must be ordered by arity
         System_Func_T,
         System_Func_T2,
@@ -348,8 +346,6 @@ namespace Microsoft.CodeAnalysis
             "Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase",
             "Microsoft.VisualBasic.Information",
             "Microsoft.VisualBasic.Interaction",
-
-            "My.InternalXmlHelper",
 
             "System.Func`1",
             "System.Func`2",

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -478,26 +478,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim metadataName = globalMetadataName
 
             Dim rootNamespace = Me.Compilation.Options.RootNamespace
-            Dim haveRootNamespace As Boolean = Not String.IsNullOrEmpty(rootNamespace)
-            If haveRootNamespace Then
+            If Not String.IsNullOrEmpty(rootNamespace) Then
                 metadataName = $"{rootNamespace}.{metadataName}"
             End If
 
             Dim emittedName = MetadataTypeName.FromFullName(metadataName, useCLSCompliantNameArityEncoding:=True)
-
-            Dim containingModule = Me.ContainingModule
-            Dim typeSymbol = containingModule.LookupTopLevelMetadataType(emittedName)
-
-            ' Roslyn emits the type into the global namespace so we should look there too.
-            If haveRootNamespace AndAlso TypeOf typeSymbol Is MissingMetadataTypeSymbol Then
-                Dim globalEmittedName = MetadataTypeName.FromFullName(globalMetadataName, useCLSCompliantNameArityEncoding:=True)
-                Dim globalTypeSymbol = containingModule.LookupTopLevelMetadataType(globalEmittedName)
-                If TypeOf globalTypeSymbol IsNot MissingMetadataTypeSymbol Then
-                    typeSymbol = globalTypeSymbol
-                End If
-            End If
-
-            Return typeSymbol
+            Return Me.ContainingModule.LookupTopLevelMetadataType(emittedName)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -3,6 +3,7 @@
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
 Imports System.Collections.Immutable
+Imports System.Reflection.Metadata
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.RuntimeMembers
@@ -326,6 +327,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Friend ReadOnly Property ContainingModule As ModuleSymbol
+            Get
+                ' If there's a containing member, it either is or has a containing module.
+                ' Otherwise, we'll just use the compilation's source module.
+                Dim containingMember = Me.ContainingMember
+                Return If(TryCast(containingMember, ModuleSymbol), If(containingMember?.ContainingModule, Me.Compilation.SourceModule))
+            End Get
+        End Property
+
         ''' <summary>
         ''' Tells whether binding is happening in a query context.
         ''' </summary>
@@ -450,6 +460,79 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function GetUseSiteErrorForWellKnownType(type As TypeSymbol) As DiagnosticInfo
             Return type.GetUseSiteErrorInfo()
+        End Function
+
+        Private Function GetInternalXmlHelperType(syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
+            Dim typeSymbol = GetInternalXmlHelperType()
+
+            Dim useSiteError = GetUseSiteErrorForWellKnownType(typeSymbol)
+            If useSiteError IsNot Nothing Then
+                ReportDiagnostic(diagBag, syntax, useSiteError)
+            End If
+
+            Return typeSymbol
+        End Function
+
+        Private Function GetInternalXmlHelperType() As NamedTypeSymbol
+            Const globalMetadataName = "My.InternalXmlHelper"
+            Dim metadataName = globalMetadataName
+
+            Dim rootNamespace = Me.Compilation.Options.RootNamespace
+            Dim haveRootNamespace As Boolean = Not String.IsNullOrEmpty(rootNamespace)
+            If haveRootNamespace Then
+                metadataName = $"{rootNamespace}.{metadataName}"
+            End If
+
+            Dim emittedName = MetadataTypeName.FromFullName(metadataName, useCLSCompliantNameArityEncoding:=True)
+
+            Dim containingModule = Me.ContainingModule
+            Dim typeSymbol = containingModule.LookupTopLevelMetadataType(emittedName)
+
+            ' Roslyn emits the type into the global namespace so we should look there too.
+            If haveRootNamespace AndAlso TypeOf typeSymbol Is MissingMetadataTypeSymbol Then
+                Dim globalEmittedName = MetadataTypeName.FromFullName(globalMetadataName, useCLSCompliantNameArityEncoding:=True)
+                Dim globalTypeSymbol = containingModule.LookupTopLevelMetadataType(globalEmittedName)
+                If TypeOf globalTypeSymbol IsNot MissingMetadataTypeSymbol Then
+                    typeSymbol = globalTypeSymbol
+                End If
+            End If
+
+            Return typeSymbol
+        End Function
+
+        ''' <summary>
+        ''' WARN: Retrieves the symbol but does not check its viability (accessibility, etc).
+        ''' </summary>
+        Private Function GetInternalXmlHelperValueExtensionProperty() As PropertySymbol
+            For Each candidate As Symbol In GetInternalXmlHelperType().GetMembers("Value")
+                If Not candidate.IsShared OrElse candidate.Kind <> SymbolKind.Property Then
+                    Continue For
+                End If
+
+                Dim candidateProperty = DirectCast(candidate, PropertySymbol)
+                If candidateProperty.Type.SpecialType <> SpecialType.System_String OrElse
+                    candidateProperty.TypeCustomModifiers.Length > 0 OrElse
+                    candidateProperty.ParameterCount <> 1 Then
+
+                    Continue For
+                End If
+
+                Dim parameter = candidateProperty.Parameters(0)
+                If parameter.CustomModifiers.Length > 0 Then
+                    Continue For
+                End If
+
+                Dim parameterType = parameter.Type
+                If parameterType.OriginalDefinition.SpecialType <> SpecialType.System_Collections_Generic_IEnumerable_T OrElse
+                        DirectCast(parameterType, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(0) <> Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement) Then
+                    Continue For
+                End If
+
+                ' Only one symbol can match the criteria above, so we don't have to worry about ambiguity.
+                Return candidateProperty
+            Next
+
+            Return Nothing
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -153,7 +153,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Check for external symbols marked with 'Microsoft.VisualBasic.Embedded' attribute
-            If Me.Compilation.SourceModule IsNot unwrappedSym.ContainingModule AndAlso unwrappedSym.IsHiddenByEmbeddedAttribute() Then
+            If unwrappedSym.ContainingModule IsNot Me.ContainingModule AndAlso unwrappedSym.IsHiddenByEmbeddedAttribute() Then
                 Return SingleLookupResult.Empty
             End If
 
@@ -1197,7 +1197,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return
                 End If
 
-                Dim symbol = compilation.GetWellKnownTypeMember(WellKnownMember.My_InternalXmlHelper__Value)
+                Dim symbol = binder.GetInternalXmlHelperValueExtensionProperty()
                 Dim singleResult As SingleLookupResult
                 If symbol Is Nothing Then
                     ' Match the native compiler which reports ERR_XmlFeaturesNotAvailable in this case.

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -354,7 +354,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Generate method group and arguments for RemoveNamespaceAttributes.
                 removeNamespacesGroup = GetXmlMethodOrPropertyGroup(syntax,
-                                                                    GetWellKnownType(WellKnownType.My_InternalXmlHelper, syntax, diagnostics),
+                                                                    GetInternalXmlHelperType(syntax, diagnostics),
                                                                     StringConstants.XmlRemoveNamespaceAttributesMethodName,
                                                                     Nothing,
                                                                     diagnostics)
@@ -423,7 +423,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                               ImmutableArray.Create(Of BoundExpression)(prefix, [namespace]),
                                                               diagnostics)
             Else
-                Dim type = GetWellKnownType(WellKnownType.My_InternalXmlHelper, syntax, diagnostics)
+                Dim type = GetInternalXmlHelperType(syntax, diagnostics)
                 Dim group = GetXmlMethodOrPropertyGroup(syntax, type, StringConstants.XmlCreateNamespaceAttributeMethodName, Nothing, diagnostics)
                 objectCreation = BindInvocationExpressionIfGroupNotNothing(syntax, group, ImmutableArray.Create(Of BoundExpression)(prefix, [namespace]), diagnostics)
             End If
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' with embedded expression values since CreateAttribute handles Nothing values.
                 value = BindXmlEmbeddedExpression(DirectCast(valueSyntax, XmlEmbeddedExpressionSyntax), diagnostics)
                 Dim group = GetXmlMethodOrPropertyGroup(valueSyntax,
-                                                        GetWellKnownType(WellKnownType.My_InternalXmlHelper, syntax, diagnostics),
+                                                        GetInternalXmlHelperType(syntax, diagnostics),
                                                         StringConstants.XmlCreateAttributeMethodName,
                                                         Nothing,
                                                         diagnostics)
@@ -653,7 +653,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
                 If receiverType.IsOrDerivedFrom(xmlType, useSiteDiagnostics) OrElse receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteDiagnostics) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
-                                                            GetWellKnownType(WellKnownType.My_InternalXmlHelper, syntax, diagnostics),
+                                                            GetInternalXmlHelperType(syntax, diagnostics),
                                                             StringConstants.XmlAttributeValueMethodName,
                                                             Nothing,
                                                             diagnostics)

--- a/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
@@ -66,6 +66,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             Next
         End Sub
+
+        Public Overrides ReadOnly Property ContainingMember As Symbol
+            Get
+                Return Me.Compilation.SourceModule
+            End Get
+        End Property
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/EmbeddedSymbols/InternalXmlHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EmbeddedSymbols/InternalXmlHelper.vb
@@ -1,7 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 ' See Compiler::LoadXmlSolutionExtension
-Namespace Global.My
+Namespace My
     <Global.Microsoft.VisualBasic.Embedded()>
     <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(), _

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/XmlLiteralsTests_UseSiteErrors.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/XmlLiteralsTests_UseSiteErrors.vb
@@ -208,12 +208,9 @@ Namespace System.Xml.Linq
     Public Class XNamespace
     End Class
 End Namespace
-Namespace My
-    Public Module InternalXmlHelper
-        Public Function RemoveNamespaceAttributes(prefixes As String(), namespaces As XNamespace(), attributes As Object, o As Object) As Object
-            Return Nothing
-        End Function
-    End Module
+Namespace Microsoft.VisualBasic.CompilerServices
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
 End Namespace
     ]]></file>
 </compilation>)
@@ -222,11 +219,20 @@ End Namespace
 <compilation name="XAttributeTypeMissing">
     <file name="c.vb"><![CDATA[
 Option Strict On
+Imports System.Collections.Generic
+Imports System.Xml.Linq
 Class C
     Private F1 As Object = <x <%= Nothing %>/>
     Private F2 As Object = <x <%= "a" %>="b"/>
     Private F3 As Object = <x a=<%= "b" %>/>
 End Class
+Namespace My
+    Public Module InternalXmlHelper
+        Public Function RemoveNamespaceAttributes(prefixes As String(), namespaces As XNamespace(), attributes As Object, o As Object) As Object
+            Return Nothing
+        End Function
+    End Module
+End Namespace
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[
@@ -271,12 +277,9 @@ Namespace System.Xml.Linq
     Public Class XNamespace
     End Class
 End Namespace
-Namespace My
-    Public Module InternalXmlHelper
-        Public Function RemoveNamespaceAttributes(prefixes As String(), namespaces As XNamespace(), attributes As List(Of XAttribute), o As Object) As Object
-            Return Nothing
-        End Function
-    End Module
+Namespace Microsoft.VisualBasic.CompilerServices
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
 End Namespace
     ]]></file>
 </compilation>)
@@ -285,11 +288,20 @@ End Namespace
 <compilation name="XAttributeTypeMissing">
     <file name="c.vb"><![CDATA[
 Option Strict On
+Imports System.Collections.Generic
+Imports System.Xml.Linq
 Class C
     Private F1 As Object = <x <%= Nothing %>/>
     Private F2 As Object = <x <%= "a" %>="b"/>
     Private F3 As Object = <x a=<%= "b" %>/>
 End Class
+Namespace My
+    Public Module InternalXmlHelper
+        Public Function RemoveNamespaceAttributes(prefixes As String(), namespaces As XNamespace(), attributes As List(Of XAttribute), o As Object) As Object
+            Return Nothing
+        End Function
+    End Module
+End Namespace
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[
@@ -599,6 +611,22 @@ Namespace System.Xml.Linq
     Public Class XNamespace
     End Class
 End Namespace
+Namespace Microsoft.VisualBasic.CompilerServices
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
+End Namespace
+    ]]></file>
+</compilation>)
+            compilation1.AssertNoErrors()
+            Dim compilation2 = CreateCompilationWithMscorlibAndReferences(
+<compilation name="XNamespaceGetMissing">
+    <file name="c.vb"><![CDATA[
+Imports <xmlns:p="http://roslyn/">
+Imports System.Collections.Generic
+Imports System.Xml.Linq
+Class C
+    Shared F As Object = <p:x><%= Nothing %></>
+End Class
 Namespace My
     Public Module InternalXmlHelper
         Public Function CreateNamespaceAttribute(name As XName, ns As XNamespace) As XAttribute
@@ -609,16 +637,6 @@ Namespace My
         End Function
     End Module
 End Namespace
-    ]]></file>
-</compilation>)
-            compilation1.AssertNoErrors()
-            Dim compilation2 = CreateCompilationWithMscorlibAndReferences(
-<compilation name="XNamespaceGetMissing">
-    <file name="c.vb"><![CDATA[
-Imports <xmlns:p="http://roslyn/">
-Class C
-    Shared F As Object = <p:x><%= Nothing %></>
-End Class
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[
@@ -711,9 +729,9 @@ Namespace System.Xml.Linq
     Public Module Extensions
     End Module
 End Namespace
-Namespace My
-    Public Module InternalXmlHelper
-    End Module
+Namespace Microsoft.VisualBasic.CompilerServices
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
 End Namespace
     ]]></file>
 </compilation>)
@@ -728,6 +746,10 @@ Class C
     Private F2 As Object = F1.<x>
     Private F3 As Object = F1.@x
 End Class
+Namespace My
+    Public Module InternalXmlHelper
+    End Module
+End Namespace
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[
@@ -758,8 +780,8 @@ Namespace System.Xml.Linq
     End Class
 End Namespace
 Namespace Microsoft.VisualBasic.CompilerServices
-    Public Module InternalXmlHelper
-    End Module
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
 End Namespace
     ]]></file>
 </compilation>)
@@ -775,6 +797,10 @@ Class C
         Return x.Value
     End Function
 End Class
+Namespace My
+    Public Module InternalXmlHelper
+    End Module
+End Namespace
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[
@@ -798,13 +824,8 @@ Namespace System.Xml.Linq
     End Class
 End Namespace
 Namespace Microsoft.VisualBasic.CompilerServices
-    Public Module InternalXmlHelper
-        Public ReadOnly Property Value(x As IEnumerable(Of XElement), y As Object, z As Object) As Object
-            Get
-                Return Nothing
-            End Get
-        End Property
-    End Module
+    Public Class StandardModuleAttribute : Inherits System.Attribute
+    End Class
 End Namespace
     ]]></file>
 </compilation>)
@@ -820,6 +841,15 @@ Class C
         Return x.VALUE
     End Function
 End Class
+Namespace My
+    Public Module InternalXmlHelper
+        Public ReadOnly Property Value(x As IEnumerable(Of XElement), y As Object, z As Object) As Object
+            Get
+                Return Nothing
+            End Get
+        End Property
+    End Module
+End Namespace
     ]]></file>
 </compilation>, references:={New VisualBasicCompilationReference(compilation1)})
             compilation2.AssertTheseDiagnostics(<errors><![CDATA[

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -1784,7 +1784,7 @@ End Class"
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 allReferences,
                 exeBytes,
-                Nothing)
+                New SymReader(pdbBytes, exeBytes)) ' Need SymReader to find root namespace.
             Dim context = CreateMethodContext(runtime, "Root.C.M")
             Dim errorMessage As String = Nothing
             Dim testData = New CompilationTestData()
@@ -1794,12 +1794,12 @@ End Class"
 "{
   // Code size       22 (0x16)
   .maxstack  3
-  .locals init (String V_0)
+  .locals init (String V_0) //y
   IL_0000:  ldarg.0
   IL_0001:  ldstr      ""a""
   IL_0006:  ldstr      """"
   IL_000b:  call       ""Function System.Xml.Linq.XName.Get(String, String) As System.Xml.Linq.XName""
-  IL_0010:  call       ""Function My.InternalXmlHelper.get_AttributeValue(System.Xml.Linq.XElement, System.Xml.Linq.XName) As String""
+  IL_0010:  call       ""Function Root.My.InternalXmlHelper.get_AttributeValue(System.Xml.Linq.XElement, System.Xml.Linq.XName) As String""
   IL_0015:  ret
 }")
         End Sub


### PR DESCRIPTION
The VB compiler embeds My.InternalXmlHelper in assemblies to provide additional System.Linq.Xml (mostly XML literal) functionality - for example, being able to use  the ```.@``` syntax to access the value of an element's attribute.

This PR should improve a couple of scenarios:
1. Enable the EE to find an unambiguous My.InternalXmlHelper implementation so that the functionality can be used in the Watch and Immediate windows.
2. Enable other tools (e.g. the Dev12 debugger) to consume our assemblies by emitting My.InternalXmlHelper under the root namespace (as it was formerly).

Details of the fix are in the individual commits.  At a high level, we remove My.InternalXmlHelper from the WellKnownTypes list and give it a dedicated code path.

This PR contains a breaking change: we look for My.InternalXmlHelper in fewer places than Dev12 did.  The compatibility council has already approved the break.

New unit tests have been added for the previously unsupported scenarios (emitting into the root namespace, consuming from the root namespace, etc) and @wschae is buddy testing the change.

Fixes #964