### PR TITLE
Remove superfluous sequence point emitted by VB await spiller

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -32,8 +32,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim awaiterTemp As LocalSymbol = Me.F.SynthesizedLocal(awaiterType, kind:=SynthesizedLocalKind.Awaiter, syntax:=node.Syntax)
                 builder.AddLocal(awaiterTemp)
 
-                builder.AddStatement(Me.F.SequencePoint(If(Me._enclosingSequencePointSyntax, node.Syntax)))
-
                 ' Replace 'awaiter' with the local
                 Dim awaiterInstancePlaceholder As BoundLValuePlaceholder = node.AwaiterInstancePlaceholder
                 Debug.Assert(awaiterInstancePlaceholder IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
@@ -863,19 +863,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                   rewritten.Type))
             End Function
 
-            Public Overrides Function VisitSequencePoint(node As BoundSequencePoint) As BoundNode
-                Dim _storedSyntax As VisualBasicSyntaxNode = Me._enclosingSequencePointSyntax
-                Me._enclosingSequencePointSyntax = node.Syntax
-                Dim rewritten = MyBase.VisitSequencePoint(node)
-                Me._enclosingSequencePointSyntax = _storedSyntax
-                Return rewritten
-            End Function
-
             Public Overrides Function VisitSequencePointExpression(node As BoundSequencePointExpression) As BoundNode
-                Dim _storedSyntax As VisualBasicSyntaxNode = Me._enclosingSequencePointSyntax
-                Me._enclosingSequencePointSyntax = node.Syntax
                 Dim rewritten = DirectCast(MyBase.VisitSequencePointExpression(node), BoundSequencePointExpression)
-                Me._enclosingSequencePointSyntax = _storedSyntax
 
                 Dim expression As BoundExpression = rewritten.Expression
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
@@ -57,8 +57,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Private ReadOnly _typesNeedingClearingCache As New Dictionary(Of TypeSymbol, Boolean)
 
-            Private _enclosingSequencePointSyntax As VisualBasicSyntaxNode = Nothing
-
             Friend Sub New(method As MethodSymbol,
                            F As SyntheticBoundNodeFactory,
                            state As FieldSymbol,

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1499,7 +1499,7 @@ End Module
             c.VerifyIL("Program.VB$StateMachine_0_Test2.MoveNext",
             <![CDATA[
 {
-  // Code size      491 (0x1eb)
+  // Code size      489 (0x1e9)
   .maxstack  8
   .locals init (Integer V_0,
                 Object V_1,
@@ -1523,207 +1523,205 @@ End Module
     IL_000d:  ldc.i4.1
     IL_000e:  beq.s      IL_0017
     IL_0010:  br.s       IL_001c
-    IL_0012:  br         IL_00b0
-    IL_0017:  br         IL_017a
+    IL_0012:  br         IL_00af
+    IL_0017:  br         IL_0178
    -IL_001c:  nop
    -IL_001d:  ldarg.0
     IL_001e:  newobj     "Sub MyTask(Of Integer)..ctor()"
     IL_0023:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-   -IL_0028:  nop
-    IL_0029:  ldarg.0
-    IL_002a:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-    IL_002f:  ldnull
-    IL_0030:  ldstr      "GetAwaiter"
-    IL_0035:  ldc.i4.0
-    IL_0036:  newarr     "Object"
+   -IL_0028:  ldarg.0
+    IL_0029:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
+    IL_002e:  ldnull
+    IL_002f:  ldstr      "GetAwaiter"
+    IL_0034:  ldc.i4.0
+    IL_0035:  newarr     "Object"
+    IL_003a:  ldnull
     IL_003b:  ldnull
     IL_003c:  ldnull
-    IL_003d:  ldnull
-    IL_003e:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0043:  stloc.1
-   ~IL_0044:  ldloc.1
-    IL_0045:  ldnull
-    IL_0046:  ldstr      "IsCompleted"
-    IL_004b:  ldc.i4.0
-    IL_004c:  newarr     "Object"
+    IL_003d:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_0042:  stloc.1
+   ~IL_0043:  ldloc.1
+    IL_0044:  ldnull
+    IL_0045:  ldstr      "IsCompleted"
+    IL_004a:  ldc.i4.0
+    IL_004b:  newarr     "Object"
+    IL_0050:  ldnull
     IL_0051:  ldnull
     IL_0052:  ldnull
-    IL_0053:  ldnull
-    IL_0054:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0059:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
-    IL_005e:  brfalse.s  IL_0062
-    IL_0060:  br.s       IL_00c7
-    IL_0062:  ldarg.0
-    IL_0063:  ldc.i4.0
-    IL_0064:  dup
-    IL_0065:  stloc.0
-    IL_0066:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-   <IL_006b:  ldarg.0
-    IL_006c:  ldloc.1
-    IL_006d:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0072:  ldloc.1
-    IL_0073:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
-    IL_0078:  stloc.2
-    IL_0079:  ldloc.2
-    IL_007a:  brfalse.s  IL_0091
-    IL_007c:  ldarg.0
-    IL_007d:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_0082:  ldloca.s   V_2
-    IL_0084:  ldarg.0
-    IL_0085:  stloc.s    V_4
-    IL_0087:  ldloca.s   V_4
-    IL_0089:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_008e:  nop
-    IL_008f:  br.s       IL_00ab
-    IL_0091:  ldloc.1
-    IL_0092:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
-    IL_0097:  stloc.3
-    IL_0098:  ldarg.0
-    IL_0099:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_009e:  ldloca.s   V_3
-    IL_00a0:  ldarg.0
-    IL_00a1:  stloc.s    V_4
-    IL_00a3:  ldloca.s   V_4
-    IL_00a5:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_00aa:  nop
-    IL_00ab:  leave      IL_01ea
-   >IL_00b0:  ldarg.0
-    IL_00b1:  ldc.i4.m1
-    IL_00b2:  dup
-    IL_00b3:  stloc.0
-    IL_00b4:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_00bf:  stloc.1
-    IL_00c0:  ldarg.0
-    IL_00c1:  ldnull
-    IL_00c2:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldloc.1
-    IL_00c9:  ldnull
-    IL_00ca:  ldstr      "GetResult"
-    IL_00cf:  ldc.i4.0
-    IL_00d0:  newarr     "Object"
+    IL_0053:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_0058:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+    IL_005d:  brfalse.s  IL_0061
+    IL_005f:  br.s       IL_00c6
+    IL_0061:  ldarg.0
+    IL_0062:  ldc.i4.0
+    IL_0063:  dup
+    IL_0064:  stloc.0
+    IL_0065:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+   <IL_006a:  ldarg.0
+    IL_006b:  ldloc.1
+    IL_006c:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0071:  ldloc.1
+    IL_0072:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
+    IL_0077:  stloc.2
+    IL_0078:  ldloc.2
+    IL_0079:  brfalse.s  IL_0090
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_0081:  ldloca.s   V_2
+    IL_0083:  ldarg.0
+    IL_0084:  stloc.s    V_4
+    IL_0086:  ldloca.s   V_4
+    IL_0088:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_008d:  nop
+    IL_008e:  br.s       IL_00aa
+    IL_0090:  ldloc.1
+    IL_0091:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
+    IL_0096:  stloc.3
+    IL_0097:  ldarg.0
+    IL_0098:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_009d:  ldloca.s   V_3
+    IL_009f:  ldarg.0
+    IL_00a0:  stloc.s    V_4
+    IL_00a2:  ldloca.s   V_4
+    IL_00a4:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_00a9:  nop
+    IL_00aa:  leave      IL_01e8
+   >IL_00af:  ldarg.0
+    IL_00b0:  ldc.i4.m1
+    IL_00b1:  dup
+    IL_00b2:  stloc.0
+    IL_00b3:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_00b8:  ldarg.0
+    IL_00b9:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_00be:  stloc.1
+    IL_00bf:  ldarg.0
+    IL_00c0:  ldnull
+    IL_00c1:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_00c6:  ldarg.0
+    IL_00c7:  ldloc.1
+    IL_00c8:  ldnull
+    IL_00c9:  ldstr      "GetResult"
+    IL_00ce:  ldc.i4.0
+    IL_00cf:  newarr     "Object"
+    IL_00d4:  ldnull
     IL_00d5:  ldnull
     IL_00d6:  ldnull
-    IL_00d7:  ldnull
-    IL_00d8:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_00dd:  stloc.s    V_5
-    IL_00df:  ldnull
-    IL_00e0:  stloc.1
-    IL_00e1:  ldloc.s    V_5
-    IL_00e3:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-    IL_00e8:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Object"
-   -IL_00ed:  nop
-    IL_00ee:  ldarg.0
-    IL_00ef:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-    IL_00f4:  ldnull
-    IL_00f5:  ldstr      "GetAwaiter"
-    IL_00fa:  ldc.i4.0
-    IL_00fb:  newarr     "Object"
+    IL_00d7:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_00dc:  stloc.s    V_5
+    IL_00de:  ldnull
+    IL_00df:  stloc.1
+    IL_00e0:  ldloc.s    V_5
+    IL_00e2:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+    IL_00e7:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Object"
+   -IL_00ec:  ldarg.0
+    IL_00ed:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
+    IL_00f2:  ldnull
+    IL_00f3:  ldstr      "GetAwaiter"
+    IL_00f8:  ldc.i4.0
+    IL_00f9:  newarr     "Object"
+    IL_00fe:  ldnull
+    IL_00ff:  ldnull
     IL_0100:  ldnull
-    IL_0101:  ldnull
-    IL_0102:  ldnull
-    IL_0103:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0108:  stloc.s    V_6
-   ~IL_010a:  ldloc.s    V_6
-    IL_010c:  ldnull
-    IL_010d:  ldstr      "IsCompleted"
-    IL_0112:  ldc.i4.0
-    IL_0113:  newarr     "Object"
+    IL_0101:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_0106:  stloc.s    V_6
+   ~IL_0108:  ldloc.s    V_6
+    IL_010a:  ldnull
+    IL_010b:  ldstr      "IsCompleted"
+    IL_0110:  ldc.i4.0
+    IL_0111:  newarr     "Object"
+    IL_0116:  ldnull
+    IL_0117:  ldnull
     IL_0118:  ldnull
-    IL_0119:  ldnull
-    IL_011a:  ldnull
-    IL_011b:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0120:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
-    IL_0125:  brfalse.s  IL_0129
-    IL_0127:  br.s       IL_0192
-    IL_0129:  ldarg.0
-    IL_012a:  ldc.i4.1
-    IL_012b:  dup
-    IL_012c:  stloc.0
-    IL_012d:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-   <IL_0132:  ldarg.0
-    IL_0133:  ldloc.s    V_6
-    IL_0135:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_013a:  ldloc.s    V_6
-    IL_013c:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
-    IL_0141:  stloc.s    V_7
-    IL_0143:  ldloc.s    V_7
-    IL_0145:  brfalse.s  IL_015c
-    IL_0147:  ldarg.0
-    IL_0148:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_014d:  ldloca.s   V_7
-    IL_014f:  ldarg.0
-    IL_0150:  stloc.s    V_4
-    IL_0152:  ldloca.s   V_4
-    IL_0154:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_0159:  nop
-    IL_015a:  br.s       IL_0178
-    IL_015c:  ldloc.s    V_6
-    IL_015e:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
-    IL_0163:  stloc.s    V_8
-    IL_0165:  ldarg.0
-    IL_0166:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_016b:  ldloca.s   V_8
-    IL_016d:  ldarg.0
-    IL_016e:  stloc.s    V_4
-    IL_0170:  ldloca.s   V_4
-    IL_0172:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_0177:  nop
-    IL_0178:  leave.s    IL_01ea
-   >IL_017a:  ldarg.0
-    IL_017b:  ldc.i4.m1
-    IL_017c:  dup
-    IL_017d:  stloc.0
-    IL_017e:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_0183:  ldarg.0
-    IL_0184:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0189:  stloc.s    V_6
-    IL_018b:  ldarg.0
-    IL_018c:  ldnull
-    IL_018d:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0192:  ldloc.s    V_6
-    IL_0194:  ldnull
-    IL_0195:  ldstr      "GetResult"
-    IL_019a:  ldc.i4.0
-    IL_019b:  newarr     "Object"
+    IL_0119:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_011e:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+    IL_0123:  brfalse.s  IL_0127
+    IL_0125:  br.s       IL_0190
+    IL_0127:  ldarg.0
+    IL_0128:  ldc.i4.1
+    IL_0129:  dup
+    IL_012a:  stloc.0
+    IL_012b:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+   <IL_0130:  ldarg.0
+    IL_0131:  ldloc.s    V_6
+    IL_0133:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0138:  ldloc.s    V_6
+    IL_013a:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
+    IL_013f:  stloc.s    V_7
+    IL_0141:  ldloc.s    V_7
+    IL_0143:  brfalse.s  IL_015a
+    IL_0145:  ldarg.0
+    IL_0146:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_014b:  ldloca.s   V_7
+    IL_014d:  ldarg.0
+    IL_014e:  stloc.s    V_4
+    IL_0150:  ldloca.s   V_4
+    IL_0152:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_0157:  nop
+    IL_0158:  br.s       IL_0176
+    IL_015a:  ldloc.s    V_6
+    IL_015c:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
+    IL_0161:  stloc.s    V_8
+    IL_0163:  ldarg.0
+    IL_0164:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_0169:  ldloca.s   V_8
+    IL_016b:  ldarg.0
+    IL_016c:  stloc.s    V_4
+    IL_016e:  ldloca.s   V_4
+    IL_0170:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_0175:  nop
+    IL_0176:  leave.s    IL_01e8
+   >IL_0178:  ldarg.0
+    IL_0179:  ldc.i4.m1
+    IL_017a:  dup
+    IL_017b:  stloc.0
+    IL_017c:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_0181:  ldarg.0
+    IL_0182:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0187:  stloc.s    V_6
+    IL_0189:  ldarg.0
+    IL_018a:  ldnull
+    IL_018b:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0190:  ldloc.s    V_6
+    IL_0192:  ldnull
+    IL_0193:  ldstr      "GetResult"
+    IL_0198:  ldc.i4.0
+    IL_0199:  newarr     "Object"
+    IL_019e:  ldnull
+    IL_019f:  ldnull
     IL_01a0:  ldnull
-    IL_01a1:  ldnull
-    IL_01a2:  ldnull
-    IL_01a3:  ldc.i4.1
-    IL_01a4:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object, System.Type, String, Object(), String(), System.Type(), Boolean(), Boolean) As Object"
-    IL_01a9:  pop
-    IL_01aa:  ldnull
-    IL_01ab:  stloc.s    V_6
-   -IL_01ad:  leave.s    IL_01d4
+    IL_01a1:  ldc.i4.1
+    IL_01a2:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object, System.Type, String, Object(), String(), System.Type(), Boolean(), Boolean) As Object"
+    IL_01a7:  pop
+    IL_01a8:  ldnull
+    IL_01a9:  stloc.s    V_6
+   -IL_01ab:  leave.s    IL_01d2
   }
   catch System.Exception
   {
-  ~$IL_01af:  dup
-    IL_01b0:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_01b5:  stloc.s    V_9
-   ~IL_01b7:  ldarg.0
-    IL_01b8:  ldc.i4.s   -2
-    IL_01ba:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_01bf:  ldarg.0
-    IL_01c0:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_01c5:  ldloc.s    V_9
-    IL_01c7:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
-    IL_01cc:  nop
-    IL_01cd:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_01d2:  leave.s    IL_01ea
+  ~$IL_01ad:  dup
+    IL_01ae:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_01b3:  stloc.s    V_9
+   ~IL_01b5:  ldarg.0
+    IL_01b6:  ldc.i4.s   -2
+    IL_01b8:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_01bd:  ldarg.0
+    IL_01be:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_01c3:  ldloc.s    V_9
+    IL_01c5:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
+    IL_01ca:  nop
+    IL_01cb:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_01d0:  leave.s    IL_01e8
   }
- -IL_01d4:  ldarg.0
-  IL_01d5:  ldc.i4.s   -2
-  IL_01d7:  dup
-  IL_01d8:  stloc.0
-  IL_01d9:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
- ~IL_01de:  ldarg.0
-  IL_01df:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-  IL_01e4:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
-  IL_01e9:  nop
-  IL_01ea:  ret
+ -IL_01d2:  ldarg.0
+  IL_01d3:  ldc.i4.s   -2
+  IL_01d5:  dup
+  IL_01d6:  stloc.0
+  IL_01d7:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+ ~IL_01dc:  ldarg.0
+  IL_01dd:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+  IL_01e2:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
+  IL_01e7:  nop
+  IL_01e8:  ret
 }
 ]]>,
             sequencePoints:="Program+VB$StateMachine_0_Test2.MoveNext")
