### PR TITLE
Ensure that FormattableString is preferred by Introduce Explaining Variable and Extract Method

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -511,6 +511,7 @@
     <Compile Include="SymbolId\SymbolKeyTestBase.cs" />
     <Compile Include="TextStructureNavigation\TextStructureNavigatorTests.cs" />
     <Compile Include="TodoComment\TodoCommentTests.cs" />
+    <Compile Include="Utilities\CodeSnippets.cs" />
     <Compile Include="Utilities\CSharpServiceTestExtensions.cs" />
     <Compile Include="Utilities\Options.cs" />
     <Compile Include="TypeInferrer\TypeInferrerTests.Delegate.cs" />

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2542,5 +2542,41 @@ class C
     }
 }");
         }
+
+        [WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void HandleFormattableStringTargetTyping1()
+        {
+            const string code = CodeSnippets.FormattableStringType + @"
+namespace N
+{
+    using System;
+
+    class C
+    {
+        public void M()
+        {
+            var f = FormattableString.Invariant([|$""""|]);
+        }
+    }
+}";
+
+            const string expected = CodeSnippets.FormattableStringType + @"
+namespace N
+{
+    using System;
+
+    class C
+    {
+        public void M()
+        {
+            FormattableString {|Rename:v|} = $"""";
+            var f = FormattableString.Invariant(v);
+        }
+    }
+}";
+
+            Test(code, expected, index: 0, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -1862,5 +1862,45 @@ public class Test<T>
                 TestExtractMethod(code, expected);
             }
         }
+
+        [WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public void HandleFormattableStringTargetTyping1()
+        {
+            const string code = CodeSnippets.FormattableStringType + @"
+namespace N
+{
+    using System;
+
+    class C
+    {
+        public void M()
+        {
+            var f = FormattableString.Invariant([|$""""|]);
+        }
+    }
+}";
+
+            const string expected = CodeSnippets.FormattableStringType + @"
+namespace N
+{
+    using System;
+
+    class C
+    {
+        public void M()
+        {
+            var f = FormattableString.Invariant(NewMethod());
+        }
+
+        private static FormattableString NewMethod()
+        {
+            return $"""";
+        }
+    }
+}";
+
+            TestExtractMethod(code, expected);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Utilities/CodeSnippets.cs
+++ b/src/EditorFeatures/CSharpTest/Utilities/CodeSnippets.cs
@@ -1,0 +1,49 @@
+﻿namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests
+{
+    internal static class CodeSnippets
+    {
+        public const string FormattableStringType = @"
+namespace System
+{
+    public abstract class FormattableString : IFormattable
+    {
+        public abstract string Format { get; }
+        public abstract object[] GetArguments();
+        public abstract int ArgumentCount { get; }
+        public abstract object GetArgument(int index);
+        public abstract string ToString(IFormatProvider formatProvider);
+
+        string IFormattable.ToString(string ignored, IFormatProvider formatProvider) => ToString(formatProvider);
+        public static string Invariant(FormattableString formattable) => formattable.ToString(Globalization.CultureInfo.InvariantCulture);
+        public override string ToString() => ToString(Globalization.CultureInfo.CurrentCulture);
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    public static class FormattableStringFactory
+    {
+        public static FormattableString Create(string format, params object[] arguments) => new ConcreteFormattableString(format, arguments);
+
+        private sealed class ConcreteFormattableString : FormattableString
+        {
+            private readonly string _format;
+            private readonly object[] _arguments;
+
+            internal ConcreteFormattableString(string format, object[] arguments)
+            {
+                _format = format;
+                _arguments = arguments;
+            }
+
+            public override string Format => _format;
+            public override object[] GetArguments() => _arguments;
+            public override int ArgumentCount => _arguments.Length;
+            public override object GetArgument(int index) => _arguments[index];
+            public override string ToString(IFormatProvider formatProvider) => string.Format(formatProvider, _format, _arguments);
+        }
+    }
+}
+";
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -521,6 +521,7 @@
     <Compile Include="TextStructureNavigation\TextStructureNavigatorTests.vb" />
     <Compile Include="TodoComment\TodoCommentTests.vb" />
     <Compile Include="TypeInferrer\TypeInferrerTests.vb" />
+    <Compile Include="Utilities\CodeSnippets.vb" />
     <Compile Include="Utils.vb" />
     <EmbeddedResource Include="Formatting\XmlLiterals.resx" />
     <None Include="app.config" />

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1626,5 +1626,38 @@ End Module
 
             Test(code, expected, index:=1, compareTokens:=False)
         End Sub
+
+        <WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub HandleFormattableStringTargetTyping1()
+            Const code = "
+Imports System
+
+" & FormattableStringType & "
+
+Namespace N
+    Class C
+        Public Sub M()
+            Dim f = FormattableString.Invariant([|$""""|])
+        End Sub
+    End Class
+End Namespace"
+
+            Const expected = "
+Imports System
+
+" & FormattableStringType & "
+
+Namespace N
+    Class C
+        Public Sub M()
+            Dim {|Rename:v|} As FormattableString = $""""
+            Dim f = FormattableString.Invariant(v)
+        End Sub
+    End Class
+End Namespace"
+
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
@@ -3321,6 +3321,43 @@ End Namespace
 </text>
                 TestExtractMethod(code, expected, dontPutOutOrRefOnStruct:=True)
             End Sub
+
+            <WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")>
+            <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
+            Public Sub HandleFormattableStringTargetTyping1()
+                Const code = "
+Imports System
+
+" & FormattableStringType & "
+
+Namespace N
+    Class C
+        Public Sub M()
+            Dim f = FormattableString.Invariant([|$""""|])
+        End Sub
+    End Class
+End Namespace"
+
+                Const expected = "
+Imports System
+
+" & FormattableStringType & "
+
+Namespace N
+    Class C
+        Public Sub M()
+            Dim f = FormattableString.Invariant(NewMethod())
+        End Sub
+
+        Private Shared Function NewMethod() As FormattableString
+            Return $""""
+        End Function
+    End Class
+End Namespace"
+
+                TestExtractMethod(code, expected)
+            End Sub
+
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -36,23 +36,23 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             End Using
         End Sub
 
-        Protected Shared Sub TestExtractMethod(codeWithMarker As XElement,
-                                               expected As XElement,
-                                               Optional temporaryFailing As Boolean = False,
-                                               Optional allowMovingDeclaration As Boolean = True,
-                                               Optional dontPutOutOrRefOnStruct As Boolean = True,
-                                               Optional metadataReference As String = Nothing,
-                                               Optional compareTokens As Boolean = False)
-
-            Dim codeWithoutMarker As String = Nothing
-            Dim textSpan As TextSpan
-            MarkupTestFile.GetSpan(codeWithMarker.NormalizedValue, codeWithoutMarker, textSpan)
+        Protected Overloads Shared Sub TestExtractMethod(
+            codeWithMarker As String,
+            expected As String,
+            Optional temporaryFailing As Boolean = False,
+            Optional allowMovingDeclaration As Boolean = True,
+            Optional dontPutOutOrRefOnStruct As Boolean = True,
+            Optional metadataReference As String = Nothing,
+            Optional compareTokens As Boolean = False
+        )
 
             Dim metadataReferences = If(metadataReference Is Nothing, Array.Empty(Of String)(), New String() {metadataReference})
 
-            Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromFiles(New String() {codeWithMarker.NormalizedValue}, metadataReferences:=metadataReferences, compilationOptions:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromFiles(New String() {codeWithMarker}, metadataReferences:=metadataReferences, compilationOptions:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
 
-                Dim subjectBuffer = workspace.Documents.First().TextBuffer
+                Dim document = workspace.Documents.First()
+                Dim subjectBuffer = document.TextBuffer
+                Dim textSpan = document.SelectedSpans.First()
 
                 Dim tree = ExtractMethod(workspace, workspace.Documents.First(), textSpan, allowMovingDeclaration:=allowMovingDeclaration, dontPutOutOrRefOnStruct:=dontPutOutOrRefOnStruct)
 
@@ -62,15 +62,28 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                 End Using
 
                 If temporaryFailing Then
-                    Assert.NotEqual(expected.NormalizedValue, subjectBuffer.CurrentSnapshot.GetText())
+                    Assert.NotEqual(expected, subjectBuffer.CurrentSnapshot.GetText())
                 Else
                     If compareTokens Then
-                        TokenUtilities.AssertTokensEqual(expected.NormalizedValue, subjectBuffer.CurrentSnapshot.GetText(), LanguageNames.VisualBasic)
+                        TokenUtilities.AssertTokensEqual(expected, subjectBuffer.CurrentSnapshot.GetText(), LanguageNames.VisualBasic)
                     Else
-                        Assert.Equal(expected.NormalizedValue, subjectBuffer.CurrentSnapshot.GetText())
+                        Assert.Equal(expected, subjectBuffer.CurrentSnapshot.GetText())
                     End If
                 End If
             End Using
+        End Sub
+
+        Protected Overloads Shared Sub TestExtractMethod(
+            codeWithMarker As XElement,
+            expected As XElement,
+            Optional temporaryFailing As Boolean = False,
+            Optional allowMovingDeclaration As Boolean = True,
+            Optional dontPutOutOrRefOnStruct As Boolean = True,
+            Optional metadataReference As String = Nothing,
+            Optional compareTokens As Boolean = False
+        )
+
+            TestExtractMethod(codeWithMarker.NormalizedValue, expected.NormalizedValue, temporaryFailing, allowMovingDeclaration, dontPutOutOrRefOnStruct, metadataReference, compareTokens)
         End Sub
 
         Private Shared Function ExtractMethod(workspace As TestWorkspace,

--- a/src/EditorFeatures/VisualBasicTest/Utilities/CodeSnippets.vb
+++ b/src/EditorFeatures/VisualBasicTest/Utilities/CodeSnippets.vb
@@ -1,0 +1,75 @@
+﻿Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests
+    Module CodeSnippets
+
+        Public Const FormattableStringType = "
+Namespace System
+    Public MustInherit Class FormattableString
+        Implements IFormattable
+
+        Public MustOverride ReadOnly Property Format As String
+        Public MustOverride Function GetArguments() As Object()
+        Public MustOverride ReadOnly Property ArgumentCount As Integer
+        Public MustOverride Function GetArgument(index As Integer) As Object
+        Public MustOverride Overloads Function ToString(formatProvider As IFormatProvider) As String
+
+        Private Function IFormattable_ToString(ignored As String, formatProvider As IFormatProvider) As String Implements IFormattable.ToString
+            Return ToString(formatProvider)
+        End Function
+
+        Public Shared Function Invariant(formattable As FormattableString) As string
+            Return formattable.ToString(Globalization.CultureInfo.InvariantCulture)
+        End Function
+
+        Public Overrides Function ToString() As String
+            Return ToString(Globalization.CultureInfo.CurrentCulture)
+        End Function
+    End Class
+End Namespace
+
+Namespace System.Runtime.CompilerServices
+    Public MustInherit Class FormattableStringFactory
+        Public Shared Function Create(format As String, ParamArray arguments As Object()) As FormattableString
+            Return new ConcreteFormattableString(format, arguments)
+        End Function
+
+        Private NotInheritable Class ConcreteFormattableString
+            Inherits FormattableString
+
+            Private ReadOnly _format As String
+            Private ReadOnly _arguments As Object()
+
+            Friend Sub New(format As String, arguments As Object())
+                _format = format
+                _arguments = arguments
+            End Sub
+
+            Public Overrides ReadOnly Property Format As String
+                Get
+                    Return _format
+                End Get
+            End Property
+
+            Public Overrides Function GetArguments() As Object()
+                Return _arguments
+            End Function
+
+            Public Overrides ReadOnly Property ArgumentCount As Integer
+                Get
+                    Return _arguments.Length
+                End Get
+            End Property
+
+            Public Overrides Function GetArgument(index As Integer) As Object
+                Return _arguments(index)
+            End Function
+
+            Public Overrides Function ToString(formatProvider As IFormatProvider) As String
+                Return String.Format(formatProvider, _format, _arguments)
+            End Function
+        End Class
+    End Class
+End Namespace
+"
+
+    End Module
+End Namespace

--- a/src/Features/CSharp/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -116,6 +116,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return info.ConvertedType;
                 }
 
+                // use FormattableString if conversion between String and FormattableString
+                if (info.Type?.SpecialType == SpecialType.System_String &&
+                    info.ConvertedType?.IsFormattableString() == true)
+                {
+                    return info.ConvertedType;
+                }
+
                 // always try to use type that is more specific than object type if possible.
                 return !info.Type.IsObjectType() ? info.Type : info.ConvertedType;
             }

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -137,7 +137,9 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
 
         private bool CanUseVar(ITypeSymbol typeSymbol)
         {
-            return typeSymbol.TypeKind != TypeKind.Delegate && !typeSymbol.IsErrorType();
+            return typeSymbol.TypeKind != TypeKind.Delegate
+                && !typeSymbol.IsErrorType()
+                && !typeSymbol.IsFormattableString();
         }
 
         private static async Task<Tuple<SemanticDocument, ISet<ExpressionSyntax>>> ComplexifyParentingStatements(

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
 
             if (typeInfo.Type?.SpecialType == SpecialType.System_String &&
-                typeInfo.ConvertedType.IsFormattableString())
+                typeInfo.ConvertedType?.IsFormattableString() == true)
             {
                 return typeInfo.ConvertedType;
             }

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -310,6 +310,12 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             var semanticModel = document.SemanticModel;
             var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
 
+            if (typeInfo.Type?.SpecialType == SpecialType.System_String &&
+                typeInfo.ConvertedType.IsFormattableString())
+            {
+                return typeInfo.ConvertedType;
+            }
+
             if (typeInfo.Type != null)
             {
                 return typeInfo.Type;

--- a/src/Features/VisualBasic/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/ExtractMethod/VisualBasicSelectionResult.vb
@@ -187,6 +187,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 End If
             End If
 
+            ' use FormattableString if conversion between String And FormattableString
+            If info.Type?.SpecialType = SpecialType.System_String AndAlso
+               info.ConvertedType?.IsFormattableString() Then
+
+                Return info.ConvertedType
+            End If
+
             ' get type without considering implicit conversion
             Return If(info.Type.IsObjectType(), info.ConvertedType, info.Type)
         End Function

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -368,6 +368,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return false;
         }
 
+        public static bool IsFormattableString(this ITypeSymbol symbol)
+        {
+            return symbol?.MetadataName == "FormattableString"
+                && symbol.ContainingNamespace?.Name == "System"
+                && symbol.ContainingNamespace.ContainingNamespace?.IsGlobalNamespace == true;
+
+        }
+
         public static ITypeSymbol RemoveUnavailableTypeParameters(
             this ITypeSymbol type,
             Compilation compilation,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -371,9 +371,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool IsFormattableString(this ITypeSymbol symbol)
         {
             return symbol?.MetadataName == "FormattableString"
+                && symbol.ContainingType == null
                 && symbol.ContainingNamespace?.Name == "System"
                 && symbol.ContainingNamespace.ContainingNamespace?.IsGlobalNamespace == true;
-
         }
 
         public static ITypeSymbol RemoveUnavailableTypeParameters(


### PR DESCRIPTION
Fixes Issue #3147

When extracting an interpolated string that is target-typed to FormattableString, the resulting declaration should use FormattableString as the type rather than string. Otherwise, the result is uncompilable code.

Consider the following code:

```C#
void M()
{
    var s = System.FormattableString.Invariant($"");
}
```

If ```$""``` is selected, Introduce Explaining Variable should produce this:

```C#
void M()
{
    System.FormattableString v = $"";
    var s = System.FormattableString.Invariant(v);
}
```

...rather than this:

```C#
void M()
{
    var v = $"";
    var s = System.FormattableString.Invariant(v);
}
```

Added unit tests for both Introduce Explaining Variable and Extract Method in both C# and VB.

Note that this really isn't the *correct* fix for Introduce Explaining Variable. There should be a simplification step that determines whether a local declaration's type is changed to var (respecting the user's options), but that's not how it was implemented. However, doing that is a larger change that is probably not appropriate for the stabilization branch. So, there are some edge cases that will slip through with this change, but they are not as functionally broken as the case this change fixes.