### PR TITLE
Execute msbuild API in domain with redirects

### DIFF
--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpHostBuildDataFactory.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpHostBuildDataFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ExportLanguageService(typeof(IHostBuildDataFactory), LanguageNames.CSharp), Shared]
     internal sealed class CSharpHostBuildDataFactory : IHostBuildDataFactory
     {
-        public HostBuildData Create(HostBuildOptions options)
+        public HostBuildData Create(IHostBuildOptions options)
         {
             var parseOptions = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, documentationMode: DocumentationMode.Parse);
             var compilationOptions = new CSharpCompilationOptions(

--- a/src/Workspaces/Core/Desktop/Utilities/RemoteTask.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/RemoteTask.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal interface IRemoteTask<T>
+    {
+        void Cancel();
+        void SetCompletion(IRemoteTaskCompletion<T> completion);
+        T GetResult();
+    }
+
+    internal interface IRemoteTaskCompletion<T>
+    {
+        void Complete(T result);
+        void Fail(Exception exception);
+    }
+
+    internal static class RemoteTask
+    {
+        public static Task<TResult> ToTask<TResult>(this IRemoteTask<TResult> asyncTask, CancellationToken cancellationToken)
+        {
+            return new RemoteTaskCompletion<TResult>(asyncTask, cancellationToken).Task;
+        }
+    }
+
+    internal class RemoteTaskCompletion<T> : MarshalByRefObject, IRemoteTaskCompletion<T>
+    {
+        private readonly TaskCompletionSource<T> _taskSource;
+
+        public RemoteTaskCompletion(IRemoteTask<T> asyncTask, CancellationToken cancellationToken)
+        {
+            _taskSource = new TaskCompletionSource<T>();
+
+            asyncTask.SetCompletion(this);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationToken.Register(() =>
+                {
+                    asyncTask.Cancel();
+                    _taskSource.TrySetCanceled();
+                });
+            }
+        }
+
+        public Task<T> Task
+        {
+            get { return _taskSource.Task; }
+        }
+
+        void IRemoteTaskCompletion<T>.Complete(T result)
+        {
+            _taskSource.TrySetResult(result);
+        }
+
+        void IRemoteTaskCompletion<T>.Fail(Exception exception)
+        {
+            _taskSource.TrySetException(exception);
+        }
+    }
+
+    internal class RemoteTask<TResult> : MarshalByRefObject, IRemoteTask<TResult>
+    {
+        private readonly Task<TResult> _task;
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public RemoteTask(Func<CancellationToken, Task<TResult>> factory)
+        {
+            _cancellationSource = new CancellationTokenSource();
+            _task = factory(_cancellationSource.Token);
+        }
+
+        public CancellationToken CancellationToken
+        {
+            get { return _cancellationSource.Token; }
+        }
+
+        void IRemoteTask<TResult>.SetCompletion(IRemoteTaskCompletion<TResult> completion)
+        {
+            _task.ContinueWith(t =>
+            {
+                try
+                {
+                    completion.Complete(t.Result);
+                }
+                catch (Exception e)
+                {
+                    var ae = e as AggregateException;
+                    if (ae != null && ae.InnerExceptions.Count == 1)
+                    {
+                        e = ae.InnerException;
+                    }
+
+                    completion.Fail(e);
+                }
+            }, this.CancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default);
+        }
+
+        void IRemoteTask<TResult>.Cancel()
+        {
+            _cancellationSource.Cancel();
+        }
+
+        TResult IRemoteTask<TResult>.GetResult()
+        {
+            try
+            {
+                return _task.Result;
+            }
+            catch (AggregateException e) when (e.InnerExceptions.Count == 1)
+            {
+                throw e.InnerException;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.cs
@@ -11,11 +11,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class CSharpProjectFileLoader : ProjectFileLoader
     {
-        private readonly HostWorkspaceServices _workspaceServices;
-
-        public CSharpProjectFileLoader(HostWorkspaceServices workspaceServices)
+        public CSharpProjectFileLoader()
         {
-            _workspaceServices = workspaceServices;
         }
 
         public override string Language
@@ -23,19 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return LanguageNames.CSharp; }
         }
 
-        public IHostBuildDataFactory MSBuildHost
-        {
-            get { return _workspaceServices.GetLanguageServices(Language).GetService<IHostBuildDataFactory>(); }
-        }
-
-        public ICommandLineArgumentsFactoryService CommandLineArgumentsFactoryService
-        {
-            get { return _workspaceServices.GetLanguageServices(Language).GetService<ICommandLineArgumentsFactoryService>(); }
-        }
-
         protected override ProjectFile CreateProjectFile(MSB.Evaluation.Project loadedProject)
         {
-            return new CSharpProjectFile(this, loadedProject, _workspaceServices.GetService<IMetadataService>(), _workspaceServices.GetService<IAnalyzerService>());
+            return new CSharpProjectFile(this, loadedProject);
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoaderFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoaderFactory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -15,9 +16,16 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ProjectTypeGuid("FAE04EC0-301F-11D3-BF4B-00C04F79EFBC")]
     internal class CSharpProjectFileLoaderFactory : ILanguageServiceFactory
     {
+        private IProjectFileLoader s_Loader;
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new CSharpProjectFileLoader(languageServices.WorkspaceServices);
+            if (s_Loader == null)
+            {
+                Interlocked.CompareExchange(ref s_Loader, RemoteProjectFileLoader.CreateProjectLoader(typeof(CSharpProjectFileLoader)), null);
+            }
+
+            return s_Loader;
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildOptions.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildOptions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.MSBuild
+{
+    [Serializable]
+    internal class BuildOptions : IHostBuildOptions
+    {
+        public string ProjectDirectory { get; set; }
+        public string OutputDirectory { get; set; }
+        public string DefineConstants { get; set; }
+        public string DocumentationFile { get; set; }
+        public string LanguageVersion { get; set; }
+        public string PlatformWith32BitPreference { get; set; }
+        public string ApplicationConfiguration { get; set; }
+        public string KeyContainer { get; set; }
+        public string KeyFile { get; set; }
+        public string MainEntryPoint { get; set; }
+        public string ModuleAssemblyName { get; set; }
+        public string Platform { get; set; }
+        public string RuleSetFile { get; set; }
+        public string OptionCompare { get; set; }
+        public string OptionStrict { get; set; }
+        public string RootNamespace { get; set; }
+        public string VBRuntime { get; set; }
+        public bool? AllowUnsafeBlocks { get; set; }
+        public bool? CheckForOverflowUnderflow { get; set; }
+        public bool? Optimize { get; set; }
+        public bool? WarningsAsErrors { get; set; }
+        public bool? NoWarnings { get; set; }
+        public bool? OptionExplicit { get; set; }
+        public bool? OptionInfer { get; set; }
+        public int? WarningLevel { get; set; }
+        public OutputKind? OutputKind { get; set; }
+        public Tuple<bool, bool> DelaySign { get; set; }
+        public List<string> GlobalImports { get; set; }
+        public Dictionary<string, ReportDiagnostic> Warnings { get; set; }
+
+        internal BuildOptions()
+        {
+            Warnings = new Dictionary<string, ReportDiagnostic>();
+            GlobalImports = new List<string>();
+        }
+    }
+
+}

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildTargets.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/BuildTargets.cs
@@ -32,6 +32,55 @@ namespace Microsoft.CodeAnalysis.MSBuild
             get { return _buildTargets.ToArray(); }
         }
 
+        // this code is for use when debugging problems with build targets not running
+#if DEBUG
+        public string[] GetExecutedTargets()
+        {
+            return TopologicalSorter.TopologicalSort(this.Targets, t => GetTargetDependents(_project, t)).ToArray();
+        }
+
+        public string[] GetAllTargets()
+        {
+            return TopologicalSorter.TopologicalSort(GetTopLevelTargets(_project), t => GetTargetDependents(_project, t)).ToArray();
+        }
+
+        public string[] GetDependingTargets(string target)
+        {
+            var map = GetReverseTargetMap();
+
+            List<string> dependers;
+            if (map.TryGetValue(target, out dependers))
+            {
+                return dependers.ToArray();
+            }
+
+            return new string[0];
+        }
+
+        public Dictionary<string, List<string>> GetReverseTargetMap()
+        {
+            var targets = GetAllTargets();
+
+            var reverseMap = new Dictionary<string, List<string>>();
+            foreach (var t in targets)
+            {
+                foreach (var dependant in GetTargetDependents(_project, t))
+                {
+                    List<string> dependers;
+                    if (!reverseMap.TryGetValue(dependant, out dependers))
+                    {
+                        dependers = new List<string>();
+                        reverseMap.Add(dependant, dependers);
+                    }
+
+                    dependers.Add(t);
+                }
+            }
+
+            return reverseMap;
+        }
+#endif
+
         /// <summary>
         /// Remove the specified target from the build targets. 
         /// 

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/DocumentFileInfo.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/DocumentFileInfo.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// <summary>
     /// Represents a source file that is part of a project file.
     /// </summary>
+    [Serializable]
     internal sealed class DocumentFileInfo
     {
         /// <summary>

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/IProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/IProjectFile.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <summary>
         /// Gets the project file info asynchronously.
         /// </summary>
-        Task<ProjectFileInfo> GetProjectFileInfoAsync(CancellationToken cancellationToken);
+        IRemoteTask<ProjectFileInfo> GetProjectFileInfoAsync();
 
         /// <summary>
         /// Get the kind of source found in the specified file. 
@@ -54,12 +54,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <summary>
         ///  Add a metadata reference to a project file.
         /// </summary>
-        void AddMetadataReference(MetadataReference reference, AssemblyIdentity identity);
+        void AddMetadataReference(ProjectMetadataReference metadata, string assemblyDisplayName);
 
         /// <summary>
         /// Remove a metadata reference from a project file.
         /// </summary>
-        void RemoveMetadataReference(MetadataReference reference, AssemblyIdentity identity);
+        void RemoveMetadataReference(ProjectMetadataReference metadata, string assemblyFullName);
 
         /// <summary>
         /// Add a reference to another project to a project file.
@@ -74,12 +74,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <summary>
         /// Add an analyzer reference to the project file.
         /// </summary>
-        void AddAnalyzerReference(AnalyzerReference reference);
+        void AddAnalyzerReference(ProjectAnalyzerReference reference);
 
         /// <summary>
         /// Remove an analyzer reference from the project file.
         /// </summary>
-        void RemoveAnalyzerReference(AnalyzerReference reference);
+        void RemoveAnalyzerReference(ProjectAnalyzerReference reference);
 
         /// <summary>
         /// Save the current state of the project file to disk.

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/IProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/IProjectFileLoader.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
     internal interface IProjectFileLoader : ILanguageService
     {
         string Language { get; }
-        Task<IProjectFile> LoadProjectFileAsync(string path, IDictionary<string, string> globalProperties, CancellationToken cancellationToken);
+        IRemoteTask<IProjectFile> LoadProjectFileAsync(string path, Dictionary<string, string> globalProperties);
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectAnalyzerReference.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectAnalyzerReference.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -14,23 +13,18 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// Represents a reference to another project file.
     /// </summary>
     [Serializable]
-    internal sealed class ProjectFileReference
+    internal sealed class ProjectAnalyzerReference
     {
         /// <summary>
-        /// The path on disk to the other project file. 
-        /// This path may be relative to the referencing project's file or an absolute path.
         /// </summary>
         public string Path { get; }
 
-        /// <summary>
-        /// The aliases assigned to this reference, if any.
-        /// </summary>
-        public IReadOnlyList<string> Aliases { get; }
+        public string Display { get; }
 
-        public ProjectFileReference(string path, IEnumerable<string> aliases)
+        public ProjectAnalyzerReference(string path, string display)
         {
             this.Path = path;
-            this.Aliases = aliases.ToList().AsReadOnly();
+            this.Display = display;
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
 
@@ -10,6 +11,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// <summary>
     /// Represents a project file loaded from disk.
     /// </summary>
+    [Serializable]
     internal sealed class ProjectFileInfo
     {
         /// <summary>
@@ -23,14 +25,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public string AssemblyName { get; }
 
         /// <summary>
-        /// The compilation options for this project.
+        /// The parse and compilation options for this project.
         /// </summary>
-        public CompilationOptions CompilationOptions { get; }
-
-        /// <summary>
-        /// The parse options for this project.
-        /// </summary>
-        public ParseOptions ParseOptions { get; }
+        public BuildOptions BuildOptions { get; }
 
         /// <summary>
         /// The codepage for this project.
@@ -53,37 +50,28 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public IReadOnlyList<ProjectFileReference> ProjectReferences { get; }
 
         /// <summary>
-        /// References to other metadata files; libraries and executables.
+        /// other information represented as command line args
         /// </summary>
-        public IReadOnlyList<MetadataReference> MetadataReferences { get; }
-
-        /// <summary>
-        /// References to analyzer assembly files; contains diagnostic analyzers.
-        /// </summary>
-        public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; }
+        public IReadOnlyList<string> CommandLineArgs { get; }
 
         public ProjectFileInfo(
             string outputPath,
             string assemblyName,
-            CompilationOptions compilationOptions,
-            ParseOptions parseOptions,
+            BuildOptions buildOptions,
             int codePage,
             IEnumerable<DocumentFileInfo> documents,
             IEnumerable<DocumentFileInfo> additionalDocuments,
             IEnumerable<ProjectFileReference> projectReferences,
-            IEnumerable<MetadataReference> metadataReferences,
-            IEnumerable<AnalyzerReference> analyzerReferences)
+            IEnumerable<string> commandLineArgs)
         {
             this.OutputFilePath = outputPath;
             this.AssemblyName = assemblyName;
-            this.CompilationOptions = compilationOptions;
-            this.ParseOptions = parseOptions;
+            this.BuildOptions = buildOptions;
             this.CodePage = codePage;
-            this.Documents = documents.ToImmutableReadOnlyListOrEmpty();
-            this.AdditionalDocuments = additionalDocuments.ToImmutableReadOnlyListOrEmpty();
-            this.ProjectReferences = projectReferences.ToImmutableReadOnlyListOrEmpty();
-            this.MetadataReferences = metadataReferences.ToImmutableReadOnlyListOrEmpty();
-            this.AnalyzerReferences = analyzerReferences.ToImmutableReadOnlyListOrEmpty();
+            this.Documents = documents.ToList().AsReadOnly();
+            this.AdditionalDocuments = additionalDocuments.ToList().AsReadOnly();
+            this.ProjectReferences = projectReferences.ToList().AsReadOnly();
+            this.CommandLineArgs = commandLineArgs.ToList().AsReadOnly();
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectMetadataReference.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectMetadataReference.cs
@@ -3,8 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -14,11 +14,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// Represents a reference to another project file.
     /// </summary>
     [Serializable]
-    internal sealed class ProjectFileReference
+    internal sealed class ProjectMetadataReference
     {
         /// <summary>
-        /// The path on disk to the other project file. 
-        /// This path may be relative to the referencing project's file or an absolute path.
         /// </summary>
         public string Path { get; }
 
@@ -27,10 +25,13 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// </summary>
         public IReadOnlyList<string> Aliases { get; }
 
-        public ProjectFileReference(string path, IEnumerable<string> aliases)
+        public bool EmbedInteropTypes { get; }
+
+        public ProjectMetadataReference(string path, IEnumerable<string> aliases, bool embedInteropTypes)
         {
             this.Path = path;
             this.Aliases = aliases.ToList().AsReadOnly();
+            this.EmbedInteropTypes = embedInteropTypes;
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/RemoteProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/RemoteProjectFileLoader.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
+using MSB = Microsoft.Build;
+
+namespace Microsoft.CodeAnalysis.MSBuild
+{
+    internal class RemoteProjectFileLoader
+    {
+        public static IProjectFileLoader CreateProjectLoader(Type loaderType)
+        {
+            return (IProjectFileLoader)GetBuildDomain().CreateInstanceAndUnwrap(loaderType.Assembly.FullName, loaderType.FullName);
+        }
+
+        // a separate app domain used for running msbuild
+        private static AppDomain s_BuildDomain;
+        private static object gate = new object();
+
+        private static AppDomain GetBuildDomain()
+        {
+            if (s_BuildDomain == null)
+            {
+                lock (gate)
+                {
+                    if (s_BuildDomain == null)
+                    {
+                        var thisAssembly = typeof(RemoteProjectFileLoader).Assembly.Location;
+                        var configFile = CreateTempFile(GetResourceText("msbuild.config"));
+
+                        s_BuildDomain = AppDomain.CreateDomain("MSBuildDomain",
+                            new System.Security.Policy.Evidence(),
+                            new AppDomainSetup
+                            {
+                                ApplicationBase = Path.GetDirectoryName(thisAssembly),
+                                ConfigurationFile = configFile
+                            });
+                    }
+                }
+            }
+
+            return s_BuildDomain;
+        }
+
+        private static string CreateTempFile(string content)
+        {
+            var filename = Path.GetTempFileName();
+            using (var stream = File.OpenWrite(filename))
+            {
+                using (var writer = new StreamWriter(stream, System.Text.Encoding.UTF8))
+                {
+                    writer.Write(content);
+                }
+            }
+
+            return filename;
+        }
+
+        private static string GetResourceText(string fileName)
+        {
+            var fullName = @"Microsoft.CodeAnalysis.Workspace.MSBuild." + fileName;
+            var resourceStream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(fullName);
+            if (resourceStream != null)
+            {
+                using (var streamReader = new StreamReader(resourceStream))
+                {
+                    return streamReader.ReadToEnd();
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException(string.Format("Cannot find resource named: '{0}'", fullName));
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoaderFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoaderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -12,9 +13,16 @@ namespace Microsoft.CodeAnalysis.VisualBasic
     [ProjectTypeGuid("F184B08F-C81C-45F6-A57F-5ABD9991F28F")]
     internal class VisualBasicProjectFileLoaderFactory : ILanguageServiceFactory
     {
+        private IProjectFileLoader s_Loader;
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new VisualBasicProjectFileLoader(languageServices.WorkspaceServices);
+            if (s_Loader == null)
+            {
+                Interlocked.CompareExchange(ref s_Loader, RemoteProjectFileLoader.CreateProjectLoader(typeof(VisualBasicProjectFileLoader)), null);
+            }
+
+            return s_Loader;
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/msbuild.config
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/msbuild.config
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
+    <section name="msbuildToolsets" type="Microsoft.Build.BuildEngine.ToolsetConfigurationSection, Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  </configSections>
+  <runtime>
+    <DisableFXClosureWalk enabled="true" />
+    <generatePublisherEvidence enabled="false" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Conversion.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CompactFramework.Build.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="9.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Log\EtwLogger.cs" />
     <Compile Include="Log\RoslynEventSource.cs" />
     <Compile Include="Options\Providers\ExportedOptionKeyOptionProvider.cs" />
+    <Compile Include="Utilities\RemoteTask.cs" />
     <Compile Include="Utilities\Documentation\FileBasedXmlDocumentationProvider.cs" />
     <Compile Include="Utilities\ReferencePathUtilities.cs" />
     <Compile Include="WorkspaceDesktopResources.Designer.cs">
@@ -109,16 +110,20 @@
     <Compile Include="Workspace\MSBuild\CSharp\CSharpProjectFileLoader.CSharpProjectFile.cs" />
     <Compile Include="Workspace\MSBuild\CSharp\CSharpProjectFileLoaderFactory.cs" />
     <Compile Include="Workspace\MSBuild\MSBuildWorkspace.cs" />
+    <Compile Include="Workspace\MSBuild\ProjectFile\BuildOptions.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\BuildTargets.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\DocumentFileInfo.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\IProjectFile.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\IProjectFileLoader.cs" />
+    <Compile Include="Workspace\MSBuild\ProjectFile\ProjectAnalyzerReference.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectFile.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectFileExtensionAttribute.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectFileInfo.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectFileLoader.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectFileReference.cs" />
+    <Compile Include="Workspace\MSBuild\ProjectFile\ProjectMetadataReference.cs" />
     <Compile Include="Workspace\MSBuild\ProjectFile\ProjectTypeGuidAttribute.cs" />
+    <Compile Include="Workspace\MSBuild\ProjectFile\RemoteProjectFileLoader.cs" />
     <Compile Include="Workspace\MSBuild\SolutionFile\LineScanner.cs" />
     <Compile Include="Workspace\MSBuild\SolutionFile\ProjectBlock.cs" />
     <Compile Include="Workspace\MSBuild\SolutionFile\SectionBlock.cs" />
@@ -161,6 +166,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <EmbeddedResource Include="Workspace\MSBuild\msbuild.config" />
     <PublicAPI Include="PublicAPI.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Workspaces/Core/Portable/HostBuild.cs
+++ b/src/Workspaces/Core/Portable/HostBuild.cs
@@ -10,43 +10,37 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class HostBuildOptions
+    internal interface IHostBuildOptions
     {
-        public string ProjectDirectory { get; set; }
-        public string OutputDirectory { get; set; }
-        public string DefineConstants { get; set; }
-        public string DocumentationFile { get; set; }
-        public string LanguageVersion { get; set; }
-        public string PlatformWith32BitPreference { get; set; }
-        public string ApplicationConfiguration { get; set; }
-        public string KeyContainer { get; set; }
-        public string KeyFile { get; set; }
-        public string MainEntryPoint { get; set; }
-        public string ModuleAssemblyName { get; set; }
-        public string Platform { get; set; }
-        public string RuleSetFile { get; set; }
-        public string OptionCompare { get; set; }
-        public string OptionStrict { get; set; }
-        public string RootNamespace { get; set; }
-        public string VBRuntime { get; set; }
-        public bool? AllowUnsafeBlocks { get; set; }
-        public bool? CheckForOverflowUnderflow { get; set; }
-        public bool? Optimize { get; set; }
-        public bool? WarningsAsErrors { get; set; }
-        public bool? NoWarnings { get; set; }
-        public bool? OptionExplicit { get; set; }
-        public bool? OptionInfer { get; set; }
-        public int? WarningLevel { get; set; }
-        public OutputKind? OutputKind { get; set; }
-        public Tuple<bool, bool> DelaySign { get; set; }
-        public List<string> GlobalImports { get; set; }
-        public Dictionary<string, ReportDiagnostic> Warnings { get; set; }
-
-        internal HostBuildOptions()
-        {
-            Warnings = new Dictionary<string, ReportDiagnostic>();
-            GlobalImports = new List<string>();
-        }
+        string ProjectDirectory { get; set; }
+        string OutputDirectory { get; set; }
+        string DefineConstants { get; set; }
+        string DocumentationFile { get; set; }
+        string LanguageVersion { get; set; }
+        string PlatformWith32BitPreference { get; set; }
+        string ApplicationConfiguration { get; set; }
+        string KeyContainer { get; set; }
+        string KeyFile { get; set; }
+        string MainEntryPoint { get; set; }
+        string ModuleAssemblyName { get; set; }
+        string Platform { get; set; }
+        string RuleSetFile { get; set; }
+        string OptionCompare { get; set; }
+        string OptionStrict { get; set; }
+        string RootNamespace { get; set; }
+        string VBRuntime { get; set; }
+        bool? AllowUnsafeBlocks { get; set; }
+        bool? CheckForOverflowUnderflow { get; set; }
+        bool? Optimize { get; set; }
+        bool? WarningsAsErrors { get; set; }
+        bool? NoWarnings { get; set; }
+        bool? OptionExplicit { get; set; }
+        bool? OptionInfer { get; set; }
+        int? WarningLevel { get; set; }
+        OutputKind? OutputKind { get; set; }
+        Tuple<bool, bool> DelaySign { get; set; }
+        List<string> GlobalImports { get; set; }
+        Dictionary<string, ReportDiagnostic> Warnings { get; set; }
     }
 
     internal sealed class HostBuildData
@@ -64,6 +58,6 @@ namespace Microsoft.CodeAnalysis
 
     internal interface IHostBuildDataFactory : ILanguageService
     {
-        HostBuildData Create(HostBuildOptions options);
+        HostBuildData Create(IHostBuildOptions options);
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -457,7 +457,7 @@ class C1
             Assert.Empty(project.ProjectReferences);
         }
 
-        [Fact(Skip = "707107"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestOpenProject_WithXaml()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicHostBuildDataFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicHostBuildDataFactory.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class VisualBasicHostBuildDataFactory
         Implements IHostBuildDataFactory
 
-        Public Function Create(options As HostBuildOptions) As HostBuildData Implements IHostBuildDataFactory.Create
+        Public Function Create(options As IHostBuildOptions) As HostBuildData Implements IHostBuildDataFactory.Create
 
             Dim parseOptions = VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse)
             Dim compilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication,


### PR DESCRIPTION
This solves the problem about needing redirects for the msbuild API dlls in order to get msbuild workspace to successfully open a project with xaml content.

The solution is to execute msbuild API's in a separate app domain with redirects specific from a config file that tells the runtime how to unify the msbuild dll references.

@Pilchie @jasonmalinowski please review
