### PR TITLE
Use block indentation not token alignment rule for multiline lambdas

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -1725,7 +1725,7 @@ End Module
             AssertSmartIndent(
                 code,
                 indentationLine:=4,
-                expectedIndentation:=24)
+                expectedIndentation:=16)
         End Sub
 
         <Fact>

--- a/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
@@ -2655,7 +2655,7 @@ Class Test
 
         ' Without End Function
         Dim last = Async Function() As Task(Of Integer)    ' Trailing
-        End Function
+                   End Function
 End Class";
 
             Verify(code, expected);
@@ -2723,7 +2723,7 @@ Class Test
 
         ' Without End Function
         Dim last = Iterator Function() As IEnumerable(Of Integer)    ' Trailing
-        End Function
+                   End Function
 End Class";
 
             Verify(code, expected);

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
@@ -363,7 +363,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 node = node.Parent
             End While
             Return False
-            'Return node.AncestorsAndSelf().Any(Function(n) TypeOf n Is SingleLineLambdaExpressionSyntax)
         End Function
 
         Private Function PartOfMultilineLambdaFooter(node As SyntaxNode) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
@@ -357,7 +357,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         Private Function PartOfSingleLineLambda(node As SyntaxNode) As Boolean
-            Return node.AncestorsAndSelf().Any(Function(n) TypeOf n Is SingleLineLambdaExpressionSyntax)
+            While node IsNot Nothing
+                If TypeOf node Is MultiLineLambdaExpressionSyntax Then Return False
+                If TypeOf node Is SingleLineLambdaExpressionSyntax Then Return True
+                node = node.Parent
+            End While
+            Return False
+            'Return node.AncestorsAndSelf().Any(Function(n) TypeOf n Is SingleLineLambdaExpressionSyntax)
         End Function
 
         Private Function PartOfMultilineLambdaFooter(node As SyntaxNode) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AlignTokensFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AlignTokensFormattingRule.vb
@@ -28,15 +28,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 End If
                 Return
             End If
-
-            Dim multiLineLambda = TryCast(node, MultiLineLambdaExpressionSyntax)
-            If multiLineLambda IsNot Nothing Then
-                Dim baseToken = multiLineLambda.SubOrFunctionHeader.GetFirstToken(includeZeroWidth:=True)
-                Dim tokenToAlign = multiLineLambda.EndSubOrFunctionStatement.GetFirstToken(includeZeroWidth:=True)
-
-                AddAlignIndentationOfTokensToBaseTokenOperation(operations, multiLineLambda, baseToken, SpecializedCollections.SingletonEnumerable(tokenToAlign))
-                Return
-            End If
         End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
@@ -119,6 +119,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 Dim baseToken = multiLineLambda.SubOrFunctionHeader.GetFirstToken(includeZeroWidth:=True)
                 Dim lastBeginningToken = If(multiLineLambda.SubOrFunctionHeader.GetLastToken().Kind = SyntaxKind.None, multiLineLambda.SubOrFunctionHeader.GetLastToken(includeZeroWidth:=True), multiLineLambda.SubOrFunctionHeader.GetLastToken())
 
+                SetAlignmentBlockOperation(operations, baseToken,
+                                        baseToken.GetNextToken(includeZeroWidth:=True),
+                                        multiLineLambda.GetLastToken(includeZeroWidth:=True))
+
                 AddIndentBlockOperation(operations, baseToken,
                                         lastBeginningToken.GetNextToken(includeZeroWidth:=True),
                                         multiLineLambda.EndSubOrFunctionStatement.GetFirstToken(includeZeroWidth:=True).GetPreviousToken(includeZeroWidth:=True))


### PR DESCRIPTION
Fixes #3092 

There are two different ways to get token/lines to align with each other in a formatting rule.  One is to use the align tokens operation and the other is to use the block indentation operation.  Unfortunately, the align token operation is not property plumbed all the way down to the trivia formatters that get used when there are intervening comments, so it gets ignored and ends up aligning against the indentation rules. Ideally, this would get fixed so that the alignment operation is honored.  However, this problem can also be fixed by switching to using a block indentation operation like xml literal blocks use.

@heejaechang @Pilchie please review