### PR TITLE
prevent duplicate signature help items from surfacing to the UI

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.Editor
             var distinctItems = items.Distinct().ToList();
             if (selectedItem.HasValue && items.Count != distinctItems.Count)
             {
-                // `selectedItem` index has already been determined to be valid, it now needs to be adjusted to account for duplicates being removed.
+                // `selectedItem` index has already been determined to be valid, it now needs to be adjusted to point
+                // to the equivalent item in the reduced list to account for duplicates being removed
                 // E.g.,
                 //   items = {A, A, B, B, C, D}
                 //   selectedItem = 4 (index for item C)

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItems.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -60,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             Contract.ThrowIfNull(items);
             Contract.ThrowIfTrue(items.IsEmpty());
-            Contract.ThrowIfTrue(selectedItem.HasValue && selectedItem.Value > items.Count);
+            Contract.ThrowIfTrue(selectedItem.HasValue && selectedItem.Value >= items.Count);
 
             if (argumentIndex < 0)
             {
@@ -72,7 +74,24 @@ namespace Microsoft.CodeAnalysis.Editor
                 throw new ArgumentException($"{nameof(argumentCount)} < {nameof(argumentIndex)}", nameof(argumentIndex));
             }
 
-            this.Items = items;
+            // Adjust the `selectedItem` index if duplicates are able to be removed.
+            var distinctItems = items.Distinct().ToList();
+            if (selectedItem.HasValue && items.Count != distinctItems.Count)
+            {
+                // `selectedItem` index has already been determined to be valid, it now needs to be adjusted to account for duplicates being removed.
+                // E.g.,
+                //   items = {A, A, B, B, C, D}
+                //   selectedItem = 4 (index for item C)
+                // ergo
+                //   distinctItems = {A, B, C, D}
+                //   actualItem = C
+                //   selectedItem = 2 (index for item C)
+                var actualItem = items[selectedItem.Value];
+                selectedItem = distinctItems.IndexOf(actualItem);
+                Debug.Assert(selectedItem.Value >= 0, "actual item was not part of the final list");
+            }
+
+            this.Items = distinctItems;
             this.ApplicableSpan = applicableSpan;
             this.ArgumentIndex = argumentIndex;
             this.ArgumentCount = argumentCount;

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -98,6 +98,18 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             GetMocks(controller).PresenterSession.Verify(Sub(p) p.SelectNextItem(), Times.Once)
         End Sub
 
+        <WorkItem(1181, "https://github.com/dotnet/roslyn/issues/1181")>
+        <Fact>
+        Public Sub UpAndDownKeysShouldStillNavigateWhenDuplicateItemsAreFiltered()
+            Dim item = CreateItems(1).Single()
+            Dim controller = CreateController(items:={item, item}, waitForPresentation:=True)
+
+            Dim handled = controller.TryHandleUpKey()
+
+            Assert.False(handled)
+            GetMocks(controller).PresenterSession.Verify(Sub(p) p.Dismiss(), Times.Once)
+        End Sub
+
         <Fact>
         Public Sub CaretMoveWithActiveSessionShouldRecomputeModel()
             Dim controller = CreateController(waitForPresentation:=True)


### PR DESCRIPTION
This is a cherry-pick of PR #3099 from `master` into `stabilization`.  Previous signoff given by @dpoeschl, @rchande, and @Pilchie with shiproom approval given by @MattGertz.