### PR TITLE
Prevent spurious warnings about missing dependencies

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AssemblyIdentityWhiteList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AssemblyIdentityWhiteList.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class AssemblyIdentityWhiteList : IAssemblyWhiteList
+    {
+        private readonly HashSet<AssemblyIdentity> _assemblyIdentities;
+
+        public AssemblyIdentityWhiteList(IEnumerable<AssemblyIdentity> assemblyIdentities)
+        {
+            Debug.Assert(assemblyIdentities != null);
+
+            _assemblyIdentities = new HashSet<AssemblyIdentity>(assemblyIdentities);
+        }
+
+        public bool Includes(AssemblyIdentity assemblyIdentity)
+        {
+            return _assemblyIdentities.Contains(assemblyIdentity);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/AssemblyNamePrefixWhiteList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AssemblyNamePrefixWhiteList.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class AssemblyNamePrefixWhiteList : IAssemblyWhiteList
+    {
+        private readonly string _prefix;
+
+        public AssemblyNamePrefixWhiteList(string prefix)
+        {
+            Debug.Assert(prefix != null);
+
+            _prefix = prefix;
+        }
+
+        public bool Includes(AssemblyIdentity assemblyIdentity)
+        {
+            return assemblyIdentity.Name.StartsWith(_prefix);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/IAssemblyWhiteList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IAssemblyWhiteList.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal interface IAssemblyWhiteList
+    {
+        bool Includes(AssemblyIdentity assemblyIdentity);
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -32,9 +32,12 @@
     <Compile Include="Implementation\AnalyzerDependencyChecker.cs" />
     <Compile Include="Implementation\AnalyzerDependencyCheckingService.cs" />
     <Compile Include="Implementation\AnalyzerDependencyConflict.cs" />
+    <Compile Include="Implementation\AssemblyIdentityWhiteList.cs" />
+    <Compile Include="Implementation\AssemblyNamePrefixWhiteList.cs" />
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
     <Compile Include="Implementation\EditAndContinue\Interop\NativeMethods.cs" />
+    <Compile Include="Implementation\IAssemblyWhiteList.cs" />
     <Compile Include="Implementation\IBindingRedirectionService.cs" />
     <Compile Include="Implementation\LanguageService\AbstractLanguageService`2.IVsLanguageBlock.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs" />

--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -31,12 +31,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         End Property
 
         Private Shared s_CSharpCompilerExecutable As String = Path.Combine(MSBuildDirectory, "csc.exe")
+        Private Shared s_mscorlibDisplayName As String = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
 
-        Private Shared Function GetWhiteList() As IEnumerable(Of AssemblyIdentity)
+        Private Shared Function GetWhiteLists() As IEnumerable(Of IAssemblyWhiteList)
             Dim mscorlib As AssemblyIdentity = Nothing
-            AssemblyIdentity.TryParseDisplayName("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", mscorlib)
+            AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib)
 
-            Return {mscorlib}
+            Return {New AssemblyIdentityWhiteList({mscorlib})}
         End Function
 
         <Fact, WorkItem(1064914)>
@@ -47,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -75,7 +76,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -107,7 +108,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -148,7 +149,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -190,7 +191,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory2, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory2, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -231,7 +232,7 @@ public class B
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -272,7 +273,7 @@ public class B
                 Dim libraryC2 = directory2.CreateFile("C.dll").CopyContentFrom(libraryC1).Path
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -324,7 +325,7 @@ public class C
                 Dim libraryCPrime = BuildLibrary(directory2, sourceCPrime, "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryCPrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryCPrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Dim conflicts = results.Conflicts
@@ -395,7 +396,7 @@ public class D
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Dim conflicts = results.Conflicts
@@ -474,7 +475,7 @@ public class E
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -526,7 +527,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryA2 = directory2.CreateFile("A.dll").CopyContentFrom(libraryA1).Path
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA1, libraryA2, libraryB, libraryBPrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA1, libraryA2, libraryB, libraryBPrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -590,7 +591,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -641,7 +642,7 @@ public class B
                 Dim libraryB2 = directory2.CreateFile("B.dll").CopyContentFrom(libraryB1).Path
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB1, libraryB2}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB1, libraryB2}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -721,7 +722,7 @@ public class D
                 Dim libraryDPrimePrime = BuildLibrary(directory3, sourceDPrimePrime, "D")
                 Dim libraryC = BuildLibrary(directory3, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Equal(expected:=3, actual:=results.Conflicts.Length)
@@ -736,7 +737,7 @@ public class D
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.MissingDependencies)
@@ -763,7 +764,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA}, GetWhiteList())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA}, GetWhiteLists())
                 Dim results = dependencyChecker.Run()
                 Dim missingDependencies = results.MissingDependencies
 
