### PR TITLE
Reload analyzers with loading errors

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
@@ -56,6 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             get { return _fullPath; }
         }
 
+        public bool HasLoadErrors
+        {
+            get { return _analyzerLoadErrors != null && _analyzerLoadErrors.Count > 0; }
+        }
+
         public AnalyzerReference GetReference()
         {
             if (_analyzerReference == null)
@@ -121,6 +126,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void Dispose()
         {
+            Reset();
+
+            _tracker.Dispose();
+            _tracker.UpdatedOnDisk -= OnUpdatedOnDisk;
+        }
+
+        public void Reset()
+        {
             var analyzerFileReference = _analyzerReference as AnalyzerFileReference;
             if (analyzerFileReference != null)
             {
@@ -135,9 +148,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             _analyzerLoadErrors = null;
-
-            _tracker.Dispose();
-            _tracker.UpdatedOnDisk -= OnUpdatedOnDisk;
+            _analyzerReference = null;
         }
 
         private void OnUpdatedOnDisk(object sender, EventArgs e)


### PR DESCRIPTION
**Bug:** Fixes #2707.

**Customer Scenario**
User adds an analyzer to their project in VS without first adding all of the dependencies. E.g., they add Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers without first adding Microsoft.CodeAnalysis.FxCopAnalyzers.

The Error List will show various warnings about missing analyzer assemblies and being unable to load diagnostic analyzers from Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers. This is correct and expected.

The user then adds the missing analyzer assembly, expecting the warnings to go away and the diagnostics to start working. Instead, the warnings remain, and the diagnostics still do not work.

**Fix**
The issue is that an `AnalyzerFileReference` only looks for
`DiagnosticAnalyzers` once, and caches the results. So even though we
add the missing dependency and *could* load the types, we don't actually
try.

The fix is in the logic to add a new analyzer assembly in VS. In
addition to pushing a new `AnalyzerFileReference` down to the workspace,
we examine the list of existing analyzers. For each one with load
errors we remove the existing `AnalyzerFileReference` and add a new one.

**Testing**
I ran through the Customer Scenario described above.

@ManishJayaswal This is ready for ship room.
@srivatsn @mavasani @heejaechang @jmarolf @shyamnamboodiripad Could you take a look, please?