### PR TITLE
Don't assume rename text parses as IdentiferNameSyntax

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 _errorText = string.IsNullOrEmpty(session.ReplacementText)
                     ? null
-                    : string.Format(EditorFeaturesResources.IsNotAValidIdentifier, session.ReplacementText);
+                    : string.Format(EditorFeaturesResources.IsNotAValidIdentifier, GetTruncatedName(session.ReplacementText));
             }
 
             UpdateSeverity();
@@ -156,15 +156,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             get
             {
-                return string.Format(EditorFeaturesResources.Rename1, GetTruncatedSymbolName());
+                return string.Format(EditorFeaturesResources.Rename1, GetTruncatedName(Session.OriginalSymbolName));
             }
         }
 
-        private string GetTruncatedSymbolName()
+        private static string GetTruncatedName(string fullName)
         {
-            return this.Session.OriginalSymbolName.Length < SymbolDescriptionTextLength
-                ? this.Session.OriginalSymbolName 
-                : this.Session.OriginalSymbolName.Substring(0, SymbolDescriptionTextLength) + "...";
+            return fullName.Length < SymbolDescriptionTextLength
+                ? fullName
+                : fullName.Substring(0, SymbolDescriptionTextLength) + "...";
         }
 
         public string SearchText

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -9,12 +9,11 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Rename.ConflictEngine;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
@@ -227,24 +226,25 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     var trackingSpansAfterEdit = new NormalizedSpanCollection(GetEditableSpansForSnapshot(args.After).Select(ss => (Span)ss));
                     var spansTouchedInEdit = new NormalizedSpanCollection(args.Changes.Select(c => c.NewSpan));
 
-                    var intersection = NormalizedSpanCollection.Intersection(trackingSpansAfterEdit, spansTouchedInEdit);
-
-                    if (intersection.Count == 0)
+                    var intersectionSpans = NormalizedSpanCollection.Intersection(trackingSpansAfterEdit, spansTouchedInEdit);
+                    if (intersectionSpans.Count == 0)
                     {
                         // In Razor we sometimes get formatting changes during inline rename that
                         // do not intersect with any of our spans. Ideally this shouldn't happen at
                         // all, but if it does happen we can just ignore it.
                         return;
                     }
-                    else if (intersection.Count > 1)
-                    {
-                        Contract.Fail("we can't allow edits to touch multiple spans");
-                    }
 
-                    var intersectionSpan = intersection.Single();
-                    var singleTrackingSpanTouched = GetEditableSpansForSnapshot(args.After).Single(ss => ss.IntersectsWith(intersectionSpan));
-                    _activeSpan = _referenceSpanToLinkedRenameSpanMap.Where(kvp => kvp.Value.TrackingSpan.GetSpan(args.After).Contains(intersectionSpan)).Single().Key;
+                    // Cases with invalid identifiers may cause there to be multiple intersection
+                    // spans, but they should still all map to a single tracked rename span (e.g.
+                    // renaming "two" to "one two three" may be interpreted as two distinct
+                    // additions of "one" and "three").
+                    var boundingIntersectionSpan = Span.FromBounds(intersectionSpans.First().Start, intersectionSpans.Last().End);
+                    var trackingSpansTouched = GetEditableSpansForSnapshot(args.After).Where(ss => ss.IntersectsWith(boundingIntersectionSpan));
+                    Contract.Assert(trackingSpansTouched.Count() == 1);
 
