### PR TITLE
Remove recursion in GetFirstToken and GetLastToken

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/AbstractSyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/AbstractSyntaxNavigator.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -51,38 +53,95 @@ namespace Microsoft.CodeAnalysis
             return GetNextToken(current, predicate, stepInto != null, stepInto);
         }
 
+        private static readonly ObjectPool<Stack<ChildSyntaxList.Enumerator>> childEnumeratorStackPool
+            = new ObjectPool<Stack<ChildSyntaxList.Enumerator>>(() => new Stack<ChildSyntaxList.Enumerator>(), 10);
+
         internal SyntaxToken GetFirstToken(SyntaxNode current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto)
         {
-            foreach (var child in current.ChildNodesAndTokens())
+            var stack = childEnumeratorStackPool.Allocate();
+            try
             {
-                var token = child.IsToken
-                    ? GetFirstToken(child.AsToken(), predicate, stepInto)
-                    : GetFirstToken(child.AsNode(), predicate, stepInto);
+                stack.Push(current.ChildNodesAndTokens().GetEnumerator());
 
-                if (token.RawKind != None)
+                while (stack.Count > 0)
                 {
-                    return token;
-                }
-            }
+                    var en = stack.Pop();
+                    if (en.MoveNext())
+                    {
+                        var child = en.Current;
 
-            return default(SyntaxToken);
+                        if (child.IsToken)
+                        {
+                            var token = GetFirstToken(child.AsToken(), predicate, stepInto);
+                            if (token.RawKind != None)
+                            {
+                                return token;
+                            }
+                        }
+
+                        // push this enumerator back, not done yet
+                        stack.Push(en);
+
+                        if (child.IsNode)
+                        {
+                            stack.Push(child.AsNode().ChildNodesAndTokens().GetEnumerator());
+                        }
+                    }
+                }
+
+                return default(SyntaxToken);
+            }
+            finally
+            {
+                stack.Clear();
+                childEnumeratorStackPool.Free(stack);
+            }
         }
+
+        private static readonly ObjectPool<Stack<ChildSyntaxList.Reversed.Enumerator>> childReversedEnumeratorStackPool
+            = new ObjectPool<Stack<ChildSyntaxList.Reversed.Enumerator>>(() => new Stack<ChildSyntaxList.Reversed.Enumerator>(), 10);
 
         internal SyntaxToken GetLastToken(SyntaxNode current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto)
         {
-            foreach (var child in current.ChildNodesAndTokens().Reverse())
+            var stack = childReversedEnumeratorStackPool.Allocate();
+            try
             {
-                var token = child.IsToken
-                    ? GetLastToken(child.AsToken(), predicate, stepInto)
-                    : GetLastToken(child.AsNode(), predicate, stepInto);
+                stack.Push(current.ChildNodesAndTokens().Reverse().GetEnumerator());
 
-                if (token.RawKind != None)
+                while (stack.Count > 0)
                 {
-                    return token;
-                }
-            }
+                    var en = stack.Pop();
 
-            return default(SyntaxToken);
+                    if (en.MoveNext())
+                    {
+                        var child = en.Current;
+
+                        if (child.IsToken)
+                        {
+                            var token = GetLastToken(child.AsToken(), predicate, stepInto);
+                            if (token.RawKind != None)
+                            {
+                                return token;
+                            }
+                        }
+
+                        // push this enumerator back, not done yet
+                        stack.Push(en);
+
+                        if (child.IsNode)
+                        {
+                            stack.Push(child.AsNode().ChildNodesAndTokens().Reverse().GetEnumerator());
+                        }
+                    }
+                }
+
+                return default(SyntaxToken);
+            }
+            finally
+            {
+                stack.Clear();
+                childReversedEnumeratorStackPool.Free(stack);
+            }
         }
 
         private SyntaxToken GetFirstToken(

--- a/src/Compilers/Core/Portable/Syntax/AbstractSyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/AbstractSyntaxNavigator.cs
@@ -53,12 +53,12 @@ namespace Microsoft.CodeAnalysis
             return GetNextToken(current, predicate, stepInto != null, stepInto);
         }
 
-        private static readonly ObjectPool<Stack<ChildSyntaxList.Enumerator>> childEnumeratorStackPool
+        private static readonly ObjectPool<Stack<ChildSyntaxList.Enumerator>> s_childEnumeratorStackPool
             = new ObjectPool<Stack<ChildSyntaxList.Enumerator>>(() => new Stack<ChildSyntaxList.Enumerator>(), 10);
 
         internal SyntaxToken GetFirstToken(SyntaxNode current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto)
         {
-            var stack = childEnumeratorStackPool.Allocate();
+            var stack = s_childEnumeratorStackPool.Allocate();
             try
             {
                 stack.Push(current.ChildNodesAndTokens().GetEnumerator());
@@ -94,16 +94,16 @@ namespace Microsoft.CodeAnalysis
             finally
             {
                 stack.Clear();
-                childEnumeratorStackPool.Free(stack);
+                s_childEnumeratorStackPool.Free(stack);
             }
         }
 
-        private static readonly ObjectPool<Stack<ChildSyntaxList.Reversed.Enumerator>> childReversedEnumeratorStackPool
+        private static readonly ObjectPool<Stack<ChildSyntaxList.Reversed.Enumerator>> s_childReversedEnumeratorStackPool
             = new ObjectPool<Stack<ChildSyntaxList.Reversed.Enumerator>>(() => new Stack<ChildSyntaxList.Reversed.Enumerator>(), 10);
 
         internal SyntaxToken GetLastToken(SyntaxNode current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto)
         {
-            var stack = childReversedEnumeratorStackPool.Allocate();
+            var stack = s_childReversedEnumeratorStackPool.Allocate();
             try
             {
                 stack.Push(current.ChildNodesAndTokens().Reverse().GetEnumerator());
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
             finally
             {
                 stack.Clear();
-                childReversedEnumeratorStackPool.Free(stack);
+                s_childReversedEnumeratorStackPool.Free(stack);
             }
         }
 


### PR DESCRIPTION
Fixes potential stack overflow when calling GetNextToken and GetPreviousToken and near the boundary of a very deep syntax tree.

@pharring @VSadov please review.

