### PR TITLE
Public API cleanup: replace fields with properties in Workspace layer

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -11,93 +11,93 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         internal const string WrappingFeatureName = "CSharp/Wrapping";
         internal const string NewLineFormattingFeatureName = "CSharp/New Line";
 
-        public static readonly Option<bool> SpacingAfterMethodDeclarationName = new Option<bool>(SpacingFeatureName, "SpacingAfterMethodDeclarationName", defaultValue: false);
+        public static Option<bool> SpacingAfterMethodDeclarationName { get; } = new Option<bool>(SpacingFeatureName, "SpacingAfterMethodDeclarationName", defaultValue: false);
 
-        public static readonly Option<bool> SpaceWithinMethodDeclarationParenthesis = new Option<bool>(SpacingFeatureName, "SpaceWithinMethodDeclarationParenthesis", defaultValue: false);
+        public static Option<bool> SpaceWithinMethodDeclarationParenthesis { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinMethodDeclarationParenthesis", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBetweenEmptyMethodDeclarationParentheses = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptyMethodDeclarationParentheses", defaultValue: false);
+        public static Option<bool> SpaceBetweenEmptyMethodDeclarationParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptyMethodDeclarationParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceAfterMethodCallName = new Option<bool>(SpacingFeatureName, "SpaceAfterMethodCallName", defaultValue: false);
+        public static Option<bool> SpaceAfterMethodCallName { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterMethodCallName", defaultValue: false);
 
-        public static readonly Option<bool> SpaceWithinMethodCallParentheses = new Option<bool>(SpacingFeatureName, "SpaceWithinMethodCallParentheses", defaultValue: false);
+        public static Option<bool> SpaceWithinMethodCallParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinMethodCallParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBetweenEmptyMethodCallParentheses = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptyMethodCallParentheses", defaultValue: false);
+        public static Option<bool> SpaceBetweenEmptyMethodCallParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptyMethodCallParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceAfterControlFlowStatementKeyword = new Option<bool>(SpacingFeatureName, "SpaceAfterControlFlowStatementKeyword", defaultValue: true);
+        public static Option<bool> SpaceAfterControlFlowStatementKeyword { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterControlFlowStatementKeyword", defaultValue: true);
 
-        public static readonly Option<bool> SpaceWithinExpressionParentheses = new Option<bool>(SpacingFeatureName, "SpaceWithinExpressionParentheses", defaultValue: false);
+        public static Option<bool> SpaceWithinExpressionParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinExpressionParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceWithinCastParentheses = new Option<bool>(SpacingFeatureName, "SpaceWithinCastParentheses", defaultValue: false);
+        public static Option<bool> SpaceWithinCastParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinCastParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceWithinOtherParentheses = new Option<bool>(SpacingFeatureName, "SpaceWithinOtherParentheses", defaultValue: false);
+        public static Option<bool> SpaceWithinOtherParentheses { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinOtherParentheses", defaultValue: false);
 
-        public static readonly Option<bool> SpaceAfterCast = new Option<bool>(SpacingFeatureName, "SpaceAfterCast", defaultValue: false);
+        public static Option<bool> SpaceAfterCast { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterCast", defaultValue: false);
 
-        public static readonly Option<bool> SpacesIgnoreAroundVariableDeclaration = new Option<bool>(SpacingFeatureName, "SpacesIgnoreAroundVariableDeclaration", defaultValue: false);
+        public static Option<bool> SpacesIgnoreAroundVariableDeclaration { get; } = new Option<bool>(SpacingFeatureName, "SpacesIgnoreAroundVariableDeclaration", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBeforeOpenSquareBracket = new Option<bool>(SpacingFeatureName, "SpaceBeforeOpenSquareBracket", defaultValue: false);
+        public static Option<bool> SpaceBeforeOpenSquareBracket { get; } = new Option<bool>(SpacingFeatureName, "SpaceBeforeOpenSquareBracket", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBetweenEmptySquareBrackets = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptySquareBrackets", defaultValue: false);
+        public static Option<bool> SpaceBetweenEmptySquareBrackets { get; } = new Option<bool>(SpacingFeatureName, "SpaceBetweenEmptySquareBrackets", defaultValue: false);
 
-        public static readonly Option<bool> SpaceWithinSquareBrackets = new Option<bool>(SpacingFeatureName, "SpaceWithinSquareBrackets", defaultValue: false);
+        public static Option<bool> SpaceWithinSquareBrackets { get; } = new Option<bool>(SpacingFeatureName, "SpaceWithinSquareBrackets", defaultValue: false);
 
-        public static readonly Option<bool> SpaceAfterColonInBaseTypeDeclaration = new Option<bool>(SpacingFeatureName, "SpaceAfterColonInBaseTypeDeclaration", defaultValue: true);
+        public static Option<bool> SpaceAfterColonInBaseTypeDeclaration { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterColonInBaseTypeDeclaration", defaultValue: true);
 
-        public static readonly Option<bool> SpaceAfterComma = new Option<bool>(SpacingFeatureName, "SpaceAfterComma", defaultValue: true);
+        public static Option<bool> SpaceAfterComma { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterComma", defaultValue: true);
 
-        public static readonly Option<bool> SpaceAfterDot = new Option<bool>(SpacingFeatureName, "SpaceAfterDot", defaultValue: false);
+        public static Option<bool> SpaceAfterDot { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterDot", defaultValue: false);
 
-        public static readonly Option<bool> SpaceAfterSemicolonsInForStatement = new Option<bool>(SpacingFeatureName, "SpaceAfterSemicolonsInForStatement", defaultValue: true);
+        public static Option<bool> SpaceAfterSemicolonsInForStatement { get; } = new Option<bool>(SpacingFeatureName, "SpaceAfterSemicolonsInForStatement", defaultValue: true);
 
-        public static readonly Option<bool> SpaceBeforeColonInBaseTypeDeclaration = new Option<bool>(SpacingFeatureName, "SpaceBeforeColonInBaseTypeDeclaration", defaultValue: true);
+        public static Option<bool> SpaceBeforeColonInBaseTypeDeclaration { get; } = new Option<bool>(SpacingFeatureName, "SpaceBeforeColonInBaseTypeDeclaration", defaultValue: true);
 
-        public static readonly Option<bool> SpaceBeforeComma = new Option<bool>(SpacingFeatureName, "SpaceBeforeComma", defaultValue: false);
+        public static Option<bool> SpaceBeforeComma { get; } = new Option<bool>(SpacingFeatureName, "SpaceBeforeComma", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBeforeDot = new Option<bool>(SpacingFeatureName, "SpaceBeforeDot", defaultValue: false);
+        public static Option<bool> SpaceBeforeDot { get; } = new Option<bool>(SpacingFeatureName, "SpaceBeforeDot", defaultValue: false);
 
-        public static readonly Option<bool> SpaceBeforeSemicolonsInForStatement = new Option<bool>(SpacingFeatureName, "SpaceBeforeSemicolonsInForStatement", defaultValue: false);
+        public static Option<bool> SpaceBeforeSemicolonsInForStatement { get; } = new Option<bool>(SpacingFeatureName, "SpaceBeforeSemicolonsInForStatement", defaultValue: false);
 
-        public static readonly Option<BinaryOperatorSpacingOptions> SpacingAroundBinaryOperator = new Option<BinaryOperatorSpacingOptions>(SpacingFeatureName, "SpacingAroundBinaryOperator", defaultValue: BinaryOperatorSpacingOptions.Single);
+        public static Option<BinaryOperatorSpacingOptions> SpacingAroundBinaryOperator { get; } = new Option<BinaryOperatorSpacingOptions>(SpacingFeatureName, "SpacingAroundBinaryOperator", defaultValue: BinaryOperatorSpacingOptions.Single);
 
-        public static readonly Option<bool> IndentBraces = new Option<bool>(IndentFeatureName, "OpenCloseBracesIndent", defaultValue: false);
+        public static Option<bool> IndentBraces { get; } = new Option<bool>(IndentFeatureName, "OpenCloseBracesIndent", defaultValue: false);
 
-        public static readonly Option<bool> IndentBlock = new Option<bool>(IndentFeatureName, "IndentBlock", defaultValue: true);
+        public static Option<bool> IndentBlock { get; } = new Option<bool>(IndentFeatureName, "IndentBlock", defaultValue: true);
 
-        public static readonly Option<bool> IndentSwitchSection = new Option<bool>(IndentFeatureName, "IndentSwitchSection", defaultValue: true);
+        public static Option<bool> IndentSwitchSection { get; } = new Option<bool>(IndentFeatureName, "IndentSwitchSection", defaultValue: true);
 
-        public static readonly Option<bool> IndentSwitchCaseSection = new Option<bool>(IndentFeatureName, "IndentSwitchCaseSection", defaultValue: true);
+        public static Option<bool> IndentSwitchCaseSection { get; } = new Option<bool>(IndentFeatureName, "IndentSwitchCaseSection", defaultValue: true);
 
-        public static readonly Option<LabelPositionOptions> LabelPositioning = new Option<LabelPositionOptions>(IndentFeatureName, "LabelPositioning", defaultValue: LabelPositionOptions.OneLess);
+        public static Option<LabelPositionOptions> LabelPositioning { get; } = new Option<LabelPositionOptions>(IndentFeatureName, "LabelPositioning", defaultValue: LabelPositionOptions.OneLess);
 
-        public static readonly Option<bool> WrappingPreserveSingleLine = new Option<bool>(WrappingFeatureName, "WrappingPreserveSingleLine", defaultValue: true);
+        public static Option<bool> WrappingPreserveSingleLine { get; } = new Option<bool>(WrappingFeatureName, "WrappingPreserveSingleLine", defaultValue: true);
 
-        public static readonly Option<bool> WrappingKeepStatementsOnSingleLine = new Option<bool>(WrappingFeatureName, "WrappingKeepStatementsOnSingleLine", defaultValue: true);
+        public static Option<bool> WrappingKeepStatementsOnSingleLine { get; } = new Option<bool>(WrappingFeatureName, "WrappingKeepStatementsOnSingleLine", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInTypes = new Option<bool>(NewLineFormattingFeatureName, "NewLinesBracesType", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInTypes { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesBracesType", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInMethods = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInMethods", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInMethods { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInMethods", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInAnonymousMethods = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInAnonymousMethods", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInAnonymousMethods { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInAnonymousMethods", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInControlBlocks = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInControlBlocks", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInControlBlocks { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInControlBlocks", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInAnonymousTypes = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInAnonymousTypes", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInAnonymousTypes { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInAnonymousTypes", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInObjectCollectionArrayInitializers = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInObjectCollectionArrayInitializers", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInObjectCollectionArrayInitializers { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInObjectCollectionArrayInitializers", defaultValue: true);
 
-        public static readonly Option<bool> NewLinesForBracesInLambdaExpressionBody = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInLambdaExpressionBody", defaultValue: true);
+        public static Option<bool> NewLinesForBracesInLambdaExpressionBody { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInLambdaExpressionBody", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForElse = new Option<bool>(NewLineFormattingFeatureName, "NewLineForElse", defaultValue: true);
+        public static Option<bool> NewLineForElse { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForElse", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForCatch = new Option<bool>(NewLineFormattingFeatureName, "NewLineForCatch", defaultValue: true);
+        public static Option<bool> NewLineForCatch { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForCatch", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForFinally = new Option<bool>(NewLineFormattingFeatureName, "NewLineForFinally", defaultValue: true);
+        public static Option<bool> NewLineForFinally { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForFinally", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForMembersInObjectInit = new Option<bool>(NewLineFormattingFeatureName, "NewLineForMembersInObjectInit", defaultValue: true);
+        public static Option<bool> NewLineForMembersInObjectInit { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForMembersInObjectInit", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForMembersInAnonymousTypes = new Option<bool>(NewLineFormattingFeatureName, "NewLineForMembersInAnonymousTypes", defaultValue: true);
+        public static Option<bool> NewLineForMembersInAnonymousTypes { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForMembersInAnonymousTypes", defaultValue: true);
 
-        public static readonly Option<bool> NewLineForClausesInQuery = new Option<bool>(NewLineFormattingFeatureName, "NewLineForClausesInQuery", defaultValue: true);
+        public static Option<bool> NewLineForClausesInQuery { get; } = new Option<bool>(NewLineFormattingFeatureName, "NewLineForClausesInQuery", defaultValue: true);
     }
 
     public enum LabelPositionOptions

--- a/src/Workspaces/CSharp/Portable/PublicAPI.txt
+++ b/src/Workspaces/CSharp/Portable/PublicAPI.txt
@@ -7,47 +7,47 @@ Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions
 Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions.LeftMost = 0 -> Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions
 Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions.NoIndent = 2 -> Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions
 Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions.OneLess = 1 -> Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBlock -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBraces -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchCaseSection -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchSection -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.LabelPositioning -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForCatch -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForClausesInQuery -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForElse -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForFinally -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForMembersInAnonymousTypes -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForMembersInObjectInit -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInControlBlocks -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInMethods -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInTypes -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterCast -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterColonInBaseTypeDeclaration -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterComma -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterDot -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterMethodCallName -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterSemicolonsInForStatement -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeComma -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeDot -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeOpenSquareBracket -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeSemicolonsInForStatement -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptyMethodDeclarationParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptySquareBrackets -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinCastParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinExpressionParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinMethodCallParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinOtherParentheses -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinSquareBrackets -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacesIgnoreAroundVariableDeclaration -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacingAfterMethodDeclarationName -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacingAroundBinaryOperator -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.BinaryOperatorSpacingOptions>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.WrappingPreserveSingleLine -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBlock.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBraces.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchCaseSection.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchSection.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.LabelPositioning.get -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForCatch.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForClausesInQuery.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForElse.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForFinally.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForMembersInAnonymousTypes.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForMembersInObjectInit.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInControlBlocks.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInMethods.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLinesForBracesInTypes.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterCast.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterColonInBaseTypeDeclaration.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterComma.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterDot.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterMethodCallName.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceAfterSemicolonsInForStatement.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeComma.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeDot.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeOpenSquareBracket.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBeforeSemicolonsInForStatement.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptyMethodDeclarationParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceBetweenEmptySquareBrackets.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinCastParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinExpressionParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinMethodCallParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinOtherParentheses.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpaceWithinSquareBrackets.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacesIgnoreAroundVariableDeclaration.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacingAfterMethodDeclarationName.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.SpacingAroundBinaryOperator.get -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.BinaryOperatorSpacingOptions>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.WrappingPreserveSingleLine.get -> Microsoft.CodeAnalysis.Options.Option<bool>

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/WellKnownFixAllProviders.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/WellKnownFixAllProviders.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <see cref="ApplyChangesOperation"/> present within the individual diagnostic fixes. Other types of
         /// operations present within these fixes are ignored.
         /// </remarks>
-        public static readonly FixAllProvider BatchFixer = BatchFixAllProvider.Instance;
+        public static FixAllProvider BatchFixer => BatchFixAllProvider.Instance;
 
         /// <summary>
         /// Default batch fix all provider for simplification fixers which only add Simplifier annotations to documents.
@@ -30,6 +30,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// This fixer supports fixes for the following fix all scopes:
         /// <see cref="FixAllScope.Document"/>, <see cref="FixAllScope.Project"/> and <see cref="FixAllScope.Solution"/>.
         /// </summary>
-        internal static readonly FixAllProvider BatchSimplificationFixer = BatchSimplificationFixAllProvider.Instance;
+        internal static FixAllProvider BatchSimplificationFixer => BatchSimplificationFixAllProvider.Instance;
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editing
 {
@@ -215,21 +214,21 @@ namespace Microsoft.CodeAnalysis.Editing
             WriteOnly = 0x1000
         }
 
-        public static readonly DeclarationModifiers None = default(DeclarationModifiers);
+        public static DeclarationModifiers None => default(DeclarationModifiers);
 
-        public static readonly DeclarationModifiers Static = new DeclarationModifiers(Modifiers.Static);
-        public static readonly DeclarationModifiers Abstract = new DeclarationModifiers(Modifiers.Abstract);
-        public static readonly DeclarationModifiers New = new DeclarationModifiers(Modifiers.New);
-        public static readonly DeclarationModifiers Unsafe = new DeclarationModifiers(Modifiers.Unsafe);
-        public static readonly DeclarationModifiers ReadOnly = new DeclarationModifiers(Modifiers.ReadOnly);
-        public static readonly DeclarationModifiers Virtual = new DeclarationModifiers(Modifiers.Virtual);
-        public static readonly DeclarationModifiers Override = new DeclarationModifiers(Modifiers.Override);
-        public static readonly DeclarationModifiers Sealed = new DeclarationModifiers(Modifiers.Sealed);
-        public static readonly DeclarationModifiers Const = new DeclarationModifiers(Modifiers.Const);
-        public static readonly DeclarationModifiers WithEvents = new DeclarationModifiers(Modifiers.WithEvents);
-        public static readonly DeclarationModifiers Partial = new DeclarationModifiers(Modifiers.Partial);
-        public static readonly DeclarationModifiers Async = new DeclarationModifiers(Modifiers.Async);
-        public static readonly DeclarationModifiers WriteOnly = new DeclarationModifiers(Modifiers.WriteOnly);
+        public static DeclarationModifiers Static => new DeclarationModifiers(Modifiers.Static);
+        public static DeclarationModifiers Abstract => new DeclarationModifiers(Modifiers.Abstract);
+        public static DeclarationModifiers New => new DeclarationModifiers(Modifiers.New);
+        public static DeclarationModifiers Unsafe => new DeclarationModifiers(Modifiers.Unsafe);
+        public static DeclarationModifiers ReadOnly => new DeclarationModifiers(Modifiers.ReadOnly);
+        public static DeclarationModifiers Virtual => new DeclarationModifiers(Modifiers.Virtual);
+        public static DeclarationModifiers Override => new DeclarationModifiers(Modifiers.Override);
+        public static DeclarationModifiers Sealed => new DeclarationModifiers(Modifiers.Sealed);
+        public static DeclarationModifiers Const => new DeclarationModifiers(Modifiers.Const);
+        public static DeclarationModifiers WithEvents => new DeclarationModifiers(Modifiers.WithEvents);
+        public static DeclarationModifiers Partial => new DeclarationModifiers(Modifiers.Partial);
+        public static DeclarationModifiers Async => new DeclarationModifiers(Modifiers.Async);
+        public static DeclarationModifiers WriteOnly => new DeclarationModifiers(Modifiers.WriteOnly);
 
         public static DeclarationModifiers operator |(DeclarationModifiers left, DeclarationModifiers right)
         {

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -7,8 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -23,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <summary>
         /// The annotation used to mark portions of a syntax tree to be formatted.
         /// </summary>
-        public static readonly SyntaxAnnotation Annotation = new SyntaxAnnotation();
+        public static SyntaxAnnotation Annotation { get; } = new SyntaxAnnotation();
 
         /// <summary>
         /// Gets the formatting rules that would be applied if left unspecified.

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
@@ -10,19 +10,19 @@ namespace Microsoft.CodeAnalysis.Formatting
         internal const string InternalTabFeatureName = "InternalTab";
         internal const string FormattingFeatureName = "Formatting";
 
-        public static readonly PerLanguageOption<bool> UseTabs = new PerLanguageOption<bool>(TabFeatureName, "UseTab", defaultValue: false);
+        public static PerLanguageOption<bool> UseTabs { get; } = new PerLanguageOption<bool>(TabFeatureName, "UseTab", defaultValue: false);
 
-        public static readonly PerLanguageOption<int> TabSize = new PerLanguageOption<int>(TabFeatureName, "TabSize", defaultValue: 4);
+        public static PerLanguageOption<int> TabSize { get; } = new PerLanguageOption<int>(TabFeatureName, "TabSize", defaultValue: 4);
 
-        public static readonly PerLanguageOption<int> IndentationSize = new PerLanguageOption<int>(TabFeatureName, "IndentationSize", defaultValue: 4);
+        public static PerLanguageOption<int> IndentationSize { get; } = new PerLanguageOption<int>(TabFeatureName, "IndentationSize", defaultValue: 4);
 
-        public static readonly PerLanguageOption<IndentStyle> SmartIndent = new PerLanguageOption<IndentStyle>(TabFeatureName, "SmartIndent", defaultValue: IndentStyle.Smart);
+        public static PerLanguageOption<IndentStyle> SmartIndent { get; } = new PerLanguageOption<IndentStyle>(TabFeatureName, "SmartIndent", defaultValue: IndentStyle.Smart);
 
-        public static readonly PerLanguageOption<string> NewLine = new PerLanguageOption<string>(FormattingFeatureName, "NewLine", defaultValue: "\r\n");
+        public static PerLanguageOption<string> NewLine { get; } = new PerLanguageOption<string>(FormattingFeatureName, "NewLine", defaultValue: "\r\n");
 
-        internal static readonly PerLanguageOption<bool> DebugMode = new PerLanguageOption<bool>(FormattingFeatureName, "DebugMode", defaultValue: false);
+        internal static PerLanguageOption<bool> DebugMode { get; } = new PerLanguageOption<bool>(FormattingFeatureName, "DebugMode", defaultValue: false);
 
-        internal static readonly Option<bool> AllowDisjointSpanMerging = new Option<bool>(FormattingFeatureName, "ShouldUseFormattingSpanCollapse", defaultValue: false);
+        internal static Option<bool> AllowDisjointSpanMerging { get; } = new Option<bool>(FormattingFeatureName, "ShouldUseFormattingSpanCollapse", defaultValue: false);
 
         public enum IndentStyle
         {

--- a/src/Workspaces/Core/Portable/Options/OptionKey.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionKey.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.Options
 {
     public struct OptionKey : IEquatable<OptionKey>
     {
-        public readonly IOption Option;
-        public readonly string Language;
+        public IOption Option { get; }
+        public string Language { get; }
 
         public OptionKey(IOption option, string language = null)
         {

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Options
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentException("name");
+                throw new ArgumentException(nameof(name));
             }
 
             this.Feature = feature;

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Options
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentException("name");
+                throw new ArgumentException(nameof(name));
             }
 
             this.Feature = feature;

--- a/src/Workspaces/Core/Portable/PublicAPI.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.txt
@@ -469,6 +469,8 @@ Microsoft.CodeAnalysis.Options.Option<T>.Option(string feature, string name, T d
 Microsoft.CodeAnalysis.Options.Option<T>.Type.get -> System.Type
 Microsoft.CodeAnalysis.Options.OptionKey
 Microsoft.CodeAnalysis.Options.OptionKey.Equals(Microsoft.CodeAnalysis.Options.OptionKey other) -> bool
+Microsoft.CodeAnalysis.Options.OptionKey.Language.get -> string
+Microsoft.CodeAnalysis.Options.OptionKey.Option.get -> Microsoft.CodeAnalysis.Options.IOption
 Microsoft.CodeAnalysis.Options.OptionKey.OptionKey(Microsoft.CodeAnalysis.Options.IOption option, string language = null) -> void
 Microsoft.CodeAnalysis.Options.OptionSet
 Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
@@ -1072,8 +1074,6 @@ override Microsoft.CodeAnalysis.VersionStamp.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.VersionStamp.GetHashCode() -> int
 override Microsoft.CodeAnalysis.VersionStamp.ToString() -> string
 override Microsoft.CodeAnalysis.WorkspaceDiagnostic.ToString() -> string
-readonly Microsoft.CodeAnalysis.Options.OptionKey.Language -> string
-readonly Microsoft.CodeAnalysis.Options.OptionKey.Option -> Microsoft.CodeAnalysis.Options.IOption
 static Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpans(Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.Text.TextSpan textSpan, Microsoft.CodeAnalysis.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Classification.ClassifiedSpan>
 static Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpansAsync(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Text.TextSpan textSpan, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Classification.ClassifiedSpan>>
 static Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(string title, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>> createChangedDocument, string equivalenceKey = null) -> Microsoft.CodeAnalysis.CodeActions.CodeAction
@@ -1083,12 +1083,27 @@ static Microsoft.CodeAnalysis.CodeActions.ConflictAnnotation.GetDescription(Micr
 static Microsoft.CodeAnalysis.CodeActions.RenameAnnotation.Create() -> Microsoft.CodeAnalysis.SyntaxAnnotation
 static Microsoft.CodeAnalysis.CodeActions.WarningAnnotation.Create(string description) -> Microsoft.CodeAnalysis.SyntaxAnnotation
 static Microsoft.CodeAnalysis.CodeActions.WarningAnnotation.GetDescription(Microsoft.CodeAnalysis.SyntaxAnnotation annotation) -> string
+static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer.get -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider
 static Microsoft.CodeAnalysis.DocumentId.CreateFromSerialized(Microsoft.CodeAnalysis.ProjectId projectId, System.Guid id, string debugName = null) -> Microsoft.CodeAnalysis.DocumentId
 static Microsoft.CodeAnalysis.DocumentId.CreateNewId(Microsoft.CodeAnalysis.ProjectId projectId, string debugName = null) -> Microsoft.CodeAnalysis.DocumentId
 static Microsoft.CodeAnalysis.DocumentId.operator !=(Microsoft.CodeAnalysis.DocumentId left, Microsoft.CodeAnalysis.DocumentId right) -> bool
 static Microsoft.CodeAnalysis.DocumentId.operator ==(Microsoft.CodeAnalysis.DocumentId left, Microsoft.CodeAnalysis.DocumentId right) -> bool
 static Microsoft.CodeAnalysis.DocumentInfo.Create(Microsoft.CodeAnalysis.DocumentId id, string name, System.Collections.Generic.IEnumerable<string> folders = null, Microsoft.CodeAnalysis.SourceCodeKind sourceCodeKind = Microsoft.CodeAnalysis.SourceCodeKind.Regular, Microsoft.CodeAnalysis.TextLoader loader = null, string filePath = null, bool isGenerated = false) -> Microsoft.CodeAnalysis.DocumentInfo
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Abstract.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Async.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Const.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.From(Microsoft.CodeAnalysis.ISymbol symbol) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.New.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.None.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Override.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Partial.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.ReadOnly.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Sealed.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Static.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Unsafe.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Virtual.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithEvents.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WriteOnly.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.operator !=(Microsoft.CodeAnalysis.Editing.DeclarationModifiers left, Microsoft.CodeAnalysis.Editing.DeclarationModifiers right) -> bool
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.operator &(Microsoft.CodeAnalysis.Editing.DeclarationModifiers left, Microsoft.CodeAnalysis.Editing.DeclarationModifiers right) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.operator +(Microsoft.CodeAnalysis.Editing.DeclarationModifiers left, Microsoft.CodeAnalysis.Editing.DeclarationModifiers right) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
@@ -1157,6 +1172,7 @@ static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsAsy
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDefinitionAsync(Microsoft.CodeAnalysis.ISymbol symbol, Microsoft.CodeAnalysis.Solution solution, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.ISymbol>
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSymbolAtPosition(Microsoft.CodeAnalysis.SemanticModel semanticModel, int position, Microsoft.CodeAnalysis.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.ISymbol
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSymbolAtPositionAsync(Microsoft.CodeAnalysis.Document document, int position, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.ISymbol>
+static Microsoft.CodeAnalysis.Formatting.Formatter.Annotation.get -> Microsoft.CodeAnalysis.SyntaxAnnotation
 static Microsoft.CodeAnalysis.Formatting.Formatter.Format(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SyntaxAnnotation annotation, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.SyntaxNode
 static Microsoft.CodeAnalysis.Formatting.Formatter.Format(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.Text.TextSpan span, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.SyntaxNode
 static Microsoft.CodeAnalysis.Formatting.Formatter.Format(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.SyntaxNode
@@ -1168,6 +1184,11 @@ static Microsoft.CodeAnalysis.Formatting.Formatter.FormatAsync(Microsoft.CodeAna
 static Microsoft.CodeAnalysis.Formatting.Formatter.GetFormattedTextChanges(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.Text.TextSpan span, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextChange>
 static Microsoft.CodeAnalysis.Formatting.Formatter.GetFormattedTextChanges(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextChange>
 static Microsoft.CodeAnalysis.Formatting.Formatter.GetFormattedTextChanges(Microsoft.CodeAnalysis.SyntaxNode node, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Text.TextSpan> spans, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextChange>
+static Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<int>
+static Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<string>
+static Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle>
+static Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<int>
+static Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Host.Mef.MefHostServices.Create(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) -> Microsoft.CodeAnalysis.Host.Mef.MefHostServices
 static Microsoft.CodeAnalysis.Host.Mef.MefHostServices.Create(System.Composition.CompositionContext compositionContext) -> Microsoft.CodeAnalysis.Host.Mef.MefHostServices
 static Microsoft.CodeAnalysis.Host.Mef.MefHostServices.DefaultAssemblies.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Assembly>
@@ -1182,8 +1203,24 @@ static Microsoft.CodeAnalysis.ProjectId.operator ==(Microsoft.CodeAnalysis.Proje
 static Microsoft.CodeAnalysis.ProjectInfo.Create(Microsoft.CodeAnalysis.ProjectId id, Microsoft.CodeAnalysis.VersionStamp version, string name, string assemblyName, string language, string filePath = null, string outputFilePath = null, Microsoft.CodeAnalysis.CompilationOptions compilationOptions = null, Microsoft.CodeAnalysis.ParseOptions parseOptions = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentInfo> documents = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ProjectReference> projectReferences = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.MetadataReference> metadataReferences = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference> analyzerReferences = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentInfo> additionalDocuments = null, bool isSubmission = false, System.Type hostObjectType = null) -> Microsoft.CodeAnalysis.ProjectInfo
 static Microsoft.CodeAnalysis.ProjectReference.operator !=(Microsoft.CodeAnalysis.ProjectReference left, Microsoft.CodeAnalysis.ProjectReference right) -> bool
 static Microsoft.CodeAnalysis.ProjectReference.operator ==(Microsoft.CodeAnalysis.ProjectReference left, Microsoft.CodeAnalysis.ProjectReference right) -> bool
+static Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.FilterOutOfScopeLocals.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.HideAdvancedMembers.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Recommendations.Recommender.GetRecommendedSymbolsAtPosition(Microsoft.CodeAnalysis.SemanticModel semanticModel, int position, Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>
+static Microsoft.CodeAnalysis.Rename.RenameOptions.PreviewChanges.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Rename.RenameOptions.RenameInComments.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Rename.RenameOptions.RenameInStrings.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Rename.RenameOptions.RenameOverloads.get -> Microsoft.CodeAnalysis.Options.Option<bool>
 static Microsoft.CodeAnalysis.Rename.Renamer.RenameSymbolAsync(Microsoft.CodeAnalysis.Solution solution, Microsoft.CodeAnalysis.ISymbol symbol, string newName, Microsoft.CodeAnalysis.Options.OptionSet optionSet, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Solution>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.AllowSimplificationToBaseType.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.AllowSimplificationToGenericType.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferAliasToQualification.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferImplicitTypeInLocalDeclaration.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferImplicitTypeInference.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferOmittingModuleNamesInQualification.get -> Microsoft.CodeAnalysis.Options.Option<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberAccessWithThisOrMe.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.Simplifier.Annotation.get -> Microsoft.CodeAnalysis.SyntaxAnnotation
 static Microsoft.CodeAnalysis.Simplification.Simplifier.Expand(Microsoft.CodeAnalysis.SyntaxToken token, Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.Workspace workspace, System.Func<Microsoft.CodeAnalysis.SyntaxNode, bool> expandInsideNode = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.SyntaxToken
 static Microsoft.CodeAnalysis.Simplification.Simplifier.Expand<TNode>(TNode node, Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.Workspace workspace, System.Func<Microsoft.CodeAnalysis.SyntaxNode, bool> expandInsideNode = null, bool expandParameter = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TNode
 static Microsoft.CodeAnalysis.Simplification.Simplifier.ExpandAsync(Microsoft.CodeAnalysis.SyntaxToken token, Microsoft.CodeAnalysis.Document document, System.Func<Microsoft.CodeAnalysis.SyntaxNode, bool> expandInsideNode = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.SyntaxToken>
@@ -1192,6 +1229,7 @@ static Microsoft.CodeAnalysis.Simplification.Simplifier.ReduceAsync(Microsoft.Co
 static Microsoft.CodeAnalysis.Simplification.Simplifier.ReduceAsync(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.SyntaxAnnotation annotation, Microsoft.CodeAnalysis.Options.OptionSet optionSet = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>
 static Microsoft.CodeAnalysis.Simplification.Simplifier.ReduceAsync(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Text.TextSpan span, Microsoft.CodeAnalysis.Options.OptionSet optionSet = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>
 static Microsoft.CodeAnalysis.Simplification.Simplifier.ReduceAsync(Microsoft.CodeAnalysis.Document document, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Text.TextSpan> spans, Microsoft.CodeAnalysis.Options.OptionSet optionSet = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>
+static Microsoft.CodeAnalysis.Simplification.Simplifier.SpecialTypeAnnotation.get -> Microsoft.CodeAnalysis.SyntaxAnnotation
 static Microsoft.CodeAnalysis.SolutionId.CreateNewId(string debugName = null) -> Microsoft.CodeAnalysis.SolutionId
 static Microsoft.CodeAnalysis.SolutionId.operator !=(Microsoft.CodeAnalysis.SolutionId left, Microsoft.CodeAnalysis.SolutionId right) -> bool
 static Microsoft.CodeAnalysis.SolutionId.operator ==(Microsoft.CodeAnalysis.SolutionId left, Microsoft.CodeAnalysis.SolutionId right) -> bool
@@ -1201,49 +1239,11 @@ static Microsoft.CodeAnalysis.TextLoader.From(Microsoft.CodeAnalysis.Text.Source
 static Microsoft.CodeAnalysis.TextLoader.From(Microsoft.CodeAnalysis.TextAndVersion textAndVersion) -> Microsoft.CodeAnalysis.TextLoader
 static Microsoft.CodeAnalysis.VersionStamp.Create() -> Microsoft.CodeAnalysis.VersionStamp
 static Microsoft.CodeAnalysis.VersionStamp.Create(System.DateTime utcIimeLastModified) -> Microsoft.CodeAnalysis.VersionStamp
+static Microsoft.CodeAnalysis.VersionStamp.Default.get -> Microsoft.CodeAnalysis.VersionStamp
 static Microsoft.CodeAnalysis.VersionStamp.operator !=(Microsoft.CodeAnalysis.VersionStamp left, Microsoft.CodeAnalysis.VersionStamp right) -> bool
 static Microsoft.CodeAnalysis.VersionStamp.operator ==(Microsoft.CodeAnalysis.VersionStamp left, Microsoft.CodeAnalysis.VersionStamp right) -> bool
 static Microsoft.CodeAnalysis.Workspace.GetWorkspaceRegistration(Microsoft.CodeAnalysis.Text.SourceTextContainer textContainer) -> Microsoft.CodeAnalysis.WorkspaceRegistration
 static Microsoft.CodeAnalysis.Workspace.TryGetWorkspace(Microsoft.CodeAnalysis.Text.SourceTextContainer textContainer, out Microsoft.CodeAnalysis.Workspace workspace) -> bool
-static readonly Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Abstract -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Async -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Const -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.New -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.None -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Override -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Partial -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.ReadOnly -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Sealed -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Static -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Unsafe -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Virtual -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithEvents -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WriteOnly -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
-static readonly Microsoft.CodeAnalysis.Formatting.Formatter.Annotation -> Microsoft.CodeAnalysis.SyntaxAnnotation
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize -> Microsoft.CodeAnalysis.Options.PerLanguageOption<int>
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine -> Microsoft.CodeAnalysis.Options.PerLanguageOption<string>
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent -> Microsoft.CodeAnalysis.Options.PerLanguageOption<Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle>
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize -> Microsoft.CodeAnalysis.Options.PerLanguageOption<int>
-static readonly Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.FilterOutOfScopeLocals -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Recommendations.RecommendationOptions.HideAdvancedMembers -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Rename.RenameOptions.PreviewChanges -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Rename.RenameOptions.RenameInComments -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Rename.RenameOptions.RenameInStrings -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Rename.RenameOptions.RenameOverloads -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.AllowSimplificationToBaseType -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.AllowSimplificationToGenericType -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferAliasToQualification -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferImplicitTypeInLocalDeclaration -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferImplicitTypeInference -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.PreferOmittingModuleNamesInQualification -> Microsoft.CodeAnalysis.Options.Option<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberAccessWithThisOrMe -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
-static readonly Microsoft.CodeAnalysis.Simplification.Simplifier.Annotation -> Microsoft.CodeAnalysis.SyntaxAnnotation
-static readonly Microsoft.CodeAnalysis.Simplification.Simplifier.SpecialTypeAnnotation -> Microsoft.CodeAnalysis.SyntaxAnnotation
-static readonly Microsoft.CodeAnalysis.VersionStamp.Default -> Microsoft.CodeAnalysis.VersionStamp
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeActionOperation>>
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputePreviewOperationsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeActionOperation>>
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.EquivalenceKey.get -> string

--- a/src/Workspaces/Core/Portable/Recommendations/RecommendationOptions.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/RecommendationOptions.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CodeAnalysis.Recommendations
     {
         internal const string RecommendationsFeatureName = "Recommendations";
 
-        public static readonly PerLanguageOption<bool> HideAdvancedMembers = new PerLanguageOption<bool>(RecommendationsFeatureName, "HideAdvancedMembers", defaultValue: false);
+        public static PerLanguageOption<bool> HideAdvancedMembers { get; } = new PerLanguageOption<bool>(RecommendationsFeatureName, "HideAdvancedMembers", defaultValue: false);
 
-        public static readonly PerLanguageOption<bool> FilterOutOfScopeLocals = new PerLanguageOption<bool>(RecommendationsFeatureName, "FilterOutOfScopeLocals", defaultValue: true);
+        public static PerLanguageOption<bool> FilterOutOfScopeLocals { get; } = new PerLanguageOption<bool>(RecommendationsFeatureName, "FilterOutOfScopeLocals", defaultValue: true);
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/RenameOptions.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameOptions.cs
@@ -8,9 +8,9 @@ namespace Microsoft.CodeAnalysis.Rename
     {
         internal const string RenameFeatureName = "Rename";
 
-        public static readonly Option<bool> RenameOverloads = new Option<bool>(RenameFeatureName, "RenameOverloads", defaultValue: false);
-        public static readonly Option<bool> RenameInStrings = new Option<bool>(RenameFeatureName, "RenameInStrings", defaultValue: false);
-        public static readonly Option<bool> RenameInComments = new Option<bool>(RenameFeatureName, "RenameInComments", defaultValue: false);
-        public static readonly Option<bool> PreviewChanges = new Option<bool>(RenameFeatureName, "PreviewChanges", defaultValue: false);
+        public static Option<bool> RenameOverloads { get; } = new Option<bool>(RenameFeatureName, "RenameOverloads", defaultValue: false);
+        public static Option<bool> RenameInStrings { get; } = new Option<bool>(RenameFeatureName, "RenameInStrings", defaultValue: false);
+        public static Option<bool> RenameInComments { get; } = new Option<bool>(RenameFeatureName, "RenameInComments", defaultValue: false);
+        public static Option<bool> PreviewChanges { get; } = new Option<bool>(RenameFeatureName, "PreviewChanges", defaultValue: false);
     }
 }

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOption.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOption.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Simplification
     /// <summary>
     /// This Object contains the options that needs to be drilled down to the Simplification Engine
     /// </summary>
-    public class SimplificationOptions
+    public static class SimplificationOptions
     {
         internal const string NonPerLanguageFeatureName = "Simplification";
         internal const string PerLanguageFeatureName = "SimplificationPerLanguage";
@@ -16,47 +16,47 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// This option tells the simplification engine if the Qualified Name should be replaced by Alias
         /// if the user had initially not used the Alias
         /// </summary>
-        public static readonly Option<bool> PreferAliasToQualification = new Option<bool>(NonPerLanguageFeatureName, "PreferAliasToQualification", true);
+        public static Option<bool> PreferAliasToQualification { get; } = new Option<bool>(NonPerLanguageFeatureName, "PreferAliasToQualification", true);
 
         /// <summary>
         /// This option influences the name reduction of members of a module in VB. If set to true, the 
         /// name reducer will e.g. reduce Namespace.Module.Member to Namespace.Member.
         /// </summary>
-        public static readonly Option<bool> PreferOmittingModuleNamesInQualification = new Option<bool>(NonPerLanguageFeatureName, "PreferOmittingModuleNamesInQualification", true);
+        public static Option<bool> PreferOmittingModuleNamesInQualification { get; } = new Option<bool>(NonPerLanguageFeatureName, "PreferOmittingModuleNamesInQualification", true);
 
         /// <summary>
         /// This option says that if we should simplify the Generic Name which has the type argument inferred
         /// </summary>
-        public static readonly Option<bool> PreferImplicitTypeInference = new Option<bool>(NonPerLanguageFeatureName, "PreferImplicitTypeInference", true);
+        public static Option<bool> PreferImplicitTypeInference { get; } = new Option<bool>(NonPerLanguageFeatureName, "PreferImplicitTypeInference", true);
 
         /// <summary>
         /// This option says if we should simplify the Explicit Type in Local Declarations
         /// </summary>
-        public static readonly Option<bool> PreferImplicitTypeInLocalDeclaration = new Option<bool>(NonPerLanguageFeatureName, "PreferImplicitTypeInLocalDeclaration", false);
+        public static Option<bool> PreferImplicitTypeInLocalDeclaration { get; } = new Option<bool>(NonPerLanguageFeatureName, "PreferImplicitTypeInLocalDeclaration", false);
 
         /// <summary>
         /// This option says if we should simplify to NonGeneric Name rather than GenericName
         /// </summary>
-        public static readonly Option<bool> AllowSimplificationToGenericType = new Option<bool>(NonPerLanguageFeatureName, "AllowSimplificationToGenericType", false);
+        public static Option<bool> AllowSimplificationToGenericType { get; } = new Option<bool>(NonPerLanguageFeatureName, "AllowSimplificationToGenericType", false);
 
         /// <summary>
         /// This option says if we should simplify from Derived types to Base types in Static Member Accesses
         /// </summary>
-        public static readonly Option<bool> AllowSimplificationToBaseType = new Option<bool>(NonPerLanguageFeatureName, "AllowSimplificationToBaseType", true);
+        public static Option<bool> AllowSimplificationToBaseType { get; } = new Option<bool>(NonPerLanguageFeatureName, "AllowSimplificationToBaseType", true);
 
         /// <summary>
         /// This option says if we should simplify away the this. or Me. in member access expression
         /// </summary>
-        public static readonly PerLanguageOption<bool> QualifyMemberAccessWithThisOrMe = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberAccessWithThisOrMe", defaultValue: false);
+        public static PerLanguageOption<bool> QualifyMemberAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberAccessWithThisOrMe", defaultValue: false);
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Declarations
         /// </summary>
-        public static readonly PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInDeclaration = new PerLanguageOption<bool>(PerLanguageFeatureName, "PreferIntrinsicPredefinedTypeKeywordInDeclaration", defaultValue: true);
+        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInDeclaration { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "PreferIntrinsicPredefinedTypeKeywordInDeclaration", defaultValue: true);
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Member Access Expression
         /// </summary>
-        public static readonly PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInMemberAccess = new PerLanguageOption<bool>(PerLanguageFeatureName, "PreferIntrinsicPredefinedTypeKeywordInMemberAccess", defaultValue: true);
+        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInMemberAccess { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "PreferIntrinsicPredefinedTypeKeywordInMemberAccess", defaultValue: true);
     }
 }

--- a/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
+++ b/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
@@ -34,13 +34,13 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// The annotation the reducer uses to identify sub trees to be reduced.
         /// The Expand operations add this annotation to nodes so that the Reduce operations later find them.
         /// </summary>
-        public static readonly SyntaxAnnotation Annotation = new SyntaxAnnotation();
+        public static SyntaxAnnotation Annotation { get; } = new SyntaxAnnotation();
 
         /// <summary>
         /// This is the annotation used by the simplifier and expander to identify Predefined type and preserving
         /// them from over simplification
         /// </summary>
-        public static readonly SyntaxAnnotation SpecialTypeAnnotation = new SyntaxAnnotation();
+        public static SyntaxAnnotation SpecialTypeAnnotation { get; } = new SyntaxAnnotation();
 
         /// <summary>
         /// Expand qualifying parts of the specified subtree, annotating the parts using the <see cref="Annotation" /> annotation.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public struct VersionStamp : IEquatable<VersionStamp>, IObjectWritable
     {
+        public static VersionStamp Default => default(VersionStamp);
+
         private const int GlobalVersionMarker = -1;
         private const int InitialGlobalVersion = 10000;
 
@@ -232,8 +234,6 @@ namespace Microsoft.CodeAnalysis
 
             return globalVersion;
         }
-
-        public static readonly VersionStamp Default = default(VersionStamp);
 
         /// <summary>
         /// True if this VersionStamp is newer than the specified one.


### PR DESCRIPTION
Fixes #2476.
Public API cleanup as per .NET Framework API design guidelines.

We have done this cleanup for compilers (see PR https://github.com/dotnet/roslyn/pull/3246). Do the same for workspaces.

@ManishJayaswal 