### PR TITLE
Rename dashboard navigation tweaks

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/RenameCommandHandler_RenameHandler.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.SuggestionSupport;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
@@ -58,14 +59,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private void ExecuteRenameWorker(RenameCommandArgs args, CancellationToken cancellationToken)
         {
-            // If there is already an active session, focus its dashboard;
-            if (_renameService.ActiveSession != null)
-            {
-                var dashboard = GetDashboard(args.TextView);
-                dashboard.Focus();
-                return;
-            }
-
             var snapshot = args.SubjectBuffer.CurrentSnapshot;
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(snapshot.AsText().Container, out workspace))
@@ -78,6 +71,25 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 ShowErrorDialog(workspace, EditorFeaturesResources.YouMustRenameAnIdentifier);
                 return;
+            }
+
+            // If there is already an active session, commit it first
+            if (_renameService.ActiveSession != null)
+            {
+                // Is the caret within any of the rename fields in this buffer?
+                // If so, focus the dashboard
+                SnapshotSpan editableSpan;
+                if (_renameService.ActiveSession.TryGetContainingEditableSpan(caretPoint.Value, out editableSpan))
+                {
+                    var dashboard = GetDashboard(args.TextView);
+                    dashboard.Focus();
+                    return;
+                }
+                else
+                {
+                    // Otherwise, commit the existing session and start a new one.
+                    _renameService.ActiveSession.Commit();
+                }
             }
 
             var position = caretPoint.Value;

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             this.Focus();
             textView.Caret.IsHidden = false;
-            ShouldReceiveKeyboardNavigation = true;
+            ShouldReceiveKeyboardNavigation = false;
         }
 
         private void ShowCaret()


### PR DESCRIPTION
* Dashboard is no longer focused when starting inline rename
* F2 outside a rename field commits the current session and starts a new
one
* F2 within a rename field focuses the dashboard

Fixes #44 