### PR TITLE
Improve performance of IVsLanguageBlock.GetCurrentBlock...

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -882,6 +882,11 @@ class C
                 throw new NotImplementedException();
             }
 
+            public string GetDisplayName(SyntaxNode node, DisplayNameOptions options, string rootNamespace = null)
+            {
+                throw new NotImplementedException();
+            }
+
             public bool TryGetExternalSourceInfo(SyntaxNode directive, out ExternalSourceInfo info)
             {
                 throw new NotImplementedException();

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -794,6 +794,10 @@ End Class]]></a>.Value.NormalizeLineEndings()
                 Throw New NotImplementedException()
             End Function
 
+            Public Function GetDisplayName(node As SyntaxNode, options As DisplayNameOptions, Optional rootNamespace As String = Nothing) As String Implements ISyntaxFactsService.GetDisplayName
+                Throw New NotImplementedException()
+            End Function
+
             Public Function TryGetExternalSourceInfo(directive As SyntaxNode, ByRef info As ExternalSourceInfo) As Boolean Implements ISyntaxFactsService.TryGetExternalSourceInfo
                 Throw New NotImplementedException()
             End Function

--- a/src/EditorFeatures/VisualBasicTest/Extensions/StatementSyntaxExtensionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Extensions/StatementSyntaxExtensionTests.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Extensions
             Assert.Equal("Public", actual)
         End Sub
 
-        Private Sub VerifyTokenName(Of T As StatementSyntax)(code As String, expectedName As String)
+        Private Sub VerifyTokenName(Of T As DeclarationStatementSyntax)(code As String, expectedName As String)
             Dim node = SyntaxFactory.ParseCompilationUnit(code).DescendantNodes.OfType(Of T).First()
             Dim actualNameToken = node.GetNameToken()
             Assert.Equal(expectedName, actualNameToken.ToString())

--- a/src/Features/VisualBasic/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
+++ b/src/Features/VisualBasic/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
@@ -82,8 +82,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
                     Return value
                 End If
 
-                Dim xName = If(ShouldCompareByName(x), x.GetNameToken(), Nothing)
-                Dim yName = If(ShouldCompareByName(x), y.GetNameToken(), Nothing)
+                Dim xName = If(ShouldCompareByName(x), TryCast(x, DeclarationStatementSyntax).GetNameToken(), Nothing)
+                Dim yName = If(ShouldCompareByName(x), TryCast(y, DeclarationStatementSyntax).GetNameToken(), Nothing)
 
                 value = TokenComparer.NormalInstance.Compare(xName, yName)
                 If value <> 0 Then

--- a/src/VisualStudio/CSharp/Impl/Debugging/LocationInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/LocationInfoGetter.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Debugging;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
@@ -24,8 +22,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
             // can with Syntax.  This approach is capable of providing parity with the pre-Roslyn implementation.
             var tree = await document.GetCSharpSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-            var token = root.FindToken(position);