@@ -1783,7 +1781,7 @@ End Module
             c.VerifyIL("Program.VB$StateMachine_0_Test2.MoveNext",
             <![CDATA[
 {
-  // Code size      224 (0xe0)
+  // Code size      223 (0xdf)
   .maxstack  3
   .locals init (Integer V_0,
                 MyTaskAwaiter(Of Integer) V_1,
@@ -1798,90 +1796,89 @@ End Module
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_0057
+    IL_000c:  br.s       IL_0056
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  newobj     "Sub MyTask(Of Integer)..ctor()"
     IL_0015:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As MyTask(Of Integer)"
-    IL_001a:  nop
-    IL_001b:  ldarg.0
-    IL_001c:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As MyTask(Of Integer)"
-    IL_0021:  callvirt   "Function MyTask(Of Integer).GetAwaiter() As MyTaskAwaiter(Of Integer)"
-    IL_0026:  stloc.1
-    IL_0027:  ldloca.s   V_1
-    IL_0029:  call       "Function MyTaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
-    IL_002e:  brtrue.s   IL_0075
-    IL_0030:  ldarg.0
-    IL_0031:  ldc.i4.0
-    IL_0032:  dup
-    IL_0033:  stloc.0
-    IL_0034:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_0039:  ldarg.0
-    IL_003a:  ldloc.1
-    IL_003b:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
-    IL_0040:  ldarg.0
-    IL_0041:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_0046:  ldloca.s   V_1
-    IL_0048:  ldarg.0
-    IL_0049:  stloc.2
-    IL_004a:  ldloca.s   V_2
-    IL_004c:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of MyTaskAwaiter(Of Integer), Program.VB$StateMachine_0_Test2)(ByRef MyTaskAwaiter(Of Integer), ByRef Program.VB$StateMachine_0_Test2)"
-    IL_0051:  nop
-    IL_0052:  leave      IL_00df
-    IL_0057:  ldarg.0
-    IL_0058:  ldc.i4.m1
-    IL_0059:  dup
-    IL_005a:  stloc.0
-    IL_005b:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_0060:  ldarg.0
-    IL_0061:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
-    IL_0066:  stloc.1
-    IL_0067:  ldarg.0
-    IL_0068:  ldflda     "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
-    IL_006d:  initobj    "MyTaskAwaiter(Of Integer)"
-    IL_0073:  br.s       IL_0075
-    IL_0075:  ldarg.0
-    IL_0076:  ldloca.s   V_1
-    IL_0078:  call       "Function MyTaskAwaiter(Of Integer).GetResult() As Object"
-    IL_007d:  stloc.3
-    IL_007e:  ldloca.s   V_1
-    IL_0080:  initobj    "MyTaskAwaiter(Of Integer)"
-    IL_0086:  ldloc.3
-    IL_0087:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-    IL_008c:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger(Object) As Integer"
-    IL_0091:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Integer"
-    IL_0096:  ldarg.0
-    IL_0097:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Integer"
-    IL_009c:  call       "Sub System.Console.WriteLine(Integer)"
-    IL_00a1:  nop
-    IL_00a2:  leave.s    IL_00c9
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As MyTask(Of Integer)"
+    IL_0020:  callvirt   "Function MyTask(Of Integer).GetAwaiter() As MyTaskAwaiter(Of Integer)"
+    IL_0025:  stloc.1
+    IL_0026:  ldloca.s   V_1
+    IL_0028:  call       "Function MyTaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_002d:  brtrue.s   IL_0074
+    IL_002f:  ldarg.0
+    IL_0030:  ldc.i4.0
+    IL_0031:  dup
+    IL_0032:  stloc.0
+    IL_0033:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_0038:  ldarg.0
+    IL_0039:  ldloc.1
+    IL_003a:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
+    IL_003f:  ldarg.0
+    IL_0040:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_0045:  ldloca.s   V_1
+    IL_0047:  ldarg.0
+    IL_0048:  stloc.2
+    IL_0049:  ldloca.s   V_2
+    IL_004b:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of MyTaskAwaiter(Of Integer), Program.VB$StateMachine_0_Test2)(ByRef MyTaskAwaiter(Of Integer), ByRef Program.VB$StateMachine_0_Test2)"
+    IL_0050:  nop
+    IL_0051:  leave      IL_00de
+    IL_0056:  ldarg.0
+    IL_0057:  ldc.i4.m1
+    IL_0058:  dup
+    IL_0059:  stloc.0
+    IL_005a:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_005f:  ldarg.0
+    IL_0060:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
+    IL_0065:  stloc.1
+    IL_0066:  ldarg.0
+    IL_0067:  ldflda     "Program.VB$StateMachine_0_Test2.$A0 As MyTaskAwaiter(Of Integer)"
+    IL_006c:  initobj    "MyTaskAwaiter(Of Integer)"
+    IL_0072:  br.s       IL_0074
+    IL_0074:  ldarg.0
+    IL_0075:  ldloca.s   V_1
+    IL_0077:  call       "Function MyTaskAwaiter(Of Integer).GetResult() As Object"
+    IL_007c:  stloc.3
+    IL_007d:  ldloca.s   V_1
+    IL_007f:  initobj    "MyTaskAwaiter(Of Integer)"
+    IL_0085:  ldloc.3
+    IL_0086:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+    IL_008b:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger(Object) As Integer"
+    IL_0090:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Integer"
+    IL_0095:  ldarg.0
+    IL_0096:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Integer"
+    IL_009b:  call       "Sub System.Console.WriteLine(Integer)"
+    IL_00a0:  nop
+    IL_00a1:  leave.s    IL_00c8
   }
   catch System.Exception
   {
-    IL_00a4:  dup
-    IL_00a5:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_00aa:  stloc.s    V_4
-    IL_00ac:  ldarg.0
-    IL_00ad:  ldc.i4.s   -2
-    IL_00af:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_00b4:  ldarg.0
-    IL_00b5:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_00ba:  ldloc.s    V_4
-    IL_00bc:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
-    IL_00c1:  nop
-    IL_00c2:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_00c7:  leave.s    IL_00df
+    IL_00a3:  dup
+    IL_00a4:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00a9:  stloc.s    V_4
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.s   -2
+    IL_00ae:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_00b9:  ldloc.s    V_4
+    IL_00bb:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
+    IL_00c0:  nop
+    IL_00c1:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00c6:  leave.s    IL_00de
   }
-  IL_00c9:  ldarg.0
-  IL_00ca:  ldc.i4.s   -2
-  IL_00cc:  dup
-  IL_00cd:  stloc.0
-  IL_00ce:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-  IL_00d3:  ldarg.0
-  IL_00d4:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-  IL_00d9:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
-  IL_00de:  nop
-  IL_00df:  ret
+  IL_00c8:  ldarg.0
+  IL_00c9:  ldc.i4.s   -2
+  IL_00cb:  dup
+  IL_00cc:  stloc.0
+  IL_00cd:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+  IL_00d2:  ldarg.0
+  IL_00d3:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+  IL_00d8:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
+  IL_00dd:  nop
+  IL_00de:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -562,7 +562,7 @@ End Class
   IL_0006:  ret
 }
 {
-  // Code size      185 (0xb9)
+  // Code size      184 (0xb8)
   .maxstack  3
   IL_0000:  ldarg.0
   IL_0001:  ldfld      0x04000001
@@ -570,77 +570,76 @@ End Class
   IL_0007:  ldloc.1
   IL_0008:  brfalse.s  IL_000c
   IL_000a:  br.s       IL_000e
-  IL_000c:  br.s       IL_004a
+  IL_000c:  br.s       IL_0049
   IL_000e:  nop
-  IL_000f:  nop
-  IL_0010:  ldc.i4.1
-  IL_0011:  call       0x2B000002
-  IL_0016:  callvirt   0x0A00000F
-  IL_001b:  stloc.3
-  IL_001c:  ldloca.s   V_3
-  IL_001e:  call       0x0A000010
-  IL_0023:  brtrue.s   IL_0068
-  IL_0025:  ldarg.0
-  IL_0026:  ldc.i4.0
-  IL_0027:  dup
-  IL_0028:  stloc.1
-  IL_0029:  stfld      0x04000001
-  IL_002e:  ldarg.0
-  IL_002f:  ldloc.3
-  IL_0030:  stfld      0x04000004
-  IL_0035:  ldarg.0
-  IL_0036:  ldflda     0x04000002
-  IL_003b:  ldloca.s   V_3
-  IL_003d:  ldarg.0
-  IL_003e:  stloc.s    V_4
-  IL_0040:  ldloca.s   V_4
-  IL_0042:  call       0x2B000003
-  IL_0047:  nop
-  IL_0048:  leave.s    IL_00b8
-  IL_004a:  ldarg.0
-  IL_004b:  ldc.i4.m1
-  IL_004c:  dup
-  IL_004d:  stloc.1
-  IL_004e:  stfld      0x04000001
-  IL_0053:  ldarg.0
-  IL_0054:  ldfld      0x04000004
-  IL_0059:  stloc.3
-  IL_005a:  ldarg.0
-  IL_005b:  ldflda     0x04000004
-  IL_0060:  initobj    0x1B000003
-  IL_0066:  br.s       IL_0068
-  IL_0068:  ldloca.s   V_3
-  IL_006a:  call       0x0A000012
-  IL_006f:  pop
-  IL_0070:  ldloca.s   V_3
-  IL_0072:  initobj    0x1B000003
-  IL_0078:  ldc.i4.0
-  IL_0079:  stloc.0
-  IL_007a:  leave.s    IL_00a1
-  IL_007c:  dup
-  IL_007d:  call       0x0A000013
-  IL_0082:  stloc.s    V_5
-  IL_0084:  ldarg.0
-  IL_0085:  ldc.i4.s   -2
-  IL_0087:  stfld      0x04000001
-  IL_008c:  ldarg.0
-  IL_008d:  ldflda     0x04000002
-  IL_0092:  ldloc.s    V_5
-  IL_0094:  call       0x0A000014
-  IL_0099:  nop
-  IL_009a:  call       0x0A000015
-  IL_009f:  leave.s    IL_00b8
-  IL_00a1:  ldarg.0
-  IL_00a2:  ldc.i4.s   -2
-  IL_00a4:  dup
-  IL_00a5:  stloc.1
-  IL_00a6:  stfld      0x04000001
-  IL_00ab:  ldarg.0
-  IL_00ac:  ldflda     0x04000002
-  IL_00b1:  ldloc.0
-  IL_00b2:  call       0x0A000016
-  IL_00b7:  nop
-  IL_00b8:  ret
+  IL_000f:  ldc.i4.1
+  IL_0010:  call       0x2B000002
+  IL_0015:  callvirt   0x0A00000F
+  IL_001a:  stloc.3
+  IL_001b:  ldloca.s   V_3
+  IL_001d:  call       0x0A000010
+  IL_0022:  brtrue.s   IL_0067
+  IL_0024:  ldarg.0
+  IL_0025:  ldc.i4.0
+  IL_0026:  dup
+  IL_0027:  stloc.1
+  IL_0028:  stfld      0x04000001
+  IL_002d:  ldarg.0
+  IL_002e:  ldloc.3
+  IL_002f:  stfld      0x04000004
+  IL_0034:  ldarg.0
+  IL_0035:  ldflda     0x04000002
+  IL_003a:  ldloca.s   V_3
+  IL_003c:  ldarg.0
+  IL_003d:  stloc.s    V_4
+  IL_003f:  ldloca.s   V_4
+  IL_0041:  call       0x2B000003
+  IL_0046:  nop
+  IL_0047:  leave.s    IL_00b7
+  IL_0049:  ldarg.0
+  IL_004a:  ldc.i4.m1
+  IL_004b:  dup
+  IL_004c:  stloc.1
+  IL_004d:  stfld      0x04000001
+  IL_0052:  ldarg.0
+  IL_0053:  ldfld      0x04000004
+  IL_0058:  stloc.3
+  IL_0059:  ldarg.0
+  IL_005a:  ldflda     0x04000004
+  IL_005f:  initobj    0x1B000003
+  IL_0065:  br.s       IL_0067
+  IL_0067:  ldloca.s   V_3
+  IL_0069:  call       0x0A000012
+  IL_006e:  pop
+  IL_006f:  ldloca.s   V_3
+  IL_0071:  initobj    0x1B000003
+  IL_0077:  ldc.i4.0
+  IL_0078:  stloc.0
+  IL_0079:  leave.s    IL_00a0
+  IL_007b:  dup
+  IL_007c:  call       0x0A000013
+  IL_0081:  stloc.s    V_5
+  IL_0083:  ldarg.0
+  IL_0084:  ldc.i4.s   -2
+  IL_0086:  stfld      0x04000001
+  IL_008b:  ldarg.0
+  IL_008c:  ldflda     0x04000002
+  IL_0091:  ldloc.s    V_5
+  IL_0093:  call       0x0A000014
+  IL_0098:  nop
+  IL_0099:  call       0x0A000015
+  IL_009e:  leave.s    IL_00b7
+  IL_00a0:  ldarg.0
+  IL_00a1:  ldc.i4.s   -2
+  IL_00a3:  dup
+  IL_00a4:  stloc.1
+  IL_00a5:  stfld      0x04000001
+  IL_00aa:  ldarg.0
+  IL_00ab:  ldflda     0x04000002
+  IL_00b0:  ldloc.0
+  IL_00b1:  call       0x0A000016
+  IL_00b6:  nop
+  IL_00b7:  ret
 }
 {
   // Code size        1 (0x1)
@@ -661,20 +660,20 @@ End Class
                 <entry offset="0x7" hidden="true" document="1"/>
                 <entry offset="0xe" startLine="3" startColumn="5" endLine="3" endColumn="43" document="1"/>
                 <entry offset="0xf" startLine="4" startColumn="9" endLine="4" endColumn="33" document="1"/>
-                <entry offset="0x1c" hidden="true" document="1"/>
-                <entry offset="0x78" startLine="5" startColumn="9" endLine="5" endColumn="17" document="1"/>
-                <entry offset="0x7c" hidden="true" document="1"/>
-                <entry offset="0x84" hidden="true" document="1"/>
-                <entry offset="0xa1" startLine="6" startColumn="5" endLine="6" endColumn="17" document="1"/>
-                <entry offset="0xab" hidden="true" document="1"/>
+                <entry offset="0x1b" hidden="true" document="1"/>
+                <entry offset="0x77" startLine="5" startColumn="9" endLine="5" endColumn="17" document="1"/>
+                <entry offset="0x7b" hidden="true" document="1"/>
+                <entry offset="0x83" hidden="true" document="1"/>
+                <entry offset="0xa0" startLine="6" startColumn="5" endLine="6" endColumn="17" document="1"/>
+                <entry offset="0xaa" hidden="true" document="1"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xb9">
+            <scope startOffset="0x0" endOffset="0xb8">
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>
             </scope>
             <asyncInfo>
                 <kickoffMethod token="0x6000002"/>
-                <await yield="0x2e" resume="0x4a" token="0x6000004"/>
+                <await yield="0x2d" resume="0x49" token="0x6000004"/>
             </asyncInfo>
         </method>
     </methods>
@@ -1249,102 +1248,7 @@ End Class
 
                 diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      187 (0xbb)
-  .maxstack  3
-  .locals init (Integer V_0,
-                Integer V_1,
-                System.Threading.Tasks.Task(Of Integer) V_2,
-                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_3,
-                C.VB$StateMachine_1_F V_4,
-                System.Exception V_5)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_0006:  stloc.1
-  .try
-  {
-    IL_0007:  ldloc.1
-    IL_0008:  brfalse.s  IL_000c
-    IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_004b
-    IL_000e:  nop
-    IL_000f:  nop
-    IL_0010:  ldc.i4.s   10
-    IL_0012:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_0017:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_001c:  stloc.3
-    IL_001d:  ldloca.s   V_3
-    IL_001f:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_0024:  brtrue.s   IL_0069
-    IL_0026:  ldarg.0
-    IL_0027:  ldc.i4.0
-    IL_0028:  dup
-    IL_0029:  stloc.1
-    IL_002a:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_002f:  ldarg.0
-    IL_0030:  ldloc.3
-    IL_0031:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0036:  ldarg.0
-    IL_0037:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_003c:  ldloca.s   V_3
-    IL_003e:  ldarg.0
-    IL_003f:  stloc.s    V_4
-    IL_0041:  ldloca.s   V_4
-    IL_0043:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
-    IL_0048:  nop
-    IL_0049:  leave.s    IL_00ba
-    IL_004b:  ldarg.0
-    IL_004c:  ldc.i4.m1
-    IL_004d:  dup
-    IL_004e:  stloc.1
-    IL_004f:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0054:  ldarg.0
-    IL_0055:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_005a:  stloc.3
-    IL_005b:  ldarg.0
-    IL_005c:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0061:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0067:  br.s       IL_0069
-    IL_0069:  ldloca.s   V_3
-    IL_006b:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_0070:  pop
-    IL_0071:  ldloca.s   V_3
-    IL_0073:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0079:  ldc.i4.s   20
-    IL_007b:  stloc.0
-    IL_007c:  leave.s    IL_00a3
-  }
-  catch System.Exception
-  {
-    IL_007e:  dup
-    IL_007f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0084:  stloc.s    V_5
-    IL_0086:  ldarg.0
-    IL_0087:  ldc.i4.s   -2
-    IL_0089:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_008e:  ldarg.0
-    IL_008f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0094:  ldloc.s    V_5
-    IL_0096:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_009b:  nop
-    IL_009c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00a1:  leave.s    IL_00ba
-  }
-  IL_00a3:  ldarg.0
-  IL_00a4:  ldc.i4.s   -2
-  IL_00a6:  dup
-  IL_00a7:  stloc.1
-  IL_00a8:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00ad:  ldarg.0
-  IL_00ae:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00b3:  ldloc.0
-  IL_00b4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00b9:  nop
-  IL_00ba:  ret
-}
-")
-                v0.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
-{
-  // Code size      185 (0xb9)
+  // Code size      186 (0xba)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -1362,8 +1266,7 @@ End Class
     IL_000a:  br.s       IL_000e
     IL_000c:  br.s       IL_004a
     IL_000e:  nop
-    IL_000f:  nop
-    IL_0010:  ldc.i4.1
+    IL_000f:  ldc.i4.s   10
     IL_0011:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
     IL_0016:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
     IL_001b:  stloc.3
@@ -1386,7 +1289,7 @@ End Class
     IL_0040:  ldloca.s   V_4
     IL_0042:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
     IL_0047:  nop
-    IL_0048:  leave.s    IL_00b8
+    IL_0048:  leave.s    IL_00b9
     IL_004a:  ldarg.0
     IL_004b:  ldc.i4.m1
     IL_004c:  dup
@@ -1404,37 +1307,131 @@ End Class
     IL_006f:  pop
     IL_0070:  ldloca.s   V_3
     IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0078:  ldc.i4.2
-    IL_0079:  stloc.0
-    IL_007a:  leave.s    IL_00a1
+    IL_0078:  ldc.i4.s   20
+    IL_007a:  stloc.0
+    IL_007b:  leave.s    IL_00a2
   }
   catch System.Exception
   {
-    IL_007c:  dup
-    IL_007d:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0082:  stloc.s    V_5
-    IL_0084:  ldarg.0
-    IL_0085:  ldc.i4.s   -2
-    IL_0087:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_008c:  ldarg.0
-    IL_008d:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0092:  ldloc.s    V_5
-    IL_0094:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_0099:  nop
-    IL_009a:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_009f:  leave.s    IL_00b8
+    IL_007d:  dup
+    IL_007e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0083:  stloc.s    V_5
+    IL_0085:  ldarg.0
+    IL_0086:  ldc.i4.s   -2
+    IL_0088:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0093:  ldloc.s    V_5
+    IL_0095:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_009a:  nop
+    IL_009b:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00a0:  leave.s    IL_00b9
   }
-  IL_00a1:  ldarg.0
-  IL_00a2:  ldc.i4.s   -2
-  IL_00a4:  dup
-  IL_00a5:  stloc.1
-  IL_00a6:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00ab:  ldarg.0
-  IL_00ac:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00b1:  ldloc.0
-  IL_00b2:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00b7:  nop
-  IL_00b8:  ret
+  IL_00a2:  ldarg.0
+  IL_00a3:  ldc.i4.s   -2
+  IL_00a5:  dup
+  IL_00a6:  stloc.1
+  IL_00a7:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00ac:  ldarg.0
+  IL_00ad:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00b2:  ldloc.0
+  IL_00b3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00b8:  nop
+  IL_00b9:  ret
+}
+")
+                v0.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
+{
+  // Code size      184 (0xb8)
+  .maxstack  3
+  .locals init (Integer V_0,
+                Integer V_1,
+                System.Threading.Tasks.Task(Of Integer) V_2,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_3,
+                C.VB$StateMachine_1_F V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0049
+    IL_000e:  nop
+    IL_000f:  ldc.i4.1
+    IL_0010:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0015:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_001a:  stloc.3
+    IL_001b:  ldloca.s   V_3
+    IL_001d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_0022:  brtrue.s   IL_0067
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.1
+    IL_0028:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_002d:  ldarg.0
+    IL_002e:  ldloc.3
+    IL_002f:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0034:  ldarg.0
+    IL_0035:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_003a:  ldloca.s   V_3
+    IL_003c:  ldarg.0
+    IL_003d:  stloc.s    V_4
+    IL_003f:  ldloca.s   V_4
+    IL_0041:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
+    IL_0046:  nop
+    IL_0047:  leave.s    IL_00b7
+    IL_0049:  ldarg.0
+    IL_004a:  ldc.i4.m1
+    IL_004b:  dup
+    IL_004c:  stloc.1
+    IL_004d:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0052:  ldarg.0
+    IL_0053:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0058:  stloc.3
+    IL_0059:  ldarg.0
+    IL_005a:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_005f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0065:  br.s       IL_0067
+    IL_0067:  ldloca.s   V_3
+    IL_0069:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_006e:  pop
+    IL_006f:  ldloca.s   V_3
+    IL_0071:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0077:  ldc.i4.2
+    IL_0078:  stloc.0
+    IL_0079:  leave.s    IL_00a0
+  }
+  catch System.Exception
+  {
+    IL_007b:  dup
+    IL_007c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0081:  stloc.s    V_5
+    IL_0083:  ldarg.0
+    IL_0084:  ldc.i4.s   -2
+    IL_0086:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_008b:  ldarg.0
+    IL_008c:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0091:  ldloc.s    V_5
+    IL_0093:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_0098:  nop
+    IL_0099:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_009e:  leave.s    IL_00b7
+  }
+  IL_00a0:  ldarg.0
+  IL_00a1:  ldc.i4.s   -2
+  IL_00a3:  dup
+  IL_00a4:  stloc.1
+  IL_00a5:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00aa:  ldarg.0
+  IL_00ab:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00b0:  ldloc.0
+  IL_00b1:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00b6:  nop
+  IL_00b7:  ret
 }
 ")
             End Using
