### PR TITLE
Add features flag support to parse options

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1914,7 +1914,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static void CheckFeatureAvailability(Location location, MessageID feature, DiagnosticBag diagnostics)
         {
-            LanguageVersion availableVersion = ((CSharpParseOptions)location.SourceTree.Options).LanguageVersion;
+            var options = (CSharpParseOptions)location.SourceTree.Options;
+            if (feature.RequiredFeature() != null)
+            {
+                if (!options.IsFeatureEnabled(feature))
+                {
+                    diagnostics.Add(ErrorCode.ERR_FeatureIsExperimental, location, feature.Localize());
+                }
+                return;
+            }
+            LanguageVersion availableVersion = options.LanguageVersion;
             LanguageVersion requiredVersion = feature.RequiredVersion();
             if (requiredVersion > availableVersion)
             {

--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -65,6 +65,44 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
+        internal CSharpCompilationOptions(
+            OutputKind outputKind,
+            ImmutableArray<string> features,
+            string moduleName = null,
+            string mainTypeName = null,
+            string scriptClassName = null,
+            IEnumerable<string> usings = null,
+            OptimizationLevel optimizationLevel = OptimizationLevel.Debug,
+            bool checkOverflow = false,
+            bool allowUnsafe = false,
+            string cryptoKeyContainer = null,
+            string cryptoKeyFile = null,
+            ImmutableArray<byte> cryptoPublicKey = default(ImmutableArray<byte>),
+            bool? delaySign = null,
+            Platform platform = Platform.AnyCpu,
+            ReportDiagnostic generalDiagnosticOption = ReportDiagnostic.Default,
+            int warningLevel = 4,
+            IEnumerable<KeyValuePair<string, ReportDiagnostic>> specificDiagnosticOptions = null,
+            bool concurrentBuild = true,
+            XmlReferenceResolver xmlReferenceResolver = null,
+            SourceReferenceResolver sourceReferenceResolver = null,
+            MetadataReferenceResolver metadataReferenceResolver = null,
+            AssemblyIdentityComparer assemblyIdentityComparer = null,
+            StrongNameProvider strongNameProvider = null)
+            : this(outputKind, moduleName, mainTypeName, scriptClassName, usings, optimizationLevel, checkOverflow, allowUnsafe,
+                   cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign, platform, generalDiagnosticOption, warningLevel,
+                   specificDiagnosticOptions, concurrentBuild,
+                   extendedCustomDebugInformation: true,
+                   xmlReferenceResolver: xmlReferenceResolver,
+                   sourceReferenceResolver: sourceReferenceResolver,
+                   metadataReferenceResolver: metadataReferenceResolver,
+                   assemblyIdentityComparer: assemblyIdentityComparer,
+                   strongNameProvider: strongNameProvider,
+                   metadataImportOptions: MetadataImportOptions.Public,
+                   features: features)
+        {
+        }
+
         // Expects correct arguments.
         internal CSharpCompilationOptions(
             OutputKind outputKind,

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -18,6 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public static readonly CSharpParseOptions Default = new CSharpParseOptions();
 
+        private ImmutableDictionary<string, string> _features;
+
         /// <summary>
         /// Gets the language version.
         /// </summary>
@@ -62,6 +64,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal CSharpParseOptions(
+            LanguageVersion languageVersion,
+            DocumentationMode documentationMode,
+            SourceCodeKind kind,
+            IEnumerable<string> preprocessorSymbols,
+            ImmutableDictionary<string, string> features)
+            : this(languageVersion, documentationMode, kind, preprocessorSymbols)
+        {
+            if (features == null)
+            {
+                throw new ArgumentNullException(nameof(features));
+            }
+
+            this._features = features;
+        }
+
         private CSharpParseOptions(CSharpParseOptions other) : this(
             languageVersion: other.LanguageVersion,
             documentationMode: other.DocumentationMode,
@@ -81,6 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!preprocessorSymbols.IsDefault);
             this.LanguageVersion = languageVersion;
             this.PreprocessorSymbols = preprocessorSymbols;
+            this._features = ImmutableDictionary<string, string>.Empty;
         }
 
         public new CSharpParseOptions WithKind(SourceCodeKind kind)
@@ -178,26 +197,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentNullException(nameof(features));
             }
 
-            // there are currently no parse options for experimental features
-            if (System.Linq.Enumerable.Any(features))
-            {
-                throw new ArgumentException("Experimental features are not supported", nameof(features));
-            }
-
-            return this;
+            return new CSharpParseOptions(this) { _features = features.ToImmutableDictionary() };
         }
 
         public override IReadOnlyDictionary<string, string> Features
         {
             get
             {
-                // there are currently no parse options for experimental features
-                return new Dictionary<string, string>();
+                return _features;
             }
         }
 
         internal bool IsFeatureEnabled(MessageID feature)
         {
+            string featureFlag = feature.RequiredFeature();
+            if (featureFlag != null)
+            {
+                return Features.ContainsKey(featureFlag);
+            }
             LanguageVersion availableVersion = LanguageVersion;
             LanguageVersion requiredVersion = feature.RequiredVersion();
             return availableVersion >= requiredVersion;

--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
@@ -1038,7 +1038,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 languageVersion: languageVersion,
                 preprocessorSymbols: defines.ToImmutableAndFree(),
                 documentationMode: parseDocumentationComments ? DocumentationMode.Diagnose : DocumentationMode.None,
-                kind: SourceCodeKind.Regular
+                kind: SourceCodeKind.Regular,
+                features: features.ToImmutableDictionary(feature => feature, feature => "true")
             );
 
             var scriptParseOptions = parseOptions.WithKind(SourceCodeKind.Script);
