### PR TITLE
Remove spaces in section of if statement of cibuild

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -6,8 +6,8 @@ set BuildConfiguration=Debug
 :ParseArguments
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
-if /I "%1" == "/debug" set BuildConfiguration=Debug && shift && goto :ParseArguments
-if /I "%1" == "/release" set BuildConfiguration=Release && shift && goto :ParseArguments
+if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
+if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
 goto :Usage && exit /b 1
 :DoneParsing
 


### PR DESCRIPTION
This was causing BuildConfiguration to become "Release " or "Debug " and thus the script failed later when copying bootstrap files