-            var memberDeclaration = token.GetAncestor<MemberDeclarationSyntax>();
+            var syntaxFactsService = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
+            var memberDeclaration = syntaxFactsService.GetContainingMemberDeclaration(root, position, useFullSpan: true);
 
             if (memberDeclaration == null)
             {
@@ -41,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
 
                 foreach (var declarator in variableDeclarators)
                 {
-                    if (declarator.FullSpan.Contains(token.FullSpan))
+                    if (declarator.FullSpan.Contains(position))
                     {
                         fieldDeclarator = declarator;
                         break;
@@ -54,76 +52,17 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
                 }
             }
 
-            var name = GetName(memberDeclaration, fieldDeclarator);
+            var name = syntaxFactsService.GetDisplayName((SyntaxNode)fieldDeclarator ?? memberDeclaration,
+                DisplayNameOptions.IncludeNamespaces |
+                DisplayNameOptions.IncludeParameters);
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var lineNumber = text.Lines.GetLineFromPosition(position).LineNumber;
-            var accessor = token.GetAncestor<AccessorDeclarationSyntax>();
+            var accessor = memberDeclaration.GetAncestorOrThis<AccessorDeclarationSyntax>();
             var memberLine = text.Lines.GetLineFromPosition(accessor?.SpanStart ?? memberDeclaration.SpanStart).LineNumber;
             var lineOffset = lineNumber - memberLine;
 
             return new DebugLocationInfo(name, lineOffset);
-        }
-
-        private static string GetName(MemberDeclarationSyntax memberDeclaration, VariableDeclaratorSyntax fieldDeclaratorOpt)
-        {
-            const string missingInformationPlaceholder = "?";
-
-            // containing namespace(s) and type(s)
-            ArrayBuilder<string> containingDeclarationNames = ArrayBuilder<string>.GetInstance();
-            var containingDeclaration = memberDeclaration.Parent;
-            while (containingDeclaration != null)
-            {
-                var @namespace = containingDeclaration as NamespaceDeclarationSyntax;
-                if (@namespace != null)
-                {
-                    var syntax = @namespace.Name;
-                    containingDeclarationNames.Add(syntax.IsMissing ? missingInformationPlaceholder : syntax.ToString());
-                }
-                else
-                {
-                    var type = containingDeclaration as TypeDeclarationSyntax;
-                    if (type != null)
-                    {
-                        var token = type.GetNameToken();
-                        containingDeclarationNames.Add(token.IsMissing ? missingInformationPlaceholder : token.Text);
-                    }
-                }
-                containingDeclaration = containingDeclaration.Parent;
-            }
-            var pooled = PooledStringBuilder.GetInstance();
-            var builder = pooled.Builder;
-            for (var i = containingDeclarationNames.Count - 1; i >= 0; i--)
-            {
-                builder.Append(containingDeclarationNames[i]);
-                builder.Append('.');
-            }
-            containingDeclarationNames.Free();
-
-            // simple name
-            var nameToken = fieldDeclaratorOpt?.Identifier ?? memberDeclaration.GetNameToken();
-            if (nameToken.IsMissing)
-            {
-                builder.Append(missingInformationPlaceholder);
-            }
-            else if (nameToken == default(SyntaxToken))
-            {
-                Debug.Assert(memberDeclaration.Kind() == SyntaxKind.ConversionOperatorDeclaration);
-                builder.Append((memberDeclaration as ConversionOperatorDeclarationSyntax)?.Type);
-            }
-            else
-            {
-                if (memberDeclaration.Kind() == SyntaxKind.DestructorDeclaration)
-                {
-                    builder.Append('~');
-                }
-                builder.Append(nameToken.Text);
-            }
-
-            // parameter list (if any)
-            builder.Append(memberDeclaration.GetParameterList());
-
-            return pooled.ToStringAndFree();
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
             return null;$$
         }
     }
-}", "Class.Property", 2);
+}", "Class.Property", 4);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
             string s = $$value;
         }
     }
-}", "Class.Property", 2);
+}", "Class.Property", 9);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
@@ -293,7 +293,7 @@ class C1
         }
     }
 }
-", "C1.this[int x]", 2);
+", "C1.this[int x]", 4);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
@@ -84,14 +84,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return false;
             }
 
-            var semanticModel = document.GetSemanticModelAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
-            if (symbol == null)
-            {
-                return false;
-            }
-
-            description = symbol.ToMinimalDisplayString(semanticModel, position);
+            description = syntaxFactsService.GetDisplayName(node,
+                DisplayNameOptions.IncludeMemberKeyword |
+                DisplayNameOptions.IncludeParameters |
+                DisplayNameOptions.IncludeType |
+                DisplayNameOptions.IncludeTypeParameters);
             span = node.Span;
             return true;
         }

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -111,9 +111,6 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ComStreamWrapper.cs">
       <Link>InternalUtilities\ComStreamWrapper.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\PooledStringBuilder.cs">
-      <Link>Collections\PooledStringBuilder.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\Test\PdbUtilities\Shared\SymUnmanagedReaderExtensions.cs">
       <Link>Shared\SymUnmanagedReaderExtensions.cs</Link>
     </Compile>

