### PR TITLE
Use undo transaction so razor docs don't have redundant undos

### DIFF
--- a/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -83,7 +84,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CommentSelection
                 var doc = workspace.Documents.First();
                 SetupSelection(doc.GetTextView(), doc.SelectedSpans.Select(s => Span.FromBounds(s.Start, s.End)));
 
-                var commandHandler = new CommentUncommentSelectionCommandHandler(TestWaitIndicator.Default);
+                var commandHandler = new CommentUncommentSelectionCommandHandler(
+                    TestWaitIndicator.Default,
+                    workspace.ExportProvider.GetExportedValue<ITextUndoHistoryRegistry>(),
+                    workspace.ExportProvider.GetExportedValue<IEditorOperationsFactoryService>());
                 var textView = doc.GetTextView();
                 var textBuffer = doc.GetTextBuffer();
                 commandHandler.ExecuteCommand(textView, textBuffer, CommentUncommentSelectionCommandHandler.Operation.Uncomment);

--- a/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
@@ -135,16 +135,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
                 });
         }
 
-        private static IEnumerable<TextSpan> GetUpdatedSpans(IEnumerable<TextChangeRange> ranges)
-        {
-            int delta = 0;
-            foreach (var range in ranges)
-            {
-                yield return new TextSpan(range.Span.Start + delta, range.NewLength);
-                delta += (range.NewLength - range.Span.Length);
-            }
-        }
-
         private void Format(ICommentUncommentService service, ITextSnapshot snapshot, IEnumerable<ITrackingSpan> changes, CancellationToken cancellationToken)
         {
             var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 using Moq;
 using Roslyn.Test.EditorUtilities;
 using Roslyn.Test.Utilities;
@@ -544,14 +545,15 @@ class Foo
         }
 
         private static void CommentOrUncommentSelection(
-
             ITextView textView,
             IEnumerable<TextChange> expectedChanges,
             IEnumerable<Span> expectedSelectedSpans,
             bool supportBlockComments,
             CommentUncommentSelectionCommandHandler.Operation operation)
         {
-            var commandHandler = new CommentUncommentSelectionCommandHandler(TestWaitIndicator.Default);
+            var textUndoHistoryRegistry = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<ITextUndoHistoryRegistry>();
+            var editorOperationsFactory = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<IEditorOperationsFactoryService>();
+            var commandHandler = new CommentUncommentSelectionCommandHandler(TestWaitIndicator.Default, textUndoHistoryRegistry, editorOperationsFactory);
             var service = new MockCommentUncommentService(supportBlockComments);
 
             var trackingSpans = new List<ITrackingSpan>();

--- a/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CommentSelection
     Public Class VisualBasicCommentSelectionTests
@@ -78,7 +79,10 @@ End Module</code>
                 Dim doc = workspace.Documents.First()
                 SetupSelection(doc.GetTextView(), spans.Select(Function(s) Span.FromBounds(s.Start, s.End)))
 
-                Dim commandHandler = New CommentUncommentSelectionCommandHandler(TestWaitIndicator.Default)
+                Dim commandHandler = New CommentUncommentSelectionCommandHandler(
+                    TestWaitIndicator.Default,
+                    workspace.ExportProvider.GetExportedValue(Of ITextUndoHistoryRegistry),
+                    workspace.ExportProvider.GetExportedValue(Of IEditorOperationsFactoryService))
                 Dim textView = doc.GetTextView()
                 Dim textBuffer = doc.GetTextBuffer()
                 commandHandler.ExecuteCommand(textView, textBuffer, operation)


### PR DESCRIPTION
Fixes devdiv 766411 (partly)

The problem is that using uncomment feature on vb code in vbhtml files leaves the undo stack with four individual undos, instead of one or maybe two.  (Usually there are two, one for the text change and one for the auto-formatting change.)

Part of the problem is that the razor docs have special logic when applying changes back to the buffer and actually do two edits, one to apply the changes and then another that does indentation adjustment after the fact.  This normally causes two undo items per call to workspace TryApplyChanges for a razor document.  However, most command handler features wrap calls to TryApplyChanges with undo transactions so they end up with only one.  The comment/un-comment handler was not doing this.  That has been changed with this PR.

Unfortunately that still leaves 3 undos instead of the desired 2, but its an improvement.

@Pilchie @jasonmalinowski please review.