### PR TITLE
Add Roslyn to build task so GAC'ing isn't necessary for IDE.

### DIFF
--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -3,6 +3,14 @@
 using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Build.Tasks.CodeAnalysis",
+    OldVersionLowerBound = Constants.OldVersionLowerBound,
+    OldVersionUpperBound = Constants.OldVersionUpperBound,
+    NewVersion = Constants.NewVersion,
+    PublicKeyToken = Constants.PublicKeyToken,
+    GenerateCodeBase = false)]
+
+[assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.CSharp",
     OldVersionLowerBound = Constants.OldVersionLowerBound,
     OldVersionUpperBound = Constants.OldVersionUpperBound,

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -28,6 +28,11 @@
     <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
   </PropertyGroup>
   <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\Compilers\Core\MSBuildTask\MSBuildTask.csproj">
+      <Project>{d874349c-8bb3-4bdc-8535-2d52ccca1198}</Project>
+      <Name>MSBuildTask</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>


### PR DESCRIPTION
This is a PR to pull 67e059dc into stabilization.

The associated bug is #2854. Without this change, aside from the generally undesirable properties of GACing a Roslyn assembly, the developer machine ETA tests are broken since they load the build task which is GAC'd rather than the build task which has just been built.