@@ -2157,7 +2154,7 @@ End Class
 
                 diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      200 (0xc8)
+  // Code size      199 (0xc7)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -2174,85 +2171,84 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_0057
+    IL_000c:  br.s       IL_0056
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  ldarg.0
     IL_0011:  ldfld      ""C.VB$StateMachine_1_F.$VB$Local_p As Integer""
     IL_0016:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_x$0 As Integer""
-    IL_001b:  nop
-    IL_001c:  ldc.i4.s   20
-    IL_001e:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_0023:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0028:  stloc.3
-    IL_0029:  ldloca.s   V_3
-    IL_002b:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_0030:  brtrue.s   IL_0075
-    IL_0032:  ldarg.0
-    IL_0033:  ldc.i4.0
-    IL_0034:  dup
-    IL_0035:  stloc.1
-    IL_0036:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_003b:  ldarg.0
-    IL_003c:  ldloc.3
-    IL_003d:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0042:  ldarg.0
-    IL_0043:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0048:  ldloca.s   V_3
-    IL_004a:  ldarg.0
-    IL_004b:  stloc.s    V_4
-    IL_004d:  ldloca.s   V_4
-    IL_004f:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
-    IL_0054:  nop
-    IL_0055:  leave.s    IL_00c7
-    IL_0057:  ldarg.0
-    IL_0058:  ldc.i4.m1
-    IL_0059:  dup
-    IL_005a:  stloc.1
-    IL_005b:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0060:  ldarg.0
-    IL_0061:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0066:  stloc.3
-    IL_0067:  ldarg.0
-    IL_0068:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_006d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0073:  br.s       IL_0075
-    IL_0075:  ldloca.s   V_3
-    IL_0077:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_007c:  stloc.s    V_5
-    IL_007e:  ldloca.s   V_3
-    IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0086:  ldloc.s    V_5
-    IL_0088:  stloc.0
-    IL_0089:  leave.s    IL_00b0
+    IL_001b:  ldc.i4.s   20
+    IL_001d:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0022:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0027:  stloc.3
+    IL_0028:  ldloca.s   V_3
+    IL_002a:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_002f:  brtrue.s   IL_0074
+    IL_0031:  ldarg.0
+    IL_0032:  ldc.i4.0
+    IL_0033:  dup
+    IL_0034:  stloc.1
+    IL_0035:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_003a:  ldarg.0
+    IL_003b:  ldloc.3
+    IL_003c:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0041:  ldarg.0
+    IL_0042:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0047:  ldloca.s   V_3
+    IL_0049:  ldarg.0
+    IL_004a:  stloc.s    V_4
+    IL_004c:  ldloca.s   V_4
+    IL_004e:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
+    IL_0053:  nop
+    IL_0054:  leave.s    IL_00c6
+    IL_0056:  ldarg.0
+    IL_0057:  ldc.i4.m1
+    IL_0058:  dup
+    IL_0059:  stloc.1
+    IL_005a:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_005f:  ldarg.0
+    IL_0060:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0065:  stloc.3
+    IL_0066:  ldarg.0
+    IL_0067:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_006c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0072:  br.s       IL_0074
+    IL_0074:  ldloca.s   V_3
+    IL_0076:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_007b:  stloc.s    V_5
+    IL_007d:  ldloca.s   V_3
+    IL_007f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0085:  ldloc.s    V_5
+    IL_0087:  stloc.0
+    IL_0088:  leave.s    IL_00af
   }
   catch System.Exception
   {
-    IL_008b:  dup
-    IL_008c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0091:  stloc.s    V_6
-    IL_0093:  ldarg.0
-    IL_0094:  ldc.i4.s   -2
-    IL_0096:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_009b:  ldarg.0
-    IL_009c:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00a1:  ldloc.s    V_6
-    IL_00a3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00a8:  nop
-    IL_00a9:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00ae:  leave.s    IL_00c7
+    IL_008a:  dup
+    IL_008b:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0090:  stloc.s    V_6
+    IL_0092:  ldarg.0
+    IL_0093:  ldc.i4.s   -2
+    IL_0095:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_009a:  ldarg.0
+    IL_009b:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00a0:  ldloc.s    V_6
+    IL_00a2:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00a7:  nop
+    IL_00a8:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00ad:  leave.s    IL_00c6
   }
