### PR TITLE
EnC: Handle anonymous types and delegates hoisted to closure or state machine

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1316,7 +1316,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (optimizations == OptimizationLevel.Debug && stateMachineTypeOpt != null)
                 {
                     Debug.Assert(method.IsAsync || method.IsIterator);
-                    GetStateMachineSlotDebugInfo(moduleBuilder.GetSynthesizedFields(stateMachineTypeOpt), out stateMachineHoistedLocalSlots, out stateMachineAwaiterSlots);
+                    GetStateMachineSlotDebugInfo(moduleBuilder, moduleBuilder.GetSynthesizedFields(stateMachineTypeOpt), variableSlotAllocatorOpt, diagnosticsForThisMethod, out stateMachineHoistedLocalSlots, out stateMachineAwaiterSlots);
+                    Debug.Assert(!diagnostics.HasAnyErrors());
                 }
 
                 return new MethodBody(
@@ -1352,7 +1353,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static void GetStateMachineSlotDebugInfo(
+            PEModuleBuilder moduleBuilder,
             IEnumerable<Cci.IFieldDefinition> fieldDefs,
+            VariableSlotAllocator variableSlotAllocatorOpt,
+            DiagnosticBag diagnostics,
             out ImmutableArray<EncHoistedLocalInfo> hoistedVariableSlots,
             out ImmutableArray<Cci.ITypeReference> awaiterSlots)
         {
@@ -1372,7 +1376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         awaiters.Add(null);
                     }
 
-                    awaiters[index] = (Cci.ITypeReference)field.Type;
+                    awaiters[index] = moduleBuilder.EncTranslateLocalVariableType(field.Type, diagnostics);
                 }
                 else if (!field.SlotDebugInfo.Id.IsNone)
                 {
@@ -1384,7 +1388,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hoistedVariables.Add(new EncHoistedLocalInfo(true));
                     }
 
-                    hoistedVariables[index] = new EncHoistedLocalInfo(field.SlotDebugInfo, (Cci.ITypeReference)field.Type);
+                    hoistedVariables[index] = new EncHoistedLocalInfo(field.SlotDebugInfo, moduleBuilder.EncTranslateLocalVariableType(field.Type, diagnostics));
+                }
+            }
+
+            // Fill in empty slots for variables deleted during EnC that are not followed by an existing variable:
+            if (variableSlotAllocatorOpt != null)
+            {
+                int previousAwaiterCount = variableSlotAllocatorOpt.PreviousAwaiterSlotCount;
+                while (awaiters.Count < previousAwaiterCount)
+                {
+                    awaiters.Add(null);
+                }
+
+                int previousAwaiterSlotCount = variableSlotAllocatorOpt.PreviousHoistedLocalSlotCount;
+                while (hoistedVariables.Count < previousAwaiterSlotCount)
+                {
+                    hoistedVariables.Add(new EncHoistedLocalInfo(true));
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
@@ -123,6 +123,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             out IReadOnlyDictionary<Cci.ITypeReference, int> awaiterMap,
             out int awaiterSlotCount)
         {
+            // we are working with PE symbols
+            Debug.Assert(stateMachineType.ContainingAssembly is PEAssemblySymbol);
+
             var hoistedLocals = new Dictionary<EncHoistedLocalInfo, int>();
             var awaiters = new Dictionary<Cci.ITypeReference, int>();
             int maxAwaiterSlotIndex = -1;

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> otherSynthesizedMembersOpt)
         {
             _defs = new MatchDefsToSource(sourceContext, otherContext);
-            _symbols = new MatchSymbols(anonymousTypeMap, sourceAssembly, otherAssembly, otherSynthesizedMembersOpt);
+            _symbols = new MatchSymbols(anonymousTypeMap, sourceAssembly, otherAssembly, otherSynthesizedMembersOpt, new DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)));
         }
 
         public CSharpSymbolMatcher(
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 anonymousTypeMap,
                 sourceAssembly,
                 otherAssembly,
-                otherSynthesizedMembersOpt: null);
+                otherSynthesizedMembersOpt: null,
+                deepTranslatorOpt: null);
         }
 
         public override Cci.IDefinition MapDefinition(Cci.IDefinition definition)
@@ -84,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public MatchDefs(EmitContext sourceContext)
             {
                 _sourceContext = sourceContext;
-                _matches = new ConcurrentDictionary<Cci.IDefinition, Cci.IDefinition>();
+                _matches = new ConcurrentDictionary<Cci.IDefinition, Cci.IDefinition>(ReferenceEqualityComparer.Instance);
             }
 
             public Cci.IDefinition VisitDef(Cci.IDefinition def)
@@ -283,14 +284,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
                 SourceAssemblySymbol sourceAssembly,
                 AssemblySymbol otherAssembly,
-                ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> otherSynthesizedMembersOpt)
+                ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> otherSynthesizedMembersOpt,
+                DeepTranslator deepTranslatorOpt)
             {
                 _anonymousTypeMap = anonymousTypeMap;
                 _sourceAssembly = sourceAssembly;
                 _otherAssembly = otherAssembly;
                 _otherSynthesizedMembersOpt = otherSynthesizedMembersOpt;
-                _comparer = new SymbolComparer(this);
-                _matches = new ConcurrentDictionary<Symbol, Symbol>();
+                _comparer = new SymbolComparer(this, deepTranslatorOpt);
+                _matches = new ConcurrentDictionary<Symbol, Symbol>(ReferenceEqualityComparer.Instance);
                 _otherTypeMembers = new ConcurrentDictionary<NamedTypeSymbol, IReadOnlyDictionary<string, ImmutableArray<Cci.ITypeDefinitionMember>>>();
             }
 
@@ -326,6 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     {
                         case SymbolKind.ArrayType:
                         case SymbolKind.PointerType:
+                        case SymbolKind.DynamicType:
                             break;
 
                         case SymbolKind.NamedType:
@@ -407,6 +410,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     default:
                         throw ExceptionUtilities.UnexpectedValue(otherContainer.Kind);
                 }
+            }
+
+            public override Symbol VisitDynamicType(DynamicTypeSymbol symbol)
+            {
+                return _otherAssembly.GetSpecialType(SpecialType.System_Object);
             }
 
             public override Symbol VisitNamedType(NamedTypeSymbol sourceType)
@@ -743,26 +751,109 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 return result;
             }
 
