### PR TITLE
Don't try to get IVsLanguageBlocks in a language that doesn't support SyntaxTrees.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             ref TextSpan span)
         {
             var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-            if (document == null)
+            if (document == null || !document.SupportsSyntaxTree)
             {
                 return false;
             }


### PR DESCRIPTION
This is the same as https://github.com/dotnet/roslyn/pull/3301 except this is against Master.  This is in case the other PR is not approved for Dev14RTM.