+                    var singleTrackingSpanTouched = trackingSpansTouched.Single();
+                    _activeSpan = _referenceSpanToLinkedRenameSpanMap.Where(kvp => kvp.Value.TrackingSpan.GetSpan(args.After).Contains(boundingIntersectionSpan)).Single().Key;
                     _session.UndoManager.OnTextChanged(this.ActiveTextview.Selection, singleTrackingSpanTouched);
                 }
             }

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3306,5 +3306,43 @@ class Program
                 result.AssertLabeledSpansAre("conflict", "Console", RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub
+
+        <WorkItem(1031, "https://github.com/dotnet/roslyn/issues/1031")>
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub InvalidNamesDoNotCauseCrash_IntroduceQualifiedName()
+            Using result = RenameEngineResult.Create(
+                   <Workspace>
+                       <Project Language="C#" CommonReferences="true">
+                           <Document>
+class {|conflict:C$$|} { }
+                            </Document>
+                       </Project>
+                   </Workspace>, renameTo:="C.D")
+
+                result.AssertReplacementTextInvalid()
+                result.AssertLabeledSpansAre("conflict", "C.D", RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
+
+        <WorkItem(1031, "https://github.com/dotnet/roslyn/issues/1031")>
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub InvalidNamesDoNotCauseCrash_AccidentallyPasteLotsOfCode()
+            Dim renameTo = "class C { public void M() { for (int i = 0; i < 10; i++) { System.Console.Writeline(""This is a test""); } } }"
+
+            Using result = RenameEngineResult.Create(
+                   <Workspace>
+                       <Project Language="C#" CommonReferences="true">
+                           <Document>
+class {|conflict:C$$|} { }
+                            </Document>
+                       </Project>
+                   </Workspace>, renameTo)
+
+                result.AssertReplacementTextInvalid()
+                result.AssertLabeledSpansAre("conflict", renameTo, RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -3013,6 +3013,52 @@ End Class
                     result.AssertLabeledSpansAre("conflict", "Test", RelatedLocationType.UnresolvedConflict)
                 End Using
             End Sub
+
+            <WorkItem(1031, "https://github.com/dotnet/roslyn/issues/1031")>
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub InvalidNamesDoNotCauseCrash_IntroduceQualifiedName()
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class {|conflict:C$$|}
+End Class
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="C.D")
+
+                    result.AssertReplacementTextInvalid()
+                    result.AssertLabeledSpansAre("conflict", "C.D", RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
+
+            <WorkItem(1031, "https://github.com/dotnet/roslyn/issues/1031")>
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            Public Sub InvalidNamesDoNotCauseCrash_AccidentallyPasteLotsOfCode()
+                Dim renameTo = "
+Class C
+    Sub M()
+        System.Console.WriteLine(""Hello, Test!"")
+    End Sub
+End Class"
+                Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="Test.cs"><![CDATA[
+Class {|conflict:C$$|}
+End Class
+]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo)
+
+                    result.AssertReplacementTextInvalid()
+                    result.AssertLabeledSpansAre("conflict", renameTo, RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -570,7 +570,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 }
 
                 // determine the canonical identifier name (unescaped, no unicode escaping, ...)
-                string valueText;
+                string valueText = currentNewIdentifier;
                 var kind = SyntaxFacts.GetKeywordKind(currentNewIdentifier);
                 if (kind != SyntaxKind.None)
                 {
@@ -578,9 +578,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 }
                 else
                 {
-                    var parsedIdentifier = (IdentifierNameSyntax)SyntaxFactory.ParseName(currentNewIdentifier);
-                    Debug.Assert(parsedIdentifier.Kind() == SyntaxKind.IdentifierName);
-                    valueText = parsedIdentifier.Identifier.ValueText;
+                    var parsedIdentifier = SyntaxFactory.ParseName(currentNewIdentifier);
+                    if (parsedIdentifier.IsKind(SyntaxKind.IdentifierName))
+                    {
+                        valueText = ((IdentifierNameSyntax)parsedIdentifier).Identifier.ValueText;
+                    }
                 }
 
                 // TODO: we can't use escaped unicode characters in xml doc comments, so we need to pass the valuetext as text as well.

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -511,8 +511,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
 
                 If name.IsKind(SyntaxKind.GlobalName) Then
                     valueText = currentNewIdentifier
-                Else
-                    Debug.Assert(name.IsKind(SyntaxKind.IdentifierName))
+                ElseIf name.IsKind(SyntaxKind.IdentifierName) Then
                     valueText = DirectCast(name, IdentifierNameSyntax).Identifier.ValueText
                 End If
 


### PR DESCRIPTION
Two commits:

**Don't assume rename text parses as IdentiferNameSyntax**
Fixes #1031

In both the C# and VB RenameRewriterLanguageServices, we were assuming
the new rename text would parse as an IdentifierNameSyntax, but if the
rename text is invalid it could parse as anything. For example, if the
user tries to rename "A" to "A.B", then it will parse as a
QualifiedNameSyntax. We now accommodate these cases.

**Improve handling of invalid rename text in Inline Rename**
This contains two small rename fixes related to invalid rename text:
1. In OnTextBufferChanged, we were trying to ensure that the
intersection of the tracked rename spans and buffer changes was a single
span. However, when the rename text is invalid, there can be many buffer
change spans that intersect a single tracked rename span, so we now use
the least bounding span of the resulting intersection. We maintain the
requirement that this bounding buffer change span intersect a single
tracked rename span.
2. When the rename text is invalid, we display it in the Rename
Dashboard. This change adds the same truncation algorithm already
applied to the original symbol name (which reduces it to 15 characters
and appends a "..." if necessary).