### PR TITLE
made internal data structure to care about dll versions

### DIFF
--- a/src/Features/Core/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Diagnostics/AnalyzerHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Get the unique ID for given diagnostic analyzer.
             // note that we also put version stamp so that we can detect changed analyzer.
             var type = analyzer.GetType();
-            return ValueTuple.Create(GetAssemblyQualifiedNameWithoutVersion(type), GetAnalyzerVersion(type.Assembly.Location));
+            return ValueTuple.Create(GetAssemblyQualifiedName(type), GetAnalyzerVersion(type.Assembly.Location));
         }
 
         public static string GetAnalyzerAssemblyName(this DiagnosticAnalyzer analyzer)
@@ -50,16 +50,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return type.Assembly.GetName().Name;
         }
 
-        private static string GetAssemblyQualifiedNameWithoutVersion(Type type)
+        private static string GetAssemblyQualifiedName(Type type)
         {
-            var name = type.AssemblyQualifiedName;
-            var versionIndex = name.IndexOf(", Version=", StringComparison.InvariantCultureIgnoreCase);
-            if (versionIndex < 0)
-            {
-                return name;
-            }
-
-            return name.Substring(0, versionIndex);
+            // AnalyzerFileReference now includes things like versions, public key as part of its identity. 
+            // so we need to consider them.
+            return type.AssemblyQualifiedName;
         }
 
         internal static AnalyzerExecutor GetAnalyzerExecutorForSupportedDiagnostics(


### PR DESCRIPTION
we have changed AnalyzerFileReference.Id to include versions, public keys and etc as its identity.

some internal data structure that generates string from it didn't changed accordingly.

this should fix the issue.