### PR TITLE
Make CodeModel.CodeTypeFromFullName rational when returning types that appear in generated code files

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/AbstractRootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractRootCodeModelTests.vb
@@ -4,7 +4,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractRootCodeModelTests
         Inherits AbstractCodeModelObjectTests(Of EnvDTE.CodeModel)
 
-        Protected Sub TestRootCodeModel(code As XElement, action As Action(Of EnvDTE.CodeModel))
+        Protected Sub TestRootCodeModel(workspaceDefinition As XElement, action As Action(Of EnvDTE.CodeModel))
+            Using state = CreateCodeModelTestState(workspaceDefinition)
+                Dim rootCodeModel = state.RootCodeModel
+                Assert.NotNull(rootCodeModel)
+
+                action(rootCodeModel)
+            End Using
+        End Sub
+
+        Protected Sub TestRootCodeModelWithCodeFile(code As XElement, action As Action(Of EnvDTE.CodeModel))
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
                 Dim rootCodeModel = state.RootCodeModel
                 Assert.NotNull(rootCodeModel)
@@ -14,7 +23,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestCodeElements(code As XElement, ParamArray expectedChildren() As Action(Of Object))
-            TestRootCodeModel(code,
+            TestRootCodeModelWithCodeFile(code,
                 Sub(rootCodeModel)
                     Dim codeElements = rootCodeModel.CodeElements
                     Assert.Equal(expectedChildren.Length, rootCodeModel.CodeElements.Count)
@@ -26,7 +35,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestCodeElements(code As XElement, ParamArray names() As String)
-            TestRootCodeModel(code,
+            TestRootCodeModelWithCodeFile(code,
                 Sub(rootCodeModel)
                     Assert.Equal(names.Length, rootCodeModel.CodeElements.Count)
 
@@ -43,7 +52,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestCreateCodeTypeRef(code As XElement, type As Object, data As CodeTypeRefData)
-            TestRootCodeModel(code,
+            TestRootCodeModelWithCodeFile(code,
                 Sub(rootCodeModel)
                     Dim codeTypeRef = rootCodeModel.CreateCodeTypeRef(type)
 
@@ -56,12 +65,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestCreateCodeTypeRef(Of TException As Exception)(code As XElement, type As Object)
-            TestRootCodeModel(code,
+            TestRootCodeModelWithCodeFile(code,
                 Sub(rootCodeModel)
                     Assert.Throws(Of TException)(
                         Sub()
                             rootCodeModel.CreateCodeTypeRef(type)
                         End Sub)
+                End Sub)
+        End Sub
+
+        Protected Sub TestCodeTypeFromFullName(workspaceDefinition As XElement, fullName As String, action As Action(Of EnvDTE.CodeType))
+            TestRootCodeModel(workspaceDefinition,
+                Sub(rootCodeModel)
+                    action(rootCodeModel.CodeTypeFromFullName(fullName))
                 End Sub)
         End Sub
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
@@ -1,6 +1,8 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -31,7 +33,7 @@ class Foo { }
 class Foo { }
 </code>
 
-            TestRootCodeModel(code,
+            TestRootCodeModelWithCodeFile(code,
                 Sub(rootCodeModel)
                     Dim systemNamespace = rootCodeModel.CodeElements.Find(Of EnvDTE.CodeNamespace)("System")
                     Assert.NotNull(systemNamespace)
@@ -95,10 +97,180 @@ class Foo { }
 
 #End Region
 
+#Region "CodeTypeFromFullName"
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_NonGenerated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.cs"><![CDATA[
+namespace N
+{
+    class C
+    {
+    }
+}
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.cs", filePath)
+                End Sub)
+
+        End Sub
+
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_Generated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.g.cs"><![CDATA[
+namespace N
+{
+    class C
+    {
+    }
+}
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.g.cs", filePath)
+                End Sub)
+
+        End Sub
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_NonGenerated_Generated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.cs"><![CDATA[
+namespace N
+{
+    partial class C
+    {
+    }
+}
+]]></Document>
+                                    <Document FilePath="C.g.cs"><![CDATA[
+namespace N
+{
+    partial class C
+    {
+    }
+}
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.cs", filePath)
+                End Sub)
+
+        End Sub
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_Generated_NonGenerated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.g.cs"><![CDATA[
+namespace N
+{
+    partial class C
+    {
+    }
+}
+]]></Document>
+                                    <Document FilePath="C.cs"><![CDATA[
+namespace N
+{
+    partial class C
+    {
+    }
+}
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.cs", filePath)
+                End Sub)
+
+        End Sub
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp
             End Get
         End Property
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
@@ -2,6 +2,8 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
@@ -67,6 +69,163 @@ End Module
                                       .CodeTypeFullName = "System.Nullable(Of System.Int32)",
                                       .TypeKind = EnvDTE.vsCMTypeRef.vsCMTypeRefCodeType
                                   })
+        End Sub
+
+#End Region
+
+#Region "CodeTypeFromFullName"
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_NonGenerated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.vb", filePath)
+                End Sub)
+
+        End Sub
+
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_Generated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.g.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.g.vb", filePath)
+                End Sub)
+
+        End Sub
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_NonGenerated_Generated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                    <Document FilePath="C.g.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.vb", filePath)
+                End Sub)
+
+        End Sub
+
+        <WorkItem(1107453)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeTypeFromFullName_Generated_NonGenerated()
+
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> CommonReferences="true">
+                                    <Document FilePath="C.g.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                    <Document FilePath="C.vb"><![CDATA[
+Namespace N
+    Class C
+    End Class
+End Namespace
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestCodeTypeFromFullName(workspace, "N.C",
+                Sub(codeType)
+                    Assert.NotNull(codeType)
+                    Assert.Equal("N.C", codeType.FullName)
+
+                    Dim codeNamespace = TryCast(codeType.Parent, EnvDTE.CodeNamespace)
+                    Assert.NotNull(codeNamespace)
+
+                    Dim fileCodeModel = TryCast(codeNamespace.Parent, EnvDTE.FileCodeModel)
+                    Assert.NotNull(fileCodeModel)
+
+                    Dim underlyingFileCodeModel = ComAggregate.GetManagedObject(Of FileCodeModel)(fileCodeModel)
+                    Assert.NotNull(underlyingFileCodeModel)
+
+                    Dim filePath = underlyingFileCodeModel.Workspace.GetFilePath(underlyingFileCodeModel.GetDocumentId())
+                    Assert.Equal("C.vb", filePath)
+                End Sub)
+
         End Sub
 
 #End Region


### PR DESCRIPTION
Fixes TFS Issue 1107453

**Customer Scenario**: This addresses a problem that can occur when CodeModel.CodeTypeFromFullName is used to determine the right location to modify user code. In the case of XAML apps, there are several generated files that shouldn't be modified which contain partial parts of class that also appear in user code (e.g. App.cs, App.g.cs, etc.). Previously, CodeTypeFromFullName might return one of these files as a location, breaking whatever feature was trying to modify the user's code.

**Description of Change**: CodeModel.CodeTypeFromFullName should prefer locations within source files that are not generated (using the same heuristic we use within the Generate Type dialog to determine whether a source file is "generated"). However, if the locations are *all* within generated sources, just return the first one. That way, searching for a type within code produced by a VS single file generator, such as "Resources.Designer.cs", would still work.

**Testing Done**: Unit tests have been added for this scenario in C# and VB that test a handful of permutations of generated and non-generated code with partial classes. Additionally, the Code Model unit testing infrastructure has been updated to support TestWorkspaces with multiple documents.

Potential reviewers: @Pilchie, @jasonmalinowski, @pharring, @dpoeschl, @rchande, @brettfo, @balajikris, @basoundr 