### PR TITLE
changed error list to use SystemBrowser API from VS.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
@@ -19,20 +19,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         private readonly string _id;
         private readonly bool _logIdVerbatimInTelemetry;
 
-        private readonly IServiceProvider _serviceProvider;
-
         private bool _isExpanded;
         private double _heightForThreeLineTitle;
         private IWpfDifferenceViewer _previewDiffViewer;
 
         public PreviewPane(Image severityIcon, string id, string title, string description, Uri helpLink, string helpLinkToolTipText,
-            object previewContent, bool logIdVerbatimInTelemetry, IServiceProvider serviceProvider)
+            object previewContent, bool logIdVerbatimInTelemetry)
         {
             InitializeComponent();
 
             _id = id;
             _logIdVerbatimInTelemetry = logIdVerbatimInTelemetry;
-            _serviceProvider = serviceProvider;
 
             // Initialize header portion.
             if ((severityIcon != null) && !string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(title))
@@ -236,7 +233,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 return;
             }
 
-            BrowserHelper.StartBrowser(_serviceProvider, e.Uri);
+            BrowserHelper.StartBrowser(e.Uri);
             e.Handled = true;
 
             var hyperlink = sender as Hyperlink;

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -21,14 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
     [ExportWorkspaceServiceFactory(typeof(IPreviewPaneService), ServiceLayer.Host), Shared]
     internal class PreviewPaneService : ForegroundThreadAffinitizedObject, IPreviewPaneService, IWorkspaceServiceFactory
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        [ImportingConstructor]
-        public PreviewPaneService(SVsServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
         IWorkspaceService IWorkspaceServiceFactory.CreateService(HostWorkspaceServices workspaceServices)
         {
             return this;
@@ -103,7 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 
                 return new PreviewPane(
                     severityIcon: null, id: null, title: null, description: null, helpLink: null, helpLinkToolTipText: null,
-                    previewContent: previewContent, logIdVerbatimInTelemetry: false, serviceProvider: _serviceProvider);
+                    previewContent: previewContent, logIdVerbatimInTelemetry: false);
             }
 
             var helpLinkToolTipText = string.Empty;
@@ -116,8 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 helpLink: helpLink,
                 helpLinkToolTipText: helpLinkToolTipText,
                 previewContent: previewContent,
-                logIdVerbatimInTelemetry: diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
-                serviceProvider: _serviceProvider);
+                logIdVerbatimInTelemetry: diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/UriNavigator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/UriNavigator.cs
@@ -15,19 +15,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     {
         private static UriNavigator s_instance;
 
-        private IServiceProvider _serviceProvider;
-
-        public UriNavigator(IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
         public static void AttachRequestNaviateEventHandler(Hyperlink hyperLink, IServiceProvider serviceProvider)
         {
             if (s_instance == null)
             {
                 // this has a race, so we might end up have more than one navigator. but it shouldn't matter.
-                s_instance = new UriNavigator(serviceProvider);
+                s_instance = new UriNavigator();
             }
 
             hyperLink.RequestNavigate += s_instance.OnRequestNavigate;
@@ -40,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 return;
             }
 
-            BrowserHelper.StartBrowser(_serviceProvider, e.Uri);
+            BrowserHelper.StartBrowser(e.Uri);
             e.Handled = true;
 
             var hyperlink = sender as Hyperlink;

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/BrowserHelper.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/BrowserHelper.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
@@ -38,34 +39,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
             return new Uri(string.Format(BingSearchString, errorCode + " " + title));
         }
 
-        public static void StartBrowser(IServiceProvider serviceProvider, Uri uri)
+        public static void StartBrowser(Uri uri)
         {
-            if (!TryStartBrowser(serviceProvider, uri))
-            {
-                StartBrowser(uri);
-            }
-        }
-
-        private static bool TryStartBrowser(IServiceProvider serviceProvider, Uri uri)
-        {
-            var browserService = serviceProvider.GetService(typeof(SVsWebBrowsingService)) as IVsWebBrowsingService;
-            if (browserService == null)
-            {
-                return false;
-            }
-
-            return TryStartBrowser(browserService, uri);
-        }
-
-        private static bool TryStartBrowser(IVsWebBrowsingService service, Uri uri)
-        {
-            IVsWindowFrame unused;
-            return ErrorHandler.Succeeded(service.Navigate(uri.AbsoluteUri, 0, out unused));
-        }
-
-        private static void StartBrowser(Uri uri)
-        {
-            Process.Start(new ProcessStartInfo(uri.AbsoluteUri));
+            VsShellUtilities.OpenSystemBrowser(uri.AbsoluteUri);
         }
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -483,7 +483,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             var uri = _tracker.SelectedDiagnosticItems[0].GetHelpLink();
             if (uri != null)
             {
-                BrowserHelper.StartBrowser(_serviceProvider, uri);
+                BrowserHelper.StartBrowser(uri);
             }
         }
 


### PR DESCRIPTION
Customer scenario: When an user click on a link in the error list\lightbulb\solution explorer, today we open the link in the VS browser. We had done this to be consistent with F1 in the error list which opens in the VS browser. Given that we navigate to bing and potentially from there to other sites, it would be best to open the links in the system browser. The platform team recently made it so that we could launch in Edge on windows 10. Without this change, we'll be stuck in IE7 quirks mode forever and we've seen reports of people complaining about websites which don't open well in the VS browser.

Fix is to make a different VS call (most of the change is removing the unnecessary IServiceProvider parameter now)

...

manual test is done to verify it opens up system browser. and debugged to make sure we are calling right Platform APIs.

this fix basically get rid of our own implementation and call VS API directly.