### PR TITLE
Loosen check in CapturedVariableRewriter.RewriteParameter

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             {
                 var typeNameKind = GeneratedNames.GetKind(symbol.Type.Name);
                 if (typeNameKind != GeneratedNameKind.None && 
-                    GeneratedNames.GetKind(symbol.Name) != GeneratedNameKind.TransparentIdentifier)
+                    typeNameKind != GeneratedNameKind.AnonymousType)
                 {
                     // The state machine case is for async lambdas.  The state machine
                     // will have a hoisted "this" field if it needs to access the


### PR DESCRIPTION
When we added support for transparent identifiers, we loosened the
existing check so that they wouldn't be flagged as erroneous.  We should
have gone further and indicated that all anonymous types (i.e. including
user-declared ones) are okay.

Because of the way its check is structured, VB is unaffected.

Fixes #3231 

Impact: If you step into a lambda that has a parameter of anonymous type, then the Locals window will be blank.  Watch expressions referencing the parameter will also fail to bind.

For example, if you were to stop on ```t.Value``` in the code below, ```t``` would have an anonymous type and would not be available in the EE (which, indirectly, would prevent any other locals from being displayed at that  point).

```C#
var anonymousTypes =  
    from a in args  
    select new { Value = a, Length = a.Length };  
var values =  
    from t in anonymousTypes  
    select t.Value;  
```

It's a little tricky to hit this case because only lambda parameters can be of anonymous types.  However, the fix is trivial, so I think the reward (a populated Locals window in such cases) outweighs the risk.