### PR TITLE
Report rude edit when a partially executed active statement is edited

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
             var arg0 = new HashSet<RudeEditKind>()
             {
                 RudeEditKind.ActiveStatementUpdate,
+                RudeEditKind.PartiallyExecutedActiveStatementUpdate,
                 RudeEditKind.DeleteActiveStatement,
                 RudeEditKind.UpdateExceptionHandlerOfActiveTry,
                 RudeEditKind.UpdateTryOrCatchWithActiveFinally,

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -991,6 +991,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 int ordinal = start + i;
                 bool hasMatching = false;
                 bool isLeaf = (oldActiveStatements[ordinal].Flags & ActiveStatementFlags.LeafFrame) != 0;
+                bool isPartiallyExecuted = (oldActiveStatements[ordinal].Flags & ActiveStatementFlags.PartiallyExecuted) != 0;
                 int statementPart = activeNodes[i].StatementPart;
                 var oldStatementSyntax = activeNodes[i].OldNode;
                 var oldEnclosingLambdaBody = activeNodes[i].EnclosingLambdaBodyOpt;
@@ -1036,10 +1037,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // E.g. "const" keyword is inserted into a local variable declaration with an initializer.
                     newSpan = FindClosestActiveSpan(newStatementSyntax, statementPart);
 
-                    if (!isLeaf && !AreEquivalentActiveStatements(oldStatementSyntax, newStatementSyntax, statementPart))
+                    if ((!isLeaf || isPartiallyExecuted) && !AreEquivalentActiveStatements(oldStatementSyntax, newStatementSyntax, statementPart))
                     {
                         // rude edit: internal active statement changed
-                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ActiveStatementUpdate, newSpan));
+                        diagnostics.Add(new RudeEditDiagnostic(isLeaf ? RudeEditKind.PartiallyExecutedActiveStatementUpdate : RudeEditKind.ActiveStatementUpdate, newSpan));
                     }
 
                     // exception handling around the statement:

--- a/src/Features/Core/EditAndContinue/ActiveStatementFlags.cs
+++ b/src/Features/Core/EditAndContinue/ActiveStatementFlags.cs
@@ -17,6 +17,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// The statement is partially executed.
         /// </summary>
+        /// <remarks>
+        /// An active statement is partially executed if the thread is stopped in between two sequence points.
+        /// This may happen when the users steps trhough the code in disassembly window (stepping over machine instructions),
+        /// when the compiler emits a call to Debugger.Break (VB Stop statement), etc.
+        /// 
+        /// Partially executed active statement can't be edited.
+        /// </remarks>
         PartiallyExecuted = 2,
 
         /// <summary>

--- a/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -75,6 +75,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.DeleteLambdaWithMultiScopeCapture,         FeaturesResources.DeleteLambdaWithMultiScopeCapture) },
             { GetDescriptorPair(RudeEditKind.ActiveStatementUpdate,                     FeaturesResources.UpdatingAnActiveStatement) },
             { GetDescriptorPair(RudeEditKind.ActiveStatementLambdaRemoved,              FeaturesResources.RemovingThatContainsActiveStatement) },
+            // TODO: change the error message to better explain what's going on
+            { GetDescriptorPair(RudeEditKind.PartiallyExecutedActiveStatementUpdate,    FeaturesResources.UpdatingAnActiveStatement) },
             { GetDescriptorPair(RudeEditKind.InsertFile,                                FeaturesResources.AddingANewFile) },
 
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.ModifyingAWhichContainsComplexQuery) },

--- a/src/Features/Core/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditKind.cs
@@ -87,6 +87,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         InsertHandlesClause = 70,
         InsertFile = 71,
+        PartiallyExecutedActiveStatementUpdate = 72,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,


### PR DESCRIPTION
Fixes #3295.

**Scenarios**
The debugger can stop thread in between sequence points. This happens when the user is stepping through disassembly, when the thread is stopped on Stop statement in VB, in some cases when 'break all' command is executed, etc. In these cases the debugger can't reliably apply an edit to the partially executed active statement and thus a change to such statement should be reported as rude.

**Fix**
Report edits to leaf partially executed statements as rude. 

**Risk**
Very low. The change adds a trivial check.

**Testing**
Added unit tests. The debugger currently doesn't correctly mark the statement as partially executed in all cases but a fix is ready. We can only validate end-to-end scenario after both fixes are applied.

@ManishJayaswal

