### PR TITLE
don't try to create an outlining span if valid start/end tokens can't be found

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/Outliners/MetadataAsSource/AbstractMetadataAsSourceOutliner.cs
+++ b/src/EditorFeatures/CSharp/Outlining/Outliners/MetadataAsSource/AbstractMetadataAsSourceOutliner.cs
@@ -17,6 +17,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining.MetadataAsSource
             var startToken = node.GetFirstToken();
             var endToken = GetEndToken(node);
 
+            if (startToken.Kind() == SyntaxKind.None || endToken.Kind() == SyntaxKind.None)
+            {
+                // if valid tokens can't be found then a meaningful span can't be generated
+                return;
+            }
+
             var firstComment = startToken.LeadingTrivia.FirstOrNullable(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia);
 
             var startPosition = firstComment.HasValue ? firstComment.Value.SpanStart : startToken.SpanStart;

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Outlining\MetadataAsSource\EventFieldDeclarationOutlinerTests.cs" />
     <Compile Include="Outlining\MetadataAsSource\FieldDeclarationOutlinerTests.cs" />
     <Compile Include="Outlining\MetadataAsSource\IndexerDeclarationOutlinerTests.cs" />
+    <Compile Include="Outlining\MetadataAsSource\InvalidIdentifierTests.cs" />
     <Compile Include="Outlining\MetadataAsSource\MethodDeclarationOutlinerTests.cs" />
     <Compile Include="Outlining\MetadataAsSource\OperatorDeclarationOutlinerTests.cs" />
     <Compile Include="Outlining\MetadataAsSource\PropertyDeclarationOutlinerTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/InvalidIdentifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/InvalidIdentifierTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Editor.Implementation.Outlining;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining.MetadataAsSource
