### PR TITLE
Treat readonly fixed buffer as a writable field.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return false;
             }
 
-            if (!field.IsReadOnly)
+            if (!field.IsReadOnly || field.IsFixed)
             {
                 return true;
             }


### PR DESCRIPTION
Addresses DevDiv 1171076.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.

VS 2013 compiler doesn't allow readonly modifier on a fixed buffer declaration. I am in the process of confirming whether allowing it is an intentional change.