### PR TITLE
fixed a race where build only errors are not cleared correctly

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -144,13 +144,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
                 SetStableState(errorSource.IsInProgress);
 
-                errorSource.DiagnosticsUpdated += OnDiagnosticsUpdated;
                 errorSource.BuildStarted += OnBuildStarted;
             }
 
             private void OnBuildStarted(object sender, bool started)
             {
                 SetStableState(started);
+
+                if (!started)
+                {
+                    OnDataAddedOrChanged(this, _buildErrorSource.GetBuildErrors().Length);
+                }
             }
 
             private void SetStableState(bool started)
@@ -162,11 +166,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             public override string DisplayName => ServicesVSResources.BuildTableSourceName;
             public override string SourceTypeIdentifier => StandardTableDataSources.ErrorTableDataSource;
             public override string Identifier => IdentifierString;
-
-            private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
-            {
-                OnDataAddedOrChanged(this, _buildErrorSource.GetBuildErrors().Length);
-            }
 
             protected void OnDataAddedOrChanged(object key, int itemCount)
             {


### PR DESCRIPTION
changed code to use different event. more reliable one.

Customer Scenario: if user sets filter to "Build Only" and fix all existing build errors and rebuild and succeed. then there is a possibility of old errors not get cleared.

 Fix: previously it re-used an event whose purpose is to merge build error to live error. but events it raised were not clearly aligned with build error state. so if event happen to be raised before clearing existing errors, we get into this stale error mode. and it happens more often when build succeed.

I made build only error source to use out of proc build start and end event instead. 

this event should be more align to build only mode. previously I used it only to turn on and off build progress bar.

Test done: passed all integration test and manual test.