@@ -1060,8 +1061,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 platform: platform,
                 generalDiagnosticOption: generalDiagnosticOption,
                 warningLevel: warningLevel,
-                specificDiagnosticOptions: diagnosticOptions
-            ).WithFeatures(features.AsImmutable());
+                specificDiagnosticOptions: diagnosticOptions,
+                features: features.AsImmutable()
+            );
 
             var emitOptions = new EmitOptions
             (

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_EncodinglessSyntaxTree = 8055,
         ERR_AccessorListAndExpressionBody = 8056,
         ERR_BlockBodyAndExpressionBody = 8057,
-        // ERR_FeatureIsExperimental = 8058,
+        ERR_FeatureIsExperimental = 8058,
         ERR_FeatureNotAvailableInVersion6 = 8059,
         // available 8060-8069
         ERR_SwitchFallOut = 8070,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -145,6 +145,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalizableErrorArgument(id);
         }
 
+        internal static string RequiredFeature(this MessageID feature)
+        {
+            switch (feature)
+            {
+                default:
+                    return null;
+            }
+        }
+
         internal static LanguageVersion RequiredVersion(this MessageID feature)
         {
             // Based on CSourceParser::GetFeatureUsage from SourceParser.cpp.

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -893,6 +893,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private void CheckFeatureAvailability(MessageID feature)
         {
+            if (feature.RequiredFeature() != null)
+            {
+                if (!this.Options.IsFeatureEnabled(feature))
+                {
+                    this.AddError(ErrorCode.ERR_FeatureIsExperimental, feature.Localize());
+                }
+                return;
+            }
+
             LanguageVersion availableVersion = this.Options.LanguageVersion;
             var requiredVersion = feature.RequiredVersion();
             if (availableVersion >= requiredVersion) return;

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -1048,13 +1048,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             var featureName = feature.Localize();
             var requiredVersion = feature.RequiredVersion();
 
-            if (forceWarning)
+            if (feature.RequiredFeature() != null)
             {
-                SyntaxDiagnosticInfo rawInfo = new SyntaxDiagnosticInfo(availableVersion.GetErrorCode(), featureName, requiredVersion.Localize());
-                return this.AddError(node, ErrorCode.WRN_ErrorOverride, rawInfo, rawInfo.Code);
-            }
+                if (forceWarning)
+                {
+                    SyntaxDiagnosticInfo rawInfo = new SyntaxDiagnosticInfo(ErrorCode.ERR_FeatureIsExperimental, featureName);
+                    return this.AddError(node, ErrorCode.WRN_ErrorOverride, rawInfo, rawInfo.Code);
+                }
 
-            return this.AddError(node, availableVersion.GetErrorCode(), featureName, requiredVersion.Localize());
+                return this.AddError(node, ErrorCode.ERR_FeatureIsExperimental, featureName);
+            }
+            else
+            {
+                if (forceWarning)
+                {
+                    SyntaxDiagnosticInfo rawInfo = new SyntaxDiagnosticInfo(availableVersion.GetErrorCode(), featureName, requiredVersion.Localize());
+                    return this.AddError(node, ErrorCode.WRN_ErrorOverride, rawInfo, rawInfo.Code);
+                }
+
+                return this.AddError(node, availableVersion.GetErrorCode(), featureName, requiredVersion.Localize());
+            }
         }
 
         protected bool IsFeatureEnabled(MessageID feature)

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6841,16 +6841,20 @@ using System.Diagnostics; // Unused.
             var args = DefaultParse(new[] { "/features:Test", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal("Test", args.CompilationOptions.Features.Single());
+            Assert.Equal("Test", args.ParseOptions.Features.Single().Key);
 
             args = DefaultParse(new[] { "/features:Test", "a.vb", "/Features:Experiment" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal(2, args.CompilationOptions.Features.Length);
             Assert.Equal("Test", args.CompilationOptions.Features[0]);
             Assert.Equal("Experiment", args.CompilationOptions.Features[1]);
+            Assert.True(args.ParseOptions.Features.ContainsKey("Test"));
+            Assert.True(args.ParseOptions.Features.ContainsKey("Experiment"));
 
             args = DefaultParse(new[] { "/features:Test:false,Key:value", "a.vb" }, _baseDirectory);
             args.Errors.Verify();
             Assert.Equal("Test:false,Key:value", args.CompilationOptions.Features.Single());
+            Assert.Equal("Test:false,Key:value", args.ParseOptions.Features.Single().Key);
 
             // We don't do any rigorous validation of /features arguments...
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7185,35 +7185,6 @@ vbc : error BC2015: the file '{1}' is not a text file
             CleanupAllGeneratedFiles(nonCompilerInputFile)
         End Sub
 
-        ''' <summary>
-        ''' Script compilation should be internal only.
-        ''' </summary>
-        <WorkItem(1979, "https://github.com/dotnet/roslyn/issues/1979")>
-        <Fact>
-        Public Sub ScriptCompilationInternalOnly()
-            Dim source = "System.Console.WriteLine()"
-            Dim dir = Temp.CreateDirectory()
-            Dim file = dir.CreateFile("b.vbx")
-            file.WriteAllText(source)
-
-            ' Compiling script file with internal API should be supported.
-            Dim compilation = CreateCompilationWithMscorlib(
-                <compilation>
-                    <file name="b.vbx"><%= source %></file>
-                </compilation>,
-                parseOptions:=New VisualBasicParseOptions(LanguageVersion.VisualBasic14, DocumentationMode.Parse, SourceCodeKind.Script, ImmutableArray(Of KeyValuePair(Of String, Object)).Empty),
-                options:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
-            compilation.VerifyDiagnostics()
-
-            ' Compiling with command-line compiler, should not treat .vbx as script.
-            Dim cmd = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/nologo", "/preferreduilang:en", file.Path})
-            Dim output As StringWriter = New StringWriter()
-            cmd.Run(output, Nothing)
-            Assert.True(output.ToString().Contains("error BC30689: Statement cannot appear outside of a method body."))
-
-            CleanupAllGeneratedFiles(file.Path)
-        End Sub
-
         <Fact, WorkItem(1093063, "DevDiv")>
         Public Sub VerifyDiagnosticSeverityNotLocalized()
             Dim source = <![CDATA[


### PR DESCRIPTION
CSharpParseOptions was hardcoded to reject any /features flags passed in, and any unit tests that used feature flags. This PR changes that, which is required for any future C#7 experimental language features, as well as use sites of feature flags.

There is a stub in MessageID.cs where feature flag strings can be defined.

@gafter @jaredpar @VSadov @AlekseyTs @agocke Please review.