-            private sealed class SymbolComparer : IEqualityComparer<Symbol>
+            private sealed class SymbolComparer
             {
                 private readonly MatchSymbols _matcher;
+                private readonly DeepTranslator _deepTranslatorOpt;
 
-                public SymbolComparer(MatchSymbols matcher)
+                public SymbolComparer(MatchSymbols matcher, DeepTranslator deepTranslatorOpt)
                 {
+                    Debug.Assert(matcher != null);
                     _matcher = matcher;
+                    _deepTranslatorOpt = deepTranslatorOpt;
                 }
 
-                public bool Equals(Symbol x, Symbol y)
+                public bool Equals(TypeSymbol source, TypeSymbol other)
                 {
-                    var other = _matcher.Visit(x);
-                    Debug.Assert((object)other != null);
-                    return other == y;
+                    var visitedSource = (TypeSymbol)_matcher.Visit(source);
+                    var visitedOther = (_deepTranslatorOpt != null) ? (TypeSymbol)_deepTranslatorOpt.Visit(other) : other;
+
+                    return visitedSource?.Equals(visitedOther, ignoreDynamic: true) == true;
+                }
+            }
+        }
+
+        internal sealed class DeepTranslator : CSharpSymbolVisitor<Symbol>
+        {
+            private readonly ConcurrentDictionary<Symbol, Symbol> _matches;
+            private readonly NamedTypeSymbol _systemObject;
+
+            public DeepTranslator(NamedTypeSymbol systemObject)
+            {
+                _matches = new ConcurrentDictionary<Symbol, Symbol>(ReferenceEqualityComparer.Instance);
+                _systemObject = systemObject;
+            }
+
+            public override Symbol DefaultVisit(Symbol symbol)
+            {
+                // Symbol should have been handled elsewhere.
+                throw new NotImplementedException();
+            }
+
+            public override Symbol Visit(Symbol symbol)
+            {
+                return _matches.GetOrAdd(symbol, base.Visit(symbol));
+            }
+
+            public override Symbol VisitArrayType(ArrayTypeSymbol symbol)
+            {
+                var translatedElementType = (TypeSymbol)this.Visit(symbol.ElementType);
+                var translatedModifiers = VisitCustomModifiers(symbol.CustomModifiers);
+                return new ArrayTypeSymbol(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, translatedElementType, translatedModifiers, symbol.Rank);
+            }
+
+            public override Symbol VisitDynamicType(DynamicTypeSymbol symbol)
+            {
+                return _systemObject;
+            }
+
+            public override Symbol VisitNamedType(NamedTypeSymbol type)
+            {
+                var originalDef = type.OriginalDefinition;
+                if ((object)originalDef != type)
+                {
+                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                    var translatedTypeArguments = type.GetAllTypeArguments(ref useSiteDiagnostics).SelectAsArray((t, v) => (TypeSymbol)v.Visit(t), this);
+
+                    var translatedOriginalDef = (NamedTypeSymbol)this.Visit(originalDef);
+                    var typeMap = new TypeMap(translatedOriginalDef.GetAllTypeParameters(), translatedTypeArguments, allowAlpha: true);
+                    return typeMap.SubstituteNamedType(translatedOriginalDef);
                 }
 
-                public int GetHashCode(Symbol obj)
+                Debug.Assert(type.IsDefinition);
+
+                if (type.IsAnonymousType)
                 {
-                    return obj.GetHashCode();
+                    return this.Visit(AnonymousTypeManager.TranslateAnonymousTypeSymbol(type));
                 }
+
+                return type;
+            }
+
+            public override Symbol VisitPointerType(PointerTypeSymbol symbol)
+            {
+                var translatedPointedAtType = (TypeSymbol)this.Visit(symbol.PointedAtType);
+                var translatedModifiers = VisitCustomModifiers(symbol.CustomModifiers);
+                return new PointerTypeSymbol(translatedPointedAtType, translatedModifiers);
+            }
+
+            public override Symbol VisitTypeParameter(TypeParameterSymbol symbol)
+            {
+                return symbol;
+            }
+
+            private ImmutableArray<CustomModifier> VisitCustomModifiers(ImmutableArray<CustomModifier> modifiers)
+            {
+                return modifiers.SelectAsArray(VisitCustomModifier);
+            }
+
+            private CustomModifier VisitCustomModifier(CustomModifier modifier)
+            {
+                var translatedType = (NamedTypeSymbol)this.Visit((Symbol)modifier.Modifier);
+                Debug.Assert((object)translatedType != null);
+                return modifier.IsOptional ?
+                    CSharpCustomModifier.CreateOptional(translatedType) :
+                    CSharpCustomModifier.CreateRequired(translatedType);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_awaiterFields.TryGetValue(awaiterType, out result))
             {
                 int slotIndex;
-                if (slotAllocatorOpt == null || !slotAllocatorOpt.TryGetPreviousAwaiterSlotIndex((Cci.ITypeReference)awaiterType, out slotIndex))
+                if (slotAllocatorOpt == null || !slotAllocatorOpt.TryGetPreviousAwaiterSlotIndex(F.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics), out slotIndex))
                 {
                     slotIndex = _nextAwaiterId++;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Editing await expression is not allowed. Thus all spilled fields will be present in the previous state machine.
                         // However, it may happen that the type changes, in which case we need to allocate a new slot.
                         int slotIndex;
-                        if (slotAllocatorOpt == null || !slotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(awaitSyntaxOpt, (Cci.ITypeReference)fieldType, kind, id, out slotIndex))
+                        if (slotAllocatorOpt == null || !slotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(awaitSyntaxOpt, F.ModuleBuilderOpt.Translate(fieldType, awaitSyntaxOpt, Diagnostics), kind, id, out slotIndex))
                         {
                             slotIndex = _nextFreeHoistedLocalSlot++;
                         }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             // map local id to the previous id, if available:
                             int previousSlotIndex;
-                            if (mapToPreviousFields && slotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(declaratorSyntax, (Cci.ITypeReference)fieldType, synthesizedKind, id, out previousSlotIndex))
+                            if (mapToPreviousFields && slotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(declaratorSyntax, F.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, diagnostics), synthesizedKind, id, out previousSlotIndex))
                             {
                                 slotIndex = previousSlotIndex;
                             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal AnonymousTypeKey GetAnonymousTypeKey()
             {
-                var properties = this.Properties.SelectAsArray(p => AnonymousTypeKeyField.CreateField(p.Name));
+                var properties = this.Properties.SelectAsArray(p => new AnonymousTypeKeyField(p.Name, isKey: false, ignoreCase: false));
                 return new AnonymousTypeKey(properties);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -2146,6 +2146,221 @@ class C
         }
 
         [Fact]
+        public void HoistedVariables_Dynamic1()
+        {
+            var template = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        dynamic <N:0>x = 1</N:0>;
+        yield return 1;
+        Console.WriteLine((int)x + <<VALUE>>);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+";
+            var source0 = MarkedSource(template.Replace("<<VALUE>>", "0"));
+            var source1 = MarkedSource(template.Replace("<<VALUE>>", "1"));
+            var source2 = MarkedSource(template.Replace("<<VALUE>>", "2"));
+
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, new[] { SystemCoreRef, CSharpRef }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var baselineIL = @"
+{
+  // Code size      149 (0x95)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  box        ""int""
+  IL_0027:  stfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0048:  brfalse.s  IL_004c
+  IL_004a:  br.s       IL_0071
+  IL_004c:  ldc.i4.s   16
+  IL_004e:  ldtoken    ""int""
+  IL_0053:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0058:  ldtoken    ""C""
+  IL_005d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0062:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0067:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_006c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0071:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0076:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
+  IL_007b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0080:  ldarg.0
+  IL_0081:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_0086:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_008b:  ldc.i4.<<VALUE>>
+  IL_008c:  add
+  IL_008d:  call       ""void System.Console.WriteLine(int)""
+  IL_0092:  nop
+  IL_0093:  ldc.i4.0
+  IL_0094:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "0").Replace("<<DYNAMIC_CONTAINER_NAME>>", "<>o__0"));
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>o__0#1, <F>d__0}",
+                "C.<>o__0#1: {<>p__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}");
+
+            diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1").Replace("<<DYNAMIC_CONTAINER_NAME>>", "<>o__0#1"));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<>o__0#2, <F>d__0, <>o__0#1}",
+                "C.<>o__0#1: {<>p__0}",
+                "C.<>o__0#2: {<>p__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}");
+
+            diff2.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "2").Replace("<<DYNAMIC_CONTAINER_NAME>>", "<>o__0#2"));
+        }
+
+        [Fact]
+        public void HoistedVariables_Dynamic2()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    private static IEnumerable<string> F()
+    {
+        dynamic <N:0>d = ""x""</N:0>;
+        yield return d;
+        Console.WriteLine(0);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    private static IEnumerable<string> F()
+    {
+        dynamic <N:0>d = ""x""</N:0>;
+        yield return d.ToString();
+        Console.WriteLine(1);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source2 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    private static IEnumerable<string> F()
+    {
+        dynamic <N:0>d = ""x""</N:0>;
+        yield return d;
+        Console.WriteLine(2);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, new[] { SystemCoreRef, CSharpRef }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation0.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                 generation0,
+                 ImmutableArray.Create(
+                     new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>o__0#1, <F>d__0}",
+                "C.<>o__0#1: {<>p__0, <>p__1}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <d>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}");
+
+            var diff2 = compilation2.EmitDifference(
+                 diff1.NextGeneration,
+                 ImmutableArray.Create(
+                     new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<>o__0#2, <F>d__0, <>o__0#1}",
+                "C.<>o__0#1: {<>p__0, <>p__1}",
+                "C.<>o__0#2: {<>p__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <d>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}");
+        }
+        
+        [Fact]
         public void Awaiters1()
         {
             var source0 = @"
@@ -2988,6 +3203,1463 @@ class C
                 "<>4__this: C.<>c",
                 "<>u__1: System.Runtime.CompilerServices.TaskAwaiter<bool>",
                 "<>u__2: System.Runtime.CompilerServices.TaskAwaiter<int>");
+        }
+
+        [Fact, WorkItem(1170899, "DevDiv")]
+        public void HoistedAnonymousTypes1()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new { A = 1 }</N:0>;
+        yield return 1;
+        Console.WriteLine(x.A + 1);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new { A = 1 }</N:0>;
+        yield return 1;
+        Console.WriteLine(x.A + 2);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source2 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new { A = 1 }</N:0>;
+        yield return 1;
+        Console.WriteLine(x.A + 3);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var baselineIL = @"
+{
+  // Code size       88 (0x58)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  newobj     ""<>f__AnonymousType0<int>..ctor(int)""
+  IL_0027:  stfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldarg.0
+  IL_0044:  ldfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
+  IL_0049:  callvirt   ""int <>f__AnonymousType0<int>.A.get""
+  IL_004e:  ldc.i4.<<VALUE>>
+  IL_004f:  add
+  IL_0050:  call       ""void System.Console.WriteLine(int)""
+  IL_0055:  nop
+  IL_0056:  ldc.i4.0
+  IL_0057:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "2"));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                 "C: {<F>d__0}",
+                 "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                 "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff2.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "3"));
+        }
+
+        [Fact, WorkItem(3192)]
+        public void HoistedAnonymousTypes_Nested()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new[] { new { A = new { B = 1 } } }</N:0>;
+        yield return 1;
+        Console.WriteLine(x[0].A.B + 1);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new[] { new { A = new { B = 1 } } }</N:0>;
+        yield return 1;
+        Console.WriteLine(x[0].A.B + 2);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source2 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new[] { new { A = new { B = 1 } } }</N:0>;
+        yield return 1;
+        Console.WriteLine(x[0].A.B + 3);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var baselineIL = @"
+{
+  // Code size      109 (0x6d)
+  .maxstack  5
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_004a
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  newarr     ""<>f__AnonymousType0<<anonymous type: int B>>""
+  IL_0027:  dup
+  IL_0028:  ldc.i4.0
+  IL_0029:  ldc.i4.1
+  IL_002a:  newobj     ""<>f__AnonymousType1<int>..ctor(int)""
+  IL_002f:  newobj     ""<>f__AnonymousType0<<anonymous type: int B>>..ctor(<anonymous type: int B>)""
+  IL_0034:  stelem.ref
+  IL_0035:  stfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
+  IL_003a:  ldarg.0
+  IL_003b:  ldc.i4.1
+  IL_003c:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0041:  ldarg.0
+  IL_0042:  ldc.i4.1
+  IL_0043:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0048:  ldc.i4.1
+  IL_0049:  ret
+  IL_004a:  ldarg.0
+  IL_004b:  ldc.i4.m1
+  IL_004c:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0051:  ldarg.0
+  IL_0052:  ldfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
+  IL_0057:  ldc.i4.0
+  IL_0058:  ldelem.ref
+  IL_0059:  callvirt   ""<anonymous type: int B> <>f__AnonymousType0<<anonymous type: int B>>.A.get""
+  IL_005e:  callvirt   ""int <>f__AnonymousType1<int>.B.get""
+  IL_0063:  ldc.i4.<<VALUE>>
+  IL_0064:  add
+  IL_0065:  call       ""void System.Console.WriteLine(int)""
+  IL_006a:  nop
+  IL_006b:  ldc.i4.0
+  IL_006c:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType1<<B>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "2"));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType1<<B>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff2.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "3"));
+        }
+        
+        [Fact, WorkItem(3192)]
+        public void HoistedGenericTypes()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class Z<T1>
+{
+    public class S<T2> { public T1 a = default(T1); public T2 b = default(T2); }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new Z<double>.S<int>()</N:0>;
+        yield return 1;
+        Console.WriteLine(x.a + x.b + 1);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class Z<T1>
+{
+    public class S<T2> { public T1 a = default(T1); public T2 b = default(T2); }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new Z<double>.S<int>()</N:0>;
+        yield return 1;
+        Console.WriteLine(x.a + x.b + 2);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source2 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+class Z<T1>
+{
+    public class S<T2> { public T1 a = default(T1); public T2 b = default(T2); }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new Z<double>.S<int>()</N:0>;
+        yield return 1;
+        Console.WriteLine(x.a + x.b + 3);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var baselineIL = @"
+{
+  // Code size      108 (0x6c)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003b
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  newobj     ""Z<double>.S<int>..ctor()""
+  IL_0026:  stfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_002b:  ldarg.0
+  IL_002c:  ldc.i4.1
+  IL_002d:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0032:  ldarg.0
+  IL_0033:  ldc.i4.1
+  IL_0034:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0039:  ldc.i4.1
+  IL_003a:  ret
+  IL_003b:  ldarg.0
+  IL_003c:  ldc.i4.m1
+  IL_003d:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0042:  ldarg.0
+  IL_0043:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_0048:  ldfld      ""double Z<double>.S<int>.a""
+  IL_004d:  ldarg.0
+  IL_004e:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_0053:  ldfld      ""int Z<double>.S<int>.b""
+  IL_0058:  conv.r8
+  IL_0059:  add
+  IL_005a:  ldc.r8     <<VALUE>>
+  IL_0063:  add
+  IL_0064:  call       ""void System.Console.WriteLine(double)""
+  IL_0069:  nop
+  IL_006a:  ldc.i4.0
+  IL_006b:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}");
+
+            diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "2"));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}");
+
+            diff2.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "3"));
+        }
+
+        [Fact]
+        public void HoistedAnonymousTypes_Dynamic()
+        {
+            var template = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        var <N:0>x = new { A = (dynamic)null, B = 1 }</N:0>;
+        yield return 1;
+        Console.WriteLine(x.B + <<VALUE>>);
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+";
+            var source0 = MarkedSource(template.Replace("<<VALUE>>", "0"));
+            var source1 = MarkedSource(template.Replace("<<VALUE>>", "1"));
+            var source2 = MarkedSource(template.Replace("<<VALUE>>", "2"));
+
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var baselineIL = @"
+{
+  // Code size       89 (0x59)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003d
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldnull
+  IL_0022:  ldc.i4.1
+  IL_0023:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
+  IL_0028:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_002d:  ldarg.0
+  IL_002e:  ldc.i4.1
+  IL_002f:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0034:  ldarg.0
+  IL_0035:  ldc.i4.1
+  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003b:  ldc.i4.1
+  IL_003c:  ret
+  IL_003d:  ldarg.0
+  IL_003e:  ldc.i4.m1
+  IL_003f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0044:  ldarg.0
+  IL_0045:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_004a:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
+  IL_004f:  ldc.i4.<<VALUE>>
+  IL_0050:  add
+  IL_0051:  call       ""void System.Console.WriteLine(int)""
+  IL_0056:  nop
+  IL_0057:  ldc.i4.0
+  IL_0058:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "0"));
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<F>d__0}",                
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType0<<A>j__TPar, <B>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<F>d__0}",
+                "C.<F>d__0: {<>1__state, <>2__current, <>l__initialThreadId, <>4__this, <x>5__1, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.Int32>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.Int32>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType0<<A>j__TPar, <B>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff2.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "2"));
+        }
+
+        [Fact, WorkItem(3192)]
+        public void HoistedAnonymousTypes_Delete()
+        {
+            var source0 = MarkedSource(@"
+using System.Linq;
+using System.Threading.Tasks;
+
+class C
+{
+    static async Task<int> F()
+    {
+        var <N:1>x = from b in new[] { 1, 2, 3 } <N:0>select new { A = b }</N:0></N:1>;
+        return <N:2>await Task.FromResult(1)</N:2>;
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source1 = MarkedSource(@"
+using System.Linq;
+using System.Threading.Tasks;
+
+class C
+{
+    static async Task<int> F()
+    {
+        var <N:1>x = from b in new[] { 1, 2, 3 } <N:0>select new { A = b }</N:0></N:1>;
+        var y = x.First();
+        return <N:2>await Task.FromResult(1)</N:2>;
+    }
+
+    void X() {} // needs to be present to work around SymWriter bug #1068894
+}
+");
+            var source2 = source0;
+            var source3 = source1;
+            var source4 = source0;
+            var source5 = source1;
+
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, new[] { SystemCoreRef }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation0.WithSource(source2.Tree);
+            var compilation3 = compilation0.WithSource(source3.Tree);
+            var compilation4 = compilation0.WithSource(source4.Tree);
+            var compilation5 = compilation0.WithSource(source5.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+            var f3 = compilation3.GetMember<MethodSymbol>("C.F");
+            var f4 = compilation4.GetMember<MethodSymbol>("C.F");
+            var f5 = compilation5.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            // y is added 
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c, <F>d__0}",
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C.<F>d__0: {<>1__state, <>t__builder, <x>5__1, <y>5__3, <>s__2, <>u__1, MoveNext, SetStateMachine}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            // y is removed
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            // Synthesized members collection still includes y field since members are only added to it and never deleted.
+            // The corresponding CLR field is also present.
+            diff2.VerifySynthesizedMembers(
+                "C: {<>c, <F>d__0}",
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C.<F>d__0: {<>1__state, <>t__builder, <x>5__1, <>s__2, <>u__1, MoveNext, SetStateMachine, <y>5__3}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            // y is added and a new slot index is allocated for it
+            var diff3 = compilation3.EmitDifference(
+                diff2.NextGeneration,
+                ImmutableArray.Create(
+                   new SemanticEdit(SemanticEditKind.Update, f2, f3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables: true)));
+
+            diff3.VerifySynthesizedMembers(
+                "C: {<>c, <F>d__0}",
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C.<F>d__0: {<>1__state, <>t__builder, <x>5__1, <y>5__4, <>s__2, <>u__1, MoveNext, SetStateMachine, <y>5__3}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            // y is removed
+            var diff4 = compilation4.EmitDifference(
+                diff3.NextGeneration,
+                ImmutableArray.Create(
+                   new SemanticEdit(SemanticEditKind.Update, f3, f4, GetSyntaxMapFromMarkers(source3, source4), preserveLocalVariables: true)));
+
+            diff4.VerifySynthesizedMembers(
+                "C: {<>c, <F>d__0}",
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C.<F>d__0: {<>1__state, <>t__builder, <x>5__1, <>s__2, <>u__1, MoveNext, SetStateMachine, <y>5__4, <y>5__3}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            // y is added
+            var diff5 = compilation5.EmitDifference(
+                diff4.NextGeneration,
+                ImmutableArray.Create(
+                   new SemanticEdit(SemanticEditKind.Update, f4, f5, GetSyntaxMapFromMarkers(source4, source5), preserveLocalVariables: true)));
+
+            diff5.VerifySynthesizedMembers(
+                "C: {<>c, <F>d__0}",
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C.<F>d__0: {<>1__state, <>t__builder, <x>5__1, <y>5__5, <>s__2, <>u__1, MoveNext, SetStateMachine, <y>5__4, <y>5__3}",
+                "<>f__AnonymousType0<<A>j__TPar>: {Equals, GetHashCode, ToString}");
+        }
+
+        [Fact]
+        public void HoistedAnonymousTypes_Dynamic2()
+        {
+            var source0 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        args = Iterator().ToArray();
+    }
+
+    private static IEnumerable<string> Iterator()
+    {
+        string[] <N:15>args = new[] { ""a"", ""bB"", ""Cc"", ""DD"" }</N:15>;
+        var <N:16>list = false ? null : new { Head = (dynamic)null, Tail = (dynamic)null }</N:16>;
+        for (int <N:18>i = 0</N:18>; i < 10; i++)
+        {
+            var <N:6>result =
+                from a in args
+                <N:0>let x = a.Reverse()</N:0>
+                <N:1>let y = x.Reverse()</N:1>
+                <N:2>where x.SequenceEqual(y)</N:2>
+                orderby <N:3>a.Length ascending</N:3>, <N:4>a descending</N:4>
+                <N:5>select new { Value = a, Length = x.Count() }</N:5></N:6>;
+
+            var <N:8>linked = result.Aggregate(
+                false ? new { Head = (string)null, Tail = (dynamic)null } : null,
+                <N:7>(total, curr) => new { Head = curr.Value, Tail = (dynamic)total }</N:7>)</N:8>;
+
+            while (linked != null)
+            {
+                <N:9>yield return linked.Head</N:9>;
+                linked = linked.Tail;
+            }
+
+            var <N:14>newArgs =
+                from a in result
+                <N:10>let value = a.Value</N:10>
+                <N:11>let length = a.Length</N:11>
+                <N:12>where value.Length == length</N:12>
+                <N:13>select value + value</N:13></N:14>;
+
+            args = args.Concat(newArgs).ToArray();
+            list = new { Head = (dynamic)i, Tail = (dynamic)list };
+            System.Diagnostics.Debugger.Break();
+        }
+        System.Diagnostics.Debugger.Break();
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        args = Iterator().ToArray();
+    }
+
+    private static IEnumerable<string> Iterator()
+    {
+        string[] <N:15>args = new[] { ""a"", ""bB"", ""Cc"", ""DD"" }</N:15>;
+        var <N:16>list = false ? null : new { Head = (dynamic)null, Tail = (dynamic)null }</N:16>;
+        for (int <N:18>i = 0</N:18>; i < 10; i++)
+        {
+            var <N:6>result =
+                from a in args
+                <N:0>let x = a.Reverse()</N:0>
+                <N:1>let y = x.Reverse()</N:1>
+                <N:2>where x.SequenceEqual(y)</N:2>
+                orderby <N:3>a.Length ascending</N:3>, <N:4>a descending</N:4>
+                <N:5>select new { Value = a, Length = x.Count() }</N:5></N:6>;
+
+            var <N:8>linked = result.Aggregate(
+                false ? new { Head = (string)null, Tail = (dynamic)null } : null,
+                <N:7>(total, curr) => new { Head = curr.Value, Tail = (dynamic)total }</N:7>)</N:8>;
+
+            var <N:17>temp = list</N:17>;
+            while (temp != null)
+            {
+                <N:9>yield return temp.Head</N:9>;
+                temp = temp.Tail;
+            }
+
+            var <N:14>newArgs =
+                from a in result
+                <N:10>let value = a.Value</N:10>
+                <N:11>let length = a.Length</N:11>
+                <N:12>where value.Length == length</N:12>
+                <N:13>select value + value</N:13></N:14>;
+
+            args = args.Concat(newArgs).ToArray();
+            list = new { Head = (dynamic)i, Tail = (dynamic)list };
+            System.Diagnostics.Debugger.Break();
+        }
+        System.Diagnostics.Debugger.Break();
+    }
+}
+");
+            var source2 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        args = Iterator().ToArray();
+    }
+
+    private static IEnumerable<string> Iterator()
+    {
+        string[] <N:15>args = new[] { ""a"", ""bB"", ""Cc"", ""DD"" }</N:15>;
+        var <N:16>list = false ? null : new { Head = (dynamic)null, Tail = (dynamic)null }</N:16>;
+        for (int <N:18>i = 0</N:18>; i < 10; i++)
+        {
+            var <N:6>result =
+                from a in args
+                <N:0>let x = a.Reverse()</N:0>
+                <N:1>let y = x.Reverse()</N:1>
+                <N:2>where x.SequenceEqual(y)</N:2>
+                orderby <N:3>a.Length ascending</N:3>, <N:4>a descending</N:4>
+                <N:5>select new { Value = a, Length = x.Count() }</N:5></N:6>;
+
+            var <N:8>linked = result.Aggregate(
+                false ? new { Head = (string)null, Tail = (dynamic)null } : null,
+                <N:7>(total, curr) => new { Head = curr.Value, Tail = (dynamic)total }</N:7>)</N:8>;
+
+            var <N:17>temp = list</N:17>;
+            while (temp != null)
+            {
+                <N:9>yield return temp.Head.ToString()</N:9>;
+                temp = temp.Tail;
+            }
+
+            var <N:14>newArgs =
+                from a in result
+                <N:10>let value = a.Value</N:10>
+                <N:11>let length = a.Length</N:11>
+                <N:12>where value.Length == length</N:12>
+                <N:13>select value + value</N:13></N:14>;
+
+            args = args.Concat(newArgs).ToArray();
+            list = new { Head = (dynamic)i, Tail = (dynamic)list };
+            System.Diagnostics.Debugger.Break();
+        }
+        System.Diagnostics.Debugger.Break();
+    }
+}
+");
+            var compilation0 = CreateCompilationWithMscorlib45(new[] { source0.Tree }, new[] { SystemCoreRef, CSharpRef }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("Program.Iterator");
+            var f1 = compilation1.GetMember<MethodSymbol>("Program.Iterator");
+            var f2 = compilation2.GetMember<MethodSymbol>("Program.Iterator");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            v0.VerifyIL("Program.<Iterator>d__1.System.Collections.IEnumerator.MoveNext()", @"
+{
+  // Code size      798 (0x31e)
+  .maxstack  5
+  .locals init (int V_0,
+                bool V_1,
+                int V_2,
+                bool V_3)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0019
+  IL_0012:  br.s       IL_001b
+  IL_0014:  br         IL_019b
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+  IL_001b:  ldarg.0
+  IL_001c:  ldc.i4.m1
+  IL_001d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0022:  nop
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.4
+  IL_0025:  newarr     ""string""
+  IL_002a:  dup
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldstr      ""a""
+  IL_0031:  stelem.ref
+  IL_0032:  dup
+  IL_0033:  ldc.i4.1
+  IL_0034:  ldstr      ""bB""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldstr      ""Cc""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.3
+  IL_0044:  ldstr      ""DD""
+  IL_0049:  stelem.ref
+  IL_004a:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_004f:  ldarg.0
+  IL_0050:  ldnull
+  IL_0051:  ldnull
+  IL_0052:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0057:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_005c:  ldarg.0
+  IL_005d:  ldc.i4.0
+  IL_005e:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0063:  br         IL_0305
+  IL_0068:  nop
+  IL_0069:  ldarg.0
+  IL_006a:  ldarg.0
+  IL_006b:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_0070:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_0075:  dup
+  IL_0076:  brtrue.s   IL_008f
+  IL_0078:  pop
+  IL_0079:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_007e:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
+  IL_0084:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
+  IL_0089:  dup
+  IL_008a:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_008f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
+  IL_0094:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_0099:  dup
+  IL_009a:  brtrue.s   IL_00b3
+  IL_009c:  pop
+  IL_009d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00a2:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
+  IL_00a8:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
+  IL_00ad:  dup
+  IL_00ae:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_00b3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
+  IL_00b8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00bd:  dup
+  IL_00be:  brtrue.s   IL_00d7
+  IL_00c0:  pop
+  IL_00c1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00c6:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00cc:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
+  IL_00d1:  dup
+  IL_00d2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00d7:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
+  IL_00dc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00e1:  dup
+  IL_00e2:  brtrue.s   IL_00fb
+  IL_00e4:  pop
+  IL_00e5:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00ea:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00f0:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
+  IL_00f5:  dup
+  IL_00f6:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00fb:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
+  IL_0100:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_0105:  dup
+  IL_0106:  brtrue.s   IL_011f
+  IL_0108:  pop
+  IL_0109:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_010e:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0114:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
+  IL_0119:  dup
+  IL_011a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_011f:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
+  IL_0124:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0129:  dup
+  IL_012a:  brtrue.s   IL_0143
+  IL_012c:  pop
+  IL_012d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0132:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0138:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
+  IL_013d:  dup
+  IL_013e:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0143:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
+  IL_0148:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_014d:  ldarg.0
+  IL_014e:  ldarg.0
+  IL_014f:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0154:  ldnull
+  IL_0155:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_015a:  dup
+  IL_015b:  brtrue.s   IL_0174
+  IL_015d:  pop
+  IL_015e:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0163:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
+  IL_0169:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
+  IL_016e:  dup
+  IL_016f:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_0174:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
+  IL_0179:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_017e:  br.s       IL_01f5
+  IL_0180:  nop
+  IL_0181:  ldarg.0
+  IL_0182:  ldarg.0
+  IL_0183:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_0188:  callvirt   ""string <>f__AnonymousType0<string, dynamic>.Head.get""
+  IL_018d:  stfld      ""string Program.<Iterator>d__1.<>2__current""
+  IL_0192:  ldarg.0
+  IL_0193:  ldc.i4.1
+  IL_0194:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0199:  ldc.i4.1
+  IL_019a:  ret
+  IL_019b:  ldarg.0
+  IL_019c:  ldc.i4.m1
+  IL_019d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01a2:  ldarg.0
+  IL_01a3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01a8:  brfalse.s  IL_01ac
+  IL_01aa:  br.s       IL_01d0
+  IL_01ac:  ldc.i4.0
+  IL_01ad:  ldtoken    ""<>f__AnonymousType0<string, dynamic>""
+  IL_01b2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01b7:  ldtoken    ""Program""
+  IL_01bc:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01c1:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_01c6:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_01cb:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01d0:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01d5:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Target""
+  IL_01da:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01df:  ldarg.0
+  IL_01e0:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01e5:  callvirt   ""dynamic <>f__AnonymousType0<string, dynamic>.Tail.get""
+  IL_01ea:  callvirt   ""<anonymous type: string Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_01ef:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01f4:  nop
+  IL_01f5:  ldarg.0
+  IL_01f6:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01fb:  ldnull
+  IL_01fc:  cgt.un
+  IL_01fe:  stloc.1
+  IL_01ff:  ldloc.1
+  IL_0200:  brtrue     IL_0180
+  IL_0205:  ldarg.0
+  IL_0206:  ldarg.0
+  IL_0207:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_020c:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_0211:  dup
+  IL_0212:  brtrue.s   IL_022b
+  IL_0214:  pop
+  IL_0215:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_021a:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
+  IL_0220:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
+  IL_0225:  dup
+  IL_0226:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_022b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
+  IL_0230:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_0235:  dup
+  IL_0236:  brtrue.s   IL_024f
+  IL_0238:  pop
+  IL_0239:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_023e:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
+  IL_0244:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
+  IL_0249:  dup
+  IL_024a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_024f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
+  IL_0254:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_0259:  dup
+  IL_025a:  brtrue.s   IL_0273
+  IL_025c:  pop
+  IL_025d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0262:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_0268:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
+  IL_026d:  dup
+  IL_026e:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_0273:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
+  IL_0278:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_027d:  dup
+  IL_027e:  brtrue.s   IL_0297
+  IL_0280:  pop
+  IL_0281:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0286:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_028c:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
+  IL_0291:  dup
+  IL_0292:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_0297:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
+  IL_029c:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02a1:  ldarg.0
+  IL_02a2:  ldarg.0
+  IL_02a3:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02a8:  ldarg.0
+  IL_02a9:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02ae:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
+  IL_02b3:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
+  IL_02b8:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02bd:  ldarg.0
+  IL_02be:  ldarg.0
+  IL_02bf:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_02c4:  box        ""int""
+  IL_02c9:  ldarg.0
+  IL_02ca:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_02cf:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_02d4:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_02d9:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_02de:  nop
+  IL_02df:  nop
+  IL_02e0:  ldarg.0
+  IL_02e1:  ldnull
+  IL_02e2:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_02e7:  ldarg.0
+  IL_02e8:  ldnull
+  IL_02e9:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_02ee:  ldarg.0
+  IL_02ef:  ldnull
+  IL_02f0:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02f5:  ldarg.0
+  IL_02f6:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_02fb:  stloc.2
+  IL_02fc:  ldarg.0
+  IL_02fd:  ldloc.2
+  IL_02fe:  ldc.i4.1
+  IL_02ff:  add
+  IL_0300:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0305:  ldarg.0
+  IL_0306:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_030b:  ldc.i4.s   10
+  IL_030d:  clt
+  IL_030f:  stloc.3
+  IL_0310:  ldloc.3
+  IL_0311:  brtrue     IL_0068
+  IL_0316:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_031b:  nop
+  IL_031c:  ldc.i4.0
+  IL_031d:  ret
+}
+");
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "Program.<>o__1#1: {<>p__0, <>p__1}",
+                "Program: {<>o__1#1, <>c, <Iterator>d__1}",
+                "Program.<>c: {<>9__1_0, <>9__1_1, <>9__1_2, <>9__1_3, <>9__1_4, <>9__1_5, <>9__1_6, <>9__1_7, <>9__1_8, <>9__1_9, <>9__1_10, <Iterator>b__1_0, <Iterator>b__1_1, <Iterator>b__1_2, <Iterator>b__1_3, <Iterator>b__1_4, <Iterator>b__1_5, <Iterator>b__1_6, <Iterator>b__1_7, <Iterator>b__1_8, <Iterator>b__1_9, <Iterator>b__1_10}",
+                "Program.<Iterator>d__1: {<>1__state, <>2__current, <>l__initialThreadId, <args>5__1, <list>5__2, <i>5__3, <result>5__4, <linked>5__5, <temp>5__7, <newArgs>5__6, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType4<<a>j__TPar, <value>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType3<<Value>j__TPar, <Length>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType5<<<>h__TransparentIdentifier0>j__TPar, <length>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType2<<<>h__TransparentIdentifier0>j__TPar, <y>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType0<<Head>j__TPar, <Tail>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType1<<a>j__TPar, <x>j__TPar>: {Equals, GetHashCode, ToString}");
+
+            diff1.VerifyIL("Program.<Iterator>d__1.System.Collections.IEnumerator.MoveNext()", @"
+{
+  // Code size      885 (0x375)
+  .maxstack  5
+  .locals init (int V_0,
+                bool V_1,
+                int V_2,
+                bool V_3)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0019
+  IL_0012:  br.s       IL_001b
+  IL_0014:  br         IL_01eb
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+  IL_001b:  ldarg.0
+  IL_001c:  ldc.i4.m1
+  IL_001d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0022:  nop
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.4
+  IL_0025:  newarr     ""string""
+  IL_002a:  dup
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldstr      ""a""
+  IL_0031:  stelem.ref
+  IL_0032:  dup
+  IL_0033:  ldc.i4.1
+  IL_0034:  ldstr      ""bB""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldstr      ""Cc""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.3
+  IL_0044:  ldstr      ""DD""
+  IL_0049:  stelem.ref
+  IL_004a:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_004f:  ldarg.0
+  IL_0050:  ldnull
+  IL_0051:  ldnull
+  IL_0052:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0057:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_005c:  ldarg.0
+  IL_005d:  ldc.i4.0
+  IL_005e:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0063:  br         IL_035c
+  IL_0068:  nop
+  IL_0069:  ldarg.0
+  IL_006a:  ldarg.0
+  IL_006b:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_0070:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_0075:  dup
+  IL_0076:  brtrue.s   IL_008f
+  IL_0078:  pop
+  IL_0079:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_007e:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
+  IL_0084:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
+  IL_0089:  dup
+  IL_008a:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_008f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
+  IL_0094:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_0099:  dup
+  IL_009a:  brtrue.s   IL_00b3
+  IL_009c:  pop
+  IL_009d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00a2:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
+  IL_00a8:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
+  IL_00ad:  dup
+  IL_00ae:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_00b3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
+  IL_00b8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00bd:  dup
+  IL_00be:  brtrue.s   IL_00d7
+  IL_00c0:  pop
+  IL_00c1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00c6:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00cc:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
+  IL_00d1:  dup
+  IL_00d2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00d7:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
+  IL_00dc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00e1:  dup
+  IL_00e2:  brtrue.s   IL_00fb
+  IL_00e4:  pop
+  IL_00e5:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00ea:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00f0:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
+  IL_00f5:  dup
+  IL_00f6:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00fb:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
+  IL_0100:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_0105:  dup
+  IL_0106:  brtrue.s   IL_011f
+  IL_0108:  pop
+  IL_0109:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_010e:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0114:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
+  IL_0119:  dup
+  IL_011a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_011f:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
+  IL_0124:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0129:  dup
+  IL_012a:  brtrue.s   IL_0143
+  IL_012c:  pop
+  IL_012d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0132:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0138:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
+  IL_013d:  dup
+  IL_013e:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0143:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
+  IL_0148:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_014d:  ldarg.0
+  IL_014e:  ldarg.0
+  IL_014f:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0154:  ldnull
+  IL_0155:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_015a:  dup
+  IL_015b:  brtrue.s   IL_0174
+  IL_015d:  pop
+  IL_015e:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0163:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
+  IL_0169:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
+  IL_016e:  dup
+  IL_016f:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_0174:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
+  IL_0179:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_017e:  ldarg.0
+  IL_017f:  ldarg.0
+  IL_0180:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_0185:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_018a:  br         IL_0245
+  IL_018f:  nop
+  IL_0190:  ldarg.0
+  IL_0191:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_0196:  brfalse.s  IL_019a
+  IL_0198:  br.s       IL_01be
+  IL_019a:  ldc.i4.0
+  IL_019b:  ldtoken    ""string""
+  IL_01a0:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01a5:  ldtoken    ""Program""
+  IL_01aa:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01af:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_01b4:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_01b9:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01be:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01c3:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Target""
+  IL_01c8:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01cd:  ldarg.0
+  IL_01ce:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_01d3:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Head.get""
+  IL_01d8:  callvirt   ""string System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_01dd:  stfld      ""string Program.<Iterator>d__1.<>2__current""
+  IL_01e2:  ldarg.0
+  IL_01e3:  ldc.i4.1
+  IL_01e4:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01e9:  ldc.i4.1
+  IL_01ea:  ret
+  IL_01eb:  ldarg.0
+  IL_01ec:  ldc.i4.m1
+  IL_01ed:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01f2:  ldarg.0
+  IL_01f3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_01f8:  brfalse.s  IL_01fc
+  IL_01fa:  br.s       IL_0220
+  IL_01fc:  ldc.i4.0
+  IL_01fd:  ldtoken    ""<>f__AnonymousType0<dynamic, dynamic>""
+  IL_0202:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0207:  ldtoken    ""Program""
+  IL_020c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0211:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0216:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_021b:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_0220:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_0225:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Target""
+  IL_022a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_022f:  ldarg.0
+  IL_0230:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0235:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Tail.get""
+  IL_023a:  callvirt   ""<anonymous type: dynamic Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_023f:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0244:  nop
+  IL_0245:  ldarg.0
+  IL_0246:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_024b:  ldnull
+  IL_024c:  cgt.un
+  IL_024e:  stloc.1
+  IL_024f:  ldloc.1
+  IL_0250:  brtrue     IL_018f
+  IL_0255:  ldarg.0
+  IL_0256:  ldarg.0
+  IL_0257:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_025c:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_0261:  dup
+  IL_0262:  brtrue.s   IL_027b
+  IL_0264:  pop
+  IL_0265:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_026a:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
+  IL_0270:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
+  IL_0275:  dup
+  IL_0276:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_027b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
+  IL_0280:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_0285:  dup
+  IL_0286:  brtrue.s   IL_029f
+  IL_0288:  pop
+  IL_0289:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_028e:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
+  IL_0294:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
+  IL_0299:  dup
+  IL_029a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_029f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
+  IL_02a4:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_02a9:  dup
+  IL_02aa:  brtrue.s   IL_02c3
+  IL_02ac:  pop
+  IL_02ad:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_02b2:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_02b8:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
+  IL_02bd:  dup
+  IL_02be:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_02c3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
+  IL_02c8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_02cd:  dup
+  IL_02ce:  brtrue.s   IL_02e7
+  IL_02d0:  pop
+  IL_02d1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_02d6:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_02dc:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
+  IL_02e1:  dup
+  IL_02e2:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_02e7:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
+  IL_02ec:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02f1:  ldarg.0
+  IL_02f2:  ldarg.0
+  IL_02f3:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02f8:  ldarg.0
+  IL_02f9:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02fe:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
+  IL_0303:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
+  IL_0308:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_030d:  ldarg.0
+  IL_030e:  ldarg.0
+  IL_030f:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0314:  box        ""int""
+  IL_0319:  ldarg.0
+  IL_031a:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_031f:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0324:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_0329:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_032e:  nop
+  IL_032f:  nop
+  IL_0330:  ldarg.0
+  IL_0331:  ldnull
+  IL_0332:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0337:  ldarg.0
+  IL_0338:  ldnull
+  IL_0339:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_033e:  ldarg.0
+  IL_033f:  ldnull
+  IL_0340:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0345:  ldarg.0
+  IL_0346:  ldnull
+  IL_0347:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_034c:  ldarg.0
+  IL_034d:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0352:  stloc.2
+  IL_0353:  ldarg.0
+  IL_0354:  ldloc.2
+  IL_0355:  ldc.i4.1
+  IL_0356:  add
+  IL_0357:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_035c:  ldarg.0
+  IL_035d:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0362:  ldc.i4.s   10
+  IL_0364:  clt
+  IL_0366:  stloc.3
+  IL_0367:  ldloc.3
+  IL_0368:  brtrue     IL_0068
+  IL_036d:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_0372:  nop
+  IL_0373:  ldc.i4.0
+  IL_0374:  ret
+}
+");
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "Program.<>o__1#1: {<>p__0, <>p__1}",
+                "Program.<>o__1#2: {<>p__0, <>p__1, <>p__2}",
+                "Program: {<>o__1#2, <>c, <Iterator>d__1, <>o__1#1}",
+                "Program.<>c: {<>9__1_0, <>9__1_1, <>9__1_2, <>9__1_3, <>9__1_4, <>9__1_5, <>9__1_6, <>9__1_7, <>9__1_8, <>9__1_9, <>9__1_10, <Iterator>b__1_0, <Iterator>b__1_1, <Iterator>b__1_2, <Iterator>b__1_3, <Iterator>b__1_4, <Iterator>b__1_5, <Iterator>b__1_6, <Iterator>b__1_7, <Iterator>b__1_8, <Iterator>b__1_9, <Iterator>b__1_10}",
+                "Program.<Iterator>d__1: {<>1__state, <>2__current, <>l__initialThreadId, <args>5__1, <list>5__2, <i>5__3, <result>5__4, <linked>5__5, <temp>5__7, <newArgs>5__6, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}",
+                "<>f__AnonymousType4<<a>j__TPar, <value>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType1<<a>j__TPar, <x>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType3<<Value>j__TPar, <Length>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType0<<Head>j__TPar, <Tail>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType5<<<>h__TransparentIdentifier0>j__TPar, <length>j__TPar>: {Equals, GetHashCode, ToString}",
+                "<>f__AnonymousType2<<<>h__TransparentIdentifier0>j__TPar, <y>j__TPar>: {Equals, GetHashCode, ToString}");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -2,13 +2,17 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -342,6 +346,145 @@ class C
             var other = matcher.MapReference((Cci.ITypeReference)member.Type);
             // For a newly added type, there is no match in the previous generation.
             Assert.Null(other);
+        }
+
+        [Fact]
+        public void HoistedAnonymousTypes()
+        {
+            var source0 = @"
+using System;
+
+class C
+{
+    static void F()
+    {
+        var x1 = new { A = 1 };
+        var x2 = new { B = 1 };
+        var y = new Func<int>(() => x1.A + x2.B);
+    }
+}
+";
+            var source1 = @"
+using System;
+
+class C
+{
+    static void F()
+    {
+        var x1 = new { A = 1 };
+        var x2 = new { b = 1 };
+        var y = new Func<int>(() => x1.A + x2.b);
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib(source0, options: TestOptions.DebugDll);
+
+            var peRef0 = compilation0.EmitToImageReference();
+            var peAssemblySymbol0 = (PEAssemblySymbol)CreateCompilationWithMscorlib("", new[] { peRef0 }).GetReferencedAssemblySymbol(peRef0);
+            var peModule0 = (PEModuleSymbol)peAssemblySymbol0.Modules[0];
+
+            var reader0 = peModule0.Module.MetadataReader;
+            var decoder0 = new MetadataDecoder(peModule0);
+
+            var anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0);
+            Assert.Equal("<>f__AnonymousType0", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("A", isKey: false, ignoreCase: false)))].Name);
+            Assert.Equal("<>f__AnonymousType1", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("B", isKey: false, ignoreCase: false)))].Name);
+            Assert.Equal(2, anonymousTypeMap0.Count);
+
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll);
+
+            var testData = new CompilationTestData();
+            compilation1.EmitToArray(testData: testData);
+            var peAssemblyBuilder = (PEAssemblyBuilder)testData.Module;
+
+            var c = compilation1.GetMember<NamedTypeSymbol>("C");
+            var displayClass = peAssemblyBuilder.GetSynthesizedTypes(c).Single();
+            Assert.Equal("<>c__DisplayClass0_0", displayClass.Name);
+
+            var emitContext = new EmitContext(peAssemblyBuilder, null, new DiagnosticBag());
+
+            var fields = displayClass.GetFields(emitContext).ToArray();
+            var x1 = fields[0];
+            var x2 = fields[1];
+            Assert.Equal("x1", x1.Name);
+            Assert.Equal("x2", x2.Name);
+
+            var matcher = new CSharpSymbolMatcher(anonymousTypeMap0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+
+            var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
+            var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
+
+            Assert.Equal("x1", mappedX1.Name);
+            Assert.Null(mappedX2);
+        }
+
+        [Fact]
+        public void HoistedAnonymousTypes_Complex()
+        {
+            var source0 = @"
+using System;
+
+class C
+{
+    static void F()
+    {
+        var x1 = new[] { new { A = new { X = 1 } } };
+        var x2 = new[] { new { A = new { Y = 1 } } };
+        var y = new Func<int>(() => x1[0].A.X + x2[0].A.Y);
+    }
+}
+";
+            var source1 = @"
+using System;
+
+class C
+{
+    static void F()
+    {
+        var x1 = new[] { new { A = new { X = 1 } } };
+        var x2 = new[] { new { A = new { Z = 1 } } };
+        var y = new Func<int>(() => x1[0].A.X + x2[0].A.Z);
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib(source0, options: TestOptions.DebugDll);
+
+            var peRef0 = compilation0.EmitToImageReference();
+            var peAssemblySymbol0 = (PEAssemblySymbol)CreateCompilationWithMscorlib("", new[] { peRef0 }).GetReferencedAssemblySymbol(peRef0);
+            var peModule0 = (PEModuleSymbol)peAssemblySymbol0.Modules[0];
+
+            var reader0 = peModule0.Module.MetadataReader;
+            var decoder0 = new MetadataDecoder(peModule0);
+
+            var anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0);
+            Assert.Equal("<>f__AnonymousType0", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("A", isKey: false, ignoreCase: false)))].Name);
+            Assert.Equal("<>f__AnonymousType1", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("X", isKey: false, ignoreCase: false)))].Name);
+            Assert.Equal("<>f__AnonymousType2", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("Y", isKey: false, ignoreCase: false)))].Name);
+            Assert.Equal(3, anonymousTypeMap0.Count);
+
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll);
+
+            var testData = new CompilationTestData();
+            compilation1.EmitToArray(testData: testData);
+            var peAssemblyBuilder = (PEAssemblyBuilder)testData.Module;
+
+            var c = compilation1.GetMember<NamedTypeSymbol>("C");
+            var displayClass = peAssemblyBuilder.GetSynthesizedTypes(c).Single();
+            Assert.Equal("<>c__DisplayClass0_0", displayClass.Name);
+
+            var emitContext = new EmitContext(peAssemblyBuilder, null, new DiagnosticBag());
+
+            var fields = displayClass.GetFields(emitContext).ToArray();
+            var x1 = fields[0];
+            var x2 = fields[1];
+            Assert.Equal("x1", x1.Name);
+            Assert.Equal("x2", x2.Name);
+
+            var matcher = new CSharpSymbolMatcher(anonymousTypeMap0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+
+            var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
+            var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
+
+            Assert.Equal("x1", mappedX1.Name);
+            Assert.Null(mappedX2);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/AnonymousTypeKey.cs
+++ b/src/Compilers/Core/Portable/Emit/AnonymousTypeKey.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Collections;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -21,40 +21,37 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         internal readonly bool IsKey;
 
-        internal static AnonymousTypeKeyField CreateField(string name)
-        {
-            return new AnonymousTypeKeyField(name, isKey: false);
-        }
+        /// <summary>
+        /// <see cref="Name"/> is case insensitive.
+        /// </summary>
+        internal readonly bool IgnoreCase;
 
-        internal static AnonymousTypeKeyField CreateField(string name, bool isKey)
+        public AnonymousTypeKeyField(string name, bool isKey, bool ignoreCase)
         {
-            return new AnonymousTypeKeyField(name.ToLowerInvariant(), isKey);
-        }
+            Debug.Assert(name != null);
 
-        private AnonymousTypeKeyField(string name, bool isKey)
-        {
-            this.Name = name;
-            this.IsKey = isKey;
+            Name = name;
+            IsKey = isKey;
+            IgnoreCase = ignoreCase;
         }
 
         public bool Equals(AnonymousTypeKeyField other)
         {
-            return (this.Name == other.Name) && (this.IsKey == other.IsKey);
+            return IsKey == other.IsKey &&
+                   IgnoreCase == other.IgnoreCase &&
+                   (IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal).Equals(Name, other.Name);
         }
 
         public override bool Equals(object obj)
         {
-            return this.Equals((AnonymousTypeKeyField)obj);
+            return Equals((AnonymousTypeKeyField)obj);
         }
 
         public override int GetHashCode()
         {
-            return Hash.Combine(this.Name.GetHashCode(), this.IsKey.GetHashCode());
-        }
-
-        public override string ToString()
-        {
-            return this.Name + (this.IsKey ? "+" : "-");
+            return Hash.Combine(IsKey,
+                   Hash.Combine(IgnoreCase,
+                   (IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal).GetHashCode(Name)));
         }
     }
 

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Emit
         internal abstract void CompilationFinished();
         internal abstract ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> GetSynthesizedMembers();
         internal abstract CommonEmbeddedTypesManager CommonEmbeddedTypesManagerOpt { get; }
