### PR TITLE
Code Model: Fix issue with parented code model objects corrupting their parents

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -482,6 +482,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             }
         }
 
+        /// <summary>
+        /// Do not use this method directly! Instead, go through <see cref="FileCodeModel.CreateCodeElement{T}(SyntaxNode)"/>
+        /// </summary>
         public override EnvDTE.CodeElement CreateInternalCodeElement(
             CodeModelState state,
             FileCodeModel fileCodeModel,

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -266,6 +266,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
         }
 
+        /// <summary>
+        /// Do not use this method directly! Instead, go through <see cref="FileCodeModel.CreateCodeElement{T}(SyntaxNode)"/>
+        /// </summary>
         public abstract EnvDTE.CodeElement CreateInternalCodeElement(
             CodeModelState state,
             FileCodeModel fileCodeModel,
@@ -350,15 +353,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         protected EnvDTE.CodeFunction CreateInternalCodeAccessorFunction(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node)
         {
-            SyntaxNode parentNode = node.Ancestors()
-                                              .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
+            SyntaxNode parentNode = node
+                .Ancestors()
+                .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
 
             if (parentNode == null)
             {
                 throw new InvalidOperationException();
             }
 
-            var parent = CreateInternalCodeElement(state, fileCodeModel, parentNode);
+            var parent = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
             var parentObj = ComAggregate.GetManagedObject<AbstractCodeMember>(parent);
             var accessorKind = GetAccessorKind(node);
 
@@ -373,7 +377,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             if (IsParameterNode(parentNode))
             {
-                var parentElement = CreateInternalCodeParameter(state, fileCodeModel, parentNode);
+                var parentElement = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
                 parentObject = ComAggregate.GetManagedObject<AbstractCodeElement>(parentElement);
             }
             else
@@ -415,7 +419,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             AbstractCodeElement parentObj = null;
             if (parentNode != null)
             {
-                var parent = CreateInternalCodeElement(state, fileCodeModel, parentNode);
+                var parent = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
                 parentObj = ComAggregate.GetManagedObject<AbstractCodeElement>(parent);
             }
 
@@ -424,8 +428,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         protected EnvDTE.CodeParameter CreateInternalCodeParameter(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node)
         {
-            SyntaxNode parentNode = node.Ancestors()
-                                              .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
+            SyntaxNode parentNode = node
+                .Ancestors()
+                .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
 
             if (parentNode == null)
             {
@@ -434,7 +439,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             string name = GetParameterName(node);
 
-            var parent = CreateInternalCodeElement(state, fileCodeModel, parentNode);
+            var parent = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
             var parentObj = ComAggregate.GetManagedObject<AbstractCodeMember>(parent);
 
             return CodeParameter.Create(state, parentObj, name);
@@ -451,8 +456,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         protected EnvDTE80.CodeElement2 CreateInternalCodeInheritsStatement(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node)
         {
-            SyntaxNode parentNode = node.Ancestors()
-                                              .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
+            SyntaxNode parentNode = node
+                .Ancestors()
+                .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
 
             if (parentNode == null)
             {
@@ -463,7 +469,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             int ordinal;
             GetInheritsNamespaceAndOrdinal(parentNode, node, out namespaceName, out ordinal);
 
-            var parent = CreateInternalCodeElement(state, fileCodeModel, parentNode);
+            var parent = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
             var parentObj = ComAggregate.GetManagedObject<AbstractCodeMember>(parent);
 
             return CodeInheritsStatement.Create(state, parentObj, namespaceName, ordinal);
@@ -471,8 +477,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         protected EnvDTE80.CodeElement2 CreateInternalCodeImplementsStatement(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node)
         {
-            SyntaxNode parentNode = node.Ancestors()
-                                              .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
+            SyntaxNode parentNode = node
+                .Ancestors()
+                .FirstOrDefault(n => TryGetNodeKey(n) != SyntaxNodeKey.Empty);
 
             if (parentNode == null)
             {
@@ -483,7 +490,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             int ordinal;
             GetImplementsNamespaceAndOrdinal(parentNode, node, out namespaceName, out ordinal);
 
-            var parent = CreateInternalCodeElement(state, fileCodeModel, parentNode);
+            var parent = fileCodeModel.CreateCodeElement<EnvDTE.CodeElement>(parentNode);
             var parentObj = ComAggregate.GetManagedObject<AbstractCodeMember>(parent);
 
             return CodeImplementsStatement.Create(state, parentObj, namespaceName, ordinal);

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -73,6 +73,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         string Language { get; }
         string AssemblyAttributeString { get; }
 
+        /// <summary>
+        /// Do not use this method directly! Instead, go through <see cref="FileCodeModel.CreateCodeElement{T}(SyntaxNode)"/>
+        /// </summary>
         EnvDTE.CodeElement CreateInternalCodeElement(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node);
         EnvDTE.CodeElement CreateExternalCodeElement(CodeModelState state, ProjectId projectId, ISymbol symbol);
         EnvDTE.CodeElement CreateUnknownCodeElement(CodeModelState state, FileCodeModel fileCodeModel, SyntaxNode node);

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -3,6 +3,8 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -1018,6 +1020,113 @@ class C
                     codeClass.Name = "NewClassName"
                     Assert.Equal("NewClassName", codeClass.Name)
                     Assert.Equal("M", codeFunction.Name)
+                End Sub)
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_PropertyAccessor()
+            Dim code =
+<code>
+class C
+{
+    int P
+    {
+        get { return 0; }
+    }
+}
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim propertyP = TryCast(classC.Members.Item(1), EnvDTE.CodeProperty)
+                    Assert.NotNull(propertyP)
+                    Assert.Equal("P", propertyP.Name)
+
+                    Dim getter = propertyP.Getter
+                    Assert.NotNull(getter)
+
+                    Dim searchedGetter = fileCodeModel.CodeElementFromPoint(getter.StartPoint, EnvDTE.vsCMElement.vsCMElementFunction)
+
+                    Dim parent = TryCast(getter.Collection.Parent, EnvDTE.CodeProperty)
+                    Assert.NotNull(parent)
+                    Assert.Equal("P", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where a property accessor creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("P") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use propertyP's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C.P,2} rather than {C.P,1}).
+                    Assert.Equal("P", propertyP.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(propertyP)
+
+                    Assert.Equal("C.P", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C.P", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
+                End Sub)
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_EventAccessor()
+            Dim code =
+<code>
+class C
+{
+    event System.EventHandler E
+    {
+        add { }
+        remove { }
+    }
+}
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim eventE = TryCast(classC.Members.Item(1), EnvDTE80.CodeEvent)
+                    Assert.NotNull(eventE)
+                    Assert.Equal("E", eventE.Name)
+
+                    Dim adder = eventE.Adder
+                    Assert.NotNull(adder)
+
+                    Dim searchedAdder = fileCodeModel.CodeElementFromPoint(adder.StartPoint, EnvDTE.vsCMElement.vsCMElementFunction)
+
+                    Dim parent = TryCast(adder.Collection.Parent, EnvDTE80.CodeEvent)
+                    Assert.NotNull(parent)
+                    Assert.Equal("E", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where an event accessor creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("P") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use propertyP's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C.E,2} rather than {C.E,1}).
+                    Assert.Equal("E", eventE.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(eventE)
+
+                    Assert.Equal("C.E", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C.E", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
                 End Sub)
         End Sub
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -4,6 +4,8 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
@@ -1019,6 +1021,209 @@ End Class
 
                 End Using
             End Using
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_InheritsStatements()
+            Dim code =
+<code>
+Class A
+End Class
+
+Class C
+    Inherits A
+End Class
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(2), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim inheritsA = TryCast(classC.Children.Item(1), EnvDTE80.CodeElement2)
+                    Assert.NotNull(inheritsA)
+
+                    Dim parent = TryCast(inheritsA.Collection.Parent, EnvDTE.CodeClass)
+                    Assert.NotNull(parent)
+                    Assert.Equal("C", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where the VB Inherits statement creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("C") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use classC's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C,2} rather than {C,1}).
+                    Assert.Equal("C", classC.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(classC)
+
+                    Assert.Equal("C", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
+                End Sub)
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_ImplementsStatements()
+            Dim code =
+<code>
+Interface I
+End Interface
+
+Class C
+    Implements I
+End Class
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(2), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim implementsI = TryCast(classC.Children.Item(1), EnvDTE80.CodeElement2)
+                    Assert.NotNull(implementsI)
+
+                    Dim parent = TryCast(implementsI.Collection.Parent, EnvDTE.CodeClass)
+                    Assert.NotNull(parent)
+                    Assert.Equal("C", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where the VB Implements statement creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("C") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use classC's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C,2} rather than {C,1}).
+                    Assert.Equal("C", classC.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(classC)
+
+                    Assert.Equal("C", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
+                End Sub)
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_PropertyAccessor()
+            Dim code =
+<code>
+Class C
+    ReadOnly Property P As Integer
+        Get
+        End Get
+    End Property
+End Class
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim propertyP = TryCast(classC.Members.Item(1), EnvDTE.CodeProperty)
+                    Assert.NotNull(propertyP)
+                    Assert.Equal("P", propertyP.Name)
+
+                    Dim getter = propertyP.Getter
+                    Assert.NotNull(getter)
+
+                    Dim searchedGetter = fileCodeModel.CodeElementFromPoint(getter.StartPoint, EnvDTE.vsCMElement.vsCMElementFunction)
+
+                    Dim parent = TryCast(getter.Collection.Parent, EnvDTE.CodeProperty)
+                    Assert.NotNull(parent)
+                    Assert.Equal("P", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where a property accessor creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("P") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use propertyP's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C.P As Integer,2} rather than {C.P As Integer,1}).
+                    Assert.Equal("P", propertyP.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(propertyP)
+
+                    Assert.Equal("C.P As Integer", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C.P As Integer", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
+                End Sub)
+        End Sub
+
+        <WorkItem(858153)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestCodeElements_EventAccessor()
+            Dim code =
+<code>
+Class C
+    Custom Event E As System.EventHandler
+        AddHandler(value As System.EventHandler)
+
+        End AddHandler
+        RemoveHandler(value As System.EventHandler)
+
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As System.EventArgs)
+
+        End RaiseEvent
+    End Event
+End Class
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim classC = TryCast(fileCodeModel.CodeElements.Item(1), EnvDTE.CodeClass)
+                    Assert.NotNull(classC)
+                    Assert.Equal("C", classC.Name)
+
+                    Dim eventE = TryCast(classC.Members.Item(1), EnvDTE80.CodeEvent)
+                    Assert.NotNull(eventE)
+                    Assert.Equal("E", eventE.Name)
+
+                    Dim adder = eventE.Adder
+                    Assert.NotNull(adder)
+
+                    Dim searchedAdder = fileCodeModel.CodeElementFromPoint(adder.StartPoint, EnvDTE.vsCMElement.vsCMElementFunction)
+
+                    Dim parent = TryCast(adder.Collection.Parent, EnvDTE80.CodeEvent)
+                    Assert.NotNull(parent)
+                    Assert.Equal("E", parent.Name)
+
+                    ' This assert is very important!
+                    '
+                    ' We are testing that we don't regress a bug where an event accessor creates its
+                    ' parent incorrectly such that *existing* Code Model objects for its parent ("E") get a different
+                    ' NodeKey that makes the existing objects invalid. If the bug regresses, the line below will
+                    ' fail with an ArguementException when trying to use propertyP's NodeKey to lookup its node.
+                    ' (Essentially, its NodeKey will be {C.E As System.EventHandler,2} rather than {C.E As System.EventHandler,1}).
+                    Assert.Equal("E", eventE.Name)
+
+                    ' Sanity: ensure that the NodeKeys are correct
+                    Dim member1 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(parent)
+                    Dim member2 = ComAggregate.GetManagedObject(Of AbstractCodeMember)(eventE)
+
+                    Assert.Equal("C.E As System.EventHandler", member1.NodeKey.Name)
+                    Assert.Equal(1, member1.NodeKey.Ordinal)
+                    Assert.Equal("C.E As System.EventHandler", member2.NodeKey.Name)
+                    Assert.Equal(1, member2.NodeKey.Ordinal)
+                End Sub)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -520,6 +520,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
             End Get
         End Property
 
+        ''' <summary>
+        ''' Do not use this method directly! Instead, go through <see cref="FileCodeModel.CreateCodeElement(Of T)(SyntaxNode)"/>
+        ''' </summary>
         Public Overloads Overrides Function CreateInternalCodeElement(
             state As CodeModelState,
             fileCodeModel As FileCodeModel,


### PR DESCRIPTION
Fixes TFS Issue 858153

This is a fairly involved issue that can manifest in a number of ways. Currently, the only known scenario where this is exposed within VS is the "Convert to Web Application" command but there are certainly others and customers using Code Model could easily run into it.

**Customer Scenario**: The scenario is essentially this:

1. In Code Model, grab and hold a reference to a code model object for some container element.
2. Access a certain type of child element parented by that container. In particular, a property accessor, an event accessor, an attribute, an attribute argument, a VB Inherits statement, a VB Implements statement, or using directive/Imports statement.
3. Try to access a property on the container reference in step 1.
4. Exception gets thrown!

Understanding why this happens will require understanding a few of the system concepts underlying Code Model.

First, Code Model elements tend to have long lifetimes that live through file edits and even renames. For example, one could grab a reference to an ```EnvDTE.CodeClass``` and hold onto it. As the user makes edits to the file containing that class the class element should continute to be valid (until the user makes an edit that breaks it). Since their lifetimes can be potentially long, Code Model elements hold onto "node keys" rather than the SyntaxTree nodes, which they use to get back to their underlying node in the source file.

Node keys have a very simple format. Essentially, they are the "name" of the node (qualified syntactically) along with an ordinal which allows there to be multiple nodes with the same name. Consider the following code:

```C#
namespace N
{
partial class C
{
void M() { }
}

partial class C
{
}
}
```

In the code above, there are four potential Code Model elements with the following node keys:

* N, 1
* N.C, 1
* N.C.M, 1
* N.C, 2

Second, some Code Model elements don't actually have node keys. These are objects that are parented by other code model objects. For example, parameters are parented within a method or propery, property accessors are parented within a property, etc. These "keyless" objects can be a bit tricky because they need to hold a reference to their parent object.

Third, each FileCodeModel maintains a cache of Code Model elements using their node keys. Whenever a Code Model element is going to be created for a particular node key, the FileCodeModel first checks to see an element already exists. If so, it returns the cached element instead.

With that background, here's what's happening:

In several cases, creating a parented keyless Code Model element was skipping the lookup in the FileCodeModel's cache when creating it's parent. So, if an element represent the parent already existed in the cache, a second Code Model element would be created for the same node. This gets ugly because the process creating a Code Model element causes it to be added to the FileCodeModel's cache. So, there is an attempt to add the newly created Code Model element when there's already one present in the cache with the same node key.

Ideally, this situation would have thrown an exception. However, when there's a collision, there's a code path in the FileCodeModel's cache that tries to find a free slot in the cache by changing the original of the element's node key. This [code](https://github.com/dotnet/roslyn/blob/master/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.ElementTable.cs#L47) is super-suspicious and is, quite honestly, probably wrong. However, removing it is a risky at this point. So, I'll look at cleaning this up in the master branch.

For now, I've audited all of the places where a parented keyless Code Model element constructs its parent and ensures that it goes through the FileCodeModel's lookup.

**Testing Done**: Unit tests have been added which fail without the fix and pass with it. Additionally, an assert was temporarily added to the bad code path to find other unit tests that expose this issue. (The assert was removed from this PR but may be added in master to catch other problems.) Finally, the original scenario, "Convert to Web Application", has been manually tested and now runs properly.

**Reviewers**: @Pilchie, @pharring, @jasonmalinowski, @basoundr