### PR TITLE
Fix ITypeSymbolExtensions.IsOrDerivedFromExceptionType to handle type…

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3749,5 +3749,45 @@ class D : C
 
 }");
         }
+
+        [WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveCastToTypeParameterWithExceptionContraint()
+        {
+            TestMissing(
+@"using System;
+
+class Program
+{
+    private static void RequiresCondition<TException>(bool condition, string messageOnFalseCondition)
+            where TException : Exception
+    {
+        if (!condition)
+        {
+            throw [|(TException)Activator.CreateInstance(typeof(TException), messageOnFalseCondition)|];
+        }
+    }
+}");
+        }
+
+        [WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public void DontRemoveCastToTypeParameterWithExceptionSubTypeContraint()
+        {
+            TestMissing(
+@"using System;
+
+class Program
+{
+    private static void RequiresCondition<TException>(bool condition, string messageOnFalseCondition)
+            where TException : ArgumentException
+    {
+        if (!condition)
+        {
+            throw [|(TException)Activator.CreateInstance(typeof(TException), messageOnFalseCondition)|];
+        }
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -2658,5 +2658,41 @@ End Class
 </File>
             TestMissing(markup)
         End Sub
+
+        <WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        Public Sub DontRemoveCastToTypeParameterWithExceptionContraint()
+            Dim markup =
+<File>
+Imports System
+
+Class Program
+    Private Shared Sub RequiresCondition(Of TException As Exception)(condition As Boolean, messageOnFalseCondition As String)
+        If Not condition Then
+            Throw [|DirectCast(Activator.CreateInstance(GetType(TException), messageOnFalseCondition), TException)|]
+        End If
+    End Sub
+End Class
+</File>
+            TestMissing(markup)
+        End Sub
+
+        <WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        Public Sub DontRemoveCastToTypeParameterWithExceptionSubTypeContraint()
+            Dim markup =
+<File>
+Imports System
+
+Class Program
+    Private Shared Sub RequiresCondition(Of TException As ArgumentException)(condition As Boolean, messageOnFalseCondition As String)
+        If Not condition Then
+            Throw [|DirectCast(Activator.CreateInstance(GetType(TException), messageOnFalseCondition), TException)|]
+        End If
+    End Sub
+End Class
+</File>
+            TestMissing(markup)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -777,12 +777,29 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (type != null)
             {
-                foreach (var baseType in type.GetBaseTypesAndThis())
+                switch(type.Kind)
                 {
-                    if (baseType.Equals(compilation.ExceptionType()))
-                    {
-                        return true;
-                    }
+                    case SymbolKind.NamedType:
+                        foreach (var baseType in type.GetBaseTypesAndThis())
+                        {
+                            if (baseType.Equals(compilation.ExceptionType()))
+                            {
+                                return true;
+                            }
+                        }
+
+                        break;
+
+                    case SymbolKind.TypeParameter:
+                        foreach (var constraint in ((ITypeParameterSymbol)type).ConstraintTypes)
+                        {
+                            if (constraint.IsOrDerivesFromExceptionType(compilation))
+                            {
+                                return true;
+                            }
+                        }
+
+                        break;
                 }
             }
 


### PR DESCRIPTION
… parameters constrained on Exception type or its subtype

**Fixes https://github.com/dotnet/roslyn/issues/3254**

**User scenario:** User writes code where they have explicit casts to a type parameter deriving from `Exception` type or its subtype. We will offer incorrect cast removal fixes to remove these explicit casts. Removing such casts will cause their code to not compile. Even worse, if they apply a FixAll occurrences code fix, then all such casts across their (document/project/solution) will be removed, causing tons of compile errors.

**Fix description:** `IsOrDerivedFromExceptionType` was only checking for base types of the given type symbol to detect if the type is an `Exception` type. We also need to handle type parameters which are constrained by `Exception` or its subtypes.

**Testing:** Added regression tests + existing tests.

/cc @ManishJayaswal @srivatsn This is for 1.0 stable milestone.