### PR TITLE
Handle out parameters in cross-language scenarios

### DIFF
--- a/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
+++ b/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
@@ -512,7 +512,7 @@ class D
         }
 
         [Fact]
-        public void TestMethodsAreNotEquivalentOutToRef()
+        public void TestMethodsAreEquivalentOutToRef()
         {
             var csharpCode1 =
 @"class Type1
@@ -534,7 +534,7 @@ class D
                 var method_v1 = type1_v1.GetMembers("Foo").Single();
                 var method_v2 = type1_v2.GetMembers("Foo").Single();
 
-                Assert.False(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+                Assert.True(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
             }
         }
 
@@ -1147,6 +1147,47 @@ class Type1
             }
         }
 
+        [WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")]
+        [Fact]
+        public void TestRefVersusOut()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M(out int i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M(ref int i) { }
+}";
+
+            using (var workspace1 = CSharpWorkspaceFactory.CreateWorkspaceFromLines(csharpCode1))
+            using (var workspace2 = CSharpWorkspaceFactory.CreateWorkspaceFromLines(csharpCode2))
+            {
+                var type1_v1 = workspace1.CurrentSolution.Projects.Single().GetCompilationAsync().Result.GlobalNamespace.GetTypeMembers("C").Single();
+                var type1_v2 = workspace2.CurrentSolution.Projects.Single().GetCompilationAsync().Result.GlobalNamespace.GetTypeMembers("C").Single();
+
+                var method_v1 = type1_v1.GetMembers("M").Single();
+                var method_v2 = type1_v2.GetMembers("M").Single();
+
+                var trueComp = new SymbolEquivalenceComparer(assemblyComparerOpt: null, distinguishRefFromOut: true);
+                var falseComp = new SymbolEquivalenceComparer(assemblyComparerOpt: null, distinguishRefFromOut: false);
+
+                Assert.False(trueComp.Equals(method_v1, method_v2));
+                Assert.False(trueComp.Equals(method_v2, method_v1));
+                // The hashcodes of distinct objects don't have to be distinct.
+
+                Assert.True(falseComp.Equals(method_v1, method_v2));
+                Assert.True(falseComp.Equals(method_v2, method_v1));
+                Assert.Equal(falseComp.GetHashCode(method_v1),
+                             falseComp.GetHashCode(method_v2));
+            }
+        }
+
         [Fact]
         public void TestCSharpReducedExtensionMethodsAreEquivalent()
         {
@@ -1338,7 +1379,7 @@ End Class
             var tb2 = (ITypeSymbol)b2.GlobalNamespace.GetMembers("T").Single();
             var tb3 = (ITypeSymbol)b3.GlobalNamespace.GetMembers("T").Single();
 
-            var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance);
+            var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false);
 
             // same name:
             Assert.True(SymbolEquivalenceComparer.IgnoreAssembliesInstance.Equals(ta1, ta2));
@@ -1428,7 +1469,7 @@ End Class
             var type1 = (ITypeSymbol)c1.GlobalNamespace.GetMembers("C").Single();
             var type2 = (ITypeSymbol)c2.GlobalNamespace.GetMembers("C").Single();
 
-            var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance);
+            var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false);
 
             var f1 = type1.GetMembers("F");
             var f2 = type2.GetMembers("F");

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -1453,7 +1453,7 @@ class C : I
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Sub TestCascadeOrdinaryMethod_RefOut2()
+        Public Sub TestCascadeOrdinaryMethod_RefOut2_Success()
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1468,6 +1468,38 @@ interface I
 class C : I
 {
   public void Foo(out System.Int32 j)
+  {
+  }
+
+  void I.{|Definition:Foo|}(ref System.Int32 j) 
+  {
+  }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestCascadeOrdinaryMethod_RefOut2_Error()
+            ' In non-compiling code, finding an almost-matching definition
+            ' seems reasonable.
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+using System.Collections.Generic;
+interface I
+{
+  void {|Definition:$$Foo|}(ref int i);
+}
+
+class C : I
+{
+  public void {|Definition:Foo|}(out System.Int32 j)
   {
   }
 }
@@ -2695,6 +2727,146 @@ class Class2
         c.[|Foo|](x);
     }
 }]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(input)