+        internal abstract Cci.ITypeReference EncTranslateType(ITypeSymbol type, DiagnosticBag diagnostics);
     }
 
     /// <summary>
@@ -147,6 +148,16 @@ namespace Microsoft.CodeAnalysis.Emit
 
         internal abstract Cci.INamedTypeReference GetSystemType(TSyntaxNode syntaxOpt, DiagnosticBag diagnostics);
         internal abstract Cci.INamedTypeReference GetSpecialType(SpecialType specialType, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
+
+        internal sealed override Cci.ITypeReference EncTranslateType(ITypeSymbol type, DiagnosticBag diagnostics)
+        {
+            return EncTranslateLocalVariableType((TTypeSymbol)type, diagnostics);
+        }
+
+        internal virtual Cci.ITypeReference EncTranslateLocalVariableType(TTypeSymbol type, DiagnosticBag diagnostics)
+        {
+            return Translate(type, null, diagnostics);
+        }
 
         protected bool HaveDeterminedTopLevelTypes
         {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -56,6 +56,21 @@ namespace Microsoft.CodeAnalysis.Emit
     {
         private static readonly ImmutableArray<int> s_emptyTableSizes = ImmutableArray.Create(new int[MetadataTokens.TableCount]);
 
+        internal sealed class MetadataSymbols
+        {
+            public readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes;
+            public readonly object MetadataDecoder;
+
+            public MetadataSymbols(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypes, object metadataDecoder)
+            {
+                Debug.Assert(anonymousTypes != null);
+                Debug.Assert(metadataDecoder != null);
+
+                this.AnonymousTypes = anonymousTypes;
+                this.MetadataDecoder = metadataDecoder;
+            }
+        }
+
         /// <summary>
         /// Creates an <see cref="EmitBaseline"/> from the metadata of the module before editing
         /// and from a function that maps from a method to an array of local names. 
@@ -138,8 +153,8 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         public ModuleMetadata OriginalMetadata { get; }
 
-        // Anonymous types extracted from metadata. Lazy since we don't know the language at the time the baseline is constructed.
-        internal IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> LazyOriginalMetadataAnonymousTypeMap;
+        // Symbols hydrated from the original metadata. Lazy since we don't know the language at the time the baseline is constructed.
+        internal MetadataSymbols LazyMetadataSymbols;
         
         internal readonly Compilation Compilation;
         internal readonly CommonPEModuleBuilder PEModuleBuilder;
@@ -344,8 +359,8 @@ namespace Microsoft.CodeAnalysis.Emit
                     return _anonymousTypeMap;
                 }
 
-                Debug.Assert(LazyOriginalMetadataAnonymousTypeMap != null);
-                return LazyOriginalMetadataAnonymousTypeMap;
+                Debug.Assert(LazyMetadataSymbols != null);
+                return LazyMetadataSymbols.AnonymousTypes;
             }
         }
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1543,7 +1543,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim stateMachineAwaiterSlots As ImmutableArray(Of Cci.ITypeReference) = Nothing
                 If optimizations = OptimizationLevel.Debug AndAlso stateMachineTypeOpt IsNot Nothing Then
                     Debug.Assert(method.IsAsync OrElse method.IsIterator)
