### PR TITLE
Do not cut short binding of “return” statement even if expression has syntax errors.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2843,7 +2843,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (arg != null)
             {
-                hasErrors = arg.HasAnyErrors;
+                hasErrors = arg.HasErrors || ((object)arg.Type != null && arg.Type.IsErrorType());
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -1159,5 +1159,142 @@ class Program
                 Diagnostic(ErrorCode.ERR_CantReturnVoid, "System.Console.Beep()").WithLocation(8, 27)
                 );
         }
+
+        [Fact, WorkItem(1179899, "DevDiv")]
+        public void ParameterReference_01()
+        {
+            var src = @"
+using System;
+
+class Program
+{
+    static Func<Program, string> stuff()
+    {
+        return a => a.
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib(src);
+            compilation.VerifyDiagnostics(
+    // (8,23): error CS1001: Identifier expected
+    //         return a => a.
+    Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(8, 23),
+    // (8,23): error CS1002: ; expected
+    //         return a => a.
+    Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(8, 23)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+
+            Assert.Equal("a.", node.Parent.ToString().Trim());
+
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var symbolInfo = semanticModel.GetSymbolInfo(node);
+
+            Assert.Equal("Program a", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(1179899, "DevDiv")]
+        public void ParameterReference_02()
+        {
+            var src = @"
+using System;
+
+class Program
+{
+    static void stuff()
+    {
+        Func<Program, string> l = a => a.
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib(src);
+            compilation.VerifyDiagnostics(
+    // (8,42): error CS1001: Identifier expected
+    //         Func<Program, string> l = a => a.
+    Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(8, 42),
+    // (8,42): error CS1002: ; expected
+    //         Func<Program, string> l = a => a.
+    Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(8, 42)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+
+            Assert.Equal("a.", node.Parent.ToString().Trim());
+
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var symbolInfo = semanticModel.GetSymbolInfo(node);
+
+            Assert.Equal("Program a", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(1179899, "DevDiv")]
+        public void ParameterReference_03()
+        {
+            var src = @"
+using System;
+
+class Program
+{
+    static void stuff()
+    {
+         M1(a => a.);
+    }
+
+    static void M1(Func<Program, string> l){}
+}
+";
+            var compilation = CreateCompilationWithMscorlib(src);
+            compilation.VerifyDiagnostics(
+    // (8,20): error CS1001: Identifier expected
+    //          M1(a => a.);
+    Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(8, 20)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+
+            Assert.Equal("a.", node.Parent.ToString().Trim());
+
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var symbolInfo = semanticModel.GetSymbolInfo(node);
+
+            Assert.Equal("Program a", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(1179899, "DevDiv")]
+        public void ParameterReference_04()
+        {
+            var src = @"
+using System;
+
+class Program
+{
+    static void stuff()
+    {
+        var l = (Func<Program, string>) (a => a.);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib(src);
+            compilation.VerifyDiagnostics(
+    // (8,49): error CS1001: Identifier expected
+    //         var l = (Func<Program, string>) (a => a.);
+    Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(8, 49)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+
+            Assert.Equal("a.", node.Parent.ToString().Trim());
+
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var symbolInfo = semanticModel.GetSymbolInfo(node);
+
+            Assert.Equal("Program a", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaSemanticInfoTests.vb
@@ -821,6 +821,154 @@ End Class
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
         End Sub
 
+        <Fact, WorkItem(1179899, "DevDiv")>
+        Public Sub ParameterReference_01()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation name="InstantiatingNamespace">
+        <file name="a.vb">
+Imports System
+
+Class Program
+    Shared Sub Main(args As String())
+    End Sub
+
+    Function stuff() As Func(Of Program, String)
+        Return Function(a) a.
+    End Function
+
+End Class
+    </file>
+    </compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30203: Identifier expected.
+        Return Function(a) a.
+                             ~
+                                               </expected>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(id) id.Identifier.ValueText = "a").Single()
+
+            Assert.Equal("a.", node.Parent.ToString())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+
+            Assert.Equal("a As Program", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem(1179899, "DevDiv")>
+        Public Sub ParameterReference_02()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation name="InstantiatingNamespace">
+        <file name="a.vb">
+Imports System
+
+Class Program
+    Shared Sub Main(args As String())
+    End Sub
+
+    Sub stuff()
+        M1(Function(a) a.)
+    End Sub
+
+    Sub M1(l as Func(Of Program, String))
+    End Sub
+End Class
+    </file>
+    </compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30203: Identifier expected.
+        M1(Function(a) a.)
+                         ~
+                                               </expected>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(id) id.Identifier.ValueText = "a").Single()
+
+            Assert.Equal("a.", node.Parent.ToString())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+
+            Assert.Equal("a As Program", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem(1179899, "DevDiv")>
+        Public Sub ParameterReference_03()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation name="InstantiatingNamespace">
+        <file name="a.vb">
+Imports System
+
+Class Program
+    Shared Sub Main(args As String())
+    End Sub
+
+    Sub stuff()
+        Dim l as Func(Of Program, String) = Function(a) a.
+    End Sub
+End Class
+    </file>
+    </compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30203: Identifier expected.
+        Dim l as Func(Of Program, String) = Function(a) a.
+                                                          ~
+                                               </expected>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(id) id.Identifier.ValueText = "a").Single()
+
+            Assert.Equal("a.", node.Parent.ToString().Trim())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+
+            Assert.Equal("a As Program", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem(1179899, "DevDiv")>
+        Public Sub ParameterReference_04()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation name="InstantiatingNamespace">
+        <file name="a.vb">
+Imports System
+
+Class Program
+    Shared Sub Main(args As String())
+    End Sub
+
+    Sub stuff()
+        Dim l = CType(Function(a) a. , Func(Of Program, String))
+    End Sub
+End Class
+    </file>
+    </compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30203: Identifier expected.
+        Dim l = CType(Function(a) a. , Func(Of Program, String))
+                                     ~
+                                               </expected>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(id) id.Identifier.ValueText = "a").Single()
+
+            Assert.Equal("a.", node.Parent.ToString().Trim())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+
+            Assert.Equal("a As Program", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Addresses DevDiv 1179899.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.