-  IL_00b0:  ldarg.0
-  IL_00b1:  ldc.i4.s   -2
-  IL_00b3:  dup
-  IL_00b4:  stloc.1
-  IL_00b5:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00ba:  ldarg.0
-  IL_00bb:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00c0:  ldloc.0
-  IL_00c1:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00c6:  nop
-  IL_00c7:  ret
+  IL_00af:  ldarg.0
+  IL_00b0:  ldc.i4.s   -2
+  IL_00b2:  dup
+  IL_00b3:  stloc.1
+  IL_00b4:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00b9:  ldarg.0
+  IL_00ba:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00bf:  ldloc.0
+  IL_00c0:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00c5:  nop
+  IL_00c6:  ret
 }
 ")
             End Using
@@ -2323,7 +2319,7 @@ End Class
 
                 diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      212 (0xd4)
+  // Code size      211 (0xd3)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -2340,7 +2336,7 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_0063
+    IL_000c:  br.s       IL_0062
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  ldarg.0
@@ -2349,80 +2345,79 @@ End Class
     IL_001b:  ldarg.0
     IL_001c:  ldc.i4.s   10
     IL_001e:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_y$1 As Integer""
-    IL_0023:  nop
-    IL_0024:  ldarg.0
-    IL_0025:  ldfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_y$1 As Integer""
-    IL_002a:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_002f:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0034:  stloc.3
-    IL_0035:  ldloca.s   V_3
-    IL_0037:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_003c:  brtrue.s   IL_0081
-    IL_003e:  ldarg.0
-    IL_003f:  ldc.i4.0
-    IL_0040:  dup
-    IL_0041:  stloc.1
-    IL_0042:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0047:  ldarg.0
-    IL_0048:  ldloc.3
-    IL_0049:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_004e:  ldarg.0
-    IL_004f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0054:  ldloca.s   V_3
-    IL_0056:  ldarg.0
-    IL_0057:  stloc.s    V_4
-    IL_0059:  ldloca.s   V_4
-    IL_005b:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
-    IL_0060:  nop
-    IL_0061:  leave.s    IL_00d3
-    IL_0063:  ldarg.0
-    IL_0064:  ldc.i4.m1
-    IL_0065:  dup
-    IL_0066:  stloc.1
-    IL_0067:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_006c:  ldarg.0
-    IL_006d:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0072:  stloc.3
-    IL_0073:  ldarg.0
-    IL_0074:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_007f:  br.s       IL_0081
-    IL_0081:  ldloca.s   V_3
-    IL_0083:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_0088:  stloc.s    V_5
-    IL_008a:  ldloca.s   V_3
-    IL_008c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0092:  ldloc.s    V_5
-    IL_0094:  stloc.0
-    IL_0095:  leave.s    IL_00bc
+    IL_0023:  ldarg.0
+    IL_0024:  ldfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_y$1 As Integer""
+    IL_0029:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_002e:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0033:  stloc.3
+    IL_0034:  ldloca.s   V_3
+    IL_0036:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_003b:  brtrue.s   IL_0080
+    IL_003d:  ldarg.0
+    IL_003e:  ldc.i4.0
+    IL_003f:  dup
+    IL_0040:  stloc.1
+    IL_0041:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0046:  ldarg.0
+    IL_0047:  ldloc.3
+    IL_0048:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_004d:  ldarg.0
+    IL_004e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0053:  ldloca.s   V_3
+    IL_0055:  ldarg.0
+    IL_0056:  stloc.s    V_4
+    IL_0058:  ldloca.s   V_4
+    IL_005a:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
+    IL_005f:  nop
+    IL_0060:  leave.s    IL_00d2
+    IL_0062:  ldarg.0
+    IL_0063:  ldc.i4.m1
+    IL_0064:  dup
+    IL_0065:  stloc.1
+    IL_0066:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_006b:  ldarg.0
+    IL_006c:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0071:  stloc.3
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_007e:  br.s       IL_0080
+    IL_0080:  ldloca.s   V_3
+    IL_0082:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_0087:  stloc.s    V_5
+    IL_0089:  ldloca.s   V_3
+    IL_008b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0091:  ldloc.s    V_5
+    IL_0093:  stloc.0
+    IL_0094:  leave.s    IL_00bb
   }
   catch System.Exception
   {
-    IL_0097:  dup
-    IL_0098:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_009d:  stloc.s    V_6
-    IL_009f:  ldarg.0
-    IL_00a0:  ldc.i4.s   -2
-    IL_00a2:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00ad:  ldloc.s    V_6
-    IL_00af:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00b4:  nop
-    IL_00b5:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00ba:  leave.s    IL_00d3
+    IL_0096:  dup
+    IL_0097:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_009c:  stloc.s    V_6
+    IL_009e:  ldarg.0
+    IL_009f:  ldc.i4.s   -2
+    IL_00a1:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_00a6:  ldarg.0
+    IL_00a7:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00ac:  ldloc.s    V_6
+    IL_00ae:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00b3:  nop
+    IL_00b4:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00b9:  leave.s    IL_00d2
   }
-  IL_00bc:  ldarg.0
-  IL_00bd:  ldc.i4.s   -2
-  IL_00bf:  dup
-  IL_00c0:  stloc.1
-  IL_00c1:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00c6:  ldarg.0
-  IL_00c7:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00cc:  ldloc.0
-  IL_00cd:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00d2:  nop
-  IL_00d3:  ret
+  IL_00bb:  ldarg.0
+  IL_00bc:  ldc.i4.s   -2
+  IL_00be:  dup
+  IL_00bf:  stloc.1
+  IL_00c0:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00c5:  ldarg.0
+  IL_00c6:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00cb:  ldloc.0
+  IL_00cc:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00d1:  nop
+  IL_00d2:  ret
 }
 ")
             End Using
@@ -2492,7 +2487,7 @@ End Class
 
                 diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      203 (0xcb)
+  // Code size      202 (0xca)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -2509,85 +2504,84 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_005a
+    IL_000c:  br.s       IL_0059
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  ldc.i4     0x4d2
     IL_0015:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_y$1 As Integer""
-    IL_001a:  nop
-    IL_001b:  ldarg.0
-    IL_001c:  ldfld      ""C.VB$StateMachine_1_F.$VB$Local_p As Integer""
-    IL_0021:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_0026:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_002b:  stloc.3
-    IL_002c:  ldloca.s   V_3
-    IL_002e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_0033:  brtrue.s   IL_0078
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.1
-    IL_0039:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.3
-    IL_0040:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004b:  ldloca.s   V_3
-    IL_004d:  ldarg.0
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloca.s   V_4
-    IL_0052:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
-    IL_0057:  nop
-    IL_0058:  leave.s    IL_00ca
-    IL_005a:  ldarg.0
-    IL_005b:  ldc.i4.m1
-    IL_005c:  dup
-    IL_005d:  stloc.1
-    IL_005e:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0063:  ldarg.0
-    IL_0064:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0069:  stloc.3
-    IL_006a:  ldarg.0
-    IL_006b:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0070:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0076:  br.s       IL_0078
-    IL_0078:  ldloca.s   V_3
-    IL_007a:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_007f:  stloc.s    V_5
-    IL_0081:  ldloca.s   V_3
-    IL_0083:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0089:  ldloc.s    V_5
-    IL_008b:  stloc.0
-    IL_008c:  leave.s    IL_00b3
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""C.VB$StateMachine_1_F.$VB$Local_p As Integer""
+    IL_0020:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0025:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_002a:  stloc.3
+    IL_002b:  ldloca.s   V_3
+    IL_002d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_0032:  brtrue.s   IL_0077
+    IL_0034:  ldarg.0
+    IL_0035:  ldc.i4.0
+    IL_0036:  dup
+    IL_0037:  stloc.1
+    IL_0038:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_003d:  ldarg.0
+    IL_003e:  ldloc.3
+    IL_003f:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0044:  ldarg.0
+    IL_0045:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004a:  ldloca.s   V_3
+    IL_004c:  ldarg.0
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloca.s   V_4
+    IL_0051:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
+    IL_0056:  nop
+    IL_0057:  leave.s    IL_00c9
+    IL_0059:  ldarg.0
+    IL_005a:  ldc.i4.m1
+    IL_005b:  dup
+    IL_005c:  stloc.1
+    IL_005d:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0062:  ldarg.0
+    IL_0063:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0068:  stloc.3
+    IL_0069:  ldarg.0
+    IL_006a:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_006f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0075:  br.s       IL_0077
+    IL_0077:  ldloca.s   V_3
+    IL_0079:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_007e:  stloc.s    V_5
+    IL_0080:  ldloca.s   V_3
+    IL_0082:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0088:  ldloc.s    V_5
+    IL_008a:  stloc.0
+    IL_008b:  leave.s    IL_00b2
   }
   catch System.Exception
   {
-    IL_008e:  dup
-    IL_008f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0094:  stloc.s    V_6
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.s   -2
-    IL_0099:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00a4:  ldloc.s    V_6
-    IL_00a6:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00ab:  nop
-    IL_00ac:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00b1:  leave.s    IL_00ca
+    IL_008d:  dup
+    IL_008e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0093:  stloc.s    V_6
+    IL_0095:  ldarg.0
+    IL_0096:  ldc.i4.s   -2
+    IL_0098:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_009d:  ldarg.0
+    IL_009e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00a3:  ldloc.s    V_6
+    IL_00a5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00aa:  nop
+    IL_00ab:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00b0:  leave.s    IL_00c9
   }
-  IL_00b3:  ldarg.0
-  IL_00b4:  ldc.i4.s   -2
-  IL_00b6:  dup
-  IL_00b7:  stloc.1
-  IL_00b8:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00bd:  ldarg.0
-  IL_00be:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00c3:  ldloc.0
-  IL_00c4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00c9:  nop
-  IL_00ca:  ret
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  dup
+  IL_00b6:  stloc.1
+  IL_00b7:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00c2:  ldloc.0
+  IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00c8:  nop
+  IL_00c9:  ret
 }
 ")
             End Using
@@ -2657,7 +2651,7 @@ End Class
 
                 diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      203 (0xcb)
+  // Code size      202 (0xca)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -2674,84 +2668,83 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_005a
+    IL_000c:  br.s       IL_0059
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  ldc.r8     10
     IL_0019:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_x$1 As Double""
-    IL_001e:  nop
-    IL_001f:  ldc.i4.s   20
-    IL_0021:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_0026:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_002b:  stloc.3
-    IL_002c:  ldloca.s   V_3
-    IL_002e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_0033:  brtrue.s   IL_0078
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.1
-    IL_0039:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.3
-    IL_0040:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004b:  ldloca.s   V_3
-    IL_004d:  ldarg.0
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloca.s   V_4
-    IL_0052:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
-    IL_0057:  nop
-    IL_0058:  leave.s    IL_00ca
-    IL_005a:  ldarg.0
-    IL_005b:  ldc.i4.m1
-    IL_005c:  dup
-    IL_005d:  stloc.1
-    IL_005e:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0063:  ldarg.0
-    IL_0064:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0069:  stloc.3
-    IL_006a:  ldarg.0
-    IL_006b:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0070:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0076:  br.s       IL_0078
-    IL_0078:  ldloca.s   V_3
-    IL_007a:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_007f:  stloc.s    V_5
-    IL_0081:  ldloca.s   V_3
-    IL_0083:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0089:  ldloc.s    V_5
-    IL_008b:  stloc.0
-    IL_008c:  leave.s    IL_00b3
+    IL_001e:  ldc.i4.s   20
+    IL_0020:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0025:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_002a:  stloc.3
+    IL_002b:  ldloca.s   V_3
+    IL_002d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_0032:  brtrue.s   IL_0077
+    IL_0034:  ldarg.0
+    IL_0035:  ldc.i4.0
+    IL_0036:  dup
+    IL_0037:  stloc.1
+    IL_0038:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_003d:  ldarg.0
+    IL_003e:  ldloc.3
+    IL_003f:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0044:  ldarg.0
+    IL_0045:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004a:  ldloca.s   V_3
+    IL_004c:  ldarg.0
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloca.s   V_4
+    IL_0051:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_1_F)""
+    IL_0056:  nop
+    IL_0057:  leave.s    IL_00c9
+    IL_0059:  ldarg.0
+    IL_005a:  ldc.i4.m1
+    IL_005b:  dup
+    IL_005c:  stloc.1
+    IL_005d:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0062:  ldarg.0
+    IL_0063:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0068:  stloc.3
+    IL_0069:  ldarg.0
+    IL_006a:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_006f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0075:  br.s       IL_0077
+    IL_0077:  ldloca.s   V_3
+    IL_0079:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_007e:  stloc.s    V_5
+    IL_0080:  ldloca.s   V_3
+    IL_0082:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0088:  ldloc.s    V_5
+    IL_008a:  stloc.0
+    IL_008b:  leave.s    IL_00b2
   }
   catch System.Exception
   {
-    IL_008e:  dup
-    IL_008f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0094:  stloc.s    V_6
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.s   -2
-    IL_0099:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00a4:  ldloc.s    V_6
-    IL_00a6:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00ab:  nop
-    IL_00ac:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00b1:  leave.s    IL_00ca
+    IL_008d:  dup
+    IL_008e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0093:  stloc.s    V_6
+    IL_0095:  ldarg.0
+    IL_0096:  ldc.i4.s   -2
+    IL_0098:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_009d:  ldarg.0
+    IL_009e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00a3:  ldloc.s    V_6
+    IL_00a5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00aa:  nop
+    IL_00ab:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00b0:  leave.s    IL_00c9
   }
-  IL_00b3:  ldarg.0
-  IL_00b4:  ldc.i4.s   -2
-  IL_00b6:  dup
-  IL_00b7:  stloc.1
-  IL_00b8:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00bd:  ldarg.0
-  IL_00be:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00c3:  ldloc.0
-  IL_00c4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00c9:  nop
-  IL_00ca:  ret
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  dup
+  IL_00b6:  stloc.1
+  IL_00b7:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00c2:  ldloc.0
+  IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00c8:  nop
+  IL_00c9:  ret
 }
 ")
             End Using
