### PR TITLE
Don't restart on failed connection sequence

### DIFF
--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 // Unable to establish a connection with the client.  The client is responsible for
                 // handling this case.  Nothing else for us to do here.
                 CompilerServerLogger.LogException(ex, "Error creating client named pipe");
-                return new ConnectionData(CompletionReason.ClientDisconnect);
+                return new ConnectionData(CompletionReason.CompilationNotStarted);
             }
 
             return await connection.ServeConnection(cancellationToken).ConfigureAwait(false);

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -267,7 +267,7 @@ class Hello
 
             tcs.SetException(new Exception());
             var connectionData = await connectionDataTask.ConfigureAwait(false);
-            Assert.Equal(ServerDispatcher.CompletionReason.ClientDisconnect, connectionData.CompletionReason);
+            Assert.Equal(ServerDispatcher.CompletionReason.CompilationNotStarted, connectionData.CompletionReason);
             Assert.Null(connectionData.KeepAlive);
         }
 


### PR DESCRIPTION
The compiler should not enter a passive shut down mode in the case where
a client connects and disconnects before it can send any request data.

This fix is a part of our AusGov perf work.  In that scenario we have a
high number of compilations running in parallel.  On medium sized
machines it is possible for the server to quickly become computation
bound and slow to respond to connection requests.  The client will break
off a connection attempt after one second and revert to a straight
command line build.

Before this change we would also restart the server in this case.  That
adds extra overhead because it will be restarted by a later client
request.  With this fix we just keep the server running in this
scenario.

The original intent of passive shut down was to handle Ctrl+C scenarios.
The user hits Ctrl+C and all computation should go away, including the
server.  A failed connection attempt shouldn't be treated as Ctrl+C.