### PR TITLE
Improve performance of IVsLanguageDebugInfo.GetNameOfLocation...

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Extensions/StatementSyntaxExtensionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Extensions/StatementSyntaxExtensionTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Extensions
 
         Private Sub VerifyTokenName(Of T As StatementSyntax)(code As String, expectedName As String)
             Dim node = SyntaxFactory.ParseCompilationUnit(code).DescendantNodes.OfType(Of T).First()
-            Dim actualNameToken = node.GetNameTokenOrNothing()
+            Dim actualNameToken = node.GetNameToken()
             Assert.Equal(expectedName, actualNameToken.ToString())
         End Sub
 

--- a/src/Features/CSharp/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.cs
+++ b/src/Features/CSharp/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.cs
@@ -99,8 +99,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
                     return compare;
                 }
 
-                var xName = x.GetNameToken();
-                var yName = y.GetNameToken();
+                var xName = ShouldCompareByName(x) ? x.GetNameToken() : default(SyntaxToken);
+                var yName = ShouldCompareByName(y) ? y.GetNameToken() : default(SyntaxToken);
 
                 if ((compare = TokenComparer.NormalInstance.Compare(xName, yName)) != 0)
                 {
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
                 return x.GetArity() - y.GetArity();
             }
 
-            private Accessibility GetAccessibility(MemberDeclarationSyntax x)
+            private static Accessibility GetAccessibility(MemberDeclarationSyntax x)
             {
                 var xModifiers = x.GetModifiers();
 
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
                 }
             }
 
-            private OuterOrdering GetOuterOrdering(MemberDeclarationSyntax x)
+            private static OuterOrdering GetOuterOrdering(MemberDeclarationSyntax x)
             {
                 switch (x.Kind())
                 {
@@ -169,6 +169,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
                         return OuterOrdering.Types;
                     default:
                         return OuterOrdering.Remaining;
+                }
+            }
+
+            private static bool ShouldCompareByName(MemberDeclarationSyntax x)
+            {
+                // Constructors, destructors, indexers and operators should not be sorted by name.
+                // Note:  Converation operators should not be sorted by name either, but it's not
+                //        necessary to deal with that here, because GetNameToken cannot return a
+                //        name for them (there's only a NameSyntax, not a Token).
+                switch (x.Kind())
+                {
+                    case SyntaxKind.ConstructorDeclaration:
+                    case SyntaxKind.DestructorDeclaration:
+                    case SyntaxKind.IndexerDeclaration:
+                    case SyntaxKind.OperatorDeclaration:
+                        return false;
+                    default:
+                        return true;
                 }
             }
         }

--- a/src/Features/VisualBasic/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
+++ b/src/Features/VisualBasic/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
@@ -82,8 +82,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
                     Return value
                 End If
 
-                Dim xName = x.GetNameTokenOrNothing()
-                Dim yName = y.GetNameTokenOrNothing()
+                Dim xName = If(ShouldCompareByName(x), x.GetNameToken(), Nothing)
+                Dim yName = If(ShouldCompareByName(x), y.GetNameToken(), Nothing)
 
                 value = TokenComparer.NormalInstance.Compare(xName, yName)
                 If value <> 0 Then
@@ -94,7 +94,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
                 Return x.GetArity() - y.GetArity()
             End Function
 
-            Private Function GetAccessibility(x As StatementSyntax) As Accessibility
+            Private Shared Function GetAccessibility(x As StatementSyntax) As Accessibility
                 Dim xModifiers = x.GetModifiers()
 
                 If xModifiers.Any(Function(t) t.Kind = SyntaxKind.PublicKeyword) Then
@@ -137,6 +137,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
                         Return OuterOrdering.Types
                     Case Else
                         Return OuterOrdering.Remaining
+                End Select
+            End Function
+
+            Private Shared Function ShouldCompareByName(x As StatementSyntax) As Boolean
+                ' Constructors and operators should not be sorted by name.
+                Select Case x.Kind
+                    Case SyntaxKind.ConstructorBlock,
+                         SyntaxKind.OperatorBlock
+                        Return False
+                    Case Else
+                        Return True
                 End Select
             End Function
         End Class