-                    GetStateMachineSlotDebugInfo(moduleBuilder.GetSynthesizedFields(stateMachineTypeOpt), stateMachineHoistedLocalSlots, stateMachineAwaiterSlots)
+                    GetStateMachineSlotDebugInfo(moduleBuilder, moduleBuilder.GetSynthesizedFields(stateMachineTypeOpt), variableSlotAllocatorOpt, diagnostics, stateMachineHoistedLocalSlots, stateMachineAwaiterSlots)
+                    Debug.Assert(Not diagnostics.HasAnyErrors())
                 End If
 
                 Dim localScopes = builder.GetAllScopes()
@@ -1572,7 +1573,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
-        Private Shared Sub GetStateMachineSlotDebugInfo(fieldDefs As IEnumerable(Of Cci.IFieldDefinition),
+        Private Shared Sub GetStateMachineSlotDebugInfo(moduleBuilder As PEModuleBuilder,
+                                                        fieldDefs As IEnumerable(Of Cci.IFieldDefinition),
+                                                        variableSlotAllocatorOpt As VariableSlotAllocator,
+                                                        diagnostics As DiagnosticBag,
                                                         ByRef hoistedVariableSlots As ImmutableArray(Of EncHoistedLocalInfo),
                                                         ByRef awaiterSlots As ImmutableArray(Of Cci.ITypeReference))
 
@@ -1589,7 +1593,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         awaiters.Add(Nothing)
                     End While
 
-                    awaiters(index) = TryCast(field.Type, Cci.ITypeReference)
+                    awaiters(index) = moduleBuilder.EncTranslateLocalVariableType(field.Type, diagnostics)
                 ElseIf Not field.SlotDebugInfo.Id.IsNone Then
                     Debug.Assert(index >= 0 AndAlso field.SlotDebugInfo.SynthesizedKind.IsLongLived())
 
@@ -1598,9 +1602,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         hoistedVariables.Add(New EncHoistedLocalInfo())
                     End While
 
-                    hoistedVariables(index) = New EncHoistedLocalInfo(field.SlotDebugInfo, TryCast(field.Type, Cci.ITypeReference))
+                    hoistedVariables(index) = New EncHoistedLocalInfo(field.SlotDebugInfo, moduleBuilder.EncTranslateLocalVariableType(field.Type, diagnostics))
                 End If
             Next
+
+            ' Fill in empty slots for variables deleted during EnC that are not followed by an existing variable
+            If variableSlotAllocatorOpt IsNot Nothing Then
+                Dim previousAwaiterCount = variableSlotAllocatorOpt.PreviousAwaiterSlotCount
+                While awaiters.Count < previousAwaiterCount
+                    awaiters.Add(Nothing)
+                End While
+
+                Dim previousAwaiterSlotCount = variableSlotAllocatorOpt.PreviousHoistedLocalSlotCount
+                While hoistedVariables.Count < previousAwaiterSlotCount
+                    hoistedVariables.Add(New EncHoistedLocalInfo(True))
+                End While
+            End If
 
             hoistedVariableSlots = hoistedVariables.ToImmutableAndFree()
             awaiterSlots = awaiters.ToImmutableAndFree()

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' to find the previous awaiter field.
                 If Not Me._awaiterFields.TryGetValue(awaiterType, result) Then
                     Dim slotIndex As Integer = -1
-                    If Me.SlotAllocatorOpt Is Nothing OrElse Not Me.SlotAllocatorOpt.TryGetPreviousAwaiterSlotIndex(DirectCast(awaiterType, Cci.ITypeReference), slotIndex) Then
+                    If Me.SlotAllocatorOpt Is Nothing OrElse Not Me.SlotAllocatorOpt.TryGetPreviousAwaiterSlotIndex(F.CompilationState.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics), slotIndex) Then
                         slotIndex = _nextAwaiterId
                         _nextAwaiterId = _nextAwaiterId + 1
                     End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 id = New LocalDebugId(syntaxOffset, ordinal)
 
                 Dim previousSlotIndex = -1