@@ -2978,7 +2971,7 @@ End Class
 
             diff1.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      203 (0xcb)
+  // Code size      202 (0xca)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -2994,7 +2987,7 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_005c
+    IL_000c:  br.s       IL_005b
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  newobj     ""Sub C..ctor()""
@@ -3002,79 +2995,78 @@ End Class
     IL_001a:  ldarg.0
     IL_001b:  ldc.i4.3
     IL_001c:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_a2$1 As Integer""
-    IL_0021:  nop
-    IL_0022:  ldc.i4.0
-    IL_0023:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
-    IL_0028:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_002d:  stloc.3
-    IL_002e:  ldloca.s   V_3
-    IL_0030:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
-    IL_0035:  brtrue.s   IL_007a
-    IL_0037:  ldarg.0
-    IL_0038:  ldc.i4.0
-    IL_0039:  dup
-    IL_003a:  stloc.1
-    IL_003b:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0040:  ldarg.0
-    IL_0041:  ldloc.3
-    IL_0042:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0047:  ldarg.0
-    IL_0048:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004d:  ldloca.s   V_3
-    IL_004f:  ldarg.0
-    IL_0050:  stloc.s    V_4
-    IL_0052:  ldloca.s   V_4
-    IL_0054:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_F)""
-    IL_0059:  nop
-    IL_005a:  leave.s    IL_00ca
-    IL_005c:  ldarg.0
-    IL_005d:  ldc.i4.m1
-    IL_005e:  dup
-    IL_005f:  stloc.1
-    IL_0060:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0065:  ldarg.0
-    IL_0066:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_006b:  stloc.3
-    IL_006c:  ldarg.0
-    IL_006d:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0078:  br.s       IL_007a
-    IL_007a:  ldloca.s   V_3
-    IL_007c:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0081:  nop
-    IL_0082:  ldloca.s   V_3
-    IL_0084:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_008a:  ldc.i4.1
-    IL_008b:  stloc.0
-    IL_008c:  leave.s    IL_00b3
+    IL_0021:  ldc.i4.0
+    IL_0022:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
+    IL_0027:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_002c:  stloc.3
+    IL_002d:  ldloca.s   V_3
+    IL_002f:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
+    IL_0034:  brtrue.s   IL_0079
+    IL_0036:  ldarg.0
+    IL_0037:  ldc.i4.0
+    IL_0038:  dup
+    IL_0039:  stloc.1
+    IL_003a:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_003f:  ldarg.0
+    IL_0040:  ldloc.3
+    IL_0041:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0046:  ldarg.0
+    IL_0047:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004c:  ldloca.s   V_3
+    IL_004e:  ldarg.0
+    IL_004f:  stloc.s    V_4
+    IL_0051:  ldloca.s   V_4
+    IL_0053:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_F)""
+    IL_0058:  nop
+    IL_0059:  leave.s    IL_00c9
+    IL_005b:  ldarg.0
+    IL_005c:  ldc.i4.m1
+    IL_005d:  dup
+    IL_005e:  stloc.1
+    IL_005f:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0064:  ldarg.0
+    IL_0065:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_006a:  stloc.3
+    IL_006b:  ldarg.0
+    IL_006c:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0071:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0077:  br.s       IL_0079
+    IL_0079:  ldloca.s   V_3
+    IL_007b:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_0080:  nop
+    IL_0081:  ldloca.s   V_3
+    IL_0083:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0089:  ldc.i4.1
+    IL_008a:  stloc.0
+    IL_008b:  leave.s    IL_00b2
   }
   catch System.Exception
   {
-    IL_008e:  dup
-    IL_008f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0094:  stloc.s    V_5
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.s   -2
-    IL_0099:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00a4:  ldloc.s    V_5
-    IL_00a6:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00ab:  nop
-    IL_00ac:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00b1:  leave.s    IL_00ca
+    IL_008d:  dup
+    IL_008e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0093:  stloc.s    V_5
+    IL_0095:  ldarg.0
+    IL_0096:  ldc.i4.s   -2
+    IL_0098:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_009d:  ldarg.0
+    IL_009e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00a3:  ldloc.s    V_5
+    IL_00a5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00aa:  nop
+    IL_00ab:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00b0:  leave.s    IL_00c9
   }
-  IL_00b3:  ldarg.0
-  IL_00b4:  ldc.i4.s   -2
-  IL_00b6:  dup
-  IL_00b7:  stloc.1
-  IL_00b8:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00bd:  ldarg.0
-  IL_00be:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00c3:  ldloc.0
-  IL_00c4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00c9:  nop
-  IL_00ca:  ret
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  dup
+  IL_00b6:  stloc.1
+  IL_00b7:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00c2:  ldloc.0
+  IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00c8:  nop
+  IL_00c9:  ret
 }
 ")
 
@@ -3093,7 +3085,7 @@ End Class
 
             diff2.VerifyIL("C.VB$StateMachine_1_F.MoveNext()", "
 {
-  // Code size      203 (0xcb)
+  // Code size      202 (0xca)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -3109,7 +3101,7 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_005c
+    IL_000c:  br.s       IL_005b
     IL_000e:  nop
     IL_000f:  ldarg.0
     IL_0010:  ldc.i4.1
@@ -3117,79 +3109,78 @@ End Class
     IL_0016:  ldarg.0
     IL_0017:  newobj     ""Sub C..ctor()""
     IL_001c:  stfld      ""C.VB$StateMachine_1_F.$VB$ResumableLocal_a2$4 As C""
-    IL_0021:  nop
-    IL_0022:  ldc.i4.0
-    IL_0023:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
-    IL_0028:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_002d:  stloc.3
-    IL_002e:  ldloca.s   V_3
-    IL_0030:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
-    IL_0035:  brtrue.s   IL_007a
-    IL_0037:  ldarg.0
-    IL_0038:  ldc.i4.0
-    IL_0039:  dup
-    IL_003a:  stloc.1
-    IL_003b:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0040:  ldarg.0
-    IL_0041:  ldloc.3
-    IL_0042:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0047:  ldarg.0
-    IL_0048:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004d:  ldloca.s   V_3
-    IL_004f:  ldarg.0
-    IL_0050:  stloc.s    V_4
-    IL_0052:  ldloca.s   V_4
-    IL_0054:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_F)""
-    IL_0059:  nop
-    IL_005a:  leave.s    IL_00ca
-    IL_005c:  ldarg.0
-    IL_005d:  ldc.i4.m1
-    IL_005e:  dup
-    IL_005f:  stloc.1
-    IL_0060:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_0065:  ldarg.0
-    IL_0066:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_006b:  stloc.3
-    IL_006c:  ldarg.0
-    IL_006d:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0078:  br.s       IL_007a
-    IL_007a:  ldloca.s   V_3
-    IL_007c:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0081:  nop
-    IL_0082:  ldloca.s   V_3
-    IL_0084:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_008a:  ldc.i4.1
-    IL_008b:  stloc.0
-    IL_008c:  leave.s    IL_00b3
+    IL_0021:  ldc.i4.0
+    IL_0022:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
+    IL_0027:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_002c:  stloc.3
+    IL_002d:  ldloca.s   V_3
+    IL_002f:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
+    IL_0034:  brtrue.s   IL_0079
+    IL_0036:  ldarg.0
+    IL_0037:  ldc.i4.0
+    IL_0038:  dup
+    IL_0039:  stloc.1
+    IL_003a:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_003f:  ldarg.0
+    IL_0040:  ldloc.3
+    IL_0041:  stfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0046:  ldarg.0
+    IL_0047:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004c:  ldloca.s   V_3
+    IL_004e:  ldarg.0
+    IL_004f:  stloc.s    V_4
+    IL_0051:  ldloca.s   V_4
+    IL_0053:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_F)""
+    IL_0058:  nop
+    IL_0059:  leave.s    IL_00c9
+    IL_005b:  ldarg.0
+    IL_005c:  ldc.i4.m1
+    IL_005d:  dup
+    IL_005e:  stloc.1
+    IL_005f:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_0064:  ldarg.0
+    IL_0065:  ldfld      ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_006a:  stloc.3
+    IL_006b:  ldarg.0
+    IL_006c:  ldflda     ""C.VB$StateMachine_1_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0071:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0077:  br.s       IL_0079
+    IL_0079:  ldloca.s   V_3
+    IL_007b:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_0080:  nop
+    IL_0081:  ldloca.s   V_3
+    IL_0083:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0089:  ldc.i4.1
+    IL_008a:  stloc.0
+    IL_008b:  leave.s    IL_00b2
   }
   catch System.Exception
   {
-    IL_008e:  dup
-    IL_008f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0094:  stloc.s    V_5
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.s   -2
-    IL_0099:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00a4:  ldloc.s    V_5
-    IL_00a6:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00ab:  nop
-    IL_00ac:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00b1:  leave.s    IL_00ca
+    IL_008d:  dup
+    IL_008e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0093:  stloc.s    V_5
+    IL_0095:  ldarg.0
+    IL_0096:  ldc.i4.s   -2
+    IL_0098:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+    IL_009d:  ldarg.0
+    IL_009e:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00a3:  ldloc.s    V_5
+    IL_00a5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00aa:  nop
+    IL_00ab:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00b0:  leave.s    IL_00c9
   }
-  IL_00b3:  ldarg.0
-  IL_00b4:  ldc.i4.s   -2
-  IL_00b6:  dup
-  IL_00b7:  stloc.1
-  IL_00b8:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
-  IL_00bd:  ldarg.0
-  IL_00be:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00c3:  ldloc.0
-  IL_00c4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00c9:  nop
-  IL_00ca:  ret
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  dup
+  IL_00b6:  stloc.1
+  IL_00b7:  stfld      ""C.VB$StateMachine_1_F.$State As Integer""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""C.VB$StateMachine_1_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00c2:  ldloc.0
+  IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00c8:  nop
+  IL_00c9:  ret
 }
 ")
 
@@ -3489,7 +3480,7 @@ End Class
 
             diff1.VerifyIL("C.VB$StateMachine_4_F.MoveNext()", "
 {
-  // Code size      317 (0x13d)
+  // Code size      315 (0x13b)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -3510,126 +3501,124 @@ End Class
     IL_000d:  ldc.i4.1
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
-    IL_0012:  br.s       IL_005d
-    IL_0014:  br         IL_00cd
+    IL_0012:  br.s       IL_005c
+    IL_0014:  br         IL_00cb
     IL_0019:  nop
-    IL_001a:  nop
-    IL_001b:  ldarg.0
-    IL_001c:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
-    IL_0021:  callvirt   ""Function C.A3() As System.Threading.Tasks.Task(Of C)""
-    IL_0026:  callvirt   ""Function System.Threading.Tasks.Task(Of C).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_002b:  stloc.3
-    IL_002c:  ldloca.s   V_3
-    IL_002e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).get_IsCompleted() As Boolean""
-    IL_0033:  brtrue.s   IL_007b
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.1
-    IL_0039:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.3
-    IL_0040:  stfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004b:  ldloca.s   V_3
-    IL_004d:  ldarg.0
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloca.s   V_4
-    IL_0052:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of C), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of C), ByRef C.VB$StateMachine_4_F)""
-    IL_0057:  nop
-    IL_0058:  leave      IL_013c
-    IL_005d:  ldarg.0
-    IL_005e:  ldc.i4.m1
-    IL_005f:  dup
-    IL_0060:  stloc.1
-    IL_0061:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_0066:  ldarg.0
-    IL_0067:  ldfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_006c:  stloc.3
-    IL_006d:  ldarg.0
-    IL_006e:  ldflda     ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_0073:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_0079:  br.s       IL_007b
-    IL_007b:  ldloca.s   V_3
-    IL_007d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).GetResult() As C""
-    IL_0082:  pop
-    IL_0083:  ldloca.s   V_3
-    IL_0085:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_008b:  nop
-    IL_008c:  ldarg.0
-    IL_008d:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
-    IL_0092:  callvirt   ""Function C.A2() As System.Threading.Tasks.Task(Of Integer)""
-    IL_0097:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_009c:  stloc.s    V_5
-    IL_009e:  ldloca.s   V_5
-    IL_00a0:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_00a5:  brtrue.s   IL_00ec
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldc.i4.1
-    IL_00a9:  dup
-    IL_00aa:  stloc.1
-    IL_00ab:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_00b0:  ldarg.0
-    IL_00b1:  ldloc.s    V_5
-    IL_00b3:  stfld      ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00be:  ldloca.s   V_5
-    IL_00c0:  ldarg.0
-    IL_00c1:  stloc.s    V_4
-    IL_00c3:  ldloca.s   V_4
-    IL_00c5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_4_F)""
-    IL_00ca:  nop
-    IL_00cb:  leave.s    IL_013c
-    IL_00cd:  ldarg.0
-    IL_00ce:  ldc.i4.m1
-    IL_00cf:  dup
-    IL_00d0:  stloc.1
-    IL_00d1:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_00d6:  ldarg.0
-    IL_00d7:  ldfld      ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00dc:  stloc.s    V_5
-    IL_00de:  ldarg.0
-    IL_00df:  ldflda     ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00e4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00ea:  br.s       IL_00ec
-    IL_00ec:  ldloca.s   V_5
-    IL_00ee:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_00f3:  pop
-    IL_00f4:  ldloca.s   V_5
-    IL_00f6:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00fc:  ldc.i4.1
-    IL_00fd:  stloc.0
-    IL_00fe:  leave.s    IL_0125
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
+    IL_0020:  callvirt   ""Function C.A3() As System.Threading.Tasks.Task(Of C)""
+    IL_0025:  callvirt   ""Function System.Threading.Tasks.Task(Of C).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_002a:  stloc.3
+    IL_002b:  ldloca.s   V_3
+    IL_002d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).get_IsCompleted() As Boolean""
+    IL_0032:  brtrue.s   IL_007a
+    IL_0034:  ldarg.0
+    IL_0035:  ldc.i4.0
+    IL_0036:  dup
+    IL_0037:  stloc.1
+    IL_0038:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_003d:  ldarg.0
+    IL_003e:  ldloc.3
+    IL_003f:  stfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_0044:  ldarg.0
+    IL_0045:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004a:  ldloca.s   V_3
+    IL_004c:  ldarg.0
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloca.s   V_4
+    IL_0051:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of C), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of C), ByRef C.VB$StateMachine_4_F)""
+    IL_0056:  nop
+    IL_0057:  leave      IL_013a
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.m1
+    IL_005e:  dup
+    IL_005f:  stloc.1
+    IL_0060:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_0065:  ldarg.0
+    IL_0066:  ldfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_006b:  stloc.3
+    IL_006c:  ldarg.0
+    IL_006d:  ldflda     ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_0078:  br.s       IL_007a
+    IL_007a:  ldloca.s   V_3
+    IL_007c:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).GetResult() As C""
+    IL_0081:  pop
+    IL_0082:  ldloca.s   V_3
+    IL_0084:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_008a:  ldarg.0
+    IL_008b:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
+    IL_0090:  callvirt   ""Function C.A2() As System.Threading.Tasks.Task(Of Integer)""
+    IL_0095:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_009a:  stloc.s    V_5
+    IL_009c:  ldloca.s   V_5
+    IL_009e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_00a3:  brtrue.s   IL_00ea
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldc.i4.1
+    IL_00a7:  dup
+    IL_00a8:  stloc.1
+    IL_00a9:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_00ae:  ldarg.0
+    IL_00af:  ldloc.s    V_5
+    IL_00b1:  stfld      ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00bc:  ldloca.s   V_5
+    IL_00be:  ldarg.0
+    IL_00bf:  stloc.s    V_4
+    IL_00c1:  ldloca.s   V_4
+    IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_4_F)""
+    IL_00c8:  nop
+    IL_00c9:  leave.s    IL_013a
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldc.i4.m1
+    IL_00cd:  dup
+    IL_00ce:  stloc.1
+    IL_00cf:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_00d4:  ldarg.0
+    IL_00d5:  ldfld      ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00da:  stloc.s    V_5
+    IL_00dc:  ldarg.0
+    IL_00dd:  ldflda     ""C.VB$StateMachine_4_F.$A1 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00e2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00e8:  br.s       IL_00ea
+    IL_00ea:  ldloca.s   V_5
+    IL_00ec:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_00f1:  pop
+    IL_00f2:  ldloca.s   V_5
+    IL_00f4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00fa:  ldc.i4.1
+    IL_00fb:  stloc.0
+    IL_00fc:  leave.s    IL_0123
   }
   catch System.Exception
   {
-    IL_0100:  dup
-    IL_0101:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0106:  stloc.s    V_6
-    IL_0108:  ldarg.0
-    IL_0109:  ldc.i4.s   -2
-    IL_010b:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_0110:  ldarg.0
-    IL_0111:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0116:  ldloc.s    V_6
-    IL_0118:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_011d:  nop
-    IL_011e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_0123:  leave.s    IL_013c
+    IL_00fe:  dup
+    IL_00ff:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0104:  stloc.s    V_6
+    IL_0106:  ldarg.0
+    IL_0107:  ldc.i4.s   -2
+    IL_0109:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_010e:  ldarg.0
+    IL_010f:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0114:  ldloc.s    V_6
+    IL_0116:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_011b:  nop
+    IL_011c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_0121:  leave.s    IL_013a
   }
