### PR TITLE
Add test to prove that encoding is unchanged after tree update

### DIFF
--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -22,6 +22,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Roslyn.Test.Utilities;
 using Xunit;
+using CS = Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -1342,6 +1343,24 @@ public class C : A {
             classC = comp3.GetTypeByMetadataName("C");
             projectForBaseType = solution2.GetProject(classC.BaseType.ContainingAssembly);
             Assert.Equal(pid1, projectForBaseType.Id);
+        }
+
+        [WorkItem(1088127, "DevDiv")]
+        [Fact]
+        public void TestEncodingRetainedAfterTreeChanged()
+        {
+            var ws = new AdhocWorkspace();
+            var proj = ws.AddProject("proj", LanguageNames.CSharp);
+            var doc = ws.AddDocument(proj.Id, "a.cs", SourceText.From("public class c { }", Encoding.UTF32));
+
+            Assert.Equal(Encoding.UTF32, doc.GetTextAsync().Result.Encoding);
+
+            // updating root doesn't change original encoding
+            var root = doc.GetSyntaxRootAsync().Result;
+            var newRoot = root.WithLeadingTrivia(root.GetLeadingTrivia().Add(CS.SyntaxFactory.Whitespace("    ")));
+            var newDoc = doc.WithSyntaxRoot(newRoot);
+
+            Assert.Equal(Encoding.UTF32, newDoc.GetTextAsync().Result.Encoding);
         }
     }
 }


### PR DESCRIPTION
@Pilchie  @jasonmalinowski please review