+{
+    /// <summary>
+    /// Identifiers coming from IL can be just about any valid string and since C# doesn't have a way to escape all possible
+    /// IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparsable code.
+    /// </summary>
+    public class InvalidIdentifierTests : AbstractOutlinerTests
+    {
+        private void Test(string fileContents, params OutliningSpan[] expectedSpans)
+        {
+            var workspace = TestWorkspaceFactory.CreateWorkspaceFromFiles(WorkspaceKind.MetadataAsSource, LanguageNames.CSharp, null, null, fileContents);
+            var outliningService = workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService<IOutliningService>();
+            var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
+            var actualOutliningSpans = outliningService.GetOutliningSpansAsync(document, CancellationToken.None).Result.Where(s => s != null).ToArray();
+
+            Assert.Equal(expectedSpans.Length, actualOutliningSpans.Length);
+            for (int i = 0; i < expectedSpans.Length; i++)
+            {
+                AssertRegion(expectedSpans[i], actualOutliningSpans[i]);
+            }
+        }
+
+        [WorkItem(1174405)]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public void PrependedDollarSign()
+        {
+            var source = @"
+class C
+{
+    public void $Invoke();
+}";
+            Test(source);
+        }
+
+        [WorkItem(1174405)]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public void SymbolsAndPunctuation()
+        {
+            var source = @"
+class C
+{
+    public void !#$%^&*(()_-+=|\}]{[""':;?/>.<,~`();
+}";
+            Test(source);
+        }
+
+        [WorkItem(1174405)]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public void IdentifierThatLooksLikeCode()
+        {
+            var source = @"
+class C
+{
+    public void } } public class CodeInjection{ } /* now everything is commented ();
+}";
+            Test(source);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.CSharp.Outlining;
@@ -105,23 +104,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining.MetadataAsSou
                 autoCollapse: true);
 
             AssertRegion(expectedRegion, actualRegion);
-        }
-
-        [WorkItem(1174405)]
-        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
-        public void WithNonIdentifierNames()
-        {
-            // methods from metadata could have names that don't parse as a valid C# identifier
-            var tree = ParseCode(
-@"class Interop
-{
-    public void $Invoke();
-}");
-            var typeDecl = tree.DigToFirstTypeDeclaration();
-            var method = typeDecl.DigToFirstNodeOfType<MethodDeclarationSyntax>();
-
-            var regions = GetRegions(method);
-            Assert.Equal(0, regions.Count());
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
@@ -111,12 +111,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining.MetadataAsSou
         [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
         public void WithNonIdentifierNames()
         {
-            // methods from metadata could have names that don't parse as a valid C#/VB identifier
+            // methods from metadata could have names that don't parse as a valid C# identifier
             var tree = ParseCode(
 @"class Interop
 {
-    public Interop();
-
     public void $Invoke();
 }");
             var typeDecl = tree.DigToFirstTypeDeclaration();

--- a/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.CSharp.Outlining;
@@ -104,6 +105,25 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining.MetadataAsSou
                 autoCollapse: true);
 
             AssertRegion(expectedRegion, actualRegion);
+        }
+
+        [WorkItem(1174405)]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public void WithNonIdentifierNames()
+        {
+            // methods from metadata could have names that don't parse as a valid C#/VB identifier
+            var tree = ParseCode(
+@"class Interop
+{
+    public Interop();
+
+    public void $Invoke();
+}");
+            var typeDecl = tree.DigToFirstTypeDeclaration();
+            var method = typeDecl.DigToFirstNodeOfType<MethodDeclarationSyntax>();
+
+            var regions = GetRegions(method);
+            Assert.Equal(0, regions.Count());
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -350,6 +350,7 @@
     <Compile Include="Outlining\MetadataAsSource\EnumMemberDeclarationOutlinerTests.vb" />
     <Compile Include="Outlining\MetadataAsSource\EventDeclarationOutlinerTests.vb" />
     <Compile Include="Outlining\MetadataAsSource\FieldDeclarationOutlinerTests.vb" />
+    <Compile Include="Outlining\MetadataAsSource\InvalidIdentifierTests.vb" />
     <Compile Include="Outlining\MetadataAsSource\MethodDeclarationOutlinerTests.vb" />
     <Compile Include="Outlining\MetadataAsSource\OperatorDeclarationOutlinerTests.vb" />
     <Compile Include="Outlining\MetadataAsSource\PropertyDeclarationOutlinerTests.vb" />

--- a/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/InvalidIdentifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/InvalidIdentifierTests.vb
@@ -1,0 +1,61 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Editor.Implementation.Outlining
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining.MetadataAsSource
+    ''' <summary>
+    ''' Identifiers coming from IL can be just about any valid string and since VB doesn't have a way to escape all possible
+    ''' IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparsable code.
+    ''' </summary>
+    Public Class InvalidIdentifierTests
+        Inherits AbstractOutlinerTests
+
+        Private Sub Test(fileContents As String, ParamArray ByVal expectedSpans As OutliningSpan())
+            Dim workspace = TestWorkspaceFactory.CreateWorkspaceFromFiles(WorkspaceKind.MetadataAsSource, LanguageNames.VisualBasic, Nothing, Nothing, fileContents)
+            Dim outliningService = workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService(Of IOutliningService)()
+            Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
+            Dim actualOutliningSpans = outliningService.GetOutliningSpansAsync(document, CancellationToken.None).Result.Where(Function(s) s IsNot Nothing).ToArray()
+
+            Assert.Equal(expectedSpans.Length, actualOutliningSpans.Length)
+            For i As Integer = 0 To expectedSpans.Length - 1
+                AssertRegion(expectedSpans(i), actualOutliningSpans(i))
+            Next
+        End Sub
+
+        <WorkItem(1174405)>
+        <Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)>
+        Public Sub PrependDollarSign()
+            Dim source = "
+Class C
+    Public Sub $Invoke()
+End Class
+"
+            Test(source)
+        End Sub
+
+        <WorkItem(1174405)>
+        <Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)>
+        Public Sub SymbolsAndPunctuation()
+            Dim source = "
+Class C
+    Public Sub !#$%^&*(()_-+=|\}]{[""':;?/>.<,~`()
+End Class
+"
+            Test(source)
+        End Sub
+
+        <WorkItem(1174405)>
+        <Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)>
+        Public Sub IdentifierThatLooksLikeCode()
+            Dim source = "
+Class C
+    Public Sub : End Sub : End Class "" now the document is a string until the next quote ()
+End Class
+"
+            Test(source)
+        End Sub
+
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.vb
@@ -109,5 +109,22 @@ End Class
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub
+
+        <WorkItem(1174405)>
+        <Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)>
+        Public Sub WithNonIdentifierNames()
+            ' methods from metadata could have names that don't parse as a valid VB identifier
+            Dim code =
+<code><![CDATA[
+Class Interop
+    Public Sub $Invoke()
+End Class
+]]></code>
+
+            Dim methodStatement As MethodStatementSyntax = GetMethodStatement(code)
+
+            Dim regions = GetRegions(methodStatement)
+            Assert.Equal(0, regions.Count())
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/MethodDeclarationOutlinerTests.vb
@@ -109,22 +109,5 @@ End Class
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub
-
-        <WorkItem(1174405)>
-        <Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)>
-        Public Sub WithNonIdentifierNames()
-            ' methods from metadata could have names that don't parse as a valid VB identifier
-            Dim code =
-<code><![CDATA[
-Class Interop
-    Public Sub $Invoke()
-End Class
-]]></code>
-
-            Dim methodStatement As MethodStatementSyntax = GetMethodStatement(code)
-
-            Dim regions = GetRegions(methodStatement)
-            Assert.Equal(0, regions.Count())
-        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
The issue arises when a metadata reference contains type/method/property/etc. names that aren't valid C#/VB identifiers, then the outliner is unable to properly parse the document and can't get appropriate start/end tokens.  The same code path will be hit for all **[C#] x [method, property, field, etc.]** or **[VB] x [method, property, field, etc.]** metadata as source outliners, so only one test was created for each language.

Fixes internal bug 1174405.

Tagging @Pilchie @dpoeschl @jasonmalinowski @DustinCampbell @rchande @balajikris @jmarolf @davkean as reviewers.