--- a/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
@@ -99,11 +99,34 @@ End Namespace
             Test(<text>
 Namespace NS1
   Class C
-      Sub Method()
-      End Sub$$
+    Sub Method()
+    End Sub$$
   End Class
 End Namespace
 </text>.NormalizedValue, "Root.NS1.C.Method()", 1, rootNamespace:="Root")
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>
+        Public Sub TestGlobalNamespaceWithRootNamespace()
+            Test(<text>
+Namespace Global.NS1
+  Class C
+    Sub Method()
+    End Sub$$
+  End Class
+End Namespace
+</text>.NormalizedValue, "NS1.C.Method()", 1, rootNamespace:="Root")
+
+            Test(<text>
+Namespace Global
+  Namespace NS1
+    Class C
+      Sub Method()
+      End Sub$$
+    End Class
+  End Namespace
+End Namespace
+</text>.NormalizedValue, "NS1.C.Method()", 1, rootNamespace:="Root")
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)>

--- a/src/VisualStudio/Core/Test/LanguageBlockTests.vb
+++ b/src/VisualStudio/Core/Test/LanguageBlockTests.vb
@@ -102,7 +102,7 @@ Namespace N
         End Property|]
     End Module
 End Namespace
-", LanguageNames.VisualBasic, "Property Program.P As Integer")
+", LanguageNames.VisualBasic, "Property Program.P() As Integer")
     End Sub
 
     <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock), WorkItem(1043580)>

--- a/src/VisualStudio/VisualBasic/Impl/Debugging/LocationInfoGetter.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Debugging/LocationInfoGetter.vb
@@ -3,8 +3,8 @@
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Debugging
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
@@ -21,10 +21,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
                 ' can with Syntax.  This approach is capable of providing parity with the pre-Roslyn implementation.
                 Dim tree = Await document.GetVisualBasicSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
                 Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
-                Dim token = root.FindToken(position)
-                Dim memberDeclaration = token.GetContainingMember()
+                Dim syntaxFactsService = document.Project.LanguageServices.GetService(Of ISyntaxFactsService)()
+                Dim memberDeclaration = TryCast(syntaxFactsService.GetContainingMemberDeclaration(root, position, useFullSpan:=True), DeclarationStatementSyntax)
+
                 ' Unlike C#, VB doesn't show field names.
-                If memberDeclaration.Kind = SyntaxKind.FieldDeclaration Then
+                If memberDeclaration?.Kind = SyntaxKind.FieldDeclaration Then
                     memberDeclaration = memberDeclaration.GetAncestor(Of DeclarationStatementSyntax)()
                 End If
 
@@ -33,7 +34,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
                 End If
 
                 Dim compilation = Await document.GetVisualBasicCompilationAsync(cancellationToken).ConfigureAwait(False)
-                Dim name = GetName(memberDeclaration, compilation.Options.RootNamespace)
+                Dim name = syntaxFactsService.GetDisplayName(memberDeclaration,
+                                                             DisplayNameOptions.IncludeNamespaces Or
+                                                             DisplayNameOptions.IncludeParameters Or
+                                                             DisplayNameOptions.IncludeType Or
+                                                             DisplayNameOptions.IncludeTypeParameters,
+                                                             compilation.Options.RootNamespace)
 
                 Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
                 Dim lineNumber = text.Lines.GetLineFromPosition(position).LineNumber
@@ -42,78 +48,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
 
                 Return New DebugLocationInfo(name, lineOffset)
             End Function
