### PR TITLE
Update encapsulate field codeaction strings

### DIFF
--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Encapsulate field: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Encapsulate field: &apos;{0}&apos; (but still use field).
         /// </summary>
         internal static string EncapsulateField {
             get {
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Encapsulate fields.
+        ///   Looks up a localized string similar to Encapsulate fields (but still use field).
         /// </summary>
         internal static string EncapsulateFields {
             get {
@@ -646,7 +646,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Encapsulate fields (usages reference field).
+        ///   Looks up a localized string similar to Encapsulate fields (and use property).
         /// </summary>
         internal static string EncapsulateFieldsUsages {
             get {
@@ -655,7 +655,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Encapsulate field: &apos;{0}&apos; (usages reference field).
+        ///   Looks up a localized string similar to Encapsulate field: &apos;{0}&apos; (and use property).
         /// </summary>
         internal static string EncapsulateFieldUsages {
             get {

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -142,16 +142,16 @@
     <value>{0} Keyword</value>
   </data>
   <data name="EncapsulateFieldUsages" xml:space="preserve">
-    <value>Encapsulate field: '{0}' (usages reference field)</value>
+    <value>Encapsulate field: '{0}' (and use property)</value>
   </data>
   <data name="EncapsulateField" xml:space="preserve">
-    <value>Encapsulate field: '{0}'</value>
+    <value>Encapsulate field: '{0}' (but still use field)</value>
   </data>
   <data name="EncapsulateFieldsUsages" xml:space="preserve">
-    <value>Encapsulate fields (usages reference field)</value>
+    <value>Encapsulate fields (and use property)</value>
   </data>
   <data name="EncapsulateFields" xml:space="preserve">
-    <value>Encapsulate fields</value>
+    <value>Encapsulate fields (but still use field)</value>
   </data>
   <data name="CouldNotExtractInterfaceSelection" xml:space="preserve">
     <value>Could not extract interface: The selection is not inside a class/interface/struct.</value>


### PR DESCRIPTION
Fixes internal bug #766354. Update encapsulate field code action resource strings to
be more clear. Also one of them is currently doing the inverse of what the text reads ("Encapsulate field: usages reference field", replaces all usages of the field with Property). 

This change fixes up the strings and also makes the behavior match what the code action title reads.

There is also a matching closed side change that updates the Integration test suite.