### PR TITLE
Remove tail recursion and enable cancellation

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             _waitIndicator.Wait(
                 title: EditorFeaturesResources.FormatDocument,
                 message: EditorFeaturesResources.FormattingDocument,
-                allowCancel: false,
+                allowCancel: true,
                 action: waitContext =>
                 {
                     Format(args.TextView, document, null, waitContext.CancellationToken);

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatSelection.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatSelection.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             _waitIndicator.Wait(
                 title: EditorFeaturesResources.FormatSelection,
                 message: EditorFeaturesResources.FormattingCurrentlySelected,
-                allowCancel: false,
+                allowCancel: true,
                 action: waitContext =>
             {
                 var buffer = args.SubjectBuffer;

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             _waitIndicator.Wait(
                 title: EditorFeaturesResources.FormatPaste,
                 message: EditorFeaturesResources.FormattingPastedText,
-                allowCancel: false,
+                allowCancel: true,
                 action: c => ExecuteCommandWorker(args, nextHandler, c.CancellationToken));
         }
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.Partitioner.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.Partitioner.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 _operationPairs = operationPairs;
             }
 
-            public List<IEnumerable<TokenPairWithOperations>> GetPartitions(int partitionCount)
+            public List<IEnumerable<TokenPairWithOperations>> GetPartitions(int partitionCount, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfFalse(partitionCount > 0);
 
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                         break;
                     }
 
-                    var nextToken = _context.GetEndTokenForRelativeIndentationSpan(_operationPairs[nextPartitionStartOperationIndex].Token1);
+                    var nextToken = _context.GetEndTokenForRelativeIndentationSpan(_operationPairs[nextPartitionStartOperationIndex].Token1, cancellationToken);
                     if (nextToken.RawKind == 0)
                     {
                         // reached the last token in the tree
@@ -79,6 +80,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                     list.Add(GetOperationPairsFromTo(currentOperationIndex, nextTokenWithIndex.IndexInStream));
                     currentOperationIndex = nextTokenWithIndex.IndexInStream;
+
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
 
                 return list;

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -441,7 +441,9 @@ namespace Microsoft.CodeAnalysis.Formatting
                 var partitioner = new Partitioner(context, tokenStream, tokenOperations);
 
                 // always create task 1 more than current processor count
-                var partitions = partitioner.GetPartitions(this.TaskExecutor == TaskExecutor.Synchronous ? 1 : Environment.ProcessorCount + 1);
+                var partitions = partitioner.GetPartitions(this.TaskExecutor == TaskExecutor.Synchronous ? 1 : Environment.ProcessorCount + 1, cancellationToken);
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var tasks = new Task[partitions.Count];
                 for (int i = 0; i < partitions.Count; i++)


### PR DESCRIPTION
Fixes devdiv 1089540 

The problem was a stack overflow in the formatter when pasting a file with a enormous array initializer.  The culprit was a method `FormattingContext.GetEndTokenForRelativeIndentationSpan` that was making a recursive call after looking forward to the next token, attempting to find the end token for a relative indentation operation.  Fortunately it was simply tail recursive and was easy to rewrite as a loop.

Also noticed that the whole operation when successful was taking tremendous amount of time (on order of 10 minutes), and was stuck in this recursive method for a long time without ability to cancel, so I plumbed cancellation through to its loop.

Also noticed that the dialog that pops up on slow execution of formatting did not have a cancel button, so I enabled that too.

@heejaechang @jasonmalinowski @Pilchie please review.