-  IL_0125:  ldarg.0
-  IL_0126:  ldc.i4.s   -2
-  IL_0128:  dup
-  IL_0129:  stloc.1
-  IL_012a:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-  IL_012f:  ldarg.0
-  IL_0130:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_0135:  ldloc.0
-  IL_0136:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_013b:  nop
-  IL_013c:  ret
+  IL_0123:  ldarg.0
+  IL_0124:  ldc.i4.s   -2
+  IL_0126:  dup
+  IL_0127:  stloc.1
+  IL_0128:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+  IL_012d:  ldarg.0
+  IL_012e:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_0133:  ldloc.0
+  IL_0134:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_0139:  nop
+  IL_013a:  ret
 }
 ")
 
@@ -3646,7 +3635,7 @@ End Class
 
             diff2.VerifyIL("C.VB$StateMachine_4_F.MoveNext()", "
 {
-  // Code size      317 (0x13d)
+  // Code size      315 (0x13b)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -3667,126 +3656,124 @@ End Class
     IL_000d:  ldc.i4.1
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
-    IL_0012:  br.s       IL_005d
-    IL_0014:  br         IL_00cd
+    IL_0012:  br.s       IL_005c
+    IL_0014:  br         IL_00cb
     IL_0019:  nop
-    IL_001a:  nop
-    IL_001b:  ldarg.0
-    IL_001c:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
-    IL_0021:  callvirt   ""Function C.A1() As System.Threading.Tasks.Task(Of Boolean)""
-    IL_0026:  callvirt   ""Function System.Threading.Tasks.Task(Of Boolean).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_002b:  stloc.3
-    IL_002c:  ldloca.s   V_3
-    IL_002e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Boolean).get_IsCompleted() As Boolean""
-    IL_0033:  brtrue.s   IL_007b
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.1
-    IL_0039:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.3
-    IL_0040:  stfld      ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_004b:  ldloca.s   V_3
-    IL_004d:  ldarg.0
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloca.s   V_4
-    IL_0052:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Boolean), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Boolean), ByRef C.VB$StateMachine_4_F)""
-    IL_0057:  nop
-    IL_0058:  leave      IL_013c
-    IL_005d:  ldarg.0
-    IL_005e:  ldc.i4.m1
-    IL_005f:  dup
-    IL_0060:  stloc.1
-    IL_0061:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_0066:  ldarg.0
-    IL_0067:  ldfld      ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_006c:  stloc.3
-    IL_006d:  ldarg.0
-    IL_006e:  ldflda     ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_0073:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_0079:  br.s       IL_007b
-    IL_007b:  ldloca.s   V_3
-    IL_007d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Boolean).GetResult() As Boolean""
-    IL_0082:  pop
-    IL_0083:  ldloca.s   V_3
-    IL_0085:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
-    IL_008b:  nop
-    IL_008c:  ldarg.0
-    IL_008d:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
-    IL_0092:  callvirt   ""Function C.A3() As System.Threading.Tasks.Task(Of C)""
-    IL_0097:  callvirt   ""Function System.Threading.Tasks.Task(Of C).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_009c:  stloc.s    V_5
-    IL_009e:  ldloca.s   V_5
-    IL_00a0:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).get_IsCompleted() As Boolean""
-    IL_00a5:  brtrue.s   IL_00ec
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldc.i4.1
-    IL_00a9:  dup
-    IL_00aa:  stloc.1
-    IL_00ab:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_00b0:  ldarg.0
-    IL_00b1:  ldloc.s    V_5
-    IL_00b3:  stfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00be:  ldloca.s   V_5
-    IL_00c0:  ldarg.0
-    IL_00c1:  stloc.s    V_4
-    IL_00c3:  ldloca.s   V_4
-    IL_00c5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of C), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of C), ByRef C.VB$StateMachine_4_F)""
-    IL_00ca:  nop
-    IL_00cb:  leave.s    IL_013c
-    IL_00cd:  ldarg.0
-    IL_00ce:  ldc.i4.m1
-    IL_00cf:  dup
-    IL_00d0:  stloc.1
-    IL_00d1:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_00d6:  ldarg.0
-    IL_00d7:  ldfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_00dc:  stloc.s    V_5
-    IL_00de:  ldarg.0
-    IL_00df:  ldflda     ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_00e4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_00ea:  br.s       IL_00ec
-    IL_00ec:  ldloca.s   V_5
-    IL_00ee:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).GetResult() As C""
-    IL_00f3:  pop
-    IL_00f4:  ldloca.s   V_5
-    IL_00f6:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
-    IL_00fc:  ldc.i4.1
-    IL_00fd:  stloc.0
-    IL_00fe:  leave.s    IL_0125
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
+    IL_0020:  callvirt   ""Function C.A1() As System.Threading.Tasks.Task(Of Boolean)""
+    IL_0025:  callvirt   ""Function System.Threading.Tasks.Task(Of Boolean).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_002a:  stloc.3
+    IL_002b:  ldloca.s   V_3
+    IL_002d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Boolean).get_IsCompleted() As Boolean""
+    IL_0032:  brtrue.s   IL_007a
+    IL_0034:  ldarg.0
+    IL_0035:  ldc.i4.0
+    IL_0036:  dup
+    IL_0037:  stloc.1
+    IL_0038:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_003d:  ldarg.0
+    IL_003e:  ldloc.3
+    IL_003f:  stfld      ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_0044:  ldarg.0
+    IL_0045:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_004a:  ldloca.s   V_3
+    IL_004c:  ldarg.0
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloca.s   V_4
+    IL_0051:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Boolean), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Boolean), ByRef C.VB$StateMachine_4_F)""
+    IL_0056:  nop
+    IL_0057:  leave      IL_013a
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.m1
+    IL_005e:  dup
+    IL_005f:  stloc.1
+    IL_0060:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_0065:  ldarg.0
+    IL_0066:  ldfld      ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_006b:  stloc.3
+    IL_006c:  ldarg.0
+    IL_006d:  ldflda     ""C.VB$StateMachine_4_F.$A3 As System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_0078:  br.s       IL_007a
+    IL_007a:  ldloca.s   V_3
+    IL_007c:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Boolean).GetResult() As Boolean""
+    IL_0081:  pop
+    IL_0082:  ldloca.s   V_3
+    IL_0084:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Boolean)""
+    IL_008a:  ldarg.0
+    IL_008b:  ldfld      ""C.VB$StateMachine_4_F.$VB$Me As C""
+    IL_0090:  callvirt   ""Function C.A3() As System.Threading.Tasks.Task(Of C)""
+    IL_0095:  callvirt   ""Function System.Threading.Tasks.Task(Of C).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_009a:  stloc.s    V_5
+    IL_009c:  ldloca.s   V_5
+    IL_009e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).get_IsCompleted() As Boolean""
+    IL_00a3:  brtrue.s   IL_00ea
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldc.i4.1
+    IL_00a7:  dup
+    IL_00a8:  stloc.1
+    IL_00a9:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_00ae:  ldarg.0
+    IL_00af:  ldloc.s    V_5
+    IL_00b1:  stfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00bc:  ldloca.s   V_5
+    IL_00be:  ldarg.0
+    IL_00bf:  stloc.s    V_4
+    IL_00c1:  ldloca.s   V_4
+    IL_00c3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of C), C.VB$StateMachine_4_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of C), ByRef C.VB$StateMachine_4_F)""
+    IL_00c8:  nop
+    IL_00c9:  leave.s    IL_013a
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldc.i4.m1
+    IL_00cd:  dup
+    IL_00ce:  stloc.1
+    IL_00cf:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_00d4:  ldarg.0
+    IL_00d5:  ldfld      ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_00da:  stloc.s    V_5
+    IL_00dc:  ldarg.0
+    IL_00dd:  ldflda     ""C.VB$StateMachine_4_F.$A2 As System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_00e2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_00e8:  br.s       IL_00ea
+    IL_00ea:  ldloca.s   V_5
+    IL_00ec:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of C).GetResult() As C""
+    IL_00f1:  pop
+    IL_00f2:  ldloca.s   V_5
+    IL_00f4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of C)""
+    IL_00fa:  ldc.i4.1
+    IL_00fb:  stloc.0
+    IL_00fc:  leave.s    IL_0123
   }
   catch System.Exception
   {
-    IL_0100:  dup
-    IL_0101:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0106:  stloc.s    V_6
-    IL_0108:  ldarg.0
-    IL_0109:  ldc.i4.s   -2
-    IL_010b:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-    IL_0110:  ldarg.0
-    IL_0111:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0116:  ldloc.s    V_6
-    IL_0118:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_011d:  nop
-    IL_011e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_0123:  leave.s    IL_013c
+    IL_00fe:  dup
+    IL_00ff:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0104:  stloc.s    V_6
+    IL_0106:  ldarg.0
+    IL_0107:  ldc.i4.s   -2
+    IL_0109:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+    IL_010e:  ldarg.0
+    IL_010f:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0114:  ldloc.s    V_6
+    IL_0116:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_011b:  nop
+    IL_011c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_0121:  leave.s    IL_013a
   }
