### PR TITLE
Enable xaml project test

### DIFF
--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -272,6 +272,7 @@
     <EmbeddedResource Include="TestFiles\VisualBasicProject_VisualBasicProject_UnknownProjectExtension.vbproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -457,7 +457,7 @@ class C1
             Assert.Empty(project.ProjectReferences);
         }
 
-        [Fact(Skip = "707107"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestOpenProject_WithXaml()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()

--- a/src/Workspaces/CoreTest/app.config
+++ b/src/Workspaces/CoreTest/app.config
@@ -1,19 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.65535.65535.65535" newVersion="1.1.36.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-    <configSections>
-      <!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
-      <section name="msbuildToolsets" type="Microsoft.Build.BuildEngine.ToolsetConfigurationSection, Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    </configSections>
-    <runtime>
-      <DisableFXClosureWalk enabled="true" />
-      <generatePublisherEvidence enabled="false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
@@ -45,5 +32,4 @@
         </dependentAssembly>
       </assemblyBinding>
     </runtime>
-  </runtime>
 </configuration>

--- a/src/Workspaces/CoreTest/app.config
+++ b/src/Workspaces/CoreTest/app.config
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.65535.65535.65535" newVersion="1.1.36.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+    <configSections>
+      <!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
+      <section name="msbuildToolsets" type="Microsoft.Build.BuildEngine.ToolsetConfigurationSection, Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    </configSections>
+    <runtime>
+      <DisableFXClosureWalk enabled="true" />
+      <generatePublisherEvidence enabled="false" />
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.CompactFramework.Build.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="9.0.0.0"/>
+        </dependentAssembly>
+      </assemblyBinding>
+    </runtime>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixes #3035 

This change just enables a skipped test to run.

It adds a config file for the unit test project needed for the test case to succeed.

@Pilchie  please review