### PR TITLE
Update versions of Microsoft.DiaSymReader and Microsoft.NetFX20 packages to release versions 1.0.5 and 1.0.3, respectively

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -55,7 +55,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Emit/packages.config
+++ b/src/Compilers/CSharp/Test/Emit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-alpha-build2576" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0-alpha-build2576" targetFramework="net45" />

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -55,7 +55,7 @@
     </Reference>
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />    
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />    
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/CSharp/Test/Symbol/packages.config
+++ b/src/Compilers/CSharp/Test/Symbol/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -67,7 +67,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="..\..\..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll" />
     <Reference Include="Microsoft.Build.Framework">
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\MSBuild\v14.0\Microsoft.Build.Framework.dll</HintPath>

--- a/src/Compilers/Core/VBCSCompilerTests/packages.config
+++ b/src/Compilers/Core/VBCSCompilerTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -53,7 +53,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/Compilers/VisualBasic/Test/Emit/packages.config
+++ b/src/Compilers/VisualBasic/Test/Emit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -49,7 +49,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />    
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />    
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Compilers/VisualBasic/Test/Semantic/packages.config
+++ b/src/Compilers/VisualBasic/Test/Semantic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Dependencies/Microsoft.DiaSymReader/NetFX20/packages.config
+++ b/src/Dependencies/Microsoft.DiaSymReader/NetFX20/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NetFX20" version="1.0.2-rc2" targetFramework="net20" />  
+  <package id="Microsoft.NetFX20" version="1.0.3" targetFramework="net20" />  
 </packages>

--- a/src/Dependencies/Microsoft.DiaSymReader/Version.targets
+++ b/src/Dependencies/Microsoft.DiaSymReader/Version.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion>1.0.4</RoslynSemanticVersion>
-    <NuGetVersion>$(RoslynSemanticVersion)-rc2</NuGetVersion>
+    <RoslynSemanticVersion>1.0.5</RoslynSemanticVersion>
+    <NuGetVersion>$(RoslynSemanticVersion)</NuGetVersion>
     <NuGetVersionType>PreRelease</NuGetVersionType>
   </PropertyGroup>
 </Project>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -28,7 +28,7 @@
       <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NetFX20" version="1.0.2-rc2" targetFramework="net20" />  
+  <package id="Microsoft.NetFX20" version="1.0.3" targetFramework="net20" />  
 </packages>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
@@ -80,7 +80,7 @@
       <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.csproj
@@ -71,7 +71,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/packages.config
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NetFX20" version="1.0.2-rc2" targetFramework="net20" />  
+  <package id="Microsoft.NetFX20" version="1.0.3" targetFramework="net20" />  
 </packages>

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
@@ -24,7 +24,7 @@
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -23,7 +23,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="$(OutDir)Microsoft.VisualStudio.Debugger.Engine.dll" />
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NetFX20" version="1.0.2-rc2" targetFramework="net20" />  
+  <package id="Microsoft.NetFX20" version="1.0.3" targetFramework="net20" />  
 </packages>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
@@ -20,7 +20,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
-    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/packages.config
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -73,7 +73,7 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/src/Test/PdbUtilities/packages.config
+++ b/src/Test/PdbUtilities/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MDbg" version="0.1.0" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/Test/Utilities/TestUtilities.csproj
+++ b/src/Test/Utilities/TestUtilities.csproj
@@ -47,7 +47,7 @@
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.0.0-rc3-20150528-03" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -109,7 +109,7 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <NoStdLib>true</NoStdLib>
-    <FrameworkPathOverride>$(NuGetPackagesPath)\Microsoft.NetFX20.1.0.2-rc2\lib\net20</FrameworkPathOverride>
+    <FrameworkPathOverride>$(NuGetPackagesPath)\Microsoft.NetFX20.1.0.3\lib\net20</FrameworkPathOverride>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ProjectLanguage)' == 'CSharp' AND '$(TargetNetFX20)' == 'true'">

--- a/src/Tools/Source/Pdb2Xml/packages.config
+++ b/src/Tools/Source/Pdb2Xml/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -186,7 +186,7 @@
     </Reference>
     <Reference Include="..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll" />
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
-    <Reference Include="..\..\..\..\packages\Microsoft.DiaSymReader.1.0.4-rc2\lib\net45\Microsoft.DiaSymReader.dll" />
+    <Reference Include="..\..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll" />
     <Reference Include="Microsoft.VisualStudio.CallHierarchy.Package.Definitions.dll">
       <HintPath>$(DevEnvDir)\Microsoft.VisualStudio.CallHierarchy.Package.Definitions.dll</HintPath>
     </Reference>

--- a/src/VisualStudio/Core/Def/packages.config
+++ b/src/VisualStudio/Core/Def/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="ManagedEsent" version="1.9.2.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
-  <package id="Microsoft.DiaSymReader" version="1.0.4-rc2" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The packages are currently versioned as pre-release "rc2", which is not appropriate for RTM.

@ManishJayaswal 