### PR TITLE
Include ContentType into assembly qualified type name emitted for an attribute argument.

### DIFF
--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
@@ -206,5 +206,42 @@ public class C
                 expectedOutput: "10\r\n0");
             verifier.VerifyDiagnostics();
         }
+
+        [Fact, WorkItem(1169511, "DevDiv")]
+        public void WinMdAssemblyQualifiedType()
+        {
+            var source =
+@"using System;
+
+[MyAttribute(typeof(C1))]
+public class C
+{
+    public static void Main(string[] args)
+    {
+    }
+}
+
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(System.Type type)
+    {
+    }
+}
+";
+            CompileAndVerify(source, 
+                             WinRtRefs.Concat(new[] { AssemblyMetadata.CreateFromImage(TestResources.WinRt.W1).GetReference() }), 
+                             symbolValidator: m =>
+                                            {
+                                                var module = (PEModuleSymbol)m;
+                                                var c = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("C");
+                                                var attributeHandle = module.Module.MetadataReader.GetCustomAttributes(c.Handle).Single();
+                                                string value;
+                                                module.Module.TryExtractStringValueFromAttribute(attributeHandle, out value);
+
+                                                Assert.Equal("C1, W, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime", value);
+                                            },
+                             emitters: TestEmitters.RefEmitBug);
+        }
+
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        private bool TryExtractStringValueFromAttribute(CustomAttributeHandle handle, out string value)
+        internal bool TryExtractStringValueFromAttribute(CustomAttributeHandle handle, out string value)
         {
             return TryExtractValueFromAttribute(handle, out value, s_attributeStringValueExtractor);
         }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -4759,6 +4759,15 @@ namespace Microsoft.Cci
                 sb.Append(", Retargetable=Yes");
             }
 
+            if (assemblyReference.ContentType == AssemblyContentType.WindowsRuntime)
+            {
+                sb.Append(", ContentType=WindowsRuntime");
+            }
+            else
+            {
+                Debug.Assert(assemblyReference.ContentType == AssemblyContentType.Default);
+            }
+
             return pooled.ToStringAndFree();
         }
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdTypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdTypeTests.vb
@@ -43,5 +43,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
             Dim value = type.GetMember(Of FieldSymbol)("value__")
             Assert.Equal(value.DeclaredAccessibility, Accessibility.Public)
         End Sub
+
+        <Fact, WorkItem(1169511, "DevDiv")>
+        Public Sub WinMdAssemblyQualifiedType()
+            Dim source =
+           <compilation>
+               <file name="a.vb"><![CDATA[
+<MyAttribute(GetType(C1))>
+Public Class C
+    Public Shared Sub Main()
+    End Sub
+End Class
+
+Public Class MyAttribute
+    Inherits System.Attribute
+    Sub New(type As System.Type)
+    End Sub
+End Class
+                   ]]></file>
+           </compilation>
+
+            Dim comp = CreateWinRtCompilation(source).AddReferences(AssemblyMetadata.CreateFromImage(TestResources.WinRt.W1).GetReference())
+
+            CompileAndVerify(comp, symbolValidator:=Sub(m)
+                                                        Dim [module] = DirectCast(m, PEModuleSymbol)
+                                                        Dim c = DirectCast([module].GlobalNamespace.GetTypeMember("C"), PENamedTypeSymbol)
+                                                        Dim attributeHandle = [module].Module.MetadataReader.GetCustomAttributes(c.Handle).Single()
+                                                        Dim value As String = Nothing
+                                                        [module].Module.TryExtractStringValueFromAttribute(attributeHandle, value)
+
+                                                        Assert.Equal("C1, W, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime", value)
+                                                    End Sub)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Addresses DevDiv 1169511.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.