+        End Sub
+
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestRefKindRef_FromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="Lib" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+
+public class C
+{
+    public static void {|Definition:$$M|}(ref int x) { }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="Test" CommonReferences="true">
+        <ProjectReference>Lib</ProjectReference>
+        <Document><![CDATA[
+Imports System
+
+Class Test
+    Sub M()
+        Dim x As Integer = 0
+        C.[|M|](x)
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(input)
+        End Sub
+
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestRefKindRef_FromReference()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="Lib" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+
+public class C
+{
+    public static void {|Definition:M|}(ref int x) { }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="Test" CommonReferences="true">
+        <ProjectReference>Lib</ProjectReference>
+        <Document><![CDATA[
+Imports System
+
+Class Test
+    Sub M()
+        Dim x As Integer = 0
+        C.[|$$M|](x)
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(input)
+        End Sub
+
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestRefKindOut_FromDefinition()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="Lib" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+
+public class C
+{
+    public static void {|Definition:$$M|}(out int x) { }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="Test" CommonReferences="true">
+        <ProjectReference>Lib</ProjectReference>
+        <Document><![CDATA[
+Imports System
+
+Class Test
+    Sub M()
+        Dim x As Integer = 0
+        C.[|M|](x)
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(input)
+        End Sub
+
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestRefKindOut_FromReference()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="Lib" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+
+public class C
+{
+    public static void {|Definition:M|}(out int x) { }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="Test" CommonReferences="true">
+        <ProjectReference>Lib</ProjectReference>
+        <Document><![CDATA[
+Imports System
+
+Class Test
+    Sub M()
+        Dim x As Integer = 0
+        C.[|$$M|](x)
+    End Sub
+End Class
+]]>
         </Document>
     </Project>
 </Workspace>

--- a/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
@@ -137,5 +137,81 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 Assert.True(mappedMember.Locations.All(Function(Loc) Loc.IsInSource))
             End Using
         End Sub
+
+        <Fact>
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        Public Sub FindMethodInVisualBasicToCSharpProject_RefKindRef()
+            Dim workspaceDefinition =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+            namespace N
+            {
+                public class CSClass
+                {
+                    public void M(ref int i) { }
+                }
+            }
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+        <ProjectReference>CSharpAssembly</ProjectReference>
+        <Document>
+        </Document>
+    </Project>
+</Workspace>
+
+            Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceDefinition)
+                Dim compilation = GetProject(workspace.CurrentSolution, "VBAssembly").GetCompilationAsync().Result
+                Dim member = compilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single().GetMembers("M").Single()
+
+                Assert.Equal(LanguageNames.VisualBasic, member.Language)
+                Assert.True(member.Locations.All(Function(Loc) Loc.IsInMetadata))
+
+                Dim mappedMember = SymbolFinder.FindSourceDefinitionAsync(member, workspace.CurrentSolution, CancellationToken.None).Result
+                Assert.NotNull(mappedMember)
+
+                Assert.Equal(LanguageNames.CSharp, mappedMember.Language)
+                Assert.True(mappedMember.Locations.All(Function(Loc) Loc.IsInSource))
+            End Using
+        End Sub
+
+        <Fact>
+        <WorkItem(599, "https://github.com/dotnet/roslyn/issues/599")>
+        Public Sub FindMethodInVisualBasicToCSharpProject_RefKindOut()
+            Dim workspaceDefinition =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+            namespace N
+            {
+                public class CSClass
+                {
+                    public void M(out int i) { }
+                }
+            }
+        </Document>
+    </Project>
+    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+        <ProjectReference>CSharpAssembly</ProjectReference>
+        <Document>
+        </Document>
+    </Project>
+</Workspace>
+
+            Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceDefinition)
+                Dim compilation = GetProject(workspace.CurrentSolution, "VBAssembly").GetCompilationAsync().Result
+                Dim member = compilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single().GetMembers("M").Single()
+
+                Assert.Equal(LanguageNames.VisualBasic, member.Language)
+                Assert.True(member.Locations.All(Function(Loc) Loc.IsInMetadata))
+
+                Dim mappedMember = SymbolFinder.FindSourceDefinitionAsync(member, workspace.CurrentSolution, CancellationToken.None).Result
+                Assert.NotNull(mappedMember)
+
+                Assert.Equal(LanguageNames.CSharp, mappedMember.Language)
+                Assert.True(mappedMember.Locations.All(Function(Loc) Loc.IsInSource))
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1950,7 +1950,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        protected static readonly SymbolEquivalenceComparer s_assemblyEqualityComparer = new SymbolEquivalenceComparer(AssemblyEqualityComparer.Instance);
+        protected static readonly SymbolEquivalenceComparer s_assemblyEqualityComparer = new SymbolEquivalenceComparer(AssemblyEqualityComparer.Instance, distinguishRefFromOut: true);
 
         protected static bool SignaturesEquivalent(ImmutableArray<IParameterSymbol> oldParameters, ITypeSymbol oldReturnType, ImmutableArray<IParameterSymbol> newParameters, ITypeSymbol newReturnType)
         {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.ParameterSymbolEqualityComparer.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.ParameterSymbolEqualityComparer.cs
@@ -14,11 +14,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         internal class ParameterSymbolEqualityComparer : IEqualityComparer<IParameterSymbol>
         {
             private readonly SymbolEquivalenceComparer _symbolEqualityComparer;
+            private readonly bool _distinguishRefFromOut;
 
             public ParameterSymbolEqualityComparer(
-                SymbolEquivalenceComparer symbolEqualityComparer)
+                SymbolEquivalenceComparer symbolEqualityComparer,
+                bool distinguishRefFromOut)
             {
                 _symbolEqualityComparer = symbolEqualityComparer;
+                _distinguishRefFromOut = distinguishRefFromOut;
             }
 
             public bool Equals(
@@ -50,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // equality, then we want to consider method type parameters by index only.
 
                 return
-                    x.RefKind == y.RefKind &&
+                    AreRefKindsEquivalent(x.RefKind, y.RefKind, _distinguishRefFromOut) &&
                     nameComparisonCheck &&
                     _symbolEqualityComparer.GetEquivalenceVisitor().AreEquivalent(x.CustomModifiers, y.CustomModifiers, equivalentTypesWithDifferingAssemblies) &&
                     _symbolEqualityComparer.SignatureTypeEquivalenceComparer.Equals(x.Type, y.Type, equivalentTypesWithDifferingAssemblies);
@@ -77,6 +80,13 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     Hash.Combine(x.IsRefOrOut(),
                     _symbolEqualityComparer.SignatureTypeEquivalenceComparer.GetHashCode(x.Type));
             }
+        }
+
+        public static bool AreRefKindsEquivalent(RefKind rk1, RefKind rk2, bool distinguishRefFromOut)
+        {
+            return distinguishRefFromOut
+                ? rk1 == rk2
+                : (rk1 == RefKind.None) == (rk2 == RefKind.None);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.cs
@@ -46,19 +46,19 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         private readonly ImmutableArray<EquivalenceVisitor> _equivalenceVisitors;
         private readonly ImmutableArray<GetHashCodeVisitor> _getHashCodeVisitors;
 
-        public static readonly SymbolEquivalenceComparer Instance = new SymbolEquivalenceComparer(SimpleNameAssemblyComparer.Instance);
-        public static readonly SymbolEquivalenceComparer IgnoreAssembliesInstance = new SymbolEquivalenceComparer(assemblyComparerOpt: null);
+        public static readonly SymbolEquivalenceComparer Instance = new SymbolEquivalenceComparer(SimpleNameAssemblyComparer.Instance, distinguishRefFromOut: false);
+        public static readonly SymbolEquivalenceComparer IgnoreAssembliesInstance = new SymbolEquivalenceComparer(assemblyComparerOpt: null, distinguishRefFromOut: false);
 
         private readonly IEqualityComparer<IAssemblySymbol> _assemblyComparerOpt;
 
         public ParameterSymbolEqualityComparer ParameterEquivalenceComparer { get; private set; }
         public SignatureTypeSymbolEquivalenceComparer SignatureTypeEquivalenceComparer { get; private set; }
 
-        internal SymbolEquivalenceComparer(IEqualityComparer<IAssemblySymbol> assemblyComparerOpt)
+        internal SymbolEquivalenceComparer(IEqualityComparer<IAssemblySymbol> assemblyComparerOpt, bool distinguishRefFromOut)
         {
             _assemblyComparerOpt = assemblyComparerOpt;
 
-            this.ParameterEquivalenceComparer = new ParameterSymbolEqualityComparer(this);
+            this.ParameterEquivalenceComparer = new ParameterSymbolEqualityComparer(this, distinguishRefFromOut);
             this.SignatureTypeEquivalenceComparer = new SignatureTypeSymbolEquivalenceComparer(this);
 
             // There are only so many EquivalenceVisitors and GetHashCodeVisitors we can have.

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -225,8 +226,10 @@ namespace Microsoft.CodeAnalysis
 
             for (int i = 0; i < refKinds.Length; i++)
             {
+                // The ref-out distinction is not interesting for SymbolKey because you can't overload
+                // based on the difference.
                 var parameter = parameters[i];
-                if (refKinds[i] != parameters[i].RefKind)
+                if (!SymbolEquivalenceComparer.AreRefKindsEquivalent(refKinds[i], parameter.RefKind, distinguishRefFromOut: false))
                 {
                     return false;
                 }


### PR DESCRIPTION
Ignore the difference between ```ref``` and ```out``` in ```SymbolKey``` and ```SymbolEquivalenceComparer``` since two overloads cannot differ by only RefKind.  This prevents VB FAR and GTD from being too discerning and missing matching references.

That is, without this fix, if you attempt to find all references to a C# method with an out parameter, no VB references will be reported.

Caveat: Switching between ```ref``` and ```out``` is still a rude edit, so EnC sets a switch to force consideration of the difference.

Fixes #599.