### PR TITLE
Add a missing null check in UnboundIdentifiersDiagnosticAnalyzer.ConstructorDoesNotExist

### DIFF
--- a/src/Features/CSharp/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
 
         protected override bool ConstructorDoesNotExist(SyntaxNode node, SymbolInfo info, SemanticModel model)
         {
-            var argList = (node.Parent as ObjectCreationExpressionSyntax)?.ArgumentList.Arguments;
+            var argList = (node.Parent as ObjectCreationExpressionSyntax)?.ArgumentList?.Arguments;
             if (!argList.HasValue)
             {
                 return false;

--- a/src/Features/VisualBasic/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics
         End Property
 
         Protected Overrides Function ConstructorDoesNotExist(node As SyntaxNode, info As SymbolInfo, semanticModel As SemanticModel) As Boolean
-            Dim arguments = (TryCast(node.Parent, ObjectCreationExpressionSyntax)?.ArgumentList.Arguments)
+            Dim arguments = (TryCast(node.Parent, ObjectCreationExpressionSyntax)?.ArgumentList?.Arguments)
             If Not arguments.HasValue Then
                 Return False
             End If


### PR DESCRIPTION
User scenario: IDE built-in analyzer UnboundIdentifiersDiagnosticAnalyzer throws a null reference exception and gets disabled with an exception diagnostic in the error list. Note that this analyzer is always enabled by default for all C# and VB projects.

Fix description: Add a missing null check when computing arguments for object creation expression.

Fixes #3027 

Testing done: Existing tests

/cc @ManishJayaswal @srivatsn This is for 1.0 (stable).