--- a/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
             {
                 var testDocument = workspace.Documents.Single();
                 var position = testDocument.CursorPosition.Value;
-                var snapshot = testDocument.TextBuffer.CurrentSnapshot;
                 var locationInfo = LocationInfoGetter.GetInfoAsync(
                     workspace.CurrentSolution.Projects.Single().Documents.Single(),
                     position,
@@ -30,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
-        public void TestCSharpLanguageDebugInfoTryGetNameOfLocation()
+        public void TestClass()
         {
             Test("class F$$oo { }", "Foo", 0);
         }
@@ -51,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
         [WorkItem(527668)]
-        public void TestNamespaces()
+        public void TestNamespace()
         {
             Test(
 @"namespace Namespace
@@ -67,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
         [WorkItem(527668)]
-        public void TestDottedNamespaces()
+        public void TestDottedNamespace()
         {
             Test(
 @"namespace Namespace.Another
@@ -82,19 +81,37 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
-        [WorkItem(527668)]
-        public void TestNestedTypes()
+        public void TestNestedNamespace()
         {
             Test(
-@"class Foo
+@"namespace Namespace
 {
-    class Bar
+    namespace Another
+    {
+        class Class
+        {
+            void Method()
+            {
+            }$$
+        }
+    }
+}", "Namespace.Another.Class.Method()", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        [WorkItem(527668)]
+        public void TestNestedType()
+        {
+            Test(
+@"class Outer
+{
+    class Inner
     {
         void Quux()
         {$$
         }
     }
-}", "Foo.Bar.Quux()", 1);
+}", "Outer.Inner.Quux()", 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
@@ -149,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
         [WorkItem(543494)]
-        public void TestField2()
+        public void TestLambdaInFieldInitializer()
         {
             Test(
 @"class Class
@@ -160,13 +177,308 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
         [WorkItem(543494)]
-        public void TestField3()
+        public void TestMultipleFields()
         {
             Test(
 @"class Class
 {
     int a1, a$$2;
 }", "Class.a2", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestConstructor()
+        {
+            Test(
+@"class C1
+{
+    C1()
+    {
+
+    $$}
+}
+", "C1.C1()", 3);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestDestructor()
+        {
+            Test(
+@"class C1
+{
+    ~C1()
+    {
+    $$}
+}
+", "C1.~C1()", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestOperator()
+        {
+            Test(
+@"namespace N1
+{
+    class C1
+    {
+        public static int operator +(C1 x, C1 y)
+        {
+            $$return 42;
+        }
+    }
+}
+", "N1.C1.+(C1 x, C1 y)", 2); // Old implementation reports "operator +" (rather than "+")...
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestConversionOperator()
+        {
+            Test(
+@"namespace N1
+{
+    class C1
+    {
+        public static explicit operator N1.C2(N1.C1 x)
+        {
+            $$return null;
+        }
+    }
+    class C2
+    {
+    }
+}
+", "N1.C1.N1.C2(N1.C1 x)", 2); // Old implementation reports "explicit operator N1.C2" (rather than "N1.C2")...
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestEvent()
+        {
+            Test(
+@"class C1
+{
+    delegate void D1();
+    event D1 e1$$;
+}
+", "C1.e1", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TextExplicitInterfaceImplementation()
+        {
+            Test(
+@"interface I1
+{
+    void M1();
+}
+class C1
+{
+    void I1.M1()
+    {
+    $$}
+}
+", "C1.M1()", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TextIndexer()
+        {
+            Test(
+@"class C1
+{
+    C1 this[int x]
+    {
+        get
+        {
+            $$return null;
+        }
+    }
+}
+", "C1.this[int x]", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestParamsParameter()
+        {
+            Test(
+@"class C1
+{
+    void M1(params int[] x) { $$ }
+}
+", "C1.M1(params int[] x)", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestArglistParameter()
+        {
+            Test(
+@"class C1
+{
+    void M1(__arglist) { $$ }
+}
+", "C1.M1(__arglist)", 0); // Old implementation does not show "__arglist"...
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestRefAndOutParameters()
+        {
+            Test(
+@"class C1
+{
+    void M1( ref int x, out int y )
+    {
+        $$y = x;
+    }
+}
+", "C1.M1( ref int x, out int y )", 2); // Old implementation did not show extra spaces around the parameters...
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestOptionalParameters()
+        {
+            Test(
+@"class C1
+{
+    void M1(int x =1)
+    {
+        $$y = x;
+    }
+}
+", "C1.M1(int x =1)", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestExtensionMethod()
+        {
+            Test(
+@"static class C1
+{
+    static void M1(this int x)
+    {
+    }$$
+}
+", "C1.M1(this int x)", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestGenericType()
+        {
+            Test(
+@"class C1<T, U>
+{
+    static void M1() { $$ }
+}
+", "C1.M1()", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestGenericMethod()
+        {
+            Test(
+@"class C1<T, U>
+{
+    static void M1<V>() { $$ }
+}
+", "C1.M1()", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestGenericParameters()
+        {
+            Test(
+@"class C1<T, U>
+{
+    static void M1<V>(C1<int, V> x, V y) { $$ }
+}
+", "C1.M1(C1<int, V> x, V y)", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestMissingNamespace()
+        {
+            Test(
+@"{
+    class Class
+    {
+        int a1, a$$2;
+    }
+}", "Class.a2", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestMissingNamespaceName()
+        {
+            Test(
+@"namespace
+{
+    class C1
+    {
+        int M1()
+        $${
+        }
+    }
+}", "?.C1.M1()", 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestMissingClassName()
+        {
+            Test(
+@"namespace N1
+    class 
+    {
+        int M1()
+        $${
+        }
+    }
+}", "N1.M1()", 1); // Old implementation displayed "N1.?.M1", but we don't see a class declaration in the syntax tree...
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestMissingMethodName()
+        {
+            Test(
+@"namespace N1
+{
+    class C1
+    {
+        static void (int x)
+        {
+        $$}
+    }
+}", "N1.C1", 4);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TestMissingParameterList()
+        {
+            Test(
+@"namespace N1
+{
+    class C1
+    {
+        static void M1
+        {
+        $$}
+    }
+}", "N1.C1.M1", 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TopLevelField()
+        {
+            Test(
+@"$$int f1;
+", "f1", 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TopLevelMethod()
+        {
+            Test(
+@"int M1(int x)
+{
+$$}
+", "M1(int x)", 2);
         }
     }
 }

--- a/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
@@ -1,39 +1,395 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Linq
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
-Imports Microsoft.VisualStudio.Text
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
-Imports Xunit
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debugging
+
     Public Class LocationInfoGetterTests
 
-        Private Sub Test(text As String, expectedName As String)
+        Private Sub Test(text As String, expectedName As String, expectedLineOffset As Integer, Optional rootNamespace As String = Nothing)
             Dim position As Integer
             MarkupTestFile.GetPosition(text, text, position)
-            Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromLines(text)
-                Dim languageDebugInfo = New VisualBasicLanguageDebugInfoService()
+            Dim compilationOptions = If(rootNamespace IsNot Nothing, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace:=rootNamespace), Nothing)
+            Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromLines(LanguageNames.VisualBasic, compilationOptions, Nothing, text)
+                Dim locationInfo = LocationInfoGetter.GetInfoAsync(
+                    workspace.CurrentSolution.Projects.Single().Documents.Single(),
+                    position,
+                    CancellationToken.None).WaitAndGetResult(CancellationToken.None)
 
-                Dim result = languageDebugInfo.GetLocationInfoAsync(workspace.CurrentSolution.Projects.Single().Documents.Single(), position, CancellationToken.None).WaitAndGetResult(CancellationToken.None)
-                Assert.Equal(expectedName, result.Name)
+                Assert.Equal(expectedName, locationInfo.Name)
+                Assert.Equal(expectedLineOffset, locationInfo.LineOffset)
             End Using
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
-        Public Sub TestLocationNameOnSub()
+        Public Sub TestClass()
             Test(<text>
-class C
-  sub Foo()$$
-  end sub
-end class</text>.NormalizedValue, "C.Foo()")
+Class Foo$$
+End Class
+</text>.NormalizedValue, "Foo", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestSub()
+            Test(<text>
+Class C
+  Sub Foo()$$
+  End Sub
+End Class
+</text>.NormalizedValue, "C.Foo()", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestFunction()
+            Test(<text>
+Class C
+  $$Function Foo() As Integer
+  End Function
+End Class
+</text>.NormalizedValue, "C.Foo() As Integer", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestNamespace()
+            Test(<text>
+Namespace NS1
+  Class C
+    Sub Method()
+    End Sub$$
+  End Class
+End Namespace
+</text>.NormalizedValue, "NS1.C.Method()", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestDottedNamespace()
+            Test(<text>
+Namespace NS1.Another
+  Class C
+    Sub Method()
+    End Sub$$
+  End Class
+End Namespace
+</text>.NormalizedValue, "NS1.Another.C.Method()", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestNestedNamespace()
+            Test(<text>
+Namespace NS1
+  Namespace Another
+    Class C
+      Sub Method()
+      End Sub$$
+    End Class
+  End Namespace
+End Namespace
+</text>.NormalizedValue, "NS1.Another.C.Method()", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestRootNamespace()
+            Test(<text>
+Namespace NS1
+  Class C
+      Sub Method()
+      End Sub$$
+  End Class
+End Namespace
+</text>.NormalizedValue, "Root.NS1.C.Method()", 1, rootNamespace:="Root")
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestNestedType()
+            Test(<text>
+Class Outer
+  Class Inner
+    Sub Quux()$$
+    End Sub
+  End Class
+End Class
+</text>.NormalizedValue, "Outer.Inner.Quux()", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestPropertyGetter()
+            Test(<text>
+Class C1
+  ReadOnly Property P() As String
+    Get
+      Return Nothing$$
+    End Get
+  End Property
+End Class
+</text>.NormalizedValue, "C1.P() As String", 2)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestPropertySetter()
+            Test(<text>
+Class C1
+  ReadOnly Property P() As String
+    Get
+      Return Nothing
+    End Get
+    Set
+      Dim s = $$value
+    End Set
+  End Property
+End Class
+</text>.NormalizedValue, "C1.P() As String", 5)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestAutoProperty()
+            Test(<text>
+Class C1
+  $$ReadOnly Property P As Object = 42
+End Class
+</text>.NormalizedValue, "C1.P As Object", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestParameterizedProperty()
+            Test(<text>
+Class C1
+  ReadOnly Property P(x As Integer) As C1
+    Get
+      Return Nothing$$
+    End Get
+  End Property
+End Class
+</text>.NormalizedValue, "C1.P(x As Integer) As C1", 2)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestField()
+            Test(<text>
+Class C1
+  Dim fi$$eld As Integer
+End Class
+</text>.NormalizedValue, "C1", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestLambdaInFieldInitializer()
+            Test(<text>
+Class C1
+  Dim a As Action(Of Integer) = Sub(b) Dim c As In$$teger
+End Class
+</text>.NormalizedValue, "C1", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMultipleFields()
+            Test(<text>
+Class C1
+  Dim a1, a$$2
+End Class
+</text>.NormalizedValue, "C1", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestConstructor()
+            Test(<text>
+Class C1
+  Sub New()
+  $$End Sub
+End Class
+</text>.NormalizedValue, "C1.New()", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestOperator()
+            Test(<text>
+Namespace NS1
+  Class C1
+    Public Shared Operator +(x As C1, y As C1) As Integer
+      $$Return 42
+    End Operator
+  End Class
+End Namespace
+</text>.NormalizedValue, "NS1.C1.+(x As C1, y As C1) As Integer", 1) ' Old implementation reports "Operator +" (rather than "+")...
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestConversionOperator()
+            Test(<text>
+Namespace NS1
+  Class C1
+    Public Shared Narrowing Operator CType(x As NS1.C1) As NS1.C2
+      $$Return Nothing
+    End Operator
+  End Class
+  Class C2
+  End Class
+End Namespace
+</text>.NormalizedValue, "NS1.C1.CType(x As NS1.C1) As NS1.C2", 1) ' Old implementation reports "Operator CType" (rather than "CType")...
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestEvent()
+            Test(<text>
+Class C1
+  Event E1(x)$$
+End Class
+</text>.NormalizedValue, "C1.E1(x)", 0) ' Old implementation did not show the parameters ("x")...
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestParamArrayParameter()
+            Test(<text>
+Class C1
+  Sub M1(ParamArray x() As Integer)$$
+  End Sub
+End Class
+</text>.NormalizedValue, "C1.M1(ParamArray x() As Integer)", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestByRefParameter()
+            Test(<text>
+Class C1
+  Sub M1( &lt;Out&gt; ByRef x As Integer )
+    $$x = 1
+  End Sub
+End Class
+</text>.NormalizedValue, "C1.M1( <Out> ByRef x As Integer )", 1) ' Old implementation did not show extra spaces around the parameters...
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestOptionalParameter()
+            Test(<text>
+Class C1
+  Sub M1(Optional x As Integer =1)
+    $$x = 1
+  End Sub
+End Class
+</text>.NormalizedValue, "C1.M1(Optional x As Integer =1)", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestGenericType()
+            Test(<text>
+Class C1(Of T, U)
+  Shared Sub M1()$$
+  End Sub
+End Class
+</text>.NormalizedValue, "C1(Of T, U).M1()", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestGenericMethod()
+            Test(<text>
+Class C1(Of T, U)
+  Shared Sub M1(Of V)()$$
+  End Sub
+End Class
+</text>.NormalizedValue, "C1(Of T, U).M1(Of V)()", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestGenericParametersAndReturn()
+            Test(<text>
+Class C1(Of T, U)
+  Shared Function M1(Of V)(C1(Of Integer, V) x, V y) As C1(Of Integer, V)$$
+  End Function
+End Class
+</text>.NormalizedValue, "C1(Of T, U).M1(Of V)(C1(Of Integer, V) x, V y) As C1(Of Integer, V)", 0)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingNamespace()
+            Test(<text>
+  Class C1
+    Dim a1, a$$2
+  End Class
+End Namespace
+</text>.NormalizedValue, "C1", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingNamespaceName()
+            Test(<text>
+Namespace
+  Class C1
+    Function M1() As Integer
+$$    End Function
+  End Class
+End Namespace
+</text>.NormalizedValue, "?.C1.M1() As Integer", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingClassName()
+            Test(<text>
+Namespace N1
+  Class
+    Function M1() As Integer
+$$    End Function
+  End Class
+End Namespace
+</text>.NormalizedValue, "N1.?.M1() As Integer", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingMethodName()
+            Test(<text>
+Namespace N1
+  Class C1
+    Shared Sub (x As Integer)
+$$    End Sub
+  End Class
+End Namespace
+</text>.NormalizedValue, "N1.C1.?(x As Integer)", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingParameterList()
+            Test(<text>
+Namespace N1
+  Class C1
+    Shared Sub M1
+$$    End Sub
+  End Class
+End Namespace
+</text>.NormalizedValue, "N1.C1.M1", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestMissingAsClause()
+            Test(<text>
+Namespace N1
+  Class C1
+    Shared Function F1(x As Integer)
+$$    End Function
+  End Class
+End Namespace
+</text>.NormalizedValue, "N1.C1.F1(x As Integer)", 1)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TopLevelField()
+            Test(<text>
+$$Dim f1 As Integer
+</text>.NormalizedValue, Nothing, 0) ' Unlike C#, VB will not report a name for top level fields (consistent with old implementation).
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TopLevelMethod()
+            Test(<text>
+Function F1(x As Integer) As Integer
+$$End Function
+</text>.NormalizedValue, "F1(x As Integer) As Integer", 1)
         End Sub
 
     End Class
+
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Debugging/LocationInfoGetter.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Debugging/LocationInfoGetter.vb
@@ -3,58 +3,117 @@
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Debugging
+Imports Microsoft.CodeAnalysis.Shared.Extensions
+Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
-Imports Microsoft.VisualStudio.LanguageServices.Implementation.Debugging
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
     ' TODO: Make this class static when we add that functionality to VB.
     Namespace LocationInfoGetter
         Friend Module LocationInfoGetterModule
-            ' TODO remove after general error format has been fixed
-            Private ReadOnly s_qualifiedNameFormat As SymbolDisplayFormat = New SymbolDisplayFormat(
-                globalNamespaceStyle:=SymbolDisplayGlobalNamespaceStyle.Omitted,
-                typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
-                genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
-                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters Or
-                                SymbolDisplayMemberOptions.IncludeContainingType,
-                parameterOptions:=SymbolDisplayParameterOptions.IncludeName Or
-                                    SymbolDisplayParameterOptions.IncludeType Or
-                                    SymbolDisplayParameterOptions.IncludeParamsRefOut Or
-                                    SymbolDisplayParameterOptions.IncludeDefaultValue,
-                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers Or
-                                        SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
-
             Friend Async Function GetInfoAsync(document As Document, position As Integer, cancellationToken As CancellationToken) As Task(Of DebugLocationInfo)
-                Dim name As String = Nothing
-                Dim lineOffset As Integer = 0
-
-                ' Note that we get the InProgressSolution here.  Technically, this means that we may
-                ' not fully understand the signature of the member.  But that's ok.  We just need this
-                ' symbol so we can create a display string to put into the debugger.  If we try to
-                ' find the document in the "CurrentSolution" then when we try to get the semantic 
-                ' model below then it might take a *long* time as all dependent compilations are built.
-
+                ' PERF:  This method will be called synchronously on the UI thread for every breakpoint in the solution.
+                ' Therefore, it is important that we make this call as cheap as possible.  Rather than constructing a
+                ' containing Symbol and using ToDisplayString (which might be more *correct*), we'll just do the best we
+                ' can with Syntax.  This approach is capable of providing parity with the pre-Roslyn implementation.
                 Dim tree = Await document.GetVisualBasicSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
                 Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
                 Dim token = root.FindToken(position)
-                Dim memberDecl = token.GetContainingMemberBlockBegin()
-
-                If memberDecl IsNot Nothing Then
-                    Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
-                    Dim memberSymbol = semanticModel.GetDeclaredSymbol(memberDecl, cancellationToken)
-
-                    Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
-                    Dim lineNumber = text.Lines.GetLineFromPosition(position).LineNumber
-                    Dim memberLine = text.Lines.GetLineFromPosition(memberDecl.SpanStart).LineNumber
-
-                    name = memberSymbol.ToDisplayString(s_qualifiedNameFormat)
-                    lineOffset = lineNumber - memberLine
-                    Return New DebugLocationInfo(name, lineOffset)
+                Dim memberDeclaration = token.GetContainingMember()
+                ' Unlike C#, VB doesn't show field names.
+                If memberDeclaration.Kind = SyntaxKind.FieldDeclaration Then
+                    memberDeclaration = memberDeclaration.GetAncestor(Of DeclarationStatementSyntax)()
                 End If
 
-                Return Nothing
+                If memberDeclaration Is Nothing Then
+                    Return Nothing
+                End If
+
+                Dim compilation = Await document.GetVisualBasicCompilationAsync(cancellationToken).ConfigureAwait(False)
+                Dim name = GetName(memberDeclaration, compilation.Options.RootNamespace)
+
+                Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+                Dim lineNumber = text.Lines.GetLineFromPosition(position).LineNumber
+                Dim memberLine = text.Lines.GetLineFromPosition(memberDeclaration.GetMemberBlockBegin().SpanStart).LineNumber
+                Dim lineOffset = lineNumber - memberLine
+
+                Return New DebugLocationInfo(name, lineOffset)
             End Function
+
+            Private Function GetName(memberDeclaration As DeclarationStatementSyntax, rootNamespace As String) As String
+                Const missingInformationPlaceholder As String = "?"
+                Const dotToken As Char = "."c
+
+                ' root namespace
+                Dim pooled = PooledStringBuilder.GetInstance()
+                Dim builder = pooled.Builder
+                If Not String.IsNullOrEmpty(rootNamespace) Then
+                    builder.Append(rootNamespace)
+                    builder.Append(dotToken)
+                End If
+                ' containing namespace(s) and type(s)
+                Dim containingDeclarationNames As ArrayBuilder(Of String) = ArrayBuilder(Of String).GetInstance()
+                Dim containingDeclaration = memberDeclaration.Parent
+                If TypeOf memberDeclaration Is TypeStatementSyntax Then
+                    containingDeclaration = containingDeclaration?.Parent
+                End If
+                While containingDeclaration IsNot Nothing
+                    Dim [namespace] = TryCast(containingDeclaration, NamespaceBlockSyntax)
+                    If [namespace] IsNot Nothing Then
+                        Dim syntax = [namespace].NamespaceStatement.Name
+                        containingDeclarationNames.Add(If(syntax.IsMissing, missingInformationPlaceholder, syntax.ToString()))
+                    Else
+                        Dim type = TryCast(containingDeclaration, TypeBlockSyntax)
+                        If type IsNot Nothing Then
+                            Dim token = type.GetNameToken()
+                            If token.IsMissing Then
+                                containingDeclarationNames.Add(missingInformationPlaceholder)
+                            Else
+                                ' generic type parameters (if any)
+                                Dim typeParameters = type.GetTypeParameterList()
+                                containingDeclarationNames.Add(If(typeParameters IsNot Nothing, token.Text & typeParameters.ToString(), token.Text))
+                            End If
+                        End If
+                    End If
+                    containingDeclaration = containingDeclaration.Parent
+                End While
+                For i = containingDeclarationNames.Count - 1 To 0 Step -1
+                    builder.Append(containingDeclarationNames(i))
+                    builder.Append(dotToken)
+                Next
+                containingDeclarationNames.Free()
+
+                ' simple name
+                Dim nameToken = memberDeclaration.GetNameToken()
+                builder.Append(If(nameToken.IsMissing, missingInformationPlaceholder, nameToken.Text))
+
+                ' generic type parameters (if any)
+                builder.Append(memberDeclaration.GetTypeParameterList())
+
+                ' parameter list (if any)
+                builder.Append(memberDeclaration.GetParameterList())
+
+                ' As clause (if any)
+                Dim asClause = memberDeclaration.GetAsClause()
+                If asClause IsNot Nothing Then
+                    builder.Append(" "c)
+                    builder.Append(asClause)
+                End If
+
+                Return pooled.ToStringAndFree()
+            End Function
+
+            Private Sub AppendContainingDeclarationNames(Of TDeclarationSyntax As DeclarationStatementSyntax)(
+                ByRef containingDeclarationNames As ArrayBuilder(Of String),
+                ByRef declaration As TDeclarationSyntax,
+                appendText As Action(Of ArrayBuilder(Of String), TDeclarationSyntax),
+                getAncestor As Func(Of TDeclarationSyntax, TDeclarationSyntax))
+
+
+            End Sub
         End Module
     End Namespace
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
@@ -575,7 +575,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
             End Sub
 
             Public Overrides Sub VisitNamespaceStatement(node As NamespaceStatementSyntax)
-                If Not TryGetDeclaredSymbol(node.GetNameTokenOrNothing()) Then
+                If Not TryGetDeclaredSymbol(node.GetNameToken()) Then
                     result = Keyword(SyntaxKind.NamespaceKeyword)
                 End If
             End Sub

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetFunctions/SnippetFunctionClassName.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetFunctions/SnippetFunctionClassName.vb
@@ -23,9 +23,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets.SnippetFu
             Dim typeBlock = syntaxTree.FindTokenOnLeftOfPosition(subjectBufferFieldSpan.Start.Position, cancellationToken).GetAncestor(Of TypeBlockSyntax)
 
             If typeBlock IsNot Nothing AndAlso
-               Not String.IsNullOrWhiteSpace(typeBlock.GetNameTokenOrNothing().ValueText) Then
+               Not String.IsNullOrWhiteSpace(typeBlock.GetNameToken().ValueText) Then
 
-                value = typeBlock.GetNameTokenOrNothing().ValueText
+                value = typeBlock.GetNameToken().ValueText
                 hasDefaultValue = 1
             End If
 

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -98,10 +98,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         return ((EventDeclarationSyntax)member).Identifier;
                     case SyntaxKind.MethodDeclaration:
                         return ((MethodDeclarationSyntax)member).Identifier;
+                    case SyntaxKind.ConstructorDeclaration:
+                        return ((ConstructorDeclarationSyntax)member).Identifier;
+                    case SyntaxKind.DestructorDeclaration:
+                        return ((DestructorDeclarationSyntax)member).Identifier;
+                    case SyntaxKind.IndexerDeclaration:
+                        return ((IndexerDeclarationSyntax)member).ThisKeyword;
+                    case SyntaxKind.OperatorDeclaration:
+                        return ((OperatorDeclarationSyntax)member).OperatorToken;
                 }
             }
 
-            // Constructors, destructors, indexers and operators don't have names.
+            // Conversion operators don't have names.
             return default(SyntaxToken);
         }
 
@@ -157,6 +165,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         return ((MethodDeclarationSyntax)member).ParameterList;
                     case SyntaxKind.ConstructorDeclaration:
                         return ((ConstructorDeclarationSyntax)member).ParameterList;
+                    case SyntaxKind.DestructorDeclaration:
+                        return ((DestructorDeclarationSyntax)member).ParameterList;
                     case SyntaxKind.IndexerDeclaration:
                         return ((IndexerDeclarationSyntax)member).ParameterList;
                     case SyntaxKind.OperatorDeclaration:

--- a/src/Workspaces/VisualBasic/Portable/Extensions/StatementSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/StatementSyntaxExtensions.vb
@@ -299,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         <Extension()>
-        Public Function GetNameTokenOrNothing(member As StatementSyntax) As SyntaxToken
+        Public Function GetNameToken(member As StatementSyntax) As SyntaxToken
             If member IsNot Nothing Then
                 Select Case member.Kind
                     Case SyntaxKind.ClassBlock,
@@ -329,6 +329,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Case SyntaxKind.FunctionBlock,
                         SyntaxKind.SubBlock
                         Return DirectCast(DirectCast(member, MethodBlockSyntax).BlockStatement, MethodStatementSyntax).Identifier
+                    Case SyntaxKind.ConstructorBlock
+                        Return DirectCast(DirectCast(member, ConstructorBlockSyntax).BlockStatement, SubNewStatementSyntax).NewKeyword
+                    Case SyntaxKind.OperatorBlock
+                        Return DirectCast(DirectCast(member, OperatorBlockSyntax).BlockStatement, OperatorStatementSyntax).OperatorToken
                     Case SyntaxKind.SubStatement,
                         SyntaxKind.FunctionStatement
                         Return DirectCast(member, MethodStatementSyntax).Identifier
@@ -341,7 +345,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End Select
             End If
 
-            ' Constructors, accessors and operators don't have names.
             Return Nothing
         End Function
 
@@ -420,7 +423,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return Nothing
         End Function
 
-        Private Function GetAsClause(member As StatementSyntax) As AsClauseSyntax
+        <Extension()>
+        Public Function GetAsClause(member As StatementSyntax) As AsClauseSyntax
             If member IsNot Nothing Then
                 Select Case member.Kind
                     Case SyntaxKind.FunctionBlock
@@ -451,7 +455,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
         <Extension()>
         Public Function GetReturnType(member As StatementSyntax) As TypeSyntax
-            Dim asClause = GetAsClause(member)
+            Dim asClause = member.GetAsClause()
             Return If(asClause IsNot Nothing, asClause.Type, Nothing)
         End Function
 


### PR DESCRIPTION
**Bug number** - Fixes #1977
**Customer scenario** - In large solutions, you may see the following dialog appear for long periods of time when opening your solution or setting new breakpoints (sometimes in excess of a minute):

![determiningname](https://cloud.githubusercontent.com/assets/6464209/7849750/b1608234-048d-11e5-9682-f30d8e2280bb.png)

**Fix description** - Previously, we would fetch a SemanticModel and build containing Symbols for each breakpoint location.  This could be very expensive in a large solution.  However, for the purposes of providing parity with the old implementation, it is adequate to just inspect Syntax.
**Testing done** - Added more comprehensive tests (56 new), ad-hoc, basic perf testing...  I'm not able to consistently repro the "worse case", but even in the best case, the new implementation is twice as fast (20ms vs 43ms when opening Roslyn.sln with 2 breakpoints set).