-                If SlotAllocatorOpt IsNot Nothing AndAlso SlotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(declaratorSyntax, DirectCast(fieldType, Cci.ITypeReference), local.SynthesizedKind, id, previousSlotIndex) Then
+                If SlotAllocatorOpt IsNot Nothing AndAlso SlotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(declaratorSyntax, F.CompilationState.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, Diagnostics), local.SynthesizedKind, id, previousSlotIndex) Then
                     slotIndex = previousSlotIndex
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Sub
 
             Friend Overrides Function GetAnonymousTypeKey() As AnonymousTypeKey
-                Dim parameters = TypeDescr.Parameters.SelectAsArray(Function(p) AnonymousTypeKeyField.CreateField(p.Name, isKey:=False))
+                Dim parameters = TypeDescr.Parameters.SelectAsArray(Function(p) New AnonymousTypeKeyField(p.Name, isKey:=False, ignoreCase:=True))
                 Return New AnonymousTypeKey(parameters, isDelegate:=True)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_TemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_TemplateSymbol.vb
@@ -88,11 +88,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 methodMembersBuilder.AddRange(otherMembersBuilder)
                 otherMembersBuilder.Free()
                 _members = methodMembersBuilder.ToImmutableAndFree()
-
             End Sub
 
             Friend Overrides Function GetAnonymousTypeKey() As AnonymousTypeKey
