### PR TITLE
Pass correct itemIDs to IVsSymbolicNavigationNotify

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -257,8 +257,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
 
                 uint itemId;
-                Project.Hierarchy.ParseCanonicalName(_itemMoniker, out itemId);
-                return itemId;
+                return Project.Hierarchy.ParseCanonicalName(_itemMoniker, out itemId) == VSConstants.S_OK
+                    ? itemId
+                    : (uint)VSConstants.VSITEMID.Nil;
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -1180,8 +1180,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             }
 
             uint itemId;
-            Project.Hierarchy.ParseCanonicalName(_itemMoniker, out itemId);
-            return itemId;
+            return Project.Hierarchy.ParseCanonicalName(_itemMoniker, out itemId) == VSConstants.S_OK
+                ? itemId
+                : (uint)VSConstants.VSITEMID.Nil;
         }
 
         private enum RazorCodeBlockType

--- a/src/VisualStudio/Core/Def/Implementation/VsRefactorNotifyService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VsRefactorNotifyService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.RQName;
@@ -15,10 +16,12 @@ using Roslyn.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     [Export(typeof(IRefactorNotifyService))]
-    internal sealed class VsRefactorNotifyService : IRefactorNotifyService
+    internal sealed class VsRefactorNotifyService : ForegroundThreadAffinitizedObject, IRefactorNotifyService
     {
         public bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure)
         {
+            AssertIsForeground();
+
             Dictionary<IVsHierarchy, List<uint>> hierarchyToItemIDsMap;
             string[] rqnames;
 
@@ -59,6 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure)
         {
+            AssertIsForeground();
+
             Dictionary<IVsHierarchy, List<uint>> hierarchyToItemIDsMap;
             string[] rqnames;
 
@@ -103,6 +108,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             out Dictionary<IVsHierarchy, List<uint>> hierarchyToItemIDsMap,
             out string[] rqnames)
         {
+            AssertIsForeground();
+
             hierarchyToItemIDsMap = null;
             rqnames = null;
 
@@ -126,6 +133,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             out Dictionary<IVsHierarchy, List<uint>> hierarchyToItemIDsMap,
             out string rqname)
         {
+            AssertIsForeground();
+
             visualStudioWorkspace = null;
             hierarchyToItemIDsMap = null;
             rqname = null;
@@ -169,6 +178,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private Dictionary<IVsHierarchy, List<uint>> GetHierarchiesAndItemIDsFromDocumentIDs(VisualStudioWorkspaceImpl visualStudioWorkspace, IEnumerable<DocumentId> changedDocumentIDs)
         {
+            AssertIsForeground();
+
             var hierarchyToItemIDsMap = new Dictionary<IVsHierarchy, List<uint>>();
 
             foreach (var docID in changedDocumentIDs)

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -8,14 +8,14 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Implementation.Outlining;
-using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.LanguageServices.Implementation.RQName;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -26,7 +26,7 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    internal partial class VisualStudioSymbolNavigationService : ISymbolNavigationService
+    internal partial class VisualStudioSymbolNavigationService : ForegroundThreadAffinitizedObject, ISymbolNavigationService
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactory;
@@ -123,38 +123,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public bool TrySymbolNavigationNotify(ISymbol symbol, Solution solution)
         {
-            foreach (var s in GetAllNavigationSymbols(symbol))
-            {
-                if (TryNotifyForSpecificSymbol(s, solution))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// If the symbol being navigated to is a constructor, then try navigating to the
-        /// constructor itself. If no third parties choose to navigate to the constructor, then try
-        /// the constructor's containing type.
-        /// </summary>
-        private IEnumerable<ISymbol> GetAllNavigationSymbols(ISymbol symbol)
-        {
-            yield return symbol;
-
-            if (symbol.IsConstructor())
-            {
-                yield return symbol.ContainingType;
-            }
+            return TryNotifyForSpecificSymbol(symbol, solution);
         }
 
         private bool TryNotifyForSpecificSymbol(ISymbol symbol, Solution solution)
         {
+            AssertIsForeground();
+
             IVsHierarchy hierarchy;
             IVsSymbolicNavigationNotify navigationNotify;
             string rqname;
-            if (!TryGetNavigationAPIRequiredArguments(symbol, solution, out hierarchy, out navigationNotify, out rqname))
+            uint itemID;
+            if (!TryGetNavigationAPIRequiredArguments(symbol, solution, out hierarchy, out itemID, out navigationNotify, out rqname))
             {
                 return false;
             }
@@ -162,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             int navigationHandled;
             int returnCode = navigationNotify.OnBeforeNavigateToSymbol(
                 hierarchy,
-                (uint)VSConstants.VSITEMID.Nil,
+                itemID,
                 rqname,
                 out navigationHandled);
 
@@ -176,12 +156,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public bool WouldNavigateToSymbol(ISymbol symbol, Solution solution, out string filePath, out int lineNumber, out int charOffset)
         {
-            foreach (var s in GetAllNavigationSymbols(symbol))
+            if (WouldNotifyToSpecificSymbol(symbol, solution, out filePath, out lineNumber, out charOffset))
             {
-                if (WouldNotifyToSpecificSymbol(s, solution, out filePath, out lineNumber, out charOffset))
-                {
-                    return true;
-                }
+                return true;
+            }
+
+            // If the symbol being considered is a constructor and no third parties choose to
+            // navigate to the constructor, then try the constructor's containing type.
+            if (symbol.IsConstructor() && WouldNotifyToSpecificSymbol(symbol.ContainingType, solution, out filePath, out lineNumber, out charOffset))
+            {
+                return true;
             }
 
             filePath = null;
@@ -192,6 +176,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public bool WouldNotifyToSpecificSymbol(ISymbol symbol, Solution solution, out string filePath, out int lineNumber, out int charOffset)
         {
+            AssertIsForeground();
+
             filePath = null;
             lineNumber = 0;
             charOffset = 0;
@@ -199,7 +185,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             IVsHierarchy hierarchy;
             IVsSymbolicNavigationNotify navigationNotify;
             string rqname;
-            if (!TryGetNavigationAPIRequiredArguments(symbol, solution, out hierarchy, out navigationNotify, out rqname))
+            uint itemID;
+            if (!TryGetNavigationAPIRequiredArguments(symbol, solution, out hierarchy, out itemID, out navigationNotify, out rqname))
             {
                 return false;
             }
@@ -211,7 +198,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             int queryNavigateStatusCode = navigationNotify.QueryNavigateToSymbol(
                 hierarchy,
-                (uint)VSConstants.VSITEMID.Nil,
+                itemID,
                 rqname,
                 out navigateToHierarchy,
                 out navigateToItem,
@@ -229,24 +216,50 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return false;
         }
 
-        private bool TryGetNavigationAPIRequiredArguments(ISymbol symbol, Solution solution, out IVsHierarchy hierarchy, out IVsSymbolicNavigationNotify navigationNotify, out string rqname)
+        private bool TryGetNavigationAPIRequiredArguments(
+            ISymbol symbol, 
+            Solution solution, 
+            out IVsHierarchy hierarchy, 
+            out uint itemID, 
+            out IVsSymbolicNavigationNotify navigationNotify, 
+            out string rqname)
         {
+            AssertIsForeground();
+
             hierarchy = null;
             navigationNotify = null;
             rqname = null;
+            itemID = (uint)VSConstants.VSITEMID.Nil;
 
-            if (!symbol.Locations.Any() || !symbol.Locations[0].IsInSource)
+            if (!symbol.Locations.Any())
             {
                 return false;
             }
 
-            var document = solution.GetDocument(symbol.Locations[0].SourceTree);
-            if (document == null)
+            var sourceLocations = symbol.Locations.Where(loc => loc.IsInSource);
+            if (!sourceLocations.Any())
             {
                 return false;
             }
 
-            hierarchy = GetVsHierarchy(document.Project);
+            var documents = sourceLocations.Select(loc => solution.GetDocument(loc.SourceTree)).WhereNotNull();
+            if (!documents.Any())
+            {
+                return false;
+            }
+
+            // We can only pass one itemid to IVsSymbolicNavigationNotify, so prefer itemids from
+            // documents we consider to be "generated" to give external language services the best
+            // chance of participating.
+
+            var generatedCodeRecognitionService = solution.Workspace.Services.GetService<IGeneratedCodeRecognitionService>();
+            var generatedDocuments = documents.Where(d => generatedCodeRecognitionService.IsGeneratedCode(d));
+
+            var documentToUse = generatedDocuments.FirstOrDefault() ?? documents.First();
+            if (!TryGetVsHierarchyAndItemId(documentToUse, out hierarchy, out itemID))
+            {
+                return false;
+            }
 
             navigationNotify = hierarchy as IVsSymbolicNavigationNotify;
             if (navigationNotify == null)
@@ -258,16 +271,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return rqname != null;
         }
 
-        private IVsHierarchy GetVsHierarchy(Project project)
+        private bool TryGetVsHierarchyAndItemId(Document document, out IVsHierarchy hierarchy, out uint itemID)
         {
-            var visualStudioWorkspace = project.Solution.Workspace as VisualStudioWorkspaceImpl;
+            AssertIsForeground();
+
+            var visualStudioWorkspace = document.Project.Solution.Workspace as VisualStudioWorkspaceImpl;
             if (visualStudioWorkspace != null)
             {
-                var hierarchy = visualStudioWorkspace.GetHierarchy(project.Id);
-                return hierarchy;
+                var hostProject = visualStudioWorkspace.GetHostProject(document.Project.Id);
+                hierarchy = hostProject.Hierarchy;
+                itemID = hostProject.GetDocumentOrAdditionalDocument(document.Id).GetItemId();
+
+                return true;
             }
 
-            return null;
+            hierarchy = null;
+            itemID = (uint)VSConstants.VSITEMID.Nil;
+            return false;
         }
 
         private I GetService<S, I>()


### PR DESCRIPTION
Retargeted to stabilization (originally reviewed at #2975)

Partial fix for internal TFS bug #1169405

We previously always passed Nil for all itemidCodeFile parameters in IVsSymbolicNavigationNotify to ensure the XAML language service heard our request (because their current implementation only processes request for Nil or 0-valued itemids.) This caused Go To Definition and Find All References to be slower than necessary in non-XAML cases and also resulted in unwanted behaviors on certain properties that are referenced in XAML.

Our two options for fixing this were to either:
1. Update our implementation to send the correct item ids for heuristically "non-generated" files and send Nil for "generated" files (to match the Dev12 behavior)
2. Always send the actual item ids, even for "generated" files, and update the XAML language service to do a fast initial check of the corresponding document to see if they're interested in processing it.

This changeset represents the Roslyn half of option 2. Any builds that contain this fix but do not contain the corresponding change to the XAML language service will see no Go To Definition navigation to .xaml files (e.g. when navigating from a reference to a named Button) and no .xaml file entries in Find All References.

Unfortunately, this does not remove all heuristics from this algorithm, because Roslyn must still decide which itemid to pass in the case of a definition spanning multiple documents (e.g. the MainWindow class created in default WPF projects). We always prefer the "generated" documents to give external language services the best opportunity to participate.

This change also adds asserts to verify all itemID handling during Rename & Navigation happens on the UI thread.