### PR TITLE
When mapping caret points, IBufferGraph.MapDownToInsertionPoint

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IBufferGraphExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
                 case BufferMapDirection.Down:
                     {
-                        return bufferGraph.MapDownToBuffer(point, PointTrackingMode.Positive, targetBuffer, PositionAffinity.Predecessor);
+                        return bufferGraph.MapDownToInsertionPoint(point, PointTrackingMode.Positive, s => s == targetBuffer.CurrentSnapshot);
                     }
 
                 case BufferMapDirection.Up:

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
@@ -31,10 +31,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         public static SnapshotPoint? GetCaretPoint(this ITextView textView, ITextBuffer subjectBuffer)
         {
             var caret = textView.Caret.Position;
-            var span = textView.BufferGraph.MapUpOrDownToBuffer(new SnapshotSpan(caret.BufferPosition, 0), subjectBuffer);
-            if (span.HasValue)
+            var point = textView.BufferGraph.MapUpOrDownToBuffer(caret.BufferPosition, subjectBuffer);
+            if (point.HasValue)
             {
-                return span.Value.Start;
+                return point.Value;
             }
             else
             {


### PR DESCRIPTION
Our BufferGraphExtensions used to map a SnapshotPoint between buffers by
converting it to a SnapshotSpan of length 0. This can produce ambiguous
results, leading to the crash in #2348. This change modifies the
position mapping extension method to use
IBufferGraph.MapDownToInsertionPoint, which produces the correct result.

Reviewers: @jasonmalinowski @dpoeschl @Pilchie @DustinCampbell @balajikris @brettfo 