-                Dim properties = _properties.SelectAsArray(Function(p) AnonymousTypeKeyField.CreateField(p.Name, isKey:=p.IsReadOnly))
+                Dim properties = _properties.SelectAsArray(Function(p) New AnonymousTypeKeyField(p.Name, isKey:=p.IsReadOnly, ignoreCase:=True))
                 Return New AnonymousTypeKey(properties)
             End Function
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.IO
 Imports System.Reflection.Metadata
 Imports System.Reflection.Metadata.Ecma335
 Imports System.Runtime.CompilerServices
@@ -20,6 +21,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         Protected Shared ReadOnly ComSafeDebugDll As VisualBasicCompilationOptions = TestOptions.DebugDll.WithConcurrentBuild(False)
 
         Friend Shared ReadOnly EmptyLocalsProvider As Func(Of MethodDefinitionHandle, EditAndContinueMethodDebugInformation) = Function(token) Nothing
+
+        Friend Shared Function Visualize(baseline As ModuleMetadata, ParamArray deltas As PinnedMetadata()) As String
+            Dim result = New StringWriter()
+            Dim visualizer = New MetadataVisualizer({baseline.MetadataReader}.Concat(deltas.Select(Function(d) d.Reader)).ToArray(), result)
+            visualizer.VisualizeAllGenerations()
+            Return result.ToString()
+        End Function
 
         Friend Shared Function MarkedSource(source As XElement, Optional fileName As String = "", Optional options As VisualBasicParseOptions = Nothing) As SourceWithMarkedNodes
             Return New SourceWithMarkedNodes(source.Value, Function(s) Parse(s, fileName, options), Function(s) CInt(GetType(SyntaxKind).GetField(s).GetValue(Nothing)))

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -774,7 +774,6 @@ End Class
 ")
         End Sub
 
