### PR TITLE
Code Model: When setting the name of a CodeElement, ensure that its members are updated

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/GlobalNodeKey.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/GlobalNodeKey.cs
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
 
@@ -106,7 +107,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         protected override void SetName(string value)
         {
-            UpdateNodeAndReaquireNodeKey(FileCodeModel.UpdateName, value);
+            var nodeKeyValidation = new NodeKeyValidation();
+            nodeKeyValidation.AddFileCodeModel(this.FileCodeModel);
+
+            var node = LookupNode();
+
+            FileCodeModel.UpdateName(node, value);
+
+            nodeKeyValidation.RestoreKeys();
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
@@ -107,14 +107,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         protected override void SetName(string value)
         {
-            var nodeKeyValidation = new NodeKeyValidation();
-            nodeKeyValidation.AddFileCodeModel(this.FileCodeModel);
+            FileCodeModel.EnsureEditor(() =>
+            {
+                var nodeKeyValidation = new NodeKeyValidation();
+                nodeKeyValidation.AddFileCodeModel(this.FileCodeModel);
 
-            var node = LookupNode();
+                var node = LookupNode();
 
-            FileCodeModel.UpdateName(node, value);
+                FileCodeModel.UpdateName(node, value);
 
-            nodeKeyValidation.RestoreKeys();
+                nodeKeyValidation.RestoreKeys();
+            });
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
@@ -28,6 +28,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
         }
 
+        public void AddFileCodeModel(FileCodeModel fileCodeModel)
+        {
+            var handle = new ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>(fileCodeModel);
+            var globalNodeKeys = fileCodeModel.GetCurrentNodeKeys();
+
+            _nodeKeysMap.Add(handle, globalNodeKeys);
+        }
+
         public void RestoreKeys()
         {
             foreach (var e in _nodeKeysMap)

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractFileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractFileCodeModelTests.vb
@@ -7,12 +7,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractFileCodeModelTests
         Inherits AbstractCodeModelObjectTests(Of EnvDTE80.FileCodeModel2)
 
-        Protected Sub TestOperation(code As XElement, expectedCode As XElement, testOperation As Action(Of EnvDTE80.FileCodeModel2))
+        Protected Sub TestOperation(code As XElement, expectedCode As XElement, operation As Action(Of EnvDTE80.FileCodeModel2))
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
                 Dim fileCodeModel = state.FileCodeModel
                 Assert.NotNull(fileCodeModel)
 
-                testOperation(fileCodeModel)
+                operation(fileCodeModel)
 
                 Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
 
@@ -24,12 +24,30 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 Assert.NotNull(fileCodeModel)
 
                 fileCodeModel.BeginBatch()
-                testOperation(fileCodeModel)
+                operation(fileCodeModel)
                 fileCodeModel.EndBatch()
 
                 Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
 
                 Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
+            End Using
+        End Sub
+
+        Protected Sub TestOperation(code As XElement, operation As Action(Of EnvDTE80.FileCodeModel2))
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim fileCodeModel = state.FileCodeModel
+                Assert.NotNull(fileCodeModel)
+
+                operation(fileCodeModel)
+            End Using
+
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim fileCodeModel = state.FileCodeModel
+                Assert.NotNull(fileCodeModel)
+
+                fileCodeModel.BeginBatch()
+                operation(fileCodeModel)
+                fileCodeModel.EndBatch()
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -994,6 +994,33 @@ class D
             End Using
         End Sub
 
+        <WorkItem(925569)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ChangeClassNameAndGetNameOfChildFunction()
+            Dim code =
+<Code>
+class C
+{
+    void M() { }
+}
+</Code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim codeClass = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(codeClass)
+                    Assert.Equal("C", codeClass.Name)
+
+                    Dim codeFunction = TryCast(codeClass.Members.Item(1), EnvDTE.CodeFunction)
+                    Assert.NotNull(codeFunction)
+                    Assert.Equal("M", codeFunction.Name)
+
+                    codeClass.Name = "NewClassName"
+                    Assert.Equal("NewClassName", codeClass.Name)
+                    Assert.Equal("M", codeFunction.Name)
+                End Sub)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -922,6 +922,33 @@ End Class
 
         End Sub
 
+        <WorkItem(925569)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ChangeClassNameAndGetNameOfChildFunction()
+            Dim code =
+<Code>
+Class C
+    Sub M()
+    End Sub
+End Class
+</Code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim codeClass = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(codeClass)
+                    Assert.Equal("C", codeClass.Name)
+
+                    Dim codeFunction = TryCast(codeClass.Members.Item(1), EnvDTE.CodeFunction)
+                    Assert.NotNull(codeFunction)
+                    Assert.Equal("M", codeFunction.Name)
+
+                    codeClass.Name = "NewClassName"
+                    Assert.Equal("NewClassName", codeClass.Name)
+                    Assert.Equal("M", codeFunction.Name)
+                End Sub)
+        End Sub
+
         <WorkItem(2355, "https://github.com/dotnet/roslyn/issues/2355")>
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub CreateUnknownElementForDeclarationFunctionAndSub()


### PR DESCRIPTION
**Customer Scenario**: This bug can manifest in many ways as its an issue in the Code Model implementation, but the scenario reported is as follows:

1. Create a V1 Workflow Sequential Console Application project (targeting .NET Framework 3.5).
2. Click on the Workflow Designer
3. In the Properties window, change the (Name) of the workflow to something else (e.g. "NewWorkflow")

This results in a very unhelpful dialog:

![image](https://cloud.githubusercontent.com/assets/116161/7924876/de78e592-0873-11e5-8cc2-c38d64be3215.png)

When the user clicks OK, the (Name) property gets reverted to what it was before. However, the name was actually partially changed by the time the exception was thrown. So, the user finds that several files have been modified but the process was incomplete.

**Fix Description**: Code Model tracks nodes with a "node key" concept, which is effectively the full name of an element coupled with an ordinal. When the name of a ```CodeElement``` is modified view ```SetName```. its node key must also be updated since the name of the underlying node has changed. However, we had failed to update the node keys of any members of that ```CodeElement```, which means that they can no longer be located after their parent container's name changes. This is now fixed by using the same ```NodeKeysValidation``` helper that ```CodeElement.RenameSymbol``` uses.

**Testing Done**: Manually verified customer scenario working properly, and added unit test that fails without the fix and passes with the fix. Additionally, the Workflow team has been given private binaries with the fix to run their automation against.

Pinging @jasonmalinowski, @Pilchie, @pharring as stellar reviewers.