### PR TITLE
Don't queue parse options compilation tracker action with possible partial semantics.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -827,7 +827,16 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return this.ForkProject(newProject, CompilationTranslationAction.ProjectParseOptions(newProject));
+            if (this.Workspace.PartialSemanticsEnabled)
+            {
+                // don't fork tracker with queued action since access via partial semantics can become inconsistent (throw).
+                // Since changing options is rare event, it is okay to start compilation building from scratch.
+                return this.ForkProject(newProject, forkTracker: false);
+            }
+            else
+            {
+                return this.ForkProject(newProject, CompilationTranslationAction.ProjectParseOptions(newProject));
+            }
         }
 
         private static async Task<Compilation> ReplaceSyntaxTreesWithTreesFromNewProjectStateAsync(Compilation compilation, ProjectState projectState, CancellationToken cancellationToken)
@@ -1742,7 +1751,8 @@ namespace Microsoft.CodeAnalysis
             ProjectState newProjectState,
             CompilationTranslationAction translate = null,
             bool withProjectReferenceChange = false,
-            ImmutableDictionary<string, ImmutableArray<DocumentId>> newLinkedFilesMap = null)
+            ImmutableDictionary<string, ImmutableArray<DocumentId>> newLinkedFilesMap = null,
+            bool forkTracker = true)
         {
             // make sure we are getting only known translate actions
             CompilationTranslationAction.CheckKnownActions(translate);
@@ -1755,10 +1765,15 @@ namespace Microsoft.CodeAnalysis
 
             // If we have a tracker for this project, then fork it as well (along with the
             // translation action and store it in the tracker map.
-            CompilationTracker state;
-            if (newTrackerMap.TryGetValue(projectId, out state))
+            CompilationTracker tracker;
+            if (newTrackerMap.TryGetValue(projectId, out tracker))
             {
-                newTrackerMap = newTrackerMap.Remove(projectId).Add(projectId, state.Fork(newProjectState, translate));
+                newTrackerMap = newTrackerMap.Remove(projectId);
+
+                if (forkTracker)
+                {
+                    newTrackerMap = newTrackerMap.Add(projectId, tracker.Fork(newProjectState, translate));
+                }
             }
 
             var modifiedDocumentOnly = translate is CompilationTranslationAction.TouchDocumentAction;


### PR DESCRIPTION
This change fixes crash Watson bug 1174396.

The crash was due to the construction of a compilation with inconsistent language versions across all syntax trees. This happens when a user changes the language version (via VS tools/options menu), and then completion attempts to work with partial semantics before the new compilation is fully rebuilt. 

When the workspace updates parse options, all documents automatically get updated, so all documents will be reparsed with the new options when next accessed. However, the change in the project only queues the work to incrementally update the compilation when next requested. Yet, the intellisense API uses an internal capability to get the compilation before it is updated and swap in the latest tree from the active document, causing the language versions to now be inconsistent.

The fix is to not queue the work to incrementally update the compilation, but restart the compilation from scratch instead.  This may cause a momentary impairment of the completion list feature immediately following the change in options until the compilation is drawn forward by another full request (such as the background compiler.)

@Pilchie @jasonmalinowski @pharring please review.
