### PR TITLE
String allocs

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
@@ -65,7 +65,8 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             {
                 service = ImmutableInterlocked.GetOrAdd(ref _serviceMap, serviceType, svctype =>
                 {
-                    return PickLanguageService(_services.Where(lz => lz.Metadata.ServiceType == svctype.AssemblyQualifiedName));
+                    var assemblyQualifiedName = svctype.AssemblyQualifiedName;
+                    return PickLanguageService(_services.Where(lz => lz.Metadata.ServiceType == assemblyQualifiedName));
                 });
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
@@ -65,6 +65,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             {
                 service = ImmutableInterlocked.GetOrAdd(ref _serviceMap, serviceType, svctype =>
                 {
+                    // PERF: Hoist AssemblyQualifiedName out of inner lambda to avoid repeated string allocations.
                     var assemblyQualifiedName = svctype.AssemblyQualifiedName;
                     return PickLanguageService(_services.Where(lz => lz.Metadata.ServiceType == assemblyQualifiedName));
                 });

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
@@ -69,7 +69,8 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             {
                 service = ImmutableInterlocked.GetOrAdd(ref _serviceMap, serviceType, svctype =>
                 {
-                    // pick from list of exported factories and instances
+                    // Pick from list of exported factories and instances
+                    // PERF: Hoist AssemblyQualifiedName out of inner lambda to avoid repeated string allocations.
                     var assemblyQualifiedName = svctype.AssemblyQualifiedName;
                     return PickWorkspaceService(_services.Where(lz => lz.Metadata.ServiceType == assemblyQualifiedName));
                 });

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.Host.Mef
                 service = ImmutableInterlocked.GetOrAdd(ref _serviceMap, serviceType, svctype =>
                 {
                     // pick from list of exported factories and instances
-                    return PickWorkspaceService(_services.Where(lz => lz.Metadata.ServiceType == svctype.AssemblyQualifiedName));
+                    var assemblyQualifiedName = svctype.AssemblyQualifiedName;
+                    return PickWorkspaceService(_services.Where(lz => lz.Metadata.ServiceType == assemblyQualifiedName));
                 });
             }
 
@@ -115,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             return default(Lazy<IWorkspaceService, WorkspaceServiceMetadata>);
         }
 
-        private bool TryGetServiceByLayer(string layer, IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> services, out Lazy<IWorkspaceService, WorkspaceServiceMetadata> service)
+        private static bool TryGetServiceByLayer(string layer, IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> services, out Lazy<IWorkspaceService, WorkspaceServiceMetadata> service)
         {
             service = services.SingleOrDefault(lz => lz.Metadata.Layer == layer);
             return service != default(Lazy<IWorkspaceService, WorkspaceServiceMetadata>);


### PR DESCRIPTION
I noticed quite a few string allocations in the "open aspx" scenario coming from the calls to AssemblyQualifiedName while building workspace and language services. This takes care of them.

I don't think this is significant enough to take to Shiproom, though.