-
-            Private Function GetName(memberDeclaration As DeclarationStatementSyntax, rootNamespace As String) As String
-                Const missingInformationPlaceholder As String = "?"
-                Const dotToken As Char = "."c
-
-                ' root namespace
-                Dim pooled = PooledStringBuilder.GetInstance()
-                Dim builder = pooled.Builder
-                If Not String.IsNullOrEmpty(rootNamespace) Then
-                    builder.Append(rootNamespace)
-                    builder.Append(dotToken)
-                End If
-                ' containing namespace(s) and type(s)
-                Dim containingDeclarationNames As ArrayBuilder(Of String) = ArrayBuilder(Of String).GetInstance()
-                Dim containingDeclaration = memberDeclaration.Parent
-                If TypeOf memberDeclaration Is TypeStatementSyntax Then
-                    containingDeclaration = containingDeclaration?.Parent
-                End If
-                While containingDeclaration IsNot Nothing
-                    Dim [namespace] = TryCast(containingDeclaration, NamespaceBlockSyntax)
-                    If [namespace] IsNot Nothing Then
-                        Dim syntax = [namespace].NamespaceStatement.Name
-                        containingDeclarationNames.Add(If(syntax.IsMissing, missingInformationPlaceholder, syntax.ToString()))
-                    Else
-                        Dim type = TryCast(containingDeclaration, TypeBlockSyntax)
-                        If type IsNot Nothing Then
-                            Dim token = type.GetNameToken()
-                            If token.IsMissing Then
-                                containingDeclarationNames.Add(missingInformationPlaceholder)
-                            Else
-                                ' generic type parameters (if any)
-                                Dim typeParameters = type.GetTypeParameterList()
-                                containingDeclarationNames.Add(If(typeParameters IsNot Nothing, token.Text & typeParameters.ToString(), token.Text))
-                            End If
-                        End If
-                    End If
-                    containingDeclaration = containingDeclaration.Parent
-                End While
-                For i = containingDeclarationNames.Count - 1 To 0 Step -1
-                    builder.Append(containingDeclarationNames(i))
-                    builder.Append(dotToken)
-                Next
-                containingDeclarationNames.Free()
-
-                ' simple name
-                Dim nameToken = memberDeclaration.GetNameToken()
-                builder.Append(If(nameToken.IsMissing, missingInformationPlaceholder, nameToken.Text))
-
-                ' generic type parameters (if any)
-                builder.Append(memberDeclaration.GetTypeParameterList())
-
-                ' parameter list (if any)
-                builder.Append(memberDeclaration.GetParameterList())
-
-                ' As clause (if any)
-                Dim asClause = memberDeclaration.GetAsClause()
-                If asClause IsNot Nothing Then
-                    builder.Append(" "c)
-                    builder.Append(asClause)
-                End If
-
-                Return pooled.ToStringAndFree()
-            End Function
-
-            Private Sub AppendContainingDeclarationNames(Of TDeclarationSyntax As DeclarationStatementSyntax)(
-                ByRef containingDeclarationNames As ArrayBuilder(Of String),
-                ByRef declaration As TDeclarationSyntax,
-                appendText As Action(Of ArrayBuilder(Of String), TDeclarationSyntax),
-                getAncestor As Func(Of TDeclarationSyntax, TDeclarationSyntax))
-
-
-            End Sub
         End Module
     End Namespace
 End Namespace

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -113,6 +114,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         bool TryGetDeclaredSymbolInfo(SyntaxNode node, out DeclaredSymbolInfo declaredSymbolInfo);
 
+        string GetDisplayName(SyntaxNode node, DisplayNameOptions options, string rootNamespace = null);
+
         SyntaxNode GetContainingTypeDeclaration(SyntaxNode root, int position);
         SyntaxNode GetContainingMemberDeclaration(SyntaxNode root, int position, bool useFullSpan = true);
         SyntaxNode GetContainingVariableDeclaratorOfFieldDeclaration(SyntaxNode node);
@@ -146,5 +149,16 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         IEnumerable<SyntaxNode> GetConstructors(SyntaxNode root, CancellationToken cancellationToken);
 
         bool TryGetCorrespondingOpenBrace(SyntaxToken token, out SyntaxToken openBrace);
+    }
+
+    [Flags]
+    internal enum DisplayNameOptions
+    {
+        None = 0,
+        IncludeMemberKeyword = 1,
+        IncludeNamespaces = 1 << 1,
+        IncludeParameters = 1 << 2,
+        IncludeType = 1 << 3,
+        IncludeTypeParameters = 1 << 4
     }
 }

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -49,6 +49,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="Linked Files">
+    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\ArrayBuilderExtensions.cs">
+      <Link>Collections\ArrayBuilderExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\Collections\BitVector.cs">
       <Link>InternalUtilities\BitVector.cs</Link>
     </Compile>
