### PR TITLE
Don't do rude edit analysis if nothing in the solution has changed...

### DIFF
--- a/src/Features/Core/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
@@ -38,7 +38,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
 
                 EditSession session = encService.EditSession;
-                if (session == null || !session.HasProject(document.Project.Id))
+                if (session == null ||
+                    session.BaseSolution.WorkspaceVersion == document.Project.Solution.WorkspaceVersion ||
+                    !session.HasProject(document.Project.Id))
                 {
                     return;
                 }


### PR DESCRIPTION
We can check WorkspaceVersion as a early-out to avoid doing text/syntax analysis.