### PR TITLE
Still enable smart indent when auto-format on close brace is off

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -58,15 +58,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         public bool SupportsFormattingOnTypedCharacter(Document document, char ch)
         {
-            var optionsService = document.Project.Solution.Workspace.Options;
-            if ((ch == '}' && !optionsService.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language)) ||
-                (ch == ';' && !optionsService.GetOption(FeatureOnOffOptions.AutoFormattingOnSemicolon, document.Project.Language)))
+            var options = document.Project.Solution.Workspace.Options;
+            var smartIndentOn = options.GetOption(FormattingOptions.SmartIndent, document.Project.Language) == FormattingOptions.IndentStyle.Smart;
+
+            if ((ch == '}' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language) && !smartIndentOn) ||
+                (ch == ';' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnSemicolon, document.Project.Language)))
             {
                 return false;
             }
 
             // don't auto format after these keys if smart indenting is not on.
-            if  ((ch == '#' || ch == 'n') && optionsService.GetOption(FormattingOptions.SmartIndent, document.Project.Language) != FormattingOptions.IndentStyle.Smart)
+            if  ((ch == '#' || ch == 'n') && !smartIndentOn)
             {
                 return false;
             }
@@ -180,11 +182,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                 return null;
             }
 
-            // if formatting range fails, do format token one at least
-            var changes = await FormatRangeAsync(document, token, formattingRules, cancellationToken).ConfigureAwait(false);
-            if (changes.Count > 0)
+            var options = document.Project.Solution.Workspace.Options;
+
+            // dont attempt to format on close brace if autoformat on close brace feature is off, instead just smart indent
+            bool smartIndentOnly =
+                token.IsKind(SyntaxKind.CloseBraceToken) &&
+                !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language);
+
+            if (!smartIndentOnly)
             {
-                return changes;
+                // if formatting range fails, do format token one at least
+                var changes = await FormatRangeAsync(document, token, formattingRules, cancellationToken).ConfigureAwait(false);
+                if (changes.Count > 0)
+                {
+                    return changes;
+                }
             }
 
             // if we can't, do normal smart indentation

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
 using Microsoft.CodeAnalysis.Editor.Options;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
@@ -1080,6 +1081,38 @@ class C : Attribute
                             {
                                 { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.None }
                             };
+            AssertFormatAfterTypeChar(code, expected, optionSet);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public void StillAutoIndentCloseBraceWhenFormatOnCloseBraceIsOff()
+        {
+            var code = @"namespace N
+{
+    class C
+    {
+             // improperly indented code
+             int x = 10;
+        }$$
+}
+";
+
+            var expected = @"namespace N
+{
+    class C
+    {
+             // improperly indented code
+             int x = 10;
+    }
+}
+";
+
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                    { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp), false }
+            };
+
             AssertFormatAfterTypeChar(code, expected, optionSet);
         }
 


### PR DESCRIPTION
Fixes devdiv 1171470

This change enables smart indent for auto-correcting the close brace position to still function when the auto-format on close brace feature is turned off.

@Pilchie @jasonmalinowski please review
