### PR TITLE
Fix System.String[] sometimes printing in unit tests

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -148,8 +148,8 @@ namespace RunTests
                 bool noResultsData = (all.Length == 0);
                 if (noResultsData)
                 {
-                    var output = processOutput.OutputLines.Concat(processOutput.ErrorLines).ToArray();
-                    Console.Write(output);
+                    var output = processOutput.OutputLines.Concat(processOutput.ErrorLines);
+                    Console.Write(string.Join(Environment.NewLine, output));
 
                     // Delete the output file.
                     File.Delete(resultsPath);


### PR DESCRIPTION
When xunit crashed (or some other edge case, not too sure) and produced no file output, we would print the processes' output/stderr and attempt to write it to console - but we were calling Console.Write(object) with a String[], which actually prints the very useful message "System.String[]".

I'm not sure why we get into this position, as I can't reproduce going into this code path (as I think it only happens upon a crash), but not printing "System.String[]" should help diagnose why it's happening next time it does.