### PR TITLE
Code Model: Clean up PartialTypeCollection, making it more resilient

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
@@ -22,29 +22,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return (EnvDTE.CodeElements)ComAggregate.CreateAggregatedObject(collection);
         }
 
-        private readonly ComHandle<EnvDTE.FileCodeModel, FileCodeModel> _fileCodeModelHandle;
-        private ImmutableArray<EnvDTE.CodeElement> _parts;
-
         private PartialTypeCollection(
             CodeModelState state,
             FileCodeModel fileCodeModel,
             AbstractCodeType parent)
             : base(state, parent)
         {
-            _fileCodeModelHandle = new ComHandle<EnvDTE.FileCodeModel, FileCodeModel>(fileCodeModel);
         }
 
-        private AbstractCodeType ParentType
-        {
-            get { return (AbstractCodeType)this.Parent; }
-        }
+        private ImmutableArray<EnvDTE.CodeElement> _parts;
+
+        private AbstractCodeType ParentType => (AbstractCodeType)this.Parent;
 
         private ImmutableArray<EnvDTE.CodeElement> GetParts()
         {
             // Retrieving the parts is potentially very expensive because it can force multiple FileCodeModels to be instantiated.
             // Here, we cache the result to avoid having to perform these calculations each time GetParts() is called.
             // This *could* be an issue because it means that a PartialTypeCollection will not necessarily reflect the
-            // current state of the user's code. However, because a new PartialTypeCollection is created everytime a the Parts
+            // current state of the user's code. However, because a new PartialTypeCollection is created everytime the Parts
             // property is accessed on CodeClass, CodeStruct or CodeInterface, consumers would hit this behavior rarely.
             if (this._parts == null)
             {
@@ -55,9 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
 
                 foreach (var location in symbol.Locations.Where(l => l.IsInSource))
                 {
-                    var tree = location.SourceTree;
-                    var document = solution.GetDocument(tree);
-
+                    var document = solution.GetDocument(location.SourceTree);
                     if (document != null)
                     {
                         var fileCodeModelObject = this.Workspace.GetFileCodeModel(document.Id);
@@ -80,11 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return this._parts;
         }
 
-        internal override Snapshot CreateSnapshot()
-        {
-            var parts = GetParts();
-            return new CodeElementSnapshot(parts);
-        }
+        internal override Snapshot CreateSnapshot() => new CodeElementSnapshot(GetParts());
 
         protected override bool TryGetItemByIndex(int index, out EnvDTE.CodeElement element)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
         }
 
         private readonly ComHandle<EnvDTE.FileCodeModel, FileCodeModel> _fileCodeModelHandle;
+        private ImmutableArray<EnvDTE.CodeElement> _parts;
 
         private PartialTypeCollection(
             CodeModelState state,
@@ -33,11 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _fileCodeModelHandle = new ComHandle<EnvDTE.FileCodeModel, FileCodeModel>(fileCodeModel);
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModelHandle.Object; }
-        }
-
         private AbstractCodeType ParentType
         {
             get { return (AbstractCodeType)this.Parent; }
@@ -45,25 +41,43 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
 
         private ImmutableArray<EnvDTE.CodeElement> GetParts()
         {
-            var partsBuilder = ImmutableArray.CreateBuilder<EnvDTE.CodeElement>();
-            var symbol = ParentType.LookupSymbol();
-
-            foreach (var location in symbol.Locations.Where(l => l.IsInSource))
+            // Retrieving the parts is potentially very expensive because it can force multiple FileCodeModels to be instantiated.
+            // Here, we cache the result to avoid having to perform these calculations each time GetParts() is called.
+            // This *could* be an issue because it means that a PartialTypeCollection will not necessarily reflect the
+            // current state of the user's code. However, because a new PartialTypeCollection is created everytime a the Parts
+            // property is accessed on CodeClass, CodeStruct or CodeInterface, consumers would hit this behavior rarely.
+            if (this._parts == null)
             {
-                var tree = location.SourceTree;
-                var document = this.Workspace.CurrentSolution.GetDocument(tree);
+                var partsBuilder = ImmutableArray.CreateBuilder<EnvDTE.CodeElement>();
 
-                var fileCodeModelObject = this.Workspace.GetFileCodeModel(document.Id);
-                var fileCodeModel = ComAggregate.GetManagedObject<FileCodeModel>(fileCodeModelObject);
+                var solution = this.Workspace.CurrentSolution;
+                var symbol = ParentType.LookupSymbol();
 
-                var element = fileCodeModel.CodeElementFromPosition(location.SourceSpan.Start, ParentType.Kind);
-                if (element != null)
+                foreach (var location in symbol.Locations.Where(l => l.IsInSource))
                 {
-                    partsBuilder.Add(element);
+                    var tree = location.SourceTree;
+                    var document = solution.GetDocument(tree);
+
+                    if (document != null)
+                    {
+                        var fileCodeModelObject = this.Workspace.GetFileCodeModel(document.Id);
+                        if (fileCodeModelObject != null)
+                        {
+                            var fileCodeModel = ComAggregate.GetManagedObject<FileCodeModel>(fileCodeModelObject);
+
+                            var element = fileCodeModel.CodeElementFromPosition(location.SourceSpan.Start, ParentType.Kind);
+                            if (element != null)
+                            {
+                                partsBuilder.Add(element);
+                            }
+                        }
+                    }
                 }
+
+                this._parts = partsBuilder.ToImmutable();
             }
 
-            return partsBuilder.ToImmutable();
+            return this._parts;
         }
 
         internal override Snapshot CreateSnapshot()
@@ -100,9 +114,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return false;
         }
 
-        public override int Count
-        {
-            get { return GetParts().Length; }
-        }
+        public override int Count => GetParts().Length;
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/Snapshot.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/Snapshot.cs
@@ -1,11 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Collections
 {
     internal abstract class Snapshot


### PR DESCRIPTION
A crash with no reliable repro was reported for Silverlight projects with a call stack pointing to Code Model's PartialTypeCollection.GetParts(). While it wasn't possible to figure out a repro from the call stack, it was clear that a NullReferenceException was being thrown after ```VisualStudioWorkspace.GetFileCodeModel(DocumentId)``` returned null. This change makes that code more resilient against crashes. Additionally, it caches the result of GetParts().