-
         <Fact>
         Public Sub SymbolMatcher_TypeArguments()
             Dim source =
@@ -4157,6 +4156,121 @@ End Class
                     End Using
                 End Using
             End Using
+        End Sub
+
+        <Fact>
+        Public Sub AnonymousTypes_Nested()
+            Dim template = "
+Imports System
+Imports System.Linq
+
+Class C
+    Sub F(args As String())
+        Dim <N:4>result</N:4> =
+            From a in args
+            Let <N:0>x = a.Reverse()</N:0>
+            Let <N:1>y = x.Reverse()</N:1>
+            <N:2>Where x.SequenceEqual(y)</N:2>
+            Select <N:3>Value = a</N:3>, Length = a.Length
+
+        Console.WriteLine(<<VALUE>>)
+    End Sub
+End Class
+"
+            Dim source0 = MarkedSource(template.Replace("<<VALUE>>", "0"))
+            Dim source1 = MarkedSource(template.Replace("<<VALUE>>", "1"))
+            Dim source2 = MarkedSource(template.Replace("<<VALUE>>", "2"))
+
+            Dim compilation0 = CreateCompilationWithMscorlib45({source0.Tree}, {SystemCoreRef}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+            Dim compilation2 = compilation0.WithSource(source2.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+            Dim f2 = compilation2.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            Dim expectedIL = "
+{
+  // Code size      175 (0xaf)
+  .maxstack  3
+  .locals init (System.Collections.Generic.IEnumerable(Of <anonymous type: Key Value As String, Key Length As Integer>) V_0) //result
+  IL_0000:  nop
+  IL_0001:  ldarg.1
+  IL_0002:  ldsfld     ""C._Closure$__.$I1-0 As System.Func(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_0007:  brfalse.s  IL_0010
+  IL_0009:  ldsfld     ""C._Closure$__.$I1-0 As System.Func(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_000e:  br.s       IL_0026
+  IL_0010:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_0015:  ldftn      ""Function C._Closure$__._Lambda$__1-0(String) As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>""
+  IL_001b:  newobj     ""Sub System.Func(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)..ctor(Object, System.IntPtr)""
+  IL_0020:  dup
+  IL_0021:  stsfld     ""C._Closure$__.$I1-0 As System.Func(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_0026:  call       ""Function System.Linq.Enumerable.Select(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)(System.Collections.Generic.IEnumerable(Of String), System.Func(Of String, <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)) As System.Collections.Generic.IEnumerable(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_002b:  ldsfld     ""C._Closure$__.$I1-1 As System.Func(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_0030:  brfalse.s  IL_0039
+  IL_0032:  ldsfld     ""C._Closure$__.$I1-1 As System.Func(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_0037:  br.s       IL_004f
+  IL_0039:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_003e:  ldftn      ""Function C._Closure$__._Lambda$__1-1(<anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>) As <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>""
+  IL_0044:  newobj     ""Sub System.Func(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)..ctor(Object, System.IntPtr)""
+  IL_0049:  dup
+  IL_004a:  stsfld     ""C._Closure$__.$I1-1 As System.Func(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_004f:  call       ""Function System.Linq.Enumerable.Select(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)(System.Collections.Generic.IEnumerable(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>), System.Func(Of <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)) As System.Collections.Generic.IEnumerable(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_0054:  ldsfld     ""C._Closure$__.$I1-2 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, Boolean)""
+  IL_0059:  brfalse.s  IL_0062
+  IL_005b:  ldsfld     ""C._Closure$__.$I1-2 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, Boolean)""
+  IL_0060:  br.s       IL_0078
+  IL_0062:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_0067:  ldftn      ""Function C._Closure$__._Lambda$__1-2(<anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>) As Boolean""
+  IL_006d:  newobj     ""Sub System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, Boolean)..ctor(Object, System.IntPtr)""
+  IL_0072:  dup
+  IL_0073:  stsfld     ""C._Closure$__.$I1-2 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, Boolean)""
+  IL_0078:  call       ""Function System.Linq.Enumerable.Where(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)(System.Collections.Generic.IEnumerable(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>), System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, Boolean)) As System.Collections.Generic.IEnumerable(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>)""
+  IL_007d:  ldsfld     ""C._Closure$__.$I1-3 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)""
+  IL_0082:  brfalse.s  IL_008b
+  IL_0084:  ldsfld     ""C._Closure$__.$I1-3 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)""
+  IL_0089:  br.s       IL_00a1
+  IL_008b:  ldsfld     ""C._Closure$__.$I As C._Closure$__""
+  IL_0090:  ldftn      ""Function C._Closure$__._Lambda$__1-3(<anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>) As <anonymous type: Key Value As String, Key Length As Integer>""
+  IL_0096:  newobj     ""Sub System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)..ctor(Object, System.IntPtr)""
+  IL_009b:  dup
+  IL_009c:  stsfld     ""C._Closure$__.$I1-3 As System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)""
+  IL_00a1:  call       ""Function System.Linq.Enumerable.Select(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)(System.Collections.Generic.IEnumerable(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>), System.Func(Of <anonymous type: Key $VB$It As <anonymous type: Key a As String, Key x As System.Collections.Generic.IEnumerable(Of Char)>, Key y As System.Collections.Generic.IEnumerable(Of Char)>, <anonymous type: Key Value As String, Key Length As Integer>)) As System.Collections.Generic.IEnumerable(Of <anonymous type: Key Value As String, Key Length As Integer>)""
+  IL_00a6:  stloc.0
+  IL_00a7:  ldc.i4.<<VALUE>>
+  IL_00a8:  call       ""Sub System.Console.WriteLine(Integer)""
+  IL_00ad:  nop
+  IL_00ae:  ret
+}"
+
+            v0.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "0"))
+
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I1-0, $I1-1, $I1-2, $I1-3, _Lambda$__1-0, _Lambda$__1-1, _Lambda$__1-2, _Lambda$__1-3}")
+
+            diff1.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "1"))
+
+            Dim diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    New SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables:=True)))
+
+            diff2.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I1-0, $I1-1, $I1-2, $I1-3, _Lambda$__1-0, _Lambda$__1-1, _Lambda$__1-2, _Lambda$__1-3}")
+
+            diff2.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "2"))
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Roslyn.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class SymbolMatcherTests
@@ -91,7 +92,7 @@ End Class
         End Sub
 
         <WorkItem(1533)>
