### PR TITLE
Handle non-source file diagnostics in the VB command line diagnostic formatter

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis
             return Succeeded;
         }
 
-        private ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger touchedFilesLogger)
+        protected virtual ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger touchedFilesLogger)
         {
             var builder = ImmutableArray.CreateBuilder<AdditionalTextFile>();
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineDiagnosticFormatter.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineDiagnosticFormatter.vb
@@ -1,16 +1,20 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
+Imports System.Runtime.InteropServices
 Imports System.Text
-Imports Roslyn.Utilities
+Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend NotInheritable Class CommandLineDiagnosticFormatter
         Inherits VisualBasicDiagnosticFormatter
 
         Private ReadOnly _baseDirectory As String
+        Private ReadOnly _getAdditionalTextFiles As Func(Of ImmutableArray(Of AdditionalTextFile))
 
-        Friend Sub New(baseDirectory As String)
+        Friend Sub New(baseDirectory As String, getAdditionalTextFiles As Func(Of ImmutableArray(Of AdditionalTextFile)))
             _baseDirectory = baseDirectory
+            _getAdditionalTextFiles = getAdditionalTextFiles
         End Sub
 
         ' Returns a diagnostic message in string.
@@ -24,30 +28,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function Format(diagnostic As Diagnostic, Optional formatter As IFormatProvider = Nothing) As String
             ' Builds a diagnostic message
             ' Dev12 vbc prints raw paths -- relative and not normalized, so we don't need to customize the base implementation.
-            Dim baseMessage = MyBase.Format(diagnostic, formatter)
-            If Not diagnostic.Location.IsInSource Then
+
+            Dim text As SourceText = Nothing
+            Dim diagnosticSpanOpt = GetDiagnosticSpanAndFileText(diagnostic, text)
+
+            If Not diagnosticSpanOpt.HasValue OrElse
+                text Is Nothing OrElse
+                text.Length < diagnosticSpanOpt.Value.End Then
+                ' Diagnostic either has Location.None OR an invalid location OR invalid file contents.
+                ' For all these cases, format the diagnostic as a no-location project level diagnostic.
+
+                ' Strip location, if required.
+                If diagnostic.Location <> Location.None Then
+                    diagnostic = diagnostic.WithLocation(Location.None)
+                End If
 
                 ' Add "vbc : " command line prefix to the start of the command line diagnostics which do not have a location to match the 
                 ' behaviour of native compiler.    This allows MSBuild output to be consistent whether Roslyn is installed or not.      
-                If diagnostic.Location.Kind = LocationKind.None Then
-                    baseMessage = VisualBasicCompiler.VbcCommandLinePrefix & baseMessage
-                End If
-
-                Return baseMessage
+                Return VisualBasicCompiler.VbcCommandLinePrefix &
+                    MyBase.Format(diagnostic, formatter)
             End If
+
+            Dim baseMessage = MyBase.Format(diagnostic, formatter)
 
             Dim sb As New StringBuilder()
             sb.AppendLine(baseMessage)
 
             ' the squiggles are displayed for the original (unmapped) location
-            Dim sourceLocation = diagnostic.Location
-            Dim text = sourceLocation.SourceTree.GetText()
-            Dim sourceSpanStart = sourceLocation.SourceSpan.Start
-            Dim sourceSpanEnd = sourceLocation.SourceSpan.End
+            Dim sourceSpan = diagnosticSpanOpt.Value
+            Dim sourceSpanStart = sourceSpan.Start
+            Dim sourceSpanEnd = sourceSpan.End
             Dim linenumber = text.Lines.IndexOf(sourceSpanStart)
             Dim line = text.Lines(linenumber)
 
-            If sourceLocation.SourceSpan.IsEmpty AndAlso line.Start = sourceSpanEnd AndAlso linenumber > 0 Then
+            If sourceSpan.IsEmpty AndAlso line.Start = sourceSpanEnd AndAlso linenumber > 0 Then
                 ' Sometimes there is something missing at the end of the line, then the error is reported with an empty span
                 ' beyond the end of the line, which makes it appear that the span starts at the beginning of the next line.
                 ' Let's go back to the previous line in this case.
@@ -71,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 ' Builds squiggles
-                If sourceLocation.SourceSpan.IsEmpty Then
+                If sourceSpan.IsEmpty Then
                     sb.Append("~")
                 Else
                     For position = Math.Max(sourceSpanStart, line.Start) To Math.Min(If(sourceSpanEnd = sourceSpanStart, sourceSpanEnd, sourceSpanEnd - 1), line.End - 1)
@@ -109,6 +123,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Overrides Function FormatSourcePath(path As String, basePath As String, formatter As IFormatProvider) As String
             Return If(FileUtilities.NormalizeRelativePath(path, basePath, _baseDirectory), path)
+        End Function
+
+        Private Function GetDiagnosticSpanAndFileText(diagnostic As Diagnostic, <Out> ByRef text As SourceText) As TextSpan?
+            If diagnostic.Location.IsInSource Then
+                text = diagnostic.Location.SourceTree.GetText()
+                Return diagnostic.Location.SourceSpan
+            End If
+
+            If diagnostic.Location.Kind = LocationKind.ExternalFile Then
+                Dim path = diagnostic.Location.GetLineSpan().Path
+                If path IsNot Nothing Then
+                    For Each additionalTextFile In _getAdditionalTextFiles()
+                        If path.Equals(additionalTextFile.Path) Then
+                            Try
+                                text = additionalTextFile.GetText()
+                            Catch
+                                text = Nothing
+                            End Try
+
+                            Return diagnostic.Location.SourceSpan
+                        End If
+                    Next
+                End If
+            End If
+
+            text = Nothing
+            Return Nothing
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7136,6 +7136,55 @@ End Class
             CleanupAllGeneratedFiles(source)
         End Sub
 
+        <Fact>
+        Public Sub AdditionalFileDiagnostics()
+            Dim dir = Temp.CreateDirectory()
+            Dim source = dir.CreateFile("a.vb").WriteAllText(<text>
+Class C
+End Class
+</text>.Value).Path
+
+            Dim additionalFile = dir.CreateFile("AdditionalFile.txt").WriteAllText(<text>
+Additional File Line 1!
+Additional File Line 2!
+</text>.Value).Path
+
+            Dim nonCompilerInputFile = dir.CreateFile("DummyFile.txt").WriteAllText(<text>
+Dummy File Line 1!
+</text>.Value).Path
+
+            Dim analyzer = New AdditionalFileDiagnosticAnalyzer(nonCompilerInputFile)
+            Dim arguments = {"/nologo", "/preferreduilang:en", "/vbruntime", "/t:library",
+                "/additionalfile:" & additionalFile, ' Valid additional text file
+                "/additionalfile:" & Assembly.GetExecutingAssembly.Location, ' Non-text file specified as an additional text file
+                source}
+            Dim vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, arguments, analyzer)
+
+            Dim outWriter = New StringWriter()
+            Dim exitCode = vbc.Run(outWriter, Nothing)
+            Assert.Equal(1, exitCode)
+            Dim output = outWriter.ToString()
+
+            AssertOutput(
+    String.Format(<text>
+AdditionalFile.txt(1) : warning AdditionalFileDiagnostic: Additional File Diagnostic: AdditionalFile
+Additional File Line 1!
+~~~~~~~~~~             
+vbc : warning AdditionalFileDiagnostic: Additional File Diagnostic: {0}
+vbc : warning AdditionalFileDiagnostic: Additional File Diagnostic: AdditionalFile
+vbc : warning AdditionalFileDiagnostic: Additional File Diagnostic: DummyFile
+vbc : warning AdditionalFileDiagnostic: Additional File Diagnostic: NonExistentPath
+vbc : error BC2015: the file '{1}' is not a text file
+</text>.Value.ToString(),
+        IO.Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly.Location),
+        Assembly.GetExecutingAssembly.Location),
+    output, fileName:="AdditionalFile.txt")
+
+            CleanupAllGeneratedFiles(source)
+            CleanupAllGeneratedFiles(additionalFile)
+            CleanupAllGeneratedFiles(nonCompilerInputFile)
+        End Sub
+
         ''' <summary>
         ''' Script compilation should be internal only.
         ''' </summary>
@@ -7279,6 +7328,57 @@ End Class
 
         Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
             context.ReportDiagnostic(Diagnostic.Create(Error01, context.Node.GetLocation()))
+        End Sub
+    End Class
+
+    Friend Class AdditionalFileDiagnosticAnalyzer
+        Inherits MockAbstractDiagnosticAnalyzer
+
+        Friend Shared ReadOnly Rule As DiagnosticDescriptor = New DiagnosticDescriptor("AdditionalFileDiagnostic", "", "Additional File Diagnostic: {0}", "", DiagnosticSeverity.Warning, isEnabledByDefault:=True)
+        Private ReadOnly _nonCompilerInputFile As String
+
+        Public Sub New(nonCompilerInputFile As String)
+            _nonCompilerInputFile = nonCompilerInputFile
+        End Sub
+
+        Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+            Get
+                Return ImmutableArray.Create(Rule)
+            End Get
+        End Property
+
+        Public Overrides Sub AnalyzeCompilation(context As CompilationAnalysisContext)
+        End Sub
+
+        Public Overrides Sub CreateAnalyzerWithinCompilation(context As CompilationStartAnalysisContext)
+            context.RegisterCompilationEndAction(AddressOf CompilationEndAction)
+        End Sub
+
+        Private Sub CompilationEndAction(context As CompilationAnalysisContext)
+            ' Diagnostic reported on additionals file, with valid span.
+            For Each additionalFile In context.Options.AdditionalFiles
+                ReportDiagnostic(additionalFile.Path, context)
+            Next
+
+            ' Diagnostic reported on an additional file, but with an invalid span.
+            ReportDiagnostic(context.Options.AdditionalFiles.First().Path, context, New TextSpan(0, 1000000)) ' Overflow span
+
+            ' Diagnostic reported on a file which is not an input for the compiler.
+            ReportDiagnostic(_nonCompilerInputFile, context)
+
+            ' Diagnostic reported on a non-existent file.
+            ReportDiagnostic("NonExistentPath", context)
+        End Sub
+
+        Private Sub ReportDiagnostic(path As String, context As CompilationAnalysisContext, Optional span As TextSpan = Nothing)
+            If span = Nothing Then
+                span = New TextSpan(0, 11)
+            End If
+
+            Dim linePosSpan = New LinePositionSpan(New LinePosition(0, 0), New LinePosition(0, span.End))
+            Dim diagLocation = Location.Create(path, span, linePosSpan)
+            Dim diag = Diagnostic.Create(Rule, diagLocation, IO.Path.GetFileNameWithoutExtension(path))
+            context.ReportDiagnostic(diag)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
**Fixes #2920**

**User scenario:** User compiles a project with analyzers, and analyzer(s) generates a diagnostic with location in a non-source additional text file, but msbuild doesn't report such analyzer diagnostics and exits with error code 1 and no output.

**Bug description:** For analyzer diagnostics in additional files, VB command line compiler doesn’t output any file information or squiggles. However, it does include the file name and location in the output. This format doesn't match the Vbc MSBuild task parsing logic, which expects the output to have either all of this information (file path, location, file content and squiggles) OR none of it for no-location diagnostic. This causes the Vbc task to ignore additional file diagnostics.

**Fix description:** Fix the VB command line diagnostic formatter to always output diagnostics in either of the above 2 formats expected by MSBuild. For additional file diagnostics, the formatter now attempts to read the additional file stream and if it succeeds, formats it as a source diagnostic with location info and squiggles. Otherwise, it formats it as a no-location project diagnostic.

**Testing:** Added regression test + existing tests.

/cc @ManishJayaswal @srivatsn @jaredpar This is for 1.0 stable milestone.