@@ -773,6 +774,62 @@ public class A
                 Assert.Equal(expected:="A.dll", actual:=analyzerFileName)
                 Assert.Equal(expected:=New AssemblyIdentity("B"), actual:=missingDependencies(0).DependencyIdentity)
             End Using
+        End Sub
+
+        <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
+        Public Sub AssemblyIdentityWhiteList_IncludesItem()
+            Dim mscorlib1 As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib1)
+
+            Dim whiteList = New AssemblyIdentityWhiteList({mscorlib1})
+
+            Dim mscorlib2 As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib2)
+
+            Assert.True(whiteList.Includes(mscorlib2))
+        End Sub
+
+        <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
+        Public Sub AssemblyIdentityWhiteList_DoesNotIncludeItem()
+            Dim mscorlib As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib)
+
+            Dim whiteList = New AssemblyIdentityWhiteList({mscorlib})
+
+            Dim alpha As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
+
+            Assert.False(whiteList.Includes(alpha))
+        End Sub
+
+        <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
+        Public Sub AssemblyNamePrefixWhiteList_IncludesItem_Prefix()
+            Dim whiteList = New AssemblyNamePrefixWhiteList("Alpha")
+
+            Dim alphaBeta As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName("Alpha.Beta, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alphaBeta)
+
+            Assert.True(whiteList.Includes(alphaBeta))
+        End Sub
+
+        <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
+        Public Sub AssemblyNamePrefixWhiteList_IncludesItem_WholeName()
+            Dim whiteList = New AssemblyNamePrefixWhiteList("Alpha")
+
+            Dim alpha As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
+
+            Assert.True(whiteList.Includes(alpha))
+        End Sub
+
+        <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
+        Public Sub AssemblyNamePrefixWhiteList_DoesNotIncludeItem()
+            Dim whiteList = New AssemblyNamePrefixWhiteList("Beta")
+
+            Dim alpha As AssemblyIdentity = Nothing
+            AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
+
+            Assert.False(whiteList.Includes(alpha))
         End Sub
 
         Private Function BuildLibrary(directory As DisposableDirectory, fileContents As String, libraryName As String, ParamArray referenceNames As String()) As String


### PR DESCRIPTION
**Bug:** Fixes #3020.

**Customer Scenario**
1. User adds any analyzer assembly that includes a code fix to their project (e.g.,  Microsoft.CodeAnalysis.FxCopAnalyzers.dll or Microsoft.CodeAnalysis.CSharp.FxCopAnalyzers.dll).
2. Users saves their project and restarts VS.
3. User reopens the same project.
4. User gets spurious warnings about 'System.Composition.AttributedModel' not being found and analyzers possibly not working. Closing and reopening the project sometimes helps, but more often than not the warnings show up.

**Fix Description**
The fix updates the `AnalyzerDependencyChecker` to allow whitelisting arbitrary sets of assemblies, not just those already loaded. This is used to then whitelist all assemblies with a name starting with "System" on the assumption that even if they are not already loaded they will in fact be found if needed. If an analyzer reference appears on any whitelist we won't report it as missing, even if we don't know where it is.

**Testing**
I tested the customer scenario listed above, and also tested that missing assemblies that *don't* start with 'System' as still reported.

@ManishJayaswal This is ready for ship room.
@srivatsn @mavasani @shyamnamboodiripad @jmarolf @heejaechang Could you take a look, please?