### PR TITLE
The mapping to metadata should use the original anonymous type map, not the map translated to the previous generation

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -102,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Emit
             var moduleVersionId = module.GetModuleVersionId();
 
             return new EmitBaseline(
+                null,
                 module,
                 compilation: null,
                 moduleBuilder: null,
@@ -130,11 +131,16 @@ namespace Microsoft.CodeAnalysis.Emit
                 methodImpls: CalculateMethodImpls(reader));
         }
 
+        internal EmitBaseline InitialBaseline { get; }
+
         /// <summary>
         /// The original metadata of the module.
         /// </summary>
         public ModuleMetadata OriginalMetadata { get; }
 
+        // Anonymous types extracted from metadata. Lazy since we don't know the language at the time the baseline is constructed.
+        internal IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> LazyOriginalMetadataAnonymousTypeMap;
+        
         internal readonly Compilation Compilation;
         internal readonly CommonPEModuleBuilder PEModuleBuilder;
         internal readonly Guid ModuleVersionId;
@@ -182,10 +188,11 @@ namespace Microsoft.CodeAnalysis.Emit
         internal readonly IReadOnlyDictionary<uint, uint> TypeToEventMap;
         internal readonly IReadOnlyDictionary<uint, uint> TypeToPropertyMap;
         internal readonly IReadOnlyDictionary<MethodImplKey, uint> MethodImpls;
-        internal readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypeMap;
+        private readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> _anonymousTypeMap;
         internal readonly ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> SynthesizedMembers;
 
         private EmitBaseline(
+            EmitBaseline initialBaseline,
             ModuleMetadata module,
             Compilation compilation,
             CommonPEModuleBuilder moduleBuilder,
@@ -215,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Emit
         {
             Debug.Assert(module != null);
             Debug.Assert((ordinal == 0) == (encId == default(Guid)));
+            Debug.Assert((ordinal == 0) == (initialBaseline == null));
             Debug.Assert(encId != module.GetModuleVersionId());
             Debug.Assert(debugInformationProvider != null);
             Debug.Assert(typeToEventMap != null);
@@ -239,6 +247,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
             var reader = module.Module.MetadataReader;
 
+            this.InitialBaseline = initialBaseline ?? this;
             this.OriginalMetadata = module;
             this.Compilation = compilation;
             this.PEModuleBuilder = moduleBuilder;
@@ -259,7 +268,7 @@ namespace Microsoft.CodeAnalysis.Emit
             this.StringStreamLengthAdded = stringStreamLengthAdded;
             this.UserStringStreamLengthAdded = userStringStreamLengthAdded;
             this.GuidStreamLengthAdded = guidStreamLengthAdded;
-            this.AnonymousTypeMap = anonymousTypeMap;
+            this._anonymousTypeMap = anonymousTypeMap;
             this.SynthesizedMembers = synthesizedMembers;
             this.AddedOrChangedMethods = methodsAddedOrChanged;
 
@@ -293,10 +302,11 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<uint, AddedOrChangedMethodInfo> addedOrChangedMethods,
             Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider)
         {
-            Debug.Assert((this.AnonymousTypeMap == null) || (anonymousTypeMap != null));
-            Debug.Assert((this.AnonymousTypeMap == null) || (anonymousTypeMap.Count >= this.AnonymousTypeMap.Count));
+            Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap != null);
+            Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap.Count >= _anonymousTypeMap.Count);
 
             return new EmitBaseline(
+                this.InitialBaseline,
                 this.OriginalMetadata,
                 compilation,
                 moduleBuilder,
@@ -325,35 +335,18 @@ namespace Microsoft.CodeAnalysis.Emit
                 methodImpls: this.MethodImpls);
         }
 
-        internal EmitBaseline WithAnonymousTypeMap(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
+        internal IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypeMap
         {
-            return new EmitBaseline(
-                this.OriginalMetadata,
-                this.Compilation,
-                this.PEModuleBuilder,
-                this.ModuleVersionId,
-                this.Ordinal,
-                this.EncId,
-                this.TypesAdded,
-                this.EventsAdded,
-                this.FieldsAdded,
-                this.MethodsAdded,
-                this.PropertiesAdded,
-                this.EventMapAdded,
-                this.PropertyMapAdded,
-                this.MethodImplsAdded,
-                this.TableEntriesAdded,
-                this.BlobStreamLengthAdded,
-                this.StringStreamLengthAdded,
-                this.UserStringStreamLengthAdded,
-                this.GuidStreamLengthAdded,
-                anonymousTypeMap,
-                this.SynthesizedMembers,
-                this.AddedOrChangedMethods,
-                this.DebugInformationProvider,
-                this.TypeToEventMap,
-                this.TypeToPropertyMap,
-                this.MethodImpls);
+            get
+            {
+                if (Ordinal > 0)
+                {
+                    return _anonymousTypeMap;
+                }
+
+                Debug.Assert(LazyOriginalMetadataAnonymousTypeMap != null);
+                return LazyOriginalMetadataAnonymousTypeMap;
+            }
         }
 
         internal MetadataReader MetadataReader


### PR DESCRIPTION
Fixes internal bug 1170706: 2nd edit of a method containing anonymous types produced an invalid TypeRef leading to a crash in EE.

**Scenario**
```
using System;
class Program
{
    static void Main(string[] args)
    {
        var v = new { A = 1, B = true };
    }
}
```
Update the method twice and then evaluate expression in EE, which crashes.
This issue also leads to locals disappearing after 2 edits.

**Tests**
Added unit tests. Manually verified the scenario works now.

@ManishJayaswal 