@@ -57,6 +60,9 @@
     </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\Collections\ImmutableArrayExtensions.cs">
       <Link>InternalUtilities\ImmutableArrayExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\PooledStringBuilder.cs">
+      <Link>Collections\PooledStringBuilder.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\MetadataReference\MetadataFileReferenceProvider.cs">
       <Link>MetadataReference\MetadataFileReferenceProvider.cs</Link>

--- a/src/Workspaces/VisualBasic/Portable/Extensions/StatementSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/StatementSyntaxExtensions.vb
@@ -299,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         <Extension()>
-        Public Function GetNameToken(member As StatementSyntax) As SyntaxToken
+        Public Function GetNameToken(member As DeclarationStatementSyntax) As SyntaxToken
             If member IsNot Nothing Then
                 Select Case member.Kind
                     Case SyntaxKind.ClassBlock,
@@ -342,6 +342,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Case SyntaxKind.DelegateSubStatement,
                         SyntaxKind.DelegateFunctionStatement
                         Return DirectCast(member, DelegateStatementSyntax).Identifier
+                End Select
+            End If
+
+            Return Nothing
+        End Function
+
+        <Extension()>
+        Public Function GetMemberKeywordToken(member As DeclarationStatementSyntax) As SyntaxToken
+            If member IsNot Nothing Then
+                Select Case member.Kind
+                    Case SyntaxKind.ConstructorBlock
+                        Return DirectCast(DirectCast(member, ConstructorBlockSyntax).BlockStatement, SubNewStatementSyntax).SubKeyword
+                    Case SyntaxKind.DeclareSubStatement,
+                        SyntaxKind.DeclareFunctionStatement
+                        Return DirectCast(member, DeclareStatementSyntax).DeclarationKeyword
+                    Case SyntaxKind.DelegateSubStatement,
+                        SyntaxKind.DelegateFunctionStatement
+                        Return DirectCast(member, DelegateStatementSyntax).DeclarationKeyword
+                    Case SyntaxKind.EventBlock
+                        Return DirectCast(member, EventBlockSyntax).EventStatement.EventKeyword
+                    Case SyntaxKind.EventStatement
+                        Return DirectCast(member, EventStatementSyntax).EventKeyword
+                    Case SyntaxKind.FunctionBlock,
+                        SyntaxKind.SubBlock
+                        Return DirectCast(DirectCast(member, MethodBlockSyntax).BlockStatement, MethodStatementSyntax).DeclarationKeyword
+                    Case SyntaxKind.FunctionStatement,
+                        SyntaxKind.SubStatement
+                        Return DirectCast(member, MethodStatementSyntax).DeclarationKeyword
+                    Case SyntaxKind.OperatorBlock
+                        Return DirectCast(DirectCast(member, OperatorBlockSyntax).BlockStatement, OperatorStatementSyntax).OperatorKeyword
+                    Case SyntaxKind.PropertyBlock
+                        Return DirectCast(member, PropertyBlockSyntax).PropertyStatement.PropertyKeyword
+                    Case SyntaxKind.PropertyStatement
+                        Return DirectCast(member, PropertyStatementSyntax).PropertyKeyword
                 End Select
             End If
 


### PR DESCRIPTION
**Bug number** - Fixes #1977 
**Customer scenario** - In large solutions, you will intermittently see the following dialog when opening new files, etc:
![currentblock](https://cloud.githubusercontent.com/assets/6464209/8010471/4352d196-0b65-11e5-845d-2222d8aaec0a.png)
It blocks user input and sometimes remains active in excess of a minute.  Cancelling is not an effective work-around, because the dialog will re-appear.
**Fix description** - Previously, we would fetch a SemanticModel and build containing Symbols for the current block.  This could be very expensive in a large solution.  However, for the purposes of this scenario, it is adequate to just inspect Syntax.  This change also unifies the implementation of ```IVsLanguageBlock.GetCurrentBlock``` and ```IVsLanguageDebugInfo.GetNameOfLocation```.
**Testing done** - TBD