### PR TITLE
Update stabilization cibuild scripts

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,17 +1,31 @@
+@setlocal enabledelayedexpansion
+
+REM Parse Arguments.
+
+set RoslynRoot=%~dp0
+set BuildConfiguration=Debug
+:ParseArguments
+if "%1" == "" goto :DoneParsing
+if /I "%1" == "/?" call :Usage && exit /b 1
+if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
+if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
+call :Usage && exit /b 1
+:DoneParsing
+
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
 REM Build the compiler so we can self host it for the full build
-src\.nuget\NuGet.exe restore src\Toolset.sln -packagesdirectory packages
-msbuild /nologo /v:m /m src/Compilers/Core/VBCSCompiler/VBCSCompiler.csproj
-msbuild /nologo /v:m /m src/Compilers/CSharp/csc2/csc2.csproj
-msbuild /nologo /v:m /m src/Compilers/VisualBasic/vbc2/vbc2.csproj
+src\.nuget\NuGet.exe restore %RoslynRoot%/src/Toolset.sln -packagesdirectory packages
+msbuild /nologo /v:m /m %RoslynRoot%/src/Compilers/Core/VBCSCompiler/VBCSCompiler.csproj /p:Configuration=%BuildConfiguration%
+msbuild /nologo /v:m /m %RoslynRoot%/src/Compilers/CSharp/csc2/csc2.csproj /p:Configuration=%BuildConfiguration%
+msbuild /nologo /v:m /m %RoslynRoot%/src/Compilers/VisualBasic/vbc2/vbc2.csproj /p:Configuration=%BuildConfiguration%
 
-mkdir Binaries\Bootstrap
-move Binaries\Debug\* Binaries\Bootstrap
-msbuild /v:m /t:Clean src/Toolset.sln
+mkdir %RoslynRoot%\Binaries\Bootstrap
+move Binaries\%BuildConfiguration%\* %RoslynRoot%\Binaries\Bootstrap
+msbuild /v:m /t:Clean src/Toolset.sln /p:Configuration=%BuildConfiguration%
 taskkill /F /IM vbcscompiler.exe
 
-msbuild /v:m /m /p:BootstrapBuildPath=%~dp0\Binaries\Bootstrap BuildAndTest.proj /p:CIBuild=true
+msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap BuildAndTest.proj /p:CIBuild=true /p:Configuration=%BuildConfiguration%
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe
     echo Build failed
@@ -25,3 +39,9 @@ taskkill /F /IM vbcscompiler.exe
 REM It is okay and expected for taskkill to fail (it's a cleanup routine).  Ensure
 REM caller sees successful exit.
 exit /b 0
+
+:Usage
+@echo Usage: cibuild.cmd [/debug^|/release]
+@echo   /debug 	Perform debug build.  This is the default.
+@echo   /release Perform release build
+@goto :eof

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage()
 {
@@ -7,12 +7,13 @@ usage()
     echo ""
     echo "Options"
     echo "  --mono-path <path>  Path to the mono installation to use for the run" 
-	echo "  --os <os>			OS to run (Linux / Darwin)"
-	echo "  --minimal			Run a minimal set of suites (used when upgrading mono)"
+    echo "  --os <os>           OS to run (Linux / Darwin)"
+    echo "  --minimal           Run a minimal set of suites (used when upgrading mono)"
 }
 
 XUNIT_VERSION=2.0.0-alpha-build2576
 FULL_RUN=true
+BUILD_CONFIGURATION=Debug
 OS_NAME=$(uname -s)
 
 while [[ $# > 0 ]]
@@ -33,6 +34,14 @@ do
         ;;
         --minimal)
         FULL_RUN=false
+        shift 1
+        ;;
+        --debug)
+        BUILD_CONFIGURATION=Debug
+        shift 1
+        ;;
+        --release)
+        BUILD_CONFIGURATION=Release
         shift 1
         ;;
         *)
@@ -74,15 +83,15 @@ compile_toolset()
 {
     echo Compiling the toolset compilers
     echo -e "\tCompiling the C# compiler"
-    run_xbuild src/Compilers/CSharp/csc/csc.csproj
+    run_xbuild src/Compilers/CSharp/csc/csc.csproj /p:Configuration=$BUILD_CONFIGURATION
 
     if [ "$FULL_RUN" = "true" ]; then
         echo -e "\tCompiling VB compiler"
-        run_xbuild src/Compilers/VisualBasic/vbc/vbc.csproj
+        run_xbuild src/Compilers/VisualBasic/vbc/vbc.csproj /p:Configuration=$BUILD_CONFIGURATION
     fi
 }
 
-# Save the toolset binaries from Binaries/Debug to Binaries/Bootstrap
+# Save the toolset binaries from Binaries/BUILD_CONFIGURATION to Binaries/Bootstrap
 save_toolset()
 {
     local compiler_binaries=(
@@ -101,7 +110,7 @@ save_toolset()
 
     mkdir Binaries/Bootstrap
     for i in ${compiler_binaries[@]}; do
-        cp Binaries/Debug/${i} Binaries/Bootstrap/${i}
+        cp Binaries/$BUILD_CONFIGURATION/${i} Binaries/Bootstrap/${i}
         if [ $? -ne 0 ]; then
             echo Saving bootstrap binaries failed
             exit 1
@@ -114,8 +123,8 @@ save_toolset()
 clean_roslyn()
 {
     echo Cleaning the enlistment
-    xbuild /v:m /t:Clean src/Toolset.sln
-    rm -rf Binaries/Debug
+    xbuild /v:m /t:Clean src/Toolset.sln /p:Configuration=$BUILD_CONFIGURATION
+    rm -rf Binaries/$BUILD_CONFIGURATION
 }
 
 build_roslyn()
@@ -126,10 +135,10 @@ build_roslyn()
 
     if [ "$FULL_RUN" = "true" ]; then
         echo -e "\tCompiling CrossPlatform.sln"
-        run_xbuild $BOOTSTRAP_ARG src/CrossPlatform.sln
+        run_xbuild $BOOTSTRAP_ARG src/CrossPlatform.sln /p:Configuration=$BUILD_CONFIGURATION
     else
         echo -e "\tCompiling the C# compiler"
-        run_xbuild $BOOTSTRAP_ARG src/Compilers/CSharp/csc/csc.csproj
+        run_xbuild $BOOTSTRAP_ARG src/Compilers/CSharp/csc/csc.csproj /p:Configuration=$BUILD_CONFIGURATION
     fi
 }
 
@@ -201,7 +210,7 @@ test_roslyn()
 
     for i in "${test_binaries[@]}"
     do
-        mono $xunit_runner Binaries/Debug/$i.dll -xml Binaries/Debug/$i.TestResults.xml -noshadow
+        mono $xunit_runner Binaries/$BUILD_CONFIGURATION/$i.dll -xml Binaries/$BUILD_CONFIGURATION/$i.TestResults.xml -noshadow
         if [ $? -ne 0 ]; then
             any_failed=true
         fi


### PR DESCRIPTION
The cibuild scripts had diverged between stabilization and master. This
change brings stabilization back in sync with master and makes a small
change to ensure passing invalid commandline arguments returns a proper
error code.

Interested parties: @amcasey @jaredpar