### PR TITLE
Gracefully bail out on extension method rewrite within conditional ac…

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3552,6 +3552,130 @@ class A
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")]
+        public void TestConditionalAccessWithExtensionMethodInvocation()
+        {
+            Test(
+            @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var [|assembly|] = t?.Something().First();
+            var identity = assembly?.ToArray();
+        }
+        return null;
+    }
+}
+", @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var identity = t?.Something().First()?.ToArray();
+        }
+        return null;
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")]
+        public void TestConditionalAccessWithExtensionMethodInvocation_2()
+        {
+            Test(
+            @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var [|assembly|] = (t?.Something2())()?.Something().First();
+            var identity = assembly?.ToArray();
+        }
+        return null;
+    }
+}
+", @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var identity = (t?.Something2())()?.Something().First()?.ToArray();
+        }
+        return null;
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestAliasQualifiedNameIntoInterpolation()
         {
             Test(

--- a/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
@@ -459,6 +459,245 @@ End Module
             Test(input, expected)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub VisualBasic_ExpandExtensionMethodInMemberAccessExpression()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = {|Expand:t.Something().First()|}
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = Global.System.Linq.Enumerable.First((CType((Global.M.Something((CType((t), Global.C)))), Global.System.Collections.Generic.IEnumerable(Of System.String))))
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact(Skip:="3260"), Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub VisualBasic_ExpandExtensionMethodInConditionalAccessExpression()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = {|Expand:t?.Something().First()|}
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = Global.System.Linq.Enumerable.First((CType(((CType((t), Global.C))?.Something()), Global.System.Collections.Generic.IEnumerable(Of System.String))))
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub VisualBasic_ExpandExtensionMethodInMemberAccessExpression_2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = {|Expand:t.Something2()().Something().First()|}
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = Global.System.Linq.Enumerable.First((CType((Global.M.Something((CType((Global.M.Something2((CType((t), Global.C)))()), Global.C)))), Global.System.Collections.Generic.IEnumerable(Of System.String))))
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact(Skip:="3260"), Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub VisualBasic_ExpandExtensionMethodInConditionalAccessExpression_2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = {|Expand:t?.Something2()?()?.Something().First()|}
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim x = Global.System.Linq.Enumerable.First((CType(((CType(((CType((t), Global.C))?.Something2()?()), Global.C)?.Something())), Global.System.Collections.Generic.IEnumerable(Of System.String))))
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</code>
+
+            Test(input, expected)
+        End Sub
 #End Region
 
 #Region "CSharp ExtensionMethodRewrite Expansion tests"
@@ -952,6 +1191,285 @@ public static class FooExtension
             Test(input, expected)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub CSharp_ExpandExtensionMethodInMemberAccessExpression()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = {|Expand:t.Something().First()|};
+        }
+        return null;
+    }
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = global::System.Linq.Enumerable.First<global::System.String>(global::M.Something(t));
+        }
+        return null;
+    }
+}]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact(Skip:="3260"), Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub CSharp_ExpandExtensionMethodInConditionalAccessExpression()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = {|Expand:t?.Something().First()|};
+        }
+        return null;
+    }
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = global::System.Linq.Enumerable.First<global::System.String>(t?.Something());
+        }
+        return null;
+    }
+}]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub CSharp_ExpandExtensionMethodInMemberAccessExpression_2()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = {|Expand:(t.Something2())().Something().First()|};
+        }
+        return null;
+    }
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = global::System.Linq.Enumerable.First<global::System.String>(global::M.Something((global::M.Something2(t))()));
+        }
+        return null;
+    }
+}]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact(Skip:="3260"), Trait(Traits.Feature, Traits.Features.Expansion)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        <WorkItem(3260, "https://github.com/dotnet/roslyn/issues/3260")>
+        Public Sub CSharp_ExpandExtensionMethodInConditionalAccessExpression_2()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = {|Expand:(t?.Something2())()?.Something().First()|};
+        }
+        return null;
+    }
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static class M
+{
+    public static IEnumerable<string> Something(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static Func<C> Something2(this C cust)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class C
+{
+    private object GetAssemblyIdentity(IEnumerable<C> types)
+    {
+        foreach (var t in types)
+        {
+            var x = global::System.Linq.Enumerable.First<global::System.String>((t?.Something2())()?.Something());
+        }
+        return null;
+    }
+}]]>
+</code>
+
+            Test(input, expected)
+        End Sub
 #End Region
 
     End Class

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -3914,6 +3914,118 @@ End Class
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        Public Sub TestConditionalAccessWithExtensionMethodInvocation()
+            Dim code =
+<File><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim [|assembly|] = t?.Something().First()
+            Dim identity = assembly?.ToArray()
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</File>
+
+            Dim expected =
+<File><![CDATA[
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim identity = (t?.Something().First())?.ToArray()
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
+        Public Sub TestConditionalAccessWithExtensionMethodInvocation_2()
+            Dim code =
+<File><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim [|assembly|] = t?.Something2?()?.Something().First()
+            Dim identity = (assembly)?.ToArray()
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</File>
+
+            Dim expected =
+<File><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Module M
+    <Extension()>
+    Public Function Something(cust As C) As IEnumerable(Of String)
+        Throw New NotImplementedException()
+    End Function
+
+    <Extension()>
+    Public Function Something2(cust As C) As Func(Of C)
+        Throw New NotImplementedException()
+    End Function
+End Module
+
+Class C
+    Private Function GetAssemblyIdentity(types As IEnumerable(Of C)) As Object
+        For Each t In types
+            Dim identity = ((t?.Something2?()?.Something().First()))?.ToArray()
+        Next
+        Return Nothing
+    End Function
+End Class]]>
+</File>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestXmlLiteral()
             Dim code =
 <File>


### PR DESCRIPTION
…cess expression

**Fixes #2593**

**User scenario:** User types a conditional access expression with a subsequent extension method invocation. For example, "a?.Method().ExtensionMethod()". Attempting to perform any simplification (cast simplification, simplify name) or refactorings (inline temporary) causes a exceptions in the simplification engine and all these IDE services are disabled for the project.

**Issue description:** We are not handling conditional access expressions, and hence member access or invocations with null "left of dot" nodes, in our expander. Additionally, performing extension method expansion (to a static method invocation with receiver replaced as the first argument to invocation) is non-trivial.

**Fix description:** This change makes a defensive fix by:

1. Guarding against null reference exceptions
2. Bailing out on extension method rewrite within conditional access expressions.

Long term fix would be to implement this feature in expand/reduce engine, but this should happen post 1.0 milestone. A separate issue will be opened to track this work.

**Testing:** Added regression tests + existing tests.

/cc @srivatsn @ManishJayaswal This is for 1.0 stable milestone.