-                                   <Fact>
+        <Fact>
         Public Sub NoPreviousType_GenericType()
             Dim sources0 = <compilation>
                                <file name="a.vb"><![CDATA[
@@ -129,6 +130,212 @@ End Class
             Dim other = matcher.MapReference(DirectCast(member.Type, Cci.ITypeReference))
             ' For a newly added type, there is no match in the previous generation.
             Assert.Null(other)
+        End Sub
+
+        <Fact>
+        Public Sub HoistedAnonymousTypes()
+            Dim source0 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = New With { .A = 1 }
+        Dim x2 = New With { .B = 1 }
+        Dim y = New Func(Of Integer)(Function() x1.A + x2.B)
+    End Sub
+End Class
+"
+            Dim source1 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = New With { .A = 1 }
+        Dim x2 = New With { .C = 1 }
+        Dim y = New Func(Of Integer)(Function() x1.A + x2.C)
+    End Sub
+End Class
+"
+
+            Dim compilation0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll)
+
+            Dim peRef0 = compilation0.EmitToImageReference()
+            Dim peAssemblySymbol0 = DirectCast(CreateCompilationWithMscorlib({""}, {peRef0}).GetReferencedAssemblySymbol(peRef0), PEAssemblySymbol)
+            Dim peModule0 = DirectCast(peAssemblySymbol0.Modules(0), PEModuleSymbol)
+
+            Dim reader0 = peModule0.Module.MetadataReader
+            Dim decoder0 = New MetadataDecoder(peModule0)
+
+            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Assert.Equal("VB$AnonymousType_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True)))).Name)
+            Assert.Equal("VB$AnonymousType_1", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("B", isKey:=False, ignoreCase:=True)))).Name)
+            Assert.Equal(2, anonymousTypeMap0.Count)
+
+            Dim compilation1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll)
+
+            Dim testData = New CompilationTestData()
+            compilation1.EmitToArray(testData:=testData)
+            Dim peAssemblyBuilder = DirectCast(testData.Module, PEAssemblyBuilder)
+
+            Dim c = compilation1.GetMember(Of NamedTypeSymbol)("C")
+            Dim displayClass = peAssemblyBuilder.GetSynthesizedTypes(c).Single()
+            Assert.Equal("_Closure$__1-0", displayClass.Name)
+
+            Dim emitContext = New EmitContext(peAssemblyBuilder, Nothing, New DiagnosticBag())
+
+            Dim fields = displayClass.GetFields(emitContext).ToArray()
+            Dim x1 = fields(0)
+            Dim x2 = fields(1)
+            Assert.Equal("$VB$Local_x1", x1.Name)
+            Assert.Equal("$VB$Local_x2", x2.Name)
+
+            Dim matcher = New VisualBasicSymbolMatcher(anonymousTypeMap0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0)
+
+            Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
+            Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)
+
+            Assert.Equal("$VB$Local_x1", mappedX1.Name)
+            Assert.Null(mappedX2)
+        End Sub
+
+        <Fact>
+        Public Sub HoistedAnonymousTypes_Complex()
+            Dim source0 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = { New With { .A = New With { .X = 1 } } }
+        Dim x2 = { New With { .A = New With { .Y = 1 } } }
+        Dim y = New Func(Of Integer)(Function() x1(0).A.X + x2(0).A.Y)
+    End Sub
+End Class
+"
+            Dim source1 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = { New With { .A = New With { .X = 1 } } }
+        Dim x2 = { New With { .A = New With { .Z = 1 } } }
+        Dim y = New Func(Of Integer)(Function() x1(0).A.X + x2(0).A.Z)
+    End Sub
+End Class
+"
+
+            Dim compilation0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll)
+
+            Dim peRef0 = compilation0.EmitToImageReference()
+            Dim peAssemblySymbol0 = DirectCast(CreateCompilationWithMscorlib({""}, {peRef0}).GetReferencedAssemblySymbol(peRef0), PEAssemblySymbol)
+            Dim peModule0 = DirectCast(peAssemblySymbol0.Modules(0), PEModuleSymbol)
+
+            Dim reader0 = peModule0.Module.MetadataReader
+            Dim decoder0 = New MetadataDecoder(peModule0)
+
+            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Assert.Equal("VB$AnonymousType_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True)))).Name)
+            Assert.Equal("VB$AnonymousType_1", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("X", isKey:=False, ignoreCase:=True)))).Name)
+            Assert.Equal("VB$AnonymousType_2", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("Y", isKey:=False, ignoreCase:=True)))).Name)
+            Assert.Equal(3, anonymousTypeMap0.Count)
+
+            Dim compilation1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll)
+
+            Dim testData = New CompilationTestData()
+            compilation1.EmitToArray(testData:=testData)
+            Dim peAssemblyBuilder = DirectCast(testData.Module, PEAssemblyBuilder)
+
+            Dim c = compilation1.GetMember(Of NamedTypeSymbol)("C")
+            Dim displayClass = peAssemblyBuilder.GetSynthesizedTypes(c).Single()
+            Assert.Equal("_Closure$__1-0", displayClass.Name)
+
+            Dim emitContext = New EmitContext(peAssemblyBuilder, Nothing, New DiagnosticBag())
+
+            Dim fields = displayClass.GetFields(emitContext).ToArray()
+            Dim x1 = fields(0)
+            Dim x2 = fields(1)
+            Assert.Equal("$VB$Local_x1", x1.Name)
+            Assert.Equal("$VB$Local_x2", x2.Name)
+
+            Dim matcher = New VisualBasicSymbolMatcher(anonymousTypeMap0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0)
+
+            Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
+            Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)
+
+            Assert.Equal("$VB$Local_x1", mappedX1.Name)
+            Assert.Null(mappedX2)
+        End Sub
+
+        <Fact>
+        Public Sub HoistedAnonymousDelegate()
+            Dim source0 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = Function(a As Integer) 1
+        Dim x2 = Function(b As Integer) 1
+        Dim y = New Func(Of Integer)(Function() x1(1) + x2(1))
+    End Sub
+End Class
+"
+            Dim source1 = "
+Imports System
+
+Class C
+    Shared Sub F()
+        Dim x1 = Function(a As Integer) 1
+        Dim x2 = Function(c As Integer) 1
+        Dim y = New Func(Of Integer)(Function() x1(1) + x2(1))
+    End Sub
+End Class
+"
+
+            Dim compilation0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll)
+
+            Dim peRef0 = compilation0.EmitToImageReference()
+            Dim peAssemblySymbol0 = DirectCast(CreateCompilationWithMscorlib({""}, {peRef0}).GetReferencedAssemblySymbol(peRef0), PEAssemblySymbol)
+            Dim peModule0 = DirectCast(peAssemblySymbol0.Modules(0), PEModuleSymbol)
+
+            Dim reader0 = peModule0.Module.MetadataReader
+            Dim decoder0 = New MetadataDecoder(peModule0)
+
+            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Assert.Equal("VB$AnonymousDelegate_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(
+                New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True),
+                New AnonymousTypeKeyField(AnonymousTypeDescriptor.FunctionReturnParameterName, isKey:=False, ignoreCase:=True)), isDelegate:=True)).Name)
+
+            Assert.Equal("VB$AnonymousDelegate_1", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(
+                New AnonymousTypeKeyField("B", isKey:=False, ignoreCase:=True),
+                New AnonymousTypeKeyField(AnonymousTypeDescriptor.FunctionReturnParameterName, isKey:=False, ignoreCase:=True)), isDelegate:=True)).Name)
+
+            Assert.Equal(2, anonymousTypeMap0.Count)
+
+            Dim compilation1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll)
+
+            Dim testData = New CompilationTestData()
+            compilation1.EmitToArray(testData:=testData)
+            Dim peAssemblyBuilder = DirectCast(testData.Module, PEAssemblyBuilder)
+
+            Dim c = compilation1.GetMember(Of NamedTypeSymbol)("C")
+            Dim displayClasses = peAssemblyBuilder.GetSynthesizedTypes(c).ToArray()
+            Assert.Equal("_Closure$__1-0", displayClasses(0).Name)
+            Assert.Equal("_Closure$__", displayClasses(1).Name)
+
+            Dim emitContext = New EmitContext(peAssemblyBuilder, Nothing, New DiagnosticBag())
+
+            Dim fields = displayClasses(0).GetFields(emitContext).ToArray()
+            Dim x1 = fields(0)
+            Dim x2 = fields(1)
+            Assert.Equal("$VB$Local_x1", x1.Name)
+            Assert.Equal("$VB$Local_x2", x2.Name)
+
+            Dim matcher = New VisualBasicSymbolMatcher(anonymousTypeMap0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0)
+
+            Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
+            Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)
+
+            Assert.Equal("$VB$Local_x1", mappedX1.Name)
+            Assert.Null(mappedX2)
         End Sub
     End Class
 End Namespace

--- a/src/Test/PdbUtilities/Metadata/ILVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/ILVisualizer.cs
@@ -187,15 +187,19 @@ namespace Roslyn.Test.MetadataUtilities
 
         public void VisualizeHeader(StringBuilder sb, int codeSize, int maxStack, ImmutableArray<LocalInfo> locals)
         {
-            if (codeSize == 0)
+            if (codeSize >= 0 && maxStack >= 0)
             {
-                sb.AppendLine("  // Unrealized IL");
+                if (codeSize == 0)
+                {
+                    sb.AppendLine("  // Unrealized IL");
+                }
+                else
+                {
+                    sb.AppendLine(string.Format("  // Code size {0,8} (0x{0:x})", codeSize));
+                }
+
+                sb.AppendLine(string.Format("  .maxstack  {0}", maxStack));
             }
-            else
-            {
-                sb.AppendLine(string.Format("  // Code size {0,8} (0x{0:x})", codeSize));
-            }
-            sb.AppendLine(string.Format("  .maxstack  {0}", maxStack));
 
             int i = 0;
             foreach (var local in locals)

--- a/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
@@ -164,6 +164,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return VerifyILImpl(qualifiedMethodName, expectedIL, realIL, sequencePoints, callerPath, callerLine, escapeQuotes: true);
             }
 
+            public void VerifyLocalSignature(
+                string qualifiedMethodName,
+                string expectedSignature,
+                [CallerLineNumber]int callerLine = 0,
+                [CallerFilePath]string callerPath = null)
+            {
+                var ilBuilder = _testData.GetMethodData(qualifiedMethodName).ILBuilder;
+                string actualSignature = ILBuilderVisualizer.LocalSignatureToString(ilBuilder);
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedSignature, actualSignature, escapeQuotes: true, expectedValueSourcePath: callerPath, expectedValueSourceLine: callerLine);
+            }
+
             private CompilationVerifier VerifyILImpl(
                 string qualifiedMethodName,
                 string expectedIL,

--- a/src/Test/Utilities/CompilationDifference.cs
+++ b/src/Test/Utilities/CompilationDifference.cs
@@ -67,6 +67,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL, escapeQuotes: true, expectedValueSourcePath: callerPath, expectedValueSourceLine: callerLine);
         }
 
+        public void VerifyLocalSignature(
+            string qualifiedMethodName,
+            string expectedSignature,
+            [CallerLineNumber]int callerLine = 0,
+            [CallerFilePath]string callerPath = null)
+        {
+            var ilBuilder = TestData.GetMethodData(qualifiedMethodName).ILBuilder;
+            string actualSignature = ILBuilderVisualizer.LocalSignatureToString(ilBuilder, ToLocalInfo);
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedSignature, actualSignature, escapeQuotes: true, expectedValueSourcePath: callerPath, expectedValueSourceLine: callerLine);
+        }
+
         public void VerifyIL(
             string qualifiedMethodName,
             string expectedIL,

--- a/src/Test/Utilities/ILBuilderVisualizer.cs
+++ b/src/Test/Utilities/ILBuilderVisualizer.cs
@@ -120,6 +120,7 @@ namespace Roslyn.Test.Utilities
             {
                 mapLocal = local => new LocalInfo(local.Name, local.Type, local.IsPinned, local.IsReference);
             }
+
             var locals = builder.LocalSlotManager.LocalsInOrder().SelectAsArray(mapLocal);
             var visualizer = new ILBuilderVisualizer(builder.module);
 
@@ -143,6 +144,24 @@ namespace Roslyn.Test.Utilities
                 sb.AppendLine("}");
             }
 
+            return sb.ToString();
+        }
+
+        internal static string LocalSignatureToString(
+            ILBuilder builder,
+            Func<Cci.ILocalDefinition, LocalInfo> mapLocal = null)
+        {
+            var sb = new StringBuilder();
+
+            if (mapLocal == null)
+            {
+                mapLocal = local => new LocalInfo(local.Name, local.Type, local.IsPinned, local.IsReference);
+            }
+
+            var locals = builder.LocalSlotManager.LocalsInOrder().SelectAsArray(mapLocal);
+            var visualizer = new ILBuilderVisualizer(builder.module);
+
+            visualizer.VisualizeHeader(sb, -1, -1, locals);
             return sb.ToString();
         }
 


### PR DESCRIPTION
Fixes 1170899: fatal error during EnC.
Fixes #3233, #3192.

**Scenarios**
When editing a method multiple times that contains a variable of an anonymous type (or delegate in VB) that is hoisted to a closure or a state machine the debugger reports a fatal error and terminates debugging session. 

Examples:
```VB
    Sub Main()
        Dim x = Function(n As Integer) n + 1
        Dim y = Sub(n As Integer) Console.WriteLine(x(n))
        y(100)
    End Sub
```

```C# 
        static void Main(string[] args)
        {
            var result =
                from a in args
                let x = a.Reverse()
                let y = x.Reverse()
                where x.SequenceEqual(y)
                select new { Value = a, Length = a.Length };            
        }
```

**Fix**
We didn't deeply translate anonymous types/delegates before comparing them in symbol matcher.
The proposed fix for RTM isn't ideal but addresses the issues and avoids risky changes. A proper fix requires extensive changes in symbol translations and should be implemented post RTM.

**Risk**
Although not ideal I'm confident that that fix is addressing the root cause of the issue. The fix introduces new code paths which are all covered by newly added unit tests. These code paths are only exercised during EnC specific code generation and emit and are not taken during regular compilation, which limits the impact only to EnC scenarios.

**Testing**
Added unit tests and manually verified that affected scenarios work for both VB and C#. Buddy tested by @wschae and @amcasey. 

@ManishJayaswal 