### PR TITLE
Don't pretty-list away line continuation characters in VB 9 or earlier

### DIFF
--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeCleanup.Providers;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1376,6 +1377,72 @@ End Module
             Verify(code, expected);
         }
 
+        [Fact]
+        [WorkItem(1085887)]
+        [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
+        public void DontRemoveLineContinuationInVisualBasic9()
+        {
+            var code = @"[|
+Module Program
+    Function Add( _
+        i As Integer, _
+        j As Integer, _
+    ) As Integer
+
+        Return i + j
+    End Function
+End Module
+|]";
+
+            var expected = @"
+Module Program
+    Function Add( _
+        i As Integer, _
+        j As Integer, _
+    ) As Integer
+
+        Return i + j
+    End Function
+End Module
+";
+            Verify(code, expected, langVersion: LanguageVersion.VisualBasic9);
+        }
+
+        [Fact]
+        [WorkItem(1085887)]
+        [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
+        public void RemoveLineContinuationInVisualBasic10_11_12_And_14()
+        {
+            var code = @"[|
+Module Program
+    Function Add( _
+        i As Integer, _
+        j As Integer, _
+    ) As Integer
+
+        Return i + j
+    End Function
+End Module
+|]";
+
+            var expected = @"
+Module Program
+    Function Add(
+        i As Integer,
+        j As Integer,
+    ) As Integer
+
+        Return i + j
+    End Function
+End Module
+";
+
+            Verify(code, expected, langVersion: LanguageVersion.VisualBasic10);
+            Verify(code, expected, langVersion: LanguageVersion.VisualBasic11);
+            Verify(code, expected, langVersion: LanguageVersion.VisualBasic12);
+            Verify(code, expected);
+        }
+
         private string CreateMethod(string body)
         {
             return @"Imports System
@@ -1385,13 +1452,13 @@ Class C
 End Class";
         }
 
-        private void Verify(string codeWithMarker, string expectedResult)
+        private void Verify(string codeWithMarker, string expectedResult, LanguageVersion langVersion = LanguageVersion.VisualBasic14)
         {
             var codeWithoutMarker = default(string);
             var textSpans = (IList<TextSpan>)new List<TextSpan>();
             MarkupTestFile.GetSpans(codeWithMarker, out codeWithoutMarker, out textSpans);
 
-            var document = CreateDocument(codeWithoutMarker, LanguageNames.VisualBasic);
+            var document = CreateDocument(codeWithoutMarker, LanguageNames.VisualBasic, langVersion);
             var codeCleanups = CodeCleaner.GetDefaultProviders(document).Where(p => p.Name == PredefinedCodeCleanupProviderNames.RemoveUnnecessaryLineContinuation || p.Name == PredefinedCodeCleanupProviderNames.Format);
 
             var cleanDocument = CodeCleaner.CleanupAsync(document, textSpans[0], codeCleanups).Result;
@@ -1399,11 +1466,17 @@ End Class";
             Assert.Equal(expectedResult, cleanDocument.GetSyntaxRootAsync().Result.ToFullString());
         }
 
-        private static Document CreateDocument(string code, string language)
+        private static Document CreateDocument(string code, string language, LanguageVersion langVersion)
         {
             var solution = new AdhocWorkspace().CurrentSolution;
             var projectId = ProjectId.CreateNewId();
-            var project = solution.AddProject(projectId, "Project", "Project.dll", language).GetProject(projectId);
+            var project = solution
+                .AddProject(projectId, "Project", "Project.dll", language)
+                .GetProject(projectId);
+
+            var parseOptions = (VisualBasicParseOptions)project.ParseOptions;
+            parseOptions = parseOptions.WithLanguageVersion(langVersion);
+            project = project.WithParseOptions(parseOptions);
 
             return project.AddDocument("Document", SourceText.From(code));
         }

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
@@ -20,6 +20,12 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
         End Property
 
         Public Async Function CleanupAsync(document As Document, spans As IEnumerable(Of TextSpan), Optional cancellationToken As CancellationToken = Nothing) As Task(Of Document) Implements ICodeCleanupProvider.CleanupAsync
+            ' Is this VB 9? If so, we shouldn't remove line continuations because implicit line continuation was introduced in VB 10.
+            Dim parseOptions = TryCast(document.Project.ParseOptions, VisualBasicParseOptions)
+            If parseOptions?.LanguageVersion <= LanguageVersion.VisualBasic9 Then
+                Return document
+            End If
+
             Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
             Dim newRoot = Cleanup(root, spans, document.Project.Solution.Workspace, cancellationToken)
 


### PR DESCRIPTION
**Customer scenario**: VB customer has legacy project targeting an earlier version of the language. If they use Visual Studio 2015, we shouldn't remove their line continuation characters and break their program.

The scenario this fix directly solves was filed on Microsoft Connect [here](https://connect.microsoft.com/VisualStudio/feedback/details/1035813/connect-vb-14-compiler-removes-line-continuations-even-when-web-config-specifies-vb-8-as-compiler). Essentially, this was filed by a customer who has a VB Web Site which specifically targets Visual Basic 8.0 for legacy reasons and can't use Visual Studio 2015 with the project.

**Description of fix**: Don't run the Remove Unnecessary Imports code cleaner if the LanguageVersion is VB 9 or earlier. This addresses the customer-reported scenario because the VB Web Site project system will set the language version to VB 9 if the target framework is less than 4.0.

**Testing done**: Unit tests added. Manually verified customer scenario.

**Sterling reviewers**: @Pilchie, @dpoeschl, @jasonmalinowski, @rchande, @AnthonyDGreen 