### PR TITLE
make formatting performance better

### DIFF
--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -211,26 +211,34 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private List<T> AddOperations<T>(List<SyntaxNode> nodes, Action<List<T>, SyntaxNode> addOperations, CancellationToken cancellationToken)
         {
-            var operations = new List<T>();
-            var list = new List<T>();
-
-            for (int i = 0; i < nodes.Count; i++)
+            using (var localOperations = new ThreadLocal<List<T>>(() => new List<T>(), trackAllValues: true))
+            using (var localList = new ThreadLocal<List<T>>(() => new List<T>(), trackAllValues: false))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                addOperations(list, nodes[i]);
-
-                foreach (var element in list)
+                // find out which executor we want to use.
+                var taskExecutor = nodes.Count > (1000 * Environment.ProcessorCount) ? TaskExecutor.Concurrent : TaskExecutor.Synchronous;
+                taskExecutor.ForEach(nodes, n =>
                 {
-                    if (element != null)
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var list = localList.Value;
+                    addOperations(list, n);
+
+                    foreach (var element in list)
                     {
-                        operations.Add(element);
+                        if (element != null)
+                        {
+                            localOperations.Value.Add(element);
+                        }
                     }
-                }
 
-                list.Clear();
+                    list.Clear();
+                }, cancellationToken);
+
+                var operations = new List<T>(localOperations.Values.Sum(v => v.Count));
+                operations.AddRange(localOperations.Values.SelectMany(v => v));
+
+                return operations;
             }
-
-            return operations;
         }
 
         private Task<TokenPairWithOperations[]> CreateTokenOperationTask(
@@ -441,7 +449,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 var partitioner = new Partitioner(context, tokenStream, tokenOperations);
 
                 // always create task 1 more than current processor count
-                var partitions = partitioner.GetPartitions(this.TaskExecutor == TaskExecutor.Synchronous ? 1 : Environment.ProcessorCount + 1);
+                var partitions = partitioner.GetPartitions(this.TaskExecutor == TaskExecutor.Synchronous ? 1 : Environment.ProcessorCount + 1, cancellationToken);
 
                 var tasks = new Task[partitions.Count];
                 for (int i = 0; i < partitions.Count; i++)

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -118,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Formatting_AggregateCreateFormattedRoot,
         Formatting_CreateTextChanges,
         Formatting_CreateFormattedRoot,
+        Formatting_Partitions,
 
         SmartIndentation_Start,
         SmartIndentation_OpenCurly,
@@ -303,6 +304,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         VirtualMemory_MemoryLow,
         Extension_Exception,
 
-        WorkCoordinator_WaitForHigherPriorityOperationsAsync,
+        WorkCoordinator_WaitForHigherPriorityOperationsAsync
     }
 }


### PR DESCRIPTION
this performance improvement is particularly for devdiv bug # 1089540

this makes the file in the bug to be formatted in several seconds compared to several minutes on my machine.

there were several issues. each one fixed by

#1, use concurrency on gathering operations.
#2, don't use too much time to split work to chunks if that requires more work than actually formatting.
#3, don't blindly set beginning of a file as inseparable start point for certain formatting options.

...

but these don't actually address the most impactful root cause of this perf issues. which is perf issue of GetPrevious/GetNextToken API in compiler.
(https://github.com/dotnet/roslyn/issues/3244)

formatter internally uses GetDescendantTokens to get all tokens at once and cache them which takes less than 1 second for the entire file (2M bytes size) in the bug. and use the cache internally.

but certain part of formatter (Rule Provider) can't use that internal cache, so it has to use the GetPrevious/GetNextToken to move around tokens, which in this particular bug, takes more than 40 seconds on my machine. and that is not even for entire file. (less than 1/12 of tokens)

I opened a bug to compiler team, hopely so that we can get better perf on those APIs.

in this PR, I mitigated the issue either by making more things to run concurrently or by changing logic which requires those APIs.