-  IL_0125:  ldarg.0
-  IL_0126:  ldc.i4.s   -2
-  IL_0128:  dup
-  IL_0129:  stloc.1
-  IL_012a:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
-  IL_012f:  ldarg.0
-  IL_0130:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_0135:  ldloc.0
-  IL_0136:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_013b:  nop
-  IL_013c:  ret
+  IL_0123:  ldarg.0
+  IL_0124:  ldc.i4.s   -2
+  IL_0126:  dup
+  IL_0127:  stloc.1
+  IL_0128:  stfld      ""C.VB$StateMachine_4_F.$State As Integer""
+  IL_012d:  ldarg.0
+  IL_012e:  ldflda     ""C.VB$StateMachine_4_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_0133:  ldloc.0
+  IL_0134:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_0139:  nop
+  IL_013a:  ret
 }
 ")
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
@@ -758,7 +758,7 @@ End Class
             Dim v0 = CompileAndVerify(compilation:=compilation0)
             v0.VerifyIL("C.VB$StateMachine_2_M.MoveNext()", "
 {
-  // Code size      234 (0xea)
+  // Code size      233 (0xe9)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -774,7 +774,7 @@ End Class
     IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_007b
+    IL_000c:  br.s       IL_007a
     IL_000e:  nop
     IL_000f:  nop
     IL_0010:  ldarg.0
@@ -802,79 +802,78 @@ End Class
       IL_003c:  br.s       IL_003e
       IL_003e:  endfinally
     }
-    IL_003f:  nop
-    IL_0040:  ldc.i4.s   10
-    IL_0042:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
-    IL_0047:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_004c:  stloc.3
-    IL_004d:  ldloca.s   V_3
-    IL_004f:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
-    IL_0054:  brtrue.s   IL_0099
-    IL_0056:  ldarg.0
-    IL_0057:  ldc.i4.0
-    IL_0058:  dup
-    IL_0059:  stloc.1
-    IL_005a:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_005f:  ldarg.0
-    IL_0060:  ldloc.3
-    IL_0061:  stfld      ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0066:  ldarg.0
-    IL_0067:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_006c:  ldloca.s   V_3
-    IL_006e:  ldarg.0
-    IL_006f:  stloc.s    V_4
-    IL_0071:  ldloca.s   V_4
-    IL_0073:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_2_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_2_M)""
-    IL_0078:  nop
-    IL_0079:  leave.s    IL_00e9
-    IL_007b:  ldarg.0
-    IL_007c:  ldc.i4.m1
-    IL_007d:  dup
-    IL_007e:  stloc.1
-    IL_007f:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_0084:  ldarg.0
-    IL_0085:  ldfld      ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_008a:  stloc.3
-    IL_008b:  ldarg.0
-    IL_008c:  ldflda     ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0091:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_0097:  br.s       IL_0099
-    IL_0099:  ldloca.s   V_3
-    IL_009b:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
-    IL_00a0:  pop
-    IL_00a1:  ldloca.s   V_3
-    IL_00a3:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
-    IL_00a9:  ldc.i4.2
-    IL_00aa:  stloc.0
-    IL_00ab:  leave.s    IL_00d2
+    IL_003f:  ldc.i4.s   10
+    IL_0041:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0046:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_004b:  stloc.3
+    IL_004c:  ldloca.s   V_3
+    IL_004e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_0053:  brtrue.s   IL_0098
+    IL_0055:  ldarg.0
+    IL_0056:  ldc.i4.0
+    IL_0057:  dup
+    IL_0058:  stloc.1
+    IL_0059:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+    IL_005e:  ldarg.0
+    IL_005f:  ldloc.3
+    IL_0060:  stfld      ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0065:  ldarg.0
+    IL_0066:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_006b:  ldloca.s   V_3
+    IL_006d:  ldarg.0
+    IL_006e:  stloc.s    V_4
+    IL_0070:  ldloca.s   V_4
+    IL_0072:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), C.VB$StateMachine_2_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef C.VB$StateMachine_2_M)""
+    IL_0077:  nop
+    IL_0078:  leave.s    IL_00e8
+    IL_007a:  ldarg.0
+    IL_007b:  ldc.i4.m1
+    IL_007c:  dup
+    IL_007d:  stloc.1
+    IL_007e:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+    IL_0083:  ldarg.0
+    IL_0084:  ldfld      ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0089:  stloc.3
+    IL_008a:  ldarg.0
+    IL_008b:  ldflda     ""C.VB$StateMachine_2_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0090:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0096:  br.s       IL_0098
+    IL_0098:  ldloca.s   V_3
+    IL_009a:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_009f:  pop
+    IL_00a0:  ldloca.s   V_3
+    IL_00a2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00a8:  ldc.i4.2
+    IL_00a9:  stloc.0
+    IL_00aa:  leave.s    IL_00d1
   }
   catch System.Exception
   {
-    IL_00ad:  dup
-    IL_00ae:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_00b3:  stloc.s    V_5
-    IL_00b5:  ldarg.0
-    IL_00b6:  ldc.i4.s   -2
-    IL_00b8:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_00bd:  ldarg.0
-    IL_00be:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_00c3:  ldloc.s    V_5
-    IL_00c5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_00ca:  nop
-    IL_00cb:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_00d0:  leave.s    IL_00e9
+    IL_00ac:  dup
+    IL_00ad:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_00b2:  stloc.s    V_5
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldc.i4.s   -2
+    IL_00b7:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+    IL_00bc:  ldarg.0
+    IL_00bd:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_00c2:  ldloc.s    V_5
+    IL_00c4:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_00c9:  nop
+    IL_00ca:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00cf:  leave.s    IL_00e8
   }
-  IL_00d2:  ldarg.0
-  IL_00d3:  ldc.i4.s   -2
-  IL_00d5:  dup
-  IL_00d6:  stloc.1
-  IL_00d7:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-  IL_00dc:  ldarg.0
-  IL_00dd:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00e2:  ldloc.0
-  IL_00e3:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00e8:  nop
-  IL_00e9:  ret
+  IL_00d1:  ldarg.0
+  IL_00d2:  ldc.i4.s   -2
+  IL_00d4:  dup
+  IL_00d5:  stloc.1
+  IL_00d6:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+  IL_00db:  ldarg.0
+  IL_00dc:  ldflda     ""C.VB$StateMachine_2_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00e1:  ldloc.0
+  IL_00e2:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00e7:  nop
+  IL_00e8:  ret
 }
 ")
 
@@ -905,19 +904,19 @@ End Class
         <entry offset=""0x27"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
         <entry offset=""0x3e"" hidden=""true"" document=""1"" />
         <entry offset=""0x3f"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x4d"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa9"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""17"" document=""1"" />
-        <entry offset=""0xad"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb5"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd2"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""17"" document=""1"" />
-        <entry offset=""0xdc"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4c"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa8"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""17"" document=""1"" />
+        <entry offset=""0xac"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb4"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""17"" document=""1"" />
+        <entry offset=""0xdb"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xea"">
+      <scope startOffset=""0x0"" endOffset=""0xe9"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" />
-        <await yield=""0x5f"" resume=""0x7b"" declaringType=""C+VB$StateMachine_2_M"" methodName=""MoveNext"" />
+        <await yield=""0x5e"" resume=""0x7a"" declaringType=""C+VB$StateMachine_2_M"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -29,7 +29,7 @@ End Class
 
             v.VerifyIL("C.VB$StateMachine_1_M.MoveNext", "
 {
-  // Code size      185 (0xb9)
+  // Code size      184 (0xb8)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -45,81 +45,80 @@ End Class
    ~IL_0007:  ldloc.1
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_004a
+    IL_000c:  br.s       IL_0049
    -IL_000e:  nop
-   -IL_000f:  nop
-    IL_0010:  ldc.i4.1
-    IL_0011:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
-    IL_0016:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_001b:  stloc.3
-   ~IL_001c:  ldloca.s   V_3
-    IL_001e:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
-    IL_0023:  brtrue.s   IL_0068
-    IL_0025:  ldarg.0
-    IL_0026:  ldc.i4.0
-    IL_0027:  dup
-    IL_0028:  stloc.1
-    IL_0029:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
-   <IL_002e:  ldarg.0
-    IL_002f:  ldloc.3
-    IL_0030:  stfld      ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0035:  ldarg.0
-    IL_0036:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_003b:  ldloca.s   V_3
-    IL_003d:  ldarg.0
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloca.s   V_4
-    IL_0042:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_M)""
-    IL_0047:  nop
-    IL_0048:  leave.s    IL_00b8
-   >IL_004a:  ldarg.0
-    IL_004b:  ldc.i4.m1
-    IL_004c:  dup
-    IL_004d:  stloc.1
-    IL_004e:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
-    IL_0053:  ldarg.0
-    IL_0054:  ldfld      ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0059:  stloc.3
-    IL_005a:  ldarg.0
-    IL_005b:  ldflda     ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0060:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0066:  br.s       IL_0068
-    IL_0068:  ldloca.s   V_3
-    IL_006a:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_006f:  nop
-    IL_0070:  ldloca.s   V_3
-    IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-   -IL_0078:  ldc.i4.1
-    IL_0079:  stloc.0
-    IL_007a:  leave.s    IL_00a1
+   -IL_000f:  ldc.i4.1
+    IL_0010:  call       ""Function System.Threading.Tasks.Task.Delay(Integer) As System.Threading.Tasks.Task""
+    IL_0015:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_001a:  stloc.3
+   ~IL_001b:  ldloca.s   V_3
+    IL_001d:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter.get_IsCompleted() As Boolean""
+    IL_0022:  brtrue.s   IL_0067
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.1
+    IL_0028:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
+   <IL_002d:  ldarg.0
+    IL_002e:  ldloc.3
+    IL_002f:  stfld      ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0034:  ldarg.0
+    IL_0035:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_003a:  ldloca.s   V_3
+    IL_003c:  ldarg.0
+    IL_003d:  stloc.s    V_4
+    IL_003f:  ldloca.s   V_4
+    IL_0041:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter, C.VB$StateMachine_1_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter, ByRef C.VB$StateMachine_1_M)""
+    IL_0046:  nop
+    IL_0047:  leave.s    IL_00b7
+   >IL_0049:  ldarg.0
+    IL_004a:  ldc.i4.m1
+    IL_004b:  dup
+    IL_004c:  stloc.1
+    IL_004d:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
+    IL_0052:  ldarg.0
+    IL_0053:  ldfld      ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0058:  stloc.3
+    IL_0059:  ldarg.0
+    IL_005a:  ldflda     ""C.VB$StateMachine_1_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter""
+    IL_005f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0065:  br.s       IL_0067
+    IL_0067:  ldloca.s   V_3
+    IL_0069:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_006e:  nop
+    IL_006f:  ldloca.s   V_3
+    IL_0071:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+   -IL_0077:  ldc.i4.1
+    IL_0078:  stloc.0
+    IL_0079:  leave.s    IL_00a0
   }
   catch System.Exception
   {
-   ~IL_007c:  dup
-    IL_007d:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-    IL_0082:  stloc.s    V_5
-   ~IL_0084:  ldarg.0
-    IL_0085:  ldc.i4.s   -2
-    IL_0087:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
-    IL_008c:  ldarg.0
-    IL_008d:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-    IL_0092:  ldloc.s    V_5
-    IL_0094:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
-    IL_0099:  nop
-    IL_009a:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-    IL_009f:  leave.s    IL_00b8
+   ~IL_007b:  dup
+    IL_007c:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_0081:  stloc.s    V_5
+   ~IL_0083:  ldarg.0
+    IL_0084:  ldc.i4.s   -2
+    IL_0086:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
+    IL_008b:  ldarg.0
+    IL_008c:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+    IL_0091:  ldloc.s    V_5
+    IL_0093:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)""
+    IL_0098:  nop
+    IL_0099:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_009e:  leave.s    IL_00b7
   }
- -IL_00a1:  ldarg.0
-  IL_00a2:  ldc.i4.s   -2
-  IL_00a4:  dup
-  IL_00a5:  stloc.1
-  IL_00a6:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
- ~IL_00ab:  ldarg.0
-  IL_00ac:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
-  IL_00b1:  ldloc.0
-  IL_00b2:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
-  IL_00b7:  nop
-  IL_00b8:  ret
+ -IL_00a0:  ldarg.0
+  IL_00a1:  ldc.i4.s   -2
+  IL_00a3:  dup
+  IL_00a4:  stloc.1
+  IL_00a5:  stfld      ""C.VB$StateMachine_1_M.$State As Integer""
+ ~IL_00aa:  ldarg.0
+  IL_00ab:  ldflda     ""C.VB$StateMachine_1_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)""
+  IL_00b0:  ldloc.0
+  IL_00b1:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)""
+  IL_00b6:  nop
+  IL_00b7:  ret
 }", sequencePoints:="C+VB$StateMachine_1_M.MoveNext")
 
             ' NOTE: No <local> for the return variable "M".
@@ -142,21 +141,21 @@ End Class
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0xe" startLine="5" startColumn="5" endLine="5" endColumn="50" document="0"/>
                 <entry offset="0xf" startLine="6" startColumn="9" endLine="6" endColumn="28" document="0"/>
-                <entry offset="0x1c" hidden="true" document="0"/>
-                <entry offset="0x78" startLine="7" startColumn="9" endLine="7" endColumn="17" document="0"/>
-                <entry offset="0x7c" hidden="true" document="0"/>
-                <entry offset="0x84" hidden="true" document="0"/>
-                <entry offset="0xa1" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
-                <entry offset="0xab" hidden="true" document="0"/>
+                <entry offset="0x1b" hidden="true" document="0"/>
+                <entry offset="0x77" startLine="7" startColumn="9" endLine="7" endColumn="17" document="0"/>
+                <entry offset="0x7b" hidden="true" document="0"/>
+                <entry offset="0x83" hidden="true" document="0"/>
+                <entry offset="0xa0" startLine="8" startColumn="5" endLine="8" endColumn="17" document="0"/>
+                <entry offset="0xaa" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xb9">
+            <scope startOffset="0x0" endOffset="0xb8">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="M"/>
-                <await yield="0x2e" resume="0x4a" declaringType="C+VB$StateMachine_1_M" methodName="MoveNext"/>
+                <await yield="0x2d" resume="0x49" declaringType="C+VB$StateMachine_1_M" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -233,19 +232,19 @@ End Module
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0xe" startLine="11" startColumn="5" endLine="11" endColumn="68" document="0"/>
                 <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="25" document="0"/>
-                <entry offset="0x1f" hidden="true" document="0"/>
-                <entry offset="0x7b" startLine="13" startColumn="9" endLine="13" endColumn="17" document="0"/>
-                <entry offset="0x7f" hidden="true" document="0"/>
-                <entry offset="0x87" hidden="true" document="0"/>
-                <entry offset="0xa4" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
-                <entry offset="0xae" hidden="true" document="0"/>
+                <entry offset="0x1e" hidden="true" document="0"/>
+                <entry offset="0x7a" startLine="13" startColumn="9" endLine="13" endColumn="17" document="0"/>
+                <entry offset="0x7e" hidden="true" document="0"/>
+                <entry offset="0x86" hidden="true" document="0"/>
+                <entry offset="0xa3" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
+                <entry offset="0xad" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xbc">
+            <scope startOffset="0x0" endOffset="0xbb">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="Module1" methodName="F" parameterNames="a"/>
-                <await yield="0x31" resume="0x4d" declaringType="Module1+VB$StateMachine_1_F" methodName="MoveNext"/>
+                <await yield="0x30" resume="0x4c" declaringType="Module1+VB$StateMachine_1_F" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -288,43 +287,35 @@ End Module
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0x5d" startLine="16" startColumn="5" endLine="16" endColumn="34" document="0"/>
                 <entry offset="0x5e" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x5f" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x60" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x73" hidden="true" document="0"/>
