### PR TITLE
C# EnC: handle addition of indexer

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -6881,6 +6881,16 @@ class SampleCollection<T>
                 Diagnostic(RudeEditKind.Delete, "public T this[int i]", CSharpFeaturesResources.IndexerSetter));
         }
 
+        [Fact, WorkItem(1174850)]
+        public void Indexer_Insert()
+        {
+            var src1 = "struct C { }";
+            var src2 = "struct C { public int this[int x, int y] { get { return x + y; } } }";
+
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemanticDiagnostics();
+        }
+
         [WorkItem(1120407)]
         [Fact]
         public void ConstField_Update()

--- a/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -825,9 +825,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return memberDeclaration.Parent.FirstAncestorOrSelf<TypeDeclarationSyntax>();
         }
 
-        internal override bool HasBackingField(SyntaxNode propertyDeclaration)
+        internal override bool HasBackingField(SyntaxNode propertyOrIndexerDeclaration)
         {
-            return SyntaxUtilities.HasBackingField((PropertyDeclarationSyntax)propertyDeclaration);
+            return propertyOrIndexerDeclaration.IsKind(SyntaxKind.PropertyDeclaration) && 
+                   SyntaxUtilities.HasBackingField((PropertyDeclarationSyntax)propertyOrIndexerDeclaration);
         }
 
         internal override bool IsDeclarationWithInitializer(SyntaxNode declaration)


### PR DESCRIPTION
Fixes: internal bug 1174850 (VS crash)

**Scenario**
An indexer is inserted into a type while debugging.

**Fix**
Property symbol may be associated with property or indexer declaration. The code assumed only the former is possible.

**Testing**
Added a unit test. Manual validation in VS that the edit is successfully applied.