### PR TITLE
Add metadata cache to default metadata service

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataReferenceCache.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Host
             private readonly NonReentrantLock _gate = new NonReentrantLock();
 
             // metadata references are held weakly, so even though this is a cache that enables reuse, it does not control lifetime.
-            private readonly Dictionary<MetadataReferenceProperties, WeakReference<MetadataReference>> references
+            private readonly Dictionary<MetadataReferenceProperties, WeakReference<MetadataReference>> _references
                 = new Dictionary<MetadataReferenceProperties, WeakReference<MetadataReference>>();
 
             public ReferenceSet(MetadataReferenceCache cache)
@@ -67,10 +67,10 @@ namespace Microsoft.CodeAnalysis.Host
                     WeakReference<MetadataReference> weakref;
                     MetadataReference mref = null;
 
-                    if (!(this.references.TryGetValue(properties, out weakref) && weakref.TryGetTarget(out mref)))
+                    if (!(_references.TryGetValue(properties, out weakref) && weakref.TryGetTarget(out mref)))
                     {
                         // try to base this metadata reference off of an existing one, so we don't load the metadata bytes twice.
-                        foreach (var wr in this.references.Values)
+                        foreach (var wr in _references.Values)
                         {
                             if (wr.TryGetTarget(out mref))
                             {
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Host
                             mref = _cache._createReference(path, properties);
                         }
 
-                        this.references[properties] = new WeakReference<MetadataReference>(mref);
+                        _references[properties] = new WeakReference<MetadataReference>(mref);
                     }
 
                     return mref;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataReferenceCache.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Host
+{
+    /// <summary>
+    /// A cache for metadata references.
+    /// </summary>
+    internal class MetadataReferenceCache
+    {
+        private ImmutableDictionary<string, ReferenceSet> _referenceSets
+            = ImmutableDictionary<string, ReferenceSet>.Empty;
+
+        private readonly Func<string, MetadataReferenceProperties, MetadataReference> _createReference;
+
+        public MetadataReferenceCache(Func<string, MetadataReferenceProperties, MetadataReference> createReference)
+        {
+            if (createReference == null)
+            {
+                throw new ArgumentNullException(nameof(createReference));
+            }
+
+            this._createReference = createReference;
+        }
+
+        public MetadataReference GetReference(string path, MetadataReferenceProperties properties)
+        {
+            ReferenceSet referenceSet;
+            if (!_referenceSets.TryGetValue(path, out referenceSet))
+            {
+                referenceSet = ImmutableInterlocked.GetOrAdd(ref _referenceSets, path, new ReferenceSet(this));
+            }
+
+            return referenceSet.GetAddOrUpdate(path, properties);
+        }
+
+        /// <summary>
+        /// A collection of references to the same underlying metadata, each with different properties.
+        /// </summary>
+        private class ReferenceSet
+        {
+            private readonly MetadataReferenceCache _cache;
+
+            private readonly NonReentrantLock _gate = new NonReentrantLock();
+
+            // metadata references are held weakly, so even though this is a cache that enables reuse, it does not control lifetime.
+            private readonly Dictionary<MetadataReferenceProperties, WeakReference<MetadataReference>> references
+                = new Dictionary<MetadataReferenceProperties, WeakReference<MetadataReference>>();
+
+            public ReferenceSet(MetadataReferenceCache cache)
+            {
+                _cache = cache;
+            }
+
+            public MetadataReference GetAddOrUpdate(string path, MetadataReferenceProperties properties)
+            {
+                using (_gate.DisposableWait())
+                {
+                    WeakReference<MetadataReference> weakref;
+                    MetadataReference mref = null;
+
+                    if (!(this.references.TryGetValue(properties, out weakref) && weakref.TryGetTarget(out mref)))
+                    {
+                        // try to base this metadata reference off of an existing one, so we don't load the metadata bytes twice.
+                        foreach (var wr in this.references.Values)
+                        {
+                            if (wr.TryGetTarget(out mref))
+                            {
+                                mref = mref.WithProperties(properties);
+                                break;
+                            }
+                        }
+
+                        if (mref == null)
+                        {
+                            mref = _cache._createReference(path, properties);
+                        }
+
+                        this.references[properties] = new WeakReference<MetadataReference>(mref);
+                    }
+
+                    return mref;
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host
 {
@@ -17,13 +21,14 @@ namespace Microsoft.CodeAnalysis.Host
 
         private sealed class Service : IMetadataService
         {
-            private readonly IDocumentationProviderService _documentationService;
             private readonly Provider _provider;
+            private readonly MetadataReferenceCache _metadataCache;
 
             public Service(IDocumentationProviderService documentationService)
             {
-                _documentationService = documentationService;
                 _provider = new Provider(this);
+                _metadataCache = new MetadataReferenceCache((path, properties) => 
+                    MetadataReference.CreateFromFile(path, properties, documentationService.GetDocumentationProvider(path)));
             }
 
             public MetadataFileReferenceProvider GetProvider()
@@ -33,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Host
 
             public PortableExecutableReference GetReference(string resolvedPath, MetadataReferenceProperties properties)
             {
-                return MetadataReference.CreateFromFile(resolvedPath, properties, _documentationService.GetDocumentationProvider(resolvedPath));
+                return (PortableExecutableReference)_metadataCache.GetReference(resolvedPath, properties);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -576,6 +576,7 @@
     <Compile Include="Workspace\Host\Mef\ServiceLayer.cs" />
     <Compile Include="Workspace\Host\Documentation\IDocumentationProviderService.cs" />
     <Compile Include="Workspace\Host\Metadata\IAnalyzerService.cs" />
+    <Compile Include="Workspace\Host\Metadata\MetadataReferenceCache.cs" />
     <Compile Include="Workspace\Host\PersistentStorage\PersistentStorageOptionsProvider.cs" />
     <Compile Include="Workspace\Host\SyntaxTreeFactory\AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs" />
     <Compile Include="Workspace\Host\SyntaxTreeFactory\AbstractSyntaxTreeFactoryService.cs" />

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -298,6 +298,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\CSharpProject_CSharpProject_ExternAlias2.csproj" />
+  </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Targets\VSL.Imports.targets" />
     <Import Project="..\..\..\build\VSL.Imports.Closed.targets" />

--- a/src/Workspaces/CoreTest/TestFiles/CSharpProject_CSharpProject_ExternAlias2.csproj
+++ b/src/Workspaces/CoreTest/TestFiles/CSharpProject_CSharpProject_ExternAlias2.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{74404B73-C865-49CF-A586-C34759F2C95B}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>bug13338</RootNamespace>
+    <AssemblyName>bug13338</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System">
+      <Aliases>Sys1, Sys3</Aliases>
+    </Reference>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -77,6 +77,99 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(5, compReferences.Count);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void Test_SharedMetadataReferences()
+        {
+            CreateFiles(GetMultiProjectSolutionFiles());
+
+            var sol = MSBuildWorkspace.Create().OpenSolutionAsync(GetSolutionFileName("TestSolution.sln")).Result;
+            var p0 = sol.Projects.ElementAt(0);
+            var p1 = sol.Projects.ElementAt(1);
+
+            Assert.NotSame(p0, p1);
+
+            var p0mscorlib = GetMetadataReference(p0, "mscorlib");
+            var p1mscorlib = GetMetadataReference(p1, "mscorlib");
+
+            Assert.NotNull(p0mscorlib);
+            Assert.NotNull(p1mscorlib);
+
+            // metadata references to mscorlib in both projects are the same
+            Assert.Same(p0mscorlib, p1mscorlib);
+        }
+
+        private static MetadataReference GetMetadataReference(Project project, string name)
+        {
+            return project.MetadataReferences.OfType<PortableExecutableReference>().SingleOrDefault(mr => mr.FilePath.Contains(name));
+        }
+
+        private static MetadataReference GetMetadataReferenceByAlias(Project project, string aliasName)
+        {
+            return project.MetadataReferences.OfType<PortableExecutableReference>().SingleOrDefault(mr => 
+            !mr.Properties.Aliases.IsDefault && mr.Properties.Aliases.Contains(aliasName));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace), WorkItem(546171, "DevDiv")]
+        public void Test_SharedMetadataReferencesWithAliases()
+        {
+            var projPath1 = @"CSharpProject\CSharpProject_ExternAlias.csproj";
+            var projPath2 = @"CSharpProject\CSharpProject_ExternAlias2.csproj";
+            var files = new FileSet(new Dictionary<string, object>
+            {
+                { projPath1, GetResourceText("CSharpProject_CSharpProject_ExternAlias.csproj") },
+                { projPath2, GetResourceText("CSharpProject_CSharpProject_ExternAlias2.csproj") },
+                { @"CSharpProject\CSharpExternAlias.cs", GetResourceText("CSharpProject_CSharpExternAlias.cs") },
+            });
+
+            CreateFiles(files);
+
+            var fullPath1 = Path.Combine(this.SolutionDirectory.Path, projPath1);
+            var fullPath2 = Path.Combine(this.SolutionDirectory.Path, projPath2);
+            using (var ws = MSBuildWorkspace.Create())
+            {
+                var proj1 = ws.OpenProjectAsync(fullPath1).Result;
+                var proj2 = ws.OpenProjectAsync(fullPath2).Result;
+
+                var p1Sys1 = GetMetadataReferenceByAlias(proj1, "Sys1");
+                var p1Sys2 = GetMetadataReferenceByAlias(proj1, "Sys2");
+                var p2Sys1 = GetMetadataReferenceByAlias(proj2, "Sys1");
+                var p2Sys3 = GetMetadataReferenceByAlias(proj2, "Sys3");
+
+                Assert.NotNull(p1Sys1);
+                Assert.NotNull(p1Sys2);
+                Assert.NotNull(p2Sys1);
+                Assert.NotNull(p2Sys3);
+
+                // same filepath but different alias so they are not the same instance
+                Assert.NotSame(p1Sys1, p1Sys2);
+                Assert.NotSame(p2Sys1, p2Sys3);
+
+                // same filepath and alias so they are the same instance
+                Assert.Same(p1Sys1, p2Sys1);
+
+                var mdp1Sys1 = GetMetadata(p1Sys1);
+                var mdp1Sys2 = GetMetadata(p1Sys2);
+                var mdp2Sys1 = GetMetadata(p2Sys1);
+                var mdp2Sys3 = GetMetadata(p2Sys1);
+
+                Assert.NotNull(mdp1Sys1);
+                Assert.NotNull(mdp1Sys2);
+                Assert.NotNull(mdp2Sys1);
+                Assert.NotNull(mdp2Sys3);
+
+                // all references to System.dll share the same metadata bytes
+                Assert.Same(mdp1Sys1, mdp1Sys2);
+                Assert.Same(mdp1Sys1, mdp2Sys1);
+                Assert.Same(mdp1Sys1, mdp2Sys3);
+            }
+        }
+
+        private Metadata GetMetadata(MetadataReference mref)
+        {
+            var fnGetMetadata = mref.GetType().GetMethod("GetMetadata", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            return fnGetMetadata?.Invoke(mref, null) as Metadata;
+        }
+
         [WorkItem(552981, "DevDiv")]
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestOpenSolution_DuplicateProjectGuids()


### PR DESCRIPTION
Fixes #3078 

This change makes it so that the default metadata service used when loading projects & solutions uses a cache so the same named metadata files are represented by the same bits in memory. Currently the default is only used by msbuild workspace.

@jasonmalinowski @tmat @Pilchie  please review