-                <entry offset="0xdd" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0xf5" hidden="true" document="0"/>
-                <entry offset="0x17a" hidden="true" document="0"/>
-                <entry offset="0x1e2" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x1e3" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x1e4" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x1e5" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x1f8" hidden="true" document="0"/>
-                <entry offset="0x271" hidden="true" document="0"/>
-                <entry offset="0x2ea" hidden="true" document="0"/>
-                <entry offset="0x354" startLine="17" startColumn="9" endLine="23" endColumn="34" document="0"/>
-                <entry offset="0x36c" hidden="true" document="0"/>
-                <entry offset="0x3ed" hidden="true" document="0"/>
-                <entry offset="0x46c" hidden="true" document="0"/>
-                <entry offset="0x4c8" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
-                <entry offset="0x4ca" hidden="true" document="0"/>
-                <entry offset="0x4d2" hidden="true" document="0"/>
-                <entry offset="0x4ef" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
-                <entry offset="0x4f9" hidden="true" document="0"/>
+                <entry offset="0x70" hidden="true" document="0"/>
+                <entry offset="0xf1" hidden="true" document="0"/>
+                <entry offset="0x176" hidden="true" document="0"/>
+                <entry offset="0x1f0" hidden="true" document="0"/>
+                <entry offset="0x269" hidden="true" document="0"/>
+                <entry offset="0x2e2" hidden="true" document="0"/>
+                <entry offset="0x363" hidden="true" document="0"/>
+                <entry offset="0x3e4" hidden="true" document="0"/>
+                <entry offset="0x463" hidden="true" document="0"/>
+                <entry offset="0x4bf" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
+                <entry offset="0x4c1" hidden="true" document="0"/>
+                <entry offset="0x4c9" hidden="true" document="0"/>
+                <entry offset="0x4e6" startLine="24" startColumn="5" endLine="24" endColumn="17" document="0"/>
+                <entry offset="0x4f0" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x506">
+            <scope startOffset="0x0" endOffset="0x4fd">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="Module1" methodName="Test"/>
-                <await yield="0x85" resume="0xa5" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x107" resume="0x127" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x18c" resume="0x1ab" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x20a" resume="0x22a" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x283" resume="0x2a3" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x2fc" resume="0x31c" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x37e" resume="0x39e" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x3ff" resume="0x41e" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
-                <await yield="0x47e" resume="0x49a" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x82" resume="0xa2" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x103" resume="0x123" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x188" resume="0x1a7" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x202" resume="0x222" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x27b" resume="0x29b" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x2f4" resume="0x314" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x375" resume="0x395" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x3f6" resume="0x415" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
+                <await yield="0x475" resume="0x491" declaringType="Module1+VB$StateMachine_2_Test" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -359,20 +350,20 @@ End Module
                 <entry offset="0x7" hidden="true" document="0"/>
                 <entry offset="0xe" startLine="26" startColumn="5" endLine="26" endColumn="18" document="0"/>
                 <entry offset="0xf" startLine="27" startColumn="9" endLine="27" endColumn="25" document="0"/>
-                <entry offset="0x1e" hidden="true" document="0"/>
-                <entry offset="0x79" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
-                <entry offset="0x7b" hidden="true" document="0"/>
-                <entry offset="0x83" hidden="true" document="0"/>
-                <entry offset="0xa0" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
-                <entry offset="0xaa" hidden="true" document="0"/>
+                <entry offset="0x1d" hidden="true" document="0"/>
+                <entry offset="0x78" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
+                <entry offset="0x7a" hidden="true" document="0"/>
+                <entry offset="0x82" hidden="true" document="0"/>
+                <entry offset="0x9f" startLine="28" startColumn="5" endLine="28" endColumn="12" document="0"/>
+                <entry offset="0xa9" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xb7">
+            <scope startOffset="0x0" endOffset="0xb6">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
             <asyncInfo>
-                <catchHandler offset="0x7b"/>
+                <catchHandler offset="0x7a"/>
                 <kickoffMethod declaringType="Module1" methodName="S"/>
-                <await yield="0x30" resume="0x4b" declaringType="Module1+VB$StateMachine_3_S" methodName="MoveNext"/>
+                <await yield="0x2f" resume="0x4a" declaringType="Module1+VB$StateMachine_3_S" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -430,23 +421,23 @@ End Class
                 <entry offset="0x29" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x35" startLine="9" startColumn="13" endLine="9" endColumn="53" document="0"/>
                 <entry offset="0x4c" startLine="11" startColumn="9" endLine="11" endColumn="55" document="0"/>
-                <entry offset="0x7c" hidden="true" document="0"/>
-                <entry offset="0xda" startLine="12" startColumn="9" endLine="12" endColumn="21" document="0"/>
-                <entry offset="0xeb" startLine="13" startColumn="9" endLine="13" endColumn="21" document="0"/>
-                <entry offset="0xfc" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
-                <entry offset="0xfe" hidden="true" document="0"/>
-                <entry offset="0x106" hidden="true" document="0"/>
-                <entry offset="0x123" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
-                <entry offset="0x12d" hidden="true" document="0"/>
+                <entry offset="0x7b" hidden="true" document="0"/>
+                <entry offset="0xd9" startLine="12" startColumn="9" endLine="12" endColumn="21" document="0"/>
+                <entry offset="0xea" startLine="13" startColumn="9" endLine="13" endColumn="21" document="0"/>
+                <entry offset="0xfb" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
+                <entry offset="0xfd" hidden="true" document="0"/>
+                <entry offset="0x105" hidden="true" document="0"/>
+                <entry offset="0x122" startLine="14" startColumn="5" endLine="14" endColumn="17" document="0"/>
+                <entry offset="0x12c" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x13a">
+            <scope startOffset="0x0" endOffset="0x139">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
-                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x13a" attributes="0"/>
-                <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x0" il_end="0x13a" attributes="0"/>
+                <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x139" attributes="0"/>
+                <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x0" il_end="0x139" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_Lambda"/>
-                <await yield="0x8e" resume="0xac" declaringType="C+VB$StateMachine_1_Async_Lambda" methodName="MoveNext"/>
+                <await yield="0x8d" resume="0xab" declaringType="C+VB$StateMachine_1_Async_Lambda" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -562,25 +553,25 @@ End Class
                 <entry offset="0xf" startLine="6" startColumn="13" endLine="6" endColumn="29" document="0"/>
                 <entry offset="0x16" startLine="7" startColumn="13" endLine="7" endColumn="29" document="0"/>
                 <entry offset="0x1d" startLine="9" startColumn="9" endLine="9" endColumn="55" document="0"/>
-                <entry offset="0x43" hidden="true" document="0"/>
-                <entry offset="0xa1" startLine="10" startColumn="9" endLine="10" endColumn="21" document="0"/>
-                <entry offset="0xad" startLine="11" startColumn="9" endLine="11" endColumn="21" document="0"/>
-                <entry offset="0xb9" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
-                <entry offset="0xbb" hidden="true" document="0"/>
-                <entry offset="0xc3" hidden="true" document="0"/>
-                <entry offset="0xe0" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
-                <entry offset="0xea" hidden="true" document="0"/>
+                <entry offset="0x42" hidden="true" document="0"/>
+                <entry offset="0xa0" startLine="10" startColumn="9" endLine="10" endColumn="21" document="0"/>
+                <entry offset="0xac" startLine="11" startColumn="9" endLine="11" endColumn="21" document="0"/>
+                <entry offset="0xb8" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
+                <entry offset="0xba" hidden="true" document="0"/>
+                <entry offset="0xc2" hidden="true" document="0"/>
+                <entry offset="0xdf" startLine="12" startColumn="5" endLine="12" endColumn="17" document="0"/>
+                <entry offset="0xe9" hidden="true" document="0"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xf7">
+            <scope startOffset="0x0" endOffset="0xf6">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Threading.Tasks" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0x0" il_end="0xf7" attributes="0"/>
-                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0x0" il_end="0xf7" attributes="0"/>
+                <local name="$VB$ResumableLocal_x$0" il_index="0" il_start="0x0" il_end="0xf6" attributes="0"/>
+                <local name="$VB$ResumableLocal_y$1" il_index="1" il_start="0x0" il_end="0xf6" attributes="0"/>
             </scope>
             <asyncInfo>
                 <kickoffMethod declaringType="C" methodName="Async_NoLambda"/>
-                <await yield="0x55" resume="0x73" declaringType="C+VB$StateMachine_1_Async_NoLambda" methodName="MoveNext"/>
+                <await yield="0x54" resume="0x72" declaringType="C+VB$StateMachine_1_Async_NoLambda" methodName="MoveNext"/>
             </asyncInfo>
         </method>
     </methods>
@@ -648,6 +639,151 @@ End Class
     </methods>
 </symbols>)
         End Sub
+
+        <Fact>
+        Sub AsyncAndClosure()
+            Dim source =
+<compilation>
+    <file>
+Imports System
+Imports System.Threading.Tasks
+
+Module M
+    Async Function F() As Task(Of Boolean)
+        Dim z = Await Task.FromResult(1)
+ 
+        Dim x = Sub()
+                    Console.WriteLine(z)
+                End Sub
+        Return False
+    End Function
+End Module
+    </file>
+</compilation>
+
+            Dim v = CompileAndVerify(source, LatestReferences, options:=TestOptions.DebugDll)
+
+            v.VerifyIL("M.VB$StateMachine_0_F.MoveNext", "
+{
+  // Code size      266 (0x10a)
+  .maxstack  3
+  .locals init (Boolean V_0,
+                Integer V_1,
+                System.Threading.Tasks.Task(Of Boolean) V_2,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_3,
+                M.VB$StateMachine_0_F V_4,
+                Integer V_5,
+                System.Exception V_6)
+ ~IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""M.VB$StateMachine_0_F.$State As Integer""
+  IL_0006:  stloc.1
+  .try
+  {
+   ~IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_006f
+   -IL_000e:  nop
+   ~IL_000f:  ldarg.0
+    IL_0010:  newobj     ""Sub M._Closure$__0-0..ctor()""
+    IL_0015:  stfld      ""M.VB$StateMachine_0_F.$VB$ResumableLocal_$VB$Closure_$0 As M._Closure$__0-0""
+   -IL_001a:  ldarg.0
+    IL_001b:  ldarg.0
+    IL_001c:  ldfld      ""M.VB$StateMachine_0_F.$VB$ResumableLocal_$VB$Closure_$0 As M._Closure$__0-0""
+    IL_0021:  stfld      ""M.VB$StateMachine_0_F.$U1 As M._Closure$__0-0""
+    IL_0026:  ldarg.0
+    IL_0027:  ldfld      ""M.VB$StateMachine_0_F.$U1 As M._Closure$__0-0""
+    IL_002c:  ldfld      ""M._Closure$__0-0.$VB$Local_z As Integer""
+    IL_0031:  pop
+    IL_0032:  ldc.i4.1
+    IL_0033:  call       ""Function System.Threading.Tasks.Task.FromResult(Of Integer)(Integer) As System.Threading.Tasks.Task(Of Integer)""
+    IL_0038:  callvirt   ""Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_003d:  stloc.3
+   ~IL_003e:  ldloca.s   V_3
+    IL_0040:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean""
+    IL_0045:  brtrue.s   IL_008d
+    IL_0047:  ldarg.0
+    IL_0048:  ldc.i4.0
+    IL_0049:  dup
+    IL_004a:  stloc.1
+    IL_004b:  stfld      ""M.VB$StateMachine_0_F.$State As Integer""
+   <IL_0050:  ldarg.0
+    IL_0051:  ldloc.3
+    IL_0052:  stfld      ""M.VB$StateMachine_0_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0057:  ldarg.0
+    IL_0058:  ldflda     ""M.VB$StateMachine_0_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean)""
+    IL_005d:  ldloca.s   V_3
+    IL_005f:  ldarg.0
+    IL_0060:  stloc.s    V_4
+    IL_0062:  ldloca.s   V_4
+    IL_0064:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), M.VB$StateMachine_0_F)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef M.VB$StateMachine_0_F)""
+    IL_0069:  nop
+    IL_006a:  leave      IL_0109
+   >IL_006f:  ldarg.0
+    IL_0070:  ldc.i4.m1
+    IL_0071:  dup
+    IL_0072:  stloc.1
+    IL_0073:  stfld      ""M.VB$StateMachine_0_F.$State As Integer""
+    IL_0078:  ldarg.0
+    IL_0079:  ldfld      ""M.VB$StateMachine_0_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_007e:  stloc.3
+    IL_007f:  ldarg.0
+    IL_0080:  ldflda     ""M.VB$StateMachine_0_F.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_0085:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_008b:  br.s       IL_008d
+    IL_008d:  ldarg.0
+    IL_008e:  ldfld      ""M.VB$StateMachine_0_F.$U1 As M._Closure$__0-0""
+    IL_0093:  ldloca.s   V_3
+    IL_0095:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer""
+    IL_009a:  stloc.s    V_5
+    IL_009c:  ldloca.s   V_3
+    IL_009e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Integer)""
+    IL_00a4:  ldloc.s    V_5
+    IL_00a6:  stfld      ""M._Closure$__0-0.$VB$Local_z As Integer""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldnull
+    IL_00ad:  stfld      ""M.VB$StateMachine_0_F.$U1 As M._Closure$__0-0""
+   -IL_00b2:  ldarg.0
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldfld      ""M.VB$StateMachine_0_F.$VB$ResumableLocal_$VB$Closure_$0 As M._Closure$__0-0""
+    IL_00b9:  ldftn      ""Sub M._Closure$__0-0._Lambda$__0()""
+    IL_00bf:  newobj     ""Sub VB$AnonymousDelegate_0..ctor(Object, System.IntPtr)""
+    IL_00c4:  stfld      ""M.VB$StateMachine_0_F.$VB$ResumableLocal_x$1 As <generated method>""
+   -IL_00c9:  ldc.i4.0
+    IL_00ca:  stloc.0
+    IL_00cb:  leave.s    IL_00f2
+  }
+  catch System.Exception
+  {
+   ~IL_00cd:  dup
+    IL_00ce:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_00d3:  stloc.s    V_6
+   ~IL_00d5:  ldarg.0
+    IL_00d6:  ldc.i4.s   -2
+    IL_00d8:  stfld      ""M.VB$StateMachine_0_F.$State As Integer""
+    IL_00dd:  ldarg.0
+    IL_00de:  ldflda     ""M.VB$StateMachine_0_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean)""
+    IL_00e3:  ldloc.s    V_6
+    IL_00e5:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean).SetException(System.Exception)""
+    IL_00ea:  nop
+    IL_00eb:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_00f0:  leave.s    IL_0109
+  }
+ -IL_00f2:  ldarg.0
+  IL_00f3:  ldc.i4.s   -2
+  IL_00f5:  dup
+  IL_00f6:  stloc.1
+  IL_00f7:  stfld      ""M.VB$StateMachine_0_F.$State As Integer""
+ ~IL_00fc:  ldarg.0
+  IL_00fd:  ldflda     ""M.VB$StateMachine_0_F.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean)""
+  IL_0102:  ldloc.0
+  IL_0103:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Boolean).SetResult(Boolean)""
+  IL_0108:  nop
+  IL_0109:  ret
+}
+", sequencePoints:="M+VB$StateMachine_0_F.MoveNext")
+        End Sub
+
 
     End Class
 End Namespace


### PR DESCRIPTION
Fixes internal bug 1092037: Compiler outputs multiple sequence points in VB await statement messing up stepping

**Scenario**
Stepping over Await expression requires more than one "step-over" action due to superfluous sequence points emitted by VB await spiller. For example, 

```
    Async Function F() As Task(Of Boolean)
        Dim z = Await Task.FromResult(1)   // break here, F10 doesn't move to the next statement
 
        Dim x = Sub()
                    Console.WriteLine(z)
                End Sub
 
        Return False
    End Function
```

**Testing**
Unit tests and manual validation that stepping in VS is correct.

@ManishJayaswal 