### PR TITLE
Prefer System.Linq over System.Core...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -551,16 +551,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
         }
 
-        internal override ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentities(Diagnostic diagnostic)
+        internal override ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentities(Diagnostic diagnostic, AssemblyIdentity linqLibrary)
         {
-            return GetMissingAssemblyIdentitiesHelper((ErrorCode)diagnostic.Code, diagnostic.Arguments);
+            return GetMissingAssemblyIdentitiesHelper((ErrorCode)diagnostic.Code, diagnostic.Arguments, linqLibrary);
         }
 
         /// <remarks>
         /// Internal for testing.
         /// </remarks>
-        internal static ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentitiesHelper(ErrorCode code, IReadOnlyList<object> arguments)
+        internal static ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentitiesHelper(ErrorCode code, IReadOnlyList<object> arguments, AssemblyIdentity linqLibrary)
         {
+            Debug.Assert(linqLibrary != null);
+
             switch (code)
             {
                 case ErrorCode.ERR_NoTypeDef:
@@ -598,7 +600,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 // MSDN says these might come from System.Dynamic.Runtime
                 case ErrorCode.ERR_QueryNoProviderStandard:
                 case ErrorCode.ERR_ExtensionAttrNotFound: // Probably can't happen.
-                    return ImmutableArray.Create(SystemCoreIdentity);
+                    return ImmutableArray.Create(linqLibrary);
                 case ErrorCode.ERR_BadAwaitArg_NeedSystem:
                     Debug.Assert(false, "Roslyn no longer produces ERR_BadAwaitArg_NeedSystem");
                     break;

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         internal static readonly AssemblyIdentity SystemIdentity = new AssemblyIdentity("System");
         internal static readonly AssemblyIdentity SystemCoreIdentity = new AssemblyIdentity("System.Core");
+        internal static readonly AssemblyIdentity SystemLinqIdentity = new AssemblyIdentity("System.Linq");
         internal static readonly AssemblyIdentity SystemXmlIdentity = new AssemblyIdentity("System.Xml");
         internal static readonly AssemblyIdentity SystemXmlLinqIdentity = new AssemblyIdentity("System.Xml.Linq");
         internal static readonly AssemblyIdentity MicrosoftVisualBasicIdentity = new AssemblyIdentity("Microsoft.VisualBasic");
@@ -45,12 +46,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             out string typeName,
             CompilationTestData testData);
 
-        internal string GetErrorMessageAndMissingAssemblyIdentities(DiagnosticBag diagnostics, DiagnosticFormatter formatter, CultureInfo preferredUICulture, out bool useReferencedModulesOnly, out ImmutableArray<AssemblyIdentity> missingAssemblyIdentities)
+        internal string GetErrorMessageAndMissingAssemblyIdentities(DiagnosticBag diagnostics, DiagnosticFormatter formatter, CultureInfo preferredUICulture, AssemblyIdentity linqLibrary, out bool useReferencedModulesOnly, out ImmutableArray<AssemblyIdentity> missingAssemblyIdentities)
         {
             var errors = diagnostics.AsEnumerable().Where(d => d.Severity == DiagnosticSeverity.Error);
             foreach (var error in errors)
             {
-                missingAssemblyIdentities = this.GetMissingAssemblyIdentities(error);
+                missingAssemblyIdentities = this.GetMissingAssemblyIdentities(error, linqLibrary);
                 if (!missingAssemblyIdentities.IsDefault)
                 {
                     break;
@@ -75,7 +76,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal abstract bool HasDuplicateTypesOrAssemblies(Diagnostic diagnostic);
 
-        internal abstract ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentities(Diagnostic diagnostic);
+        internal abstract ImmutableArray<AssemblyIdentity> GetMissingAssemblyIdentities(Diagnostic diagnostic, AssemblyIdentity linqLibrary);
 
         // ILOffset == 0xffffffff indicates an instruction outside of IL.
         // Treat such values as the beginning of the IL.

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -322,6 +322,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             PooledHashSet<AssemblyIdentity> assembliesLoadedInRetryLoop = null;
             bool tryAgain;
+            var linqLibrary = EvaluationContextBase.SystemLinqIdentity;
             do
             {
                 errorMessage = null;
@@ -338,8 +339,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         diagnostics,
                         formatter,
                         preferredUICulture: null,
+                        linqLibrary: linqLibrary,
                         useReferencedModulesOnly: out useReferencedModulesOnly,
                         missingAssemblyIdentities: out missingAssemblyIdentities);
+                    // If there were LINQ-related errors, we'll initially add System.Linq (set above).
+                    // If that doesn't work, we'll fall back to System.Core for subsequent retries.
+                    linqLibrary = EvaluationContextBase.SystemCoreIdentity;
+
                     if (useReferencedModulesOnly)
                     {
                         Debug.Assert(missingAssemblyIdentities.IsEmpty);

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             if (diagnostics.HasAnyErrors())
             {
                 bool useReferencedModulesOnly;
-                error = context.GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, out useReferencedModulesOnly, out missingAssemblyIdentities);
+                error = context.GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, EvaluationContextBase.SystemCoreIdentity, out useReferencedModulesOnly, out missingAssemblyIdentities);
             }
             else
             {
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             if (diagnostics.HasAnyErrors())
             {
                 bool useReferencedModulesOnly;
-                error = evaluationContext.GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, out useReferencedModulesOnly, out missingAssemblyIdentities);
+                error = evaluationContext.GetErrorMessageAndMissingAssemblyIdentities(diagnostics, formatter, preferredUICulture, EvaluationContextBase.SystemCoreIdentity, out useReferencedModulesOnly, out missingAssemblyIdentities);
             }
             else
             {


### PR DESCRIPTION
**Bug number** - Fixes #2547
**Customer scenario** - In a Win10 UWP application (or any app running on that version of CoreCLR):

- Results View will not work before System.Linq.dll has been loaded into the process.
- If you use Linq in a debugger window before System.Linq.dll has been loaded into the process, then Results View will be broken for the remainder of the debug session.

**Fix description** - This is part of a coordinated change with the debugger team.  They will be fixing VIL to be able to interpret Linq queries compiled against System.Linq.  When that is done, we will change the EE logic prefer to loading System.Linq (and then fall back to System.Core if that fails).
**Testing (todo)** - Test combined fixes in Win10 UWP (both C# and VB).  Ensure that Linq and Results View work before and after System.Linq is loaded into the process.  Ensure that the same is true for Winforms apps (both C# and VB) running on the desktop framework.