### PR TITLE
Add regression test for bug #2671.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -3938,5 +3938,27 @@ End Class
 
             Test(code, expected, compareTokens:=False)
         End Sub
+
+        <WorkItem(2671, "https://github.com/dotnet/roslyn/issues/2671")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub ReplaceReferencesInWithBlocks()
+            Dim code =
+<MethodBody>
+Dim [||]s As String = "test"
+With s
+    .ToLower()
+End With
+</MethodBody>
+
+            Dim expected =
+<MethodBody>
+With "test"
+    Call .ToLower()
+End With
+</MethodBody>
+            ' Introduction of the Call keyword in this scenario is by design, see bug 529694.
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
#2671 was fixed (not sure where or how) in the past week or two. This PR adds regression test for the scenario.

Fixes #2671 