### PR TITLE
don't put p2p reference to implicit cache.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
@@ -15,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
     {
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            var projectCacheService = new ProjectCacheService();
+            var projectCacheService = new ProjectCacheService(workspaceServices.Workspace);
             var documentTrackingService = workspaceServices.GetService<IDocumentTrackingService>();
 
             // Subscribe to events so that we can cache items from the active document's project
@@ -43,13 +45,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         internal class ProjectCacheService : IProjectCacheHostService
         {
             private readonly object _gate = new object();
-            private readonly Dictionary<object, Cache> _activeCaches = new Dictionary<object, Cache>();
+
+            private readonly Workspace _workspace;
+            private readonly Dictionary<ProjectId, Cache> _activeCaches = new Dictionary<ProjectId, Cache>();
             private readonly Queue<object> _implicitCache = new Queue<object>();
             internal const int ImplicitCacheSize = 3;
 
+            public ProjectCacheService(Workspace workspace)
+            {
+                _workspace = workspace;
+            }
+
             public void ClearImplicitCache()
             {
-                _implicitCache.Clear();
+                lock (_gate)
+                {
+                    _implicitCache.Clear();
+                }
             }
 
             public IDisposable EnableCaching(ProjectId key)
@@ -77,8 +89,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
                     {
                         cache.CreateStrongReference(owner, instance);
                     }
-                    else
+                    else if (!PartOfP2PReferences(key))
                     {
+                        // TODO: improve our implicit cache. this LRU is a bit wrong since already existing item
+                        //       doesn't move to the last slot even if it is most recently used item.
                         if (!_implicitCache.Contains(instance))
                         {
                             if (_implicitCache.Count == ImplicitCacheSize)
@@ -92,6 +106,29 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 
                     return instance;
                 }
+            }
+
+            private bool PartOfP2PReferences(ProjectId key)
+            {
+                if (_activeCaches.Count == 0 || _workspace == null)
+                {
+                    return false;
+                }
+
+                var solution = _workspace.CurrentSolution;
+                var graph = solution.GetProjectDependencyGraph();
+
+                foreach (var projectId in _activeCaches.Keys)
+                {
+                    // this should be cheap. graph is cached everytime project reference is updated.
+                    var p2pReferences = (ImmutableHashSet<ProjectId>)graph.GetProjectsThatThisProjectTransitivelyDependsOn(projectId);
+                    if (p2pReferences.Contains(key))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             public T CacheObjectIfCachingEnabledForKey<T>(ProjectId key, ICachedObjectOwner owner, T instance) where T : class
@@ -109,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
                 }
             }
 
-            private void DisableCaching(object key, Cache cache)
+            private void DisableCaching(ProjectId key, Cache cache)
             {
                 lock (_gate)
                 {
@@ -126,11 +163,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             {
                 internal int Count;
                 private readonly ProjectCacheService _cacheService;
-                private readonly object _key;
+                private readonly ProjectId _key;
                 private readonly ConditionalWeakTable<object, object> _cache = new ConditionalWeakTable<object, object>();
                 private readonly List<WeakReference<ICachedObjectOwner>> _ownerObjects = new List<WeakReference<ICachedObjectOwner>>();
 
-                public Cache(ProjectCacheService cacheService, object key)
+                public Cache(ProjectCacheService cacheService, ProjectId key)
                 {
                     _cacheService = cacheService;
                     _key = key;

--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Implementation.Workspaces;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             // Putting cacheService.CreateStrongReference in a using statement
             // creates a temporary local that isn't collected in Debug builds
             // Wrapping it in a lambda allows it to get collected.
-            var cacheService = new ProjectCacheHostServiceFactory.ProjectCacheService();
+            var cacheService = new ProjectCacheHostServiceFactory.ProjectCacheService(null);
             var projectId = ProjectId.CreateNewId();
             var owner = new Owner();
             var instance = new ObjectReference();
@@ -104,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact]
         public void TestImplicitCacheKeepsObjectAlive1()
         {
-            var cacheService = new ProjectCacheHostServiceFactory.ProjectCacheService();
+            var cacheService = new ProjectCacheHostServiceFactory.ProjectCacheService(null);
             var instance = new object();
             var weak = new WeakReference(instance);
             cacheService.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, instance);
@@ -112,6 +113,37 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             CollectGarbage();
             Assert.True(weak.IsAlive);
             GC.KeepAlive(cacheService);
+        }
+
+        [Fact]
+        public void TestP2PReference()
+        {
+            var workspace = new AdhocWorkspace();
+
+            var project1 = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Default, "proj1", "proj1", LanguageNames.CSharp);
+            var project2 = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Default, "proj2", "proj2", LanguageNames.CSharp, projectReferences: SpecializedCollections.SingletonEnumerable(new ProjectReference(project1.Id)));
+            var solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, projects: new ProjectInfo[] { project1, project2 });
+
+            var solution = workspace.AddSolution(solutionInfo);
+
+            var instance = new object();
+            var weak = new WeakReference(instance);
+
+            var cacheService = new ProjectCacheHostServiceFactory.ProjectCacheService(workspace);
+            using (var cache = cacheService.EnableCaching(project2.Id))
+            {
+                cacheService.CacheObjectIfCachingEnabledForKey(project1.Id, (object)null, instance);
+                instance = null;
+                solution = null;
+
+                workspace.OnProjectRemoved(project1.Id);
+                workspace.OnProjectRemoved(project2.Id);
+            }
+
+            // make sure p2p reference doesnt go to implicit cache
+            CollectGarbage();
+            Assert.False(weak.IsAlive);
+
         }
 
         [Fact]
@@ -126,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weakFirst = new WeakReference(compilations[0]);
             var weakLast = new WeakReference(compilations[compilations.Count - 1]);
 
-            var cache = new ProjectCacheHostServiceFactory.ProjectCacheService();
+            var cache = new ProjectCacheHostServiceFactory.ProjectCacheService(null);
             for (int i = 0; i < ProjectCacheHostServiceFactory.ProjectCacheService.ImplicitCacheSize + 1; i++)
             {
                 cache.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, compilations[i]);
@@ -150,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weak3 = new WeakReference(comp3);
             var weak1 = new WeakReference(comp1);
 
-            var cache = new ProjectCacheHostServiceFactory.ProjectCacheService();
+            var cache = new ProjectCacheHostServiceFactory.ProjectCacheService(null);
             var key = ProjectId.CreateNewId();
             var owner = new object();
             cache.CacheObjectIfCachingEnabledForKey(key, owner, comp1);


### PR DESCRIPTION
while looking around this code path, I realized we are putting p2p references to implicit cache.

this is bad since p2p graph is already implicitly cached by root compilation and the implicit cache is for things like winform which uses Roslyn without explicit cache from us.

this p2p causes compilation for winform to be kicked out from implicit cache for no reason.

...

*NOTE* 
this makes umbraco to not use implicit cache at all