### PR TITLE
Disabling 258 C# Symbol Unit Tests.

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
+++ b/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -798,7 +798,7 @@ class D : C, I { }
             }
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void MissingTypeInTypeArgumentsOfImplementedInterface()
         {
             var lib1 = CreateCompilationWithMscorlib(@"
@@ -1275,7 +1275,7 @@ namespace ErrorTest
                 );
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void MissingBaseClass()
         {
             var lib1 = CreateCompilationWithMscorlib(@"

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -605,7 +605,7 @@ class D
         }
 
         [WorkItem(713356, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void MissedModuleA()
         {
             var netModule1 = CreateCompilationWithMscorlib(

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -3858,7 +3858,7 @@ class C
         }
 
         [WorkItem(544651, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SpeculativelyBindPropertyGroup1()
         {
             var source1 =
@@ -3897,7 +3897,7 @@ class C
         }
 
         [WorkItem(544651, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SpeculativelyBindPropertyGroup2()
         {
             var source1 =
@@ -3946,7 +3946,7 @@ class C
         //public void UnambiguousPropertyGroupWithoutBoundParent1()
 
         [WorkItem(546117, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void UnambiguousPropertyGroupWithoutBoundParent2()
         {
             var source1 =

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public partial class IndexedProperties_BindingTests : SemanticModelTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void OldGetFormat_IndexedProperties()
         {
             var reference = GetReference();
@@ -37,7 +37,7 @@ class B
             IndexedPropertiesBindingChecks(source, reference, SymbolKind.Method, "get_P1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedProperties_Complete()
         {
             var reference = GetReference();
@@ -58,7 +58,7 @@ class B
             IndexedPropertiesBindingChecks(source, reference, SymbolKind.Property, "P1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedProperties_Incomplete()
         {
             var reference = GetReference();
@@ -79,7 +79,7 @@ class B
             IndexedPropertiesBindingChecks(source, reference, SymbolKind.Property, "P1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedProperties_Set_In_Constructor()
         {
             var reference = GetReference();
@@ -99,7 +99,7 @@ class B
             IndexedPropertiesBindingChecks(source, reference, SymbolKind.Property, "P1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedProperties_LINQ()
         {
             var reference = GetReference();

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -3207,7 +3207,7 @@ class C
 
         [WorkItem(1019366, "DevDiv")]
         [WorkItem(273, "CodePlex")]
-        [Fact]
+        [ClrOnlyFact]
         public void Bug1019366()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -1400,7 +1400,7 @@ static class E
                 "void object.F(object y, object z)");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyGroup()
         {
             var source1 =
@@ -1520,7 +1520,7 @@ End Class";
                 "string A.P[int x, string y]");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyGroupOverloadsOverridesHides()
         {
             var source1 =

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -5454,7 +5454,7 @@ public class C : IEquatable<C>
         }
 
         [WorkItem(531505, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void Pia()
         {
             var source = @"
@@ -6119,7 +6119,8 @@ class Module1
 
         #endregion Dev10 bugs
 
-        [Fact, WorkItem(1115058, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(1115058, "DevDiv")]
         public void UnterminatedElement()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AccessorOverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AccessorOverriddenOrHiddenMembersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -852,7 +852,7 @@ public class G<T>
         }
 
         [WorkItem(546143, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void OverridingExplicitInterfaceImplementationFromSource()
         {
             var il = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -445,7 +445,7 @@ class ClassA
             Assert.Equal("<anonymous type: System.Int32 x, <empty anonymous type> y>..ctor(System.Int32 x, <empty anonymous type> y)", info0.Symbol.ToTestDisplayString());
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbols_DontCrashIfNameIsQueriedBeforeEmit()
         {
             var source = @"
@@ -700,7 +700,7 @@ public class A
         }
 
         [WorkItem(546416, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void TestAnonymousTypeInsideGroupBy_Queryable()
         {
             CompileAndVerify(
@@ -728,7 +728,7 @@ public class Program
         }
 
         [WorkItem(546416, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void TestAnonymousTypeInsideGroupBy_Enumerable()
         {
             CompileAndVerify(
@@ -757,7 +757,7 @@ public class Program
         }
 
         [WorkItem(546416, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void TestAnonymousTypeInsideGroupBy_Enumerable2()
         {
             CompileAndVerify(

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class AnonymousTypesSymbolTests : CompilingTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_InQuery()
         {
             var source = LINQ + @"
@@ -49,7 +49,7 @@ class Query
             TestAnonymousTypeFieldSymbols_InQuery(verifier.EmittedAssemblyData);
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_Mix()
         {
             var source = @"
@@ -89,7 +89,7 @@ namespace Test
             CompileAndVerify(source);
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeInConstructedMethod_NonEmpty()
         {
             var source = @"
@@ -114,7 +114,7 @@ class Program
             );
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeInConstructedMethod_NonEmpty2()
         {
             var source = @"
@@ -140,7 +140,7 @@ class Program
             );
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeInConstructedMethod_NonEmpty3()
         {
             var source = @"
@@ -170,7 +170,7 @@ class Program
             );
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeInConstructedMethod_NonEmpty4()
         {
             var source = @"
@@ -200,7 +200,7 @@ class Program
             );
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeInConstructedMethod_Empty()
         {
             var source = @"
@@ -257,7 +257,7 @@ class Program
 
         #endregion
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_Simple()
         {
             var source = @"
@@ -616,7 +616,7 @@ class Query
         }
 
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_Empty()
         {
             var source = @"
@@ -701,7 +701,7 @@ class Query
         }
 
         [WorkItem(543022, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_StandardNames()
         {
             var source = @"
@@ -724,7 +724,7 @@ class Query
         }
 
         [WorkItem(543022, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_StandardNames2()
         {
             var source = @"
@@ -1196,7 +1196,7 @@ class Query
 
         #endregion
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_BaseAccess()
         {
             var source = @"
@@ -1225,7 +1225,7 @@ class Derived: Base
                 expectedOutput: "{ field = 123 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_PropertyAccess()
         {
             var source = @"
@@ -1249,7 +1249,7 @@ class Class1
                 expectedOutput: "{ PropertyA = pa-value }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_Simple()
         {
             var source = @"
@@ -1270,7 +1270,7 @@ class Query
                 expectedOutput: "a=1; b=text");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_CustModifiersOnPropertyFields()
         {
             var source = @"
@@ -1294,7 +1294,7 @@ class Query
                 emitters: TestEmitters.RefEmitUnsupported_646023);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_ToString()
         {
             // test AnonymousType.ToString()
@@ -1323,7 +1323,7 @@ class Query
             }
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_Equals()
         {
             var source = @"
@@ -1385,7 +1385,7 @@ class Query
 ");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_GetHashCode()
         {
             var source = @"
@@ -1440,7 +1440,7 @@ class Query
 ");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AnonymousType_MultiplyEmitDoesNotChangeTheOrdering()
         {
             //  this test checks whether or not anonymous types which came from speculative 
@@ -1518,7 +1518,7 @@ class Class3
         }
 
         [WorkItem(543134)]
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_Simple_1()
         {
             var source = @"
@@ -1534,7 +1534,7 @@ class Test
             CompileAndVerify(source);
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypeSymbol_NamesConflictInsideLambda()
         {
             var source = @"
@@ -1557,7 +1557,7 @@ class Test
         }
 
         [WorkItem(543693, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void Bug11593a()
         {
             var source = @"
@@ -1594,7 +1594,7 @@ class P
         }
 
         [WorkItem(543693, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void Bug11593b()
         {
             var source = @"
@@ -1633,7 +1633,7 @@ class P
         }
 
         [WorkItem(543177, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void AnonymousTypePropertyValueWithWarning()
         {
             var source = @"
@@ -1886,7 +1886,7 @@ class C
                 Diagnostic(ErrorCode.ERR_InvalidAnonymousTypeMemberDeclarator, "array?[0]").WithLocation(13, 24));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         [WorkItem(991505, "DevDiv")]
         [WorkItem(199, "CodePlex")]
         public void Bug991505()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -1517,7 +1517,7 @@ public class Test {
         }
 
         [WorkItem(545361, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void NullableIntToStructViaDecimal()
         {
             var source = @"
@@ -1616,7 +1616,7 @@ public struct S
         }
 
         [WorkItem(545471, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void CheckedConversionsInExpressionTrees()
         {
             var source = @"
@@ -1718,7 +1718,7 @@ class C<T>
         }
 
         [WorkItem(715207, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void LiftingReturnTypeOfExplicitUserDefinedConversion()
         {
             var source = @"
@@ -1817,7 +1817,7 @@ public struct C
         }
 
         [WorkItem(742345, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void MethodGroupConversion_ContravarianceAndDynamic()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/EnumTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/EnumTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Text;
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
     }
 }";
 
-        [Fact]
+        [ClrOnlyFact]
         public void EnumWithPrivateInstanceField()
         {
             // No errors.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class ExtensionMethodTests : CSharpTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void IsExtensionMethod()
         {
             var source =
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             Assert.False(method.IsExtensionMethod);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OverloadResolution()
         {
             var source =
@@ -264,7 +264,7 @@ static class S
                 Diagnostic(ErrorCode.ERR_BadArgType, "c.P").WithArguments("1", "object", "System.Action").WithLocation(11, 11));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ExtensionMethodInTheSameClass()
         {
             var source =
@@ -294,7 +294,7 @@ xyz");
         }
 
         [WorkItem(541143, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void NumericConversionsAreNotAllowed()
         {
             var source =
@@ -323,7 +323,7 @@ static class Program
         }
 
         [WorkItem(541144, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void EnumerationConversionsAreNotAllowed()
         {
             var source =
@@ -352,7 +352,7 @@ static class Program
         }
 
         [WorkItem(541145, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void CannotCreateDelegateToExtensionMethodOnValueType()
         {
             var source =
@@ -376,7 +376,7 @@ static class Program
         }
 
         [WorkItem(528426, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void TypedReferenceCannotBeUsedAsTypeArgument()
         {
             var source =
@@ -460,7 +460,7 @@ namespace N
         }
 
         [WorkItem(541189, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ExtensionMethodsDeclaredInEnclosingNamespaceArePreferredOverImported2()
         {
             var source =
@@ -489,7 +489,7 @@ namespace N
         }
 
         [WorkItem(541189, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ExtensionMethodsDeclaredInEnclosingNamespaceArePreferredOverImported()
         {
             var source =
@@ -518,7 +518,7 @@ namespace N
             CompileAndVerify(source, expectedOutput: "1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CandidateSearchByArgType()
         {
             var source =
@@ -547,7 +547,7 @@ namespace N1.N2
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CandidateSearchConversion()
         {
             var source =
@@ -777,7 +777,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadAccess, "((this.E))(null, null)").WithArguments("S.E(object, object, object)").WithLocation(13, 9));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DelegateMembers()
         {
             var source =
@@ -841,7 +841,7 @@ static class S
                 Diagnostic(ErrorCode.ERR_BadArgType, "1.0").WithArguments("1", "double", "int").WithLocation(10, 16));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DelegatesFromOverloads()
         {
             var source =
@@ -899,7 +899,7 @@ static class B
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DelegatesAsArguments()
         {
             var source =
@@ -1557,7 +1557,7 @@ static class S
                 Diagnostic(ErrorCode.ERR_NoSuchMember, "E").WithArguments("C", "E").WithLocation(8, 14));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DefinedInSameClass()
         {
             var source =
@@ -1668,7 +1668,7 @@ static class E
         /// <summary>
         /// Prefer methods on classes on inner namespaces.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void InnerNamespacesBeforeOuter()
         {
             var source =
@@ -1838,7 +1838,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "E").WithArguments("S.E(object)", "method").WithLocation(19, 11));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void GenericDelegate()
         {
             var source =
@@ -1989,7 +1989,7 @@ static class S
                 Diagnostic(ErrorCode.ERR_BadExtensionArgTypes, "E3").WithArguments("int", "E3", "S.E3(long, params object[])").WithLocation(7, 11));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ParamsArray()
         {
             var source =
@@ -2013,7 +2013,7 @@ static class S
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Using()
         {
             var source =
@@ -2145,7 +2145,7 @@ internal static class C
                 Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(4, 29));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SystemLinqEnumerable()
         {
             var source =
@@ -2202,7 +2202,7 @@ class C
         /// extension method. Note: Dev10 reports an error in such cases ("No overload for
         /// 'C.F(object)' matches delegate 'System.Action'") even though these cases are valid.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void BoxingConversionOfDelegateReceiver01()
         {
             var source =
@@ -2272,7 +2272,7 @@ G: S");
         /// Similar to the test above, but using instances of type
         /// parameters for the delegate receiver.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void BoxingConversionOfDelegateReceiver02()
         {
             var source =
@@ -2372,7 +2372,7 @@ B");
             Utils.CheckSymbol((Symbol)symbol, "IEnumerable<string> IEnumerable<string>.Take<string>(int count)");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AssemblyMightContainExtensionMethods()
         {
             var source =
@@ -2420,7 +2420,7 @@ B");
         /// emit, after all types within the assembly have been inspected, if there
         /// are no types with extension methods.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void AssemblyMightContainExtensionMethodsReset()
         {
             var source =
@@ -2447,7 +2447,7 @@ B");
             Assert.False(sourceAssembly.MightContainExtensionMethods);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ReducedExtensionMethodSymbols()
         {
             var source =
@@ -2517,7 +2517,7 @@ static class S
         /// <summary>
         /// Roslyn bug 7782: NullRef in PeWriter.DebuggerShouldHideMethod
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void ExtensionMethod_ValidateExtensionAttribute()
         {
             var source =
@@ -2574,7 +2574,7 @@ namespace ConsoleApplication1
         /// <summary>
         /// Box value type receiver if passed as reference type.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void BoxValueTypeReceiverIfNecessary()
         {
             var source =
@@ -2634,7 +2634,7 @@ S");
         }
 
         [WorkItem(541652, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ReduceExtensionMethodWithNullReceiverType()
         {
             var source =
@@ -2960,7 +2960,8 @@ static class DevDivBugs142219
                 Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "x.Foo").WithArguments("DevDivBugs142219.Foo<T>(T)", "T"));
         }
 
-        [Fact, WorkItem(545734, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(545734, "DevDiv")]
         public void ExtensionMethodWithRefParameterFromMetadata()
         {
             var lib = @"
@@ -3142,7 +3143,7 @@ class Test
         }
 
         [WorkItem(546093, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void VBExtensionMethod()
         {
             var source1 =
@@ -3166,7 +3167,7 @@ End Module";
         }
 
         [WorkItem(602893, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void Bug602893()
         {
             var source1 =
@@ -3309,7 +3310,7 @@ namespace CSharpApp
             compilation.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void InternalExtensionAttribute()
         {
             var source =
@@ -3333,7 +3334,8 @@ internal static class Test
             CompileAndVerify(compilation);
         }
 
-        [Fact, WorkItem(1010648, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(1010648, "DevDiv")]
         public void ExtensionMethodFromUsingStatic()
         {
             const string source = @"
@@ -3394,7 +3396,8 @@ namespace N
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Foo").WithArguments("Foo").WithLocation(10, 9));
         }
 
-        [Fact, WorkItem(1010648, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(1010648, "DevDiv")]
         public void ExtensionMethodImportedTwiceNoErrors()
         {
             const string source = @"
@@ -3461,7 +3464,8 @@ namespace N
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Foo").WithArguments("N.S.Foo(int)", "N.R.Foo(int)").WithLocation(9, 11));
         }
 
-        [Fact, WorkItem(1010648, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(1010648, "DevDiv")]
         public void ExtensionMethodIsDisambiguatedByUsingStaticAtDeeperLevel()
         {
             const string source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintConversionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -825,7 +825,7 @@ class B : A<int>
         /// <summary>
         /// 6.1.10
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void EmitImplicitConversions()
         {
             var source =
@@ -888,7 +888,7 @@ class C<T1, T2, T3, T4, T5, T6>
         /// <summary>
         /// 6.2.7
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void EmitExplicitConversions()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class GenericConstraintTests : CSharpTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void LoadAndPersist()
         {
             var source =
@@ -54,7 +54,7 @@ class D<T> where T : A<int>, new() { }";
                 symbolValidator: validator);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OverriddenMethods()
         {
             var source =
@@ -93,7 +93,7 @@ class B1 : A<int>
                 symbolValidator: validator);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ExplicitInterfaceMethods()
         {
             var source =
@@ -125,7 +125,7 @@ class C : I<C, object>
         /// of partial methods early - in the constructor. Ensure constraints for
         /// overridden methods are handled in these cases.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void PartialClassOverriddenMethods()
         {
             var source =
@@ -177,7 +177,7 @@ partial class B<T> : A<T>
                 symbolValidator: validator);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ConstraintWithTypeParameter()
         {
             var source =
@@ -194,7 +194,7 @@ delegate void D<T>() where T : I<T>;";
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ConstraintWithContainingType()
         {
             var source =
@@ -204,7 +204,7 @@ interface IB<T> where T : IB<T> { }";
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ConstraintWithSameType()
         {
             var source =
@@ -213,7 +213,7 @@ class C<T, U> where T : C<T, U> { }";
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void BaseWithSameType()
         {
             var source =
@@ -377,7 +377,7 @@ class G<T> where T : C
         /// <summary>
         /// Implicit implementations must specify constraints.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void ImplicitImplementation()
         {
             var source =
@@ -406,7 +406,7 @@ class B : I<object>
         /// <summary>
         /// Explicit implementations do not specify constraints.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void ExplicitImplementation()
         {
             var source =
@@ -683,7 +683,7 @@ partial class B<T> where T : struct
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M5").WithArguments("A<T>", "T", "U").WithLocation(11, 25));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void StructAndUnconstrainedTypeParameterConstraints()
         {
             var source =
@@ -694,7 +694,7 @@ partial class B<T> where T : struct
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void WhereTypeParameter()
         {
             var source =
@@ -703,7 +703,7 @@ class C<where> where where : I<where> { }";
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NewConstraintWithValueType()
         {
             var source =
@@ -738,7 +738,7 @@ class C<T> where T : new()
                 Diagnostic(ErrorCode.ERR_NoNewTyvar, "new T()").WithArguments("T").WithLocation(8, 11));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void RedundantConstraints()
         {
             var source =
@@ -1002,7 +1002,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<T>").WithArguments("C<T>", "T", "C<T>").WithLocation(4, 19));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PartialClass()
         {
             var source =
@@ -1014,7 +1014,7 @@ partial class C<T> { }";
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SubstitutedLambdaConstraints()
         {
             var source =
@@ -1089,7 +1089,7 @@ static class C
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "i.F").WithArguments("C.F<T>(T)", "T", "I").WithLocation(9, 9));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DefaultT()
         {
             var source =
@@ -1145,7 +1145,7 @@ S");
         }
 
         [WorkItem(542376, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void NullT()
         {
             var source =
@@ -1206,7 +1206,7 @@ S");
             compilation.VerifyIL("C.F6<T>()", expectedIL);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TryCast()
         {
             var source =
@@ -1248,7 +1248,7 @@ class B2<T>
             compilation.VerifyIL("B2<T>.F4<U>(U)", expectedIL);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NewT()
         {
             var source =
@@ -1310,7 +1310,7 @@ S");
         }
 
         [WorkItem(542312, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void NewTStatement()
         {
             var source =
@@ -1385,7 +1385,7 @@ class C
         /// <summary>
         /// Invoke methods and properties on constrained generic types.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void Members()
         {
             var source =
@@ -1509,7 +1509,7 @@ B.M");
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Indexers()
         {
             var source =
@@ -1578,7 +1578,7 @@ S[0]");
         /// <summary>
         /// Access fields on constrained generic types.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void Fields()
         {
             var source =
@@ -1640,7 +1640,7 @@ class C
         /// <summary>
         /// Access events on constrained generic types.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void Events()
         {
             var source =
@@ -1776,7 +1776,7 @@ class D2 : C<A, B>
                 Diagnostic(ErrorCode.ERR_BaseConstraintConflict, "X").WithArguments("X", "B", "A").WithLocation(10, 30));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void MovedConstraints()
         {
             var source =
@@ -2285,7 +2285,7 @@ class C
         /// Class constraint members should hide
         /// interface constraint members.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void EffectiveInterfaceSet03()
         {
             var source =
@@ -2360,7 +2360,7 @@ class C
             CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ThrowT()
         {
             var source =
@@ -2396,7 +2396,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CatchT()
         {
             var source =
@@ -2413,7 +2413,7 @@ class C
             CompileAndVerify(source);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CatchTLifted()
         {
             var source =
@@ -2537,7 +2537,7 @@ class C<T>
                 Diagnostic(ErrorCode.ERR_ClassBoundNotFirst, "A").WithArguments("A").WithLocation(13, 30));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LookupObjectMembers()
         {
             var source =
@@ -3068,7 +3068,7 @@ class C
         }
 
         [WorkItem(542174, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ConstraintsOnOverriddenMethod()
         {
             var source =
@@ -3554,7 +3554,7 @@ class C4 : B4<I, A, object> { }
         }
 
         [WorkItem(542755, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SpellingOfGenericClassNameIsPreserved()
         {
             var ilSource =
@@ -3588,7 +3588,7 @@ class C : I
             CompileWithCustomILSource(csharpSource, ilSource, compilationVerifier: compilationVerifier, emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SpellingOfGenericClassNameIsPreserved2()
         {
             var ilSource =
@@ -3622,7 +3622,7 @@ class C : I
             CompileWithCustomILSource(csharpSource, ilSource, compilationVerifier: compilationVerifier, emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SpellingOfGenericClassNameIsPreserved3()
         {
             var ilSource =
@@ -3656,7 +3656,7 @@ class C : I
             CompileWithCustomILSource(csharpSource, ilSource, compilationVerifier: compilationVerifier, emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SpellingOfGenericClassNameIsPreserved4()
         {
             var ilSource =
@@ -3690,7 +3690,7 @@ class C : I
             CompileWithCustomILSource(csharpSource, ilSource, compilationVerifier: compilationVerifier, emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SpellingOfGenericClassNameIsPreserved5()
         {
             var ilSource =
@@ -4598,7 +4598,7 @@ class B
         }
 
         [WorkItem(542527, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SelfReferentialInheritedConstraints01()
         {
             var source =
@@ -4643,7 +4643,7 @@ System.String
 System.String");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SelfReferentialInheritedConstraints02()
         {
             var source =
@@ -4709,7 +4709,7 @@ abstract class E : D, IB
         }
 
         [WorkItem(542601, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SelfReferentialInheritedConstraints03()
         {
             var source =
@@ -4740,7 +4740,7 @@ System.Int32");
         }
 
         [WorkItem(542601, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SelfReferentialInheritedConstraints04()
         {
             var source =
@@ -4782,7 +4782,7 @@ class C : I<object>, I<C>
         }
 
         [WorkItem(542532, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void SelfReferentialConstraintsWithLambda()
         {
             var source =
@@ -4819,7 +4819,7 @@ M1<T, U>");
         }
 
         [WorkItem(542277, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void AccessToMembersOfInheritedConstraints()
         {
             var source =
@@ -4912,7 +4912,7 @@ class B<T>
                 Diagnostic(ErrorCode.ERR_NoExplicitConv, "(T[])x").WithArguments("U[]", "T[]").WithLocation(36, 16));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ImplicitReferenceTypeParameterConversion()
         {
             var source =
@@ -4949,7 +4949,7 @@ class B<T>
         }
 
         [WorkItem(542620, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void DuplicateConstraintTypes()
         {
             var source =
@@ -5031,7 +5031,7 @@ class C
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<object, object>").WithArguments("C.M<T1, T2>()", "I<object>", "T2", "object").WithLocation(13, 9));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ContravariantInterfacesInConstraints()
         {
             var source =
@@ -5334,7 +5334,7 @@ class D0 : D<object>
         /// for compatibility with Dev10.
         /// </summary>
         [WorkItem(543710, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void EmittedObjectConstraint()
         {
             var source =
@@ -5503,7 +5503,7 @@ class B : A
         }
 
         [WorkItem(543710, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void InheritedObjectConstraint2()
         {
             var csCompilation = CreateCSharpCompilation("InheritedObjectConstraint2CS",
@@ -6315,7 +6315,7 @@ class B2 : A<dynamic>, I
         }
 
         [WorkItem(654522, "DevDiv")]
-        [Fact()]
+        [ClrOnlyFact]
         public void Bug654522()
         {
             var compilation = CreateCompilationWithMscorlibAndSystemCore("public interface I<W> where W : struct {}").VerifyDiagnostics();
@@ -6554,7 +6554,7 @@ class B : A
         }
 
         [WorkItem(767334, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ConstraintOnSynthesizedExplicitImplementationMethod()
         {
             var source1 =
@@ -6615,7 +6615,7 @@ C`1[A]");
         }
 
         [WorkItem(837422, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void RedundantValueTypeConstraint()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class IndexedPropertyTests : CSharpTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedProperties()
         {
             var source1 =
@@ -72,7 +72,7 @@ P[2] = 2
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OptionalParameters()
         {
             var source1 =
@@ -164,7 +164,7 @@ P[1, 2].set
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ParamsArrayParameters()
         {
             var source1 =
@@ -232,7 +232,7 @@ End Class";
 ");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void RefParameters()
         {
             var source1 =
@@ -618,7 +618,7 @@ F()
 ");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OptionalRefParameters()
         {
             var source1 =
@@ -818,7 +818,7 @@ F()
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void DefaultProperty()
         {
             var source1 =
@@ -899,7 +899,7 @@ End Class";
         /// Allow calling indexed property accessors
         /// directly, for legacy code.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void CanBeReferencedByName()
         {
             var source1 =
@@ -1048,7 +1048,7 @@ Q[6] = 5
         /// CanBeReferencedByName should return false if
         /// the accessor name is not a valid identifier.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void CanBeReferencedByName_InvalidName()
         {
             // Note: Dev11 treats I.Q as invalid so Q is not recognized from source.
@@ -1147,7 +1147,7 @@ class B
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "R").WithArguments("A", "R").WithLocation(16, 15));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void BaseProperties()
         {
             var source1 =
@@ -1183,7 +1183,7 @@ End Class";
             compilation2.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void StaticProperties()
         {
             var source1 =
@@ -1230,7 +1230,7 @@ End Class";
         /// <summary>
         /// Indexed properties are only supported from [ComImport] types.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void ComImport()
         {
             var source1 =
@@ -1266,7 +1266,7 @@ End Interface";
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "Q").WithArguments("IA.Q[object]", "IA.get_Q(object)", "IA.set_Q(object, object)").WithLocation(5, 23));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyAccesses()
         {
             var source1 =
@@ -1334,7 +1334,7 @@ End Interface";
         /// Cases where a PropertyGroup must be converted to a PropertyAccess.
         /// (resulting from an indexed property expression with no args).
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyGroup()
         {
             var source1 =
@@ -1364,7 +1364,7 @@ End Interface";
         /// Overload resolution should be supported for indexed properties,
         /// even though COM does not support overloads.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void OverloadResolution()
         {
             var source1 =
@@ -1402,7 +1402,7 @@ End Interface";
             compilation2.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OverloadResolutionWithSimpleProperty()
         {
             var source1 =
@@ -1488,7 +1488,7 @@ End Class";
             compilation2.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void OverridesHidesImplements()
         {
             var source1 =
@@ -1581,7 +1581,7 @@ End Class";
         /// from C# if the accessors are implemented/overridden directly.
         /// </summary>
         [WorkItem(545516, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void InterfaceImplementation()
         {
             var source1 =
@@ -1763,7 +1763,7 @@ B2.set_P(6, ...)
         /// "new" required to hide indexed property accessors, although
         /// property from base class can still be invoked using property syntax.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void Hiding()
         {
             var source1 =
@@ -1876,7 +1876,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P").WithArguments("A1.P[int]", "A1.get_P(int)", "A1.set_P(int, object)").WithLocation(25, 22));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ReadOnlyWriteOnly()
         {
             var source1 =
@@ -1907,7 +1907,7 @@ End Interface";
                 Diagnostic(ErrorCode.ERR_PropertyLacksGet, "a.Q[null]").WithArguments("IA.Q[object]").WithLocation(6, 21));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ObjectInitializer()
         {
             var source1 =
@@ -2006,7 +2006,7 @@ P3(3).get
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ObjectInitializer_Errors()
         {
             var source1 =
@@ -2058,7 +2058,7 @@ End Class";
                 Diagnostic(ErrorCode.ERR_BadAccess, "P3").WithArguments("A.P3[int]").WithLocation(8, 23));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Attributes()
         {
             var source1 =
@@ -2113,7 +2113,7 @@ class B
             var compilation3 = CompileAndVerify(source3, new[] { reference1 }, emitters: TestEmitters.CCI);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LinqMember()
         {
             var source1 =
@@ -2146,7 +2146,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NonInvocableMemberCalled, "select o.P").WithArguments("IEnumerableOfA.Select[System.Func<IA, object>]"));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AmbiguityPropertyAndNonProperty()
         {
             var source1 =
@@ -2185,7 +2185,7 @@ End Interface";
                 Diagnostic(ErrorCode.ERR_AmbigMember, "P").WithArguments("IA.P", "IB.P[object]").WithLocation(5, 18));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LambdaWithIndexedProperty()
         {
             var source1 = @"
@@ -2271,7 +2271,7 @@ P1(5).get
              */
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void QueryStatementIndexedProperty()
         {
             var source1 = @"
@@ -2348,7 +2348,7 @@ P1(2).get
              */
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void IncrementersAndIndexedProperties()
         {
             var source1 = @"
@@ -2581,7 +2581,7 @@ class Test
         }
 
         [WorkItem(846234, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedPropertyColorColor()
         {
             var source1 =
@@ -2644,7 +2644,7 @@ P[2] = 2
         }
 
         [WorkItem(853401, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedPropertyDynamicInvocation()
         {
             var source1 =
@@ -2703,7 +2703,7 @@ End Class";
 
         [WorkItem(846234, "DevDiv")]
         [WorkItem(853401, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void IndexedPropertyDynamicColorColorInvocation()
         {
             var source1 =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class IndexerTests : CSharpTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void Indexers()
         {
             var source =
@@ -67,7 +67,7 @@ struct S
                 options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void InterfaceImplementations()
         {
             var source =
@@ -1095,7 +1095,7 @@ public class C : B
                 Diagnostic(ErrorCode.ERR_CantOverrideNonVirtual, "this").WithArguments("C.this[int]", "B.this[int]"));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CanBeReferencedByName()
         {
             var source = @"
@@ -1189,7 +1189,7 @@ class C : I
         /// This is unfortunate, but less so that having something declared with an IndexerDeclarationSyntax
         /// return false for IsIndexer.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void ExplicitInterfaceImplementationIndexers()
         {
             var text = @"
@@ -2479,7 +2479,7 @@ class Test
         }
 
         [WorkItem(543261, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void OverrideOneAccessorOnly()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -1778,7 +1778,7 @@ class D : I
         }
 
         [WorkItem(528898, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void GenericTypeWithObsoleteBangAritySuffixIsNotAvailable()
         {
             var ilSource =
@@ -2113,7 +2113,7 @@ class Derived2 : Base2, Interface
         }
 
         [WorkItem(718115, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ExplicitlyImplementedAccessorsWithoutEvent()
         {
             var il = @"
@@ -2312,7 +2312,7 @@ public class Derived : Base, I
         }
 
         [WorkItem(943542, "DevDiv"), WorkItem(137, "CodePlex")]
-        [Fact]
+        [ClrOnlyFact]
         public void Bug943542()
         {
             var il = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataMemberTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataMemberTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -391,7 +391,7 @@ class C
             Assert.Equal(1, classC.GetMembers(WellKnownMemberNames.StaticConstructorName).Length);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void ImportDecimalConstantAttribute()
         {
             const string ilSource = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
@@ -448,7 +449,7 @@ class D
                 Diagnostic(ErrorCode.ERR_BindToBogus, "P2").WithArguments("C.P2"));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TestDynamicTransformsBadMetadata()
         {
             var il = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingIndexers.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingIndexers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LoadNonIndexer_NoDefaultMember()
         {
             string ilSource = @"
@@ -741,7 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LoadParameterNames()
         {
             string ilSource = @"
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         /// types of bogus properties - just setter param name if setter available and getter
         /// param name if getter available (i.e. same as success case).
         /// </remarks>
-        [Fact]
+        [ClrOnlyFact]
         public void LoadBogusParameterNames()
         {
             string ilSource = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -837,7 +837,7 @@ class Override : MetadataModifiers
                 Diagnostic(ErrorCode.ERR_CantOverrideNonVirtual, "M13").WithArguments("Override.M13()", "MetadataModifiers.M13()"));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TestVirtualnessFlags_CSharpRepresentation()
         {
             // All combinations of VirtualContract, NewSlotVTable, AbstractImpl, and FinalContract - without explicit overriding

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
@@ -284,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(dictionary.GetTypeMembers("ValueCollection", 1).Length, 0);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TestStructParameterlessConstructor_Explicit()
         {
             var ilSource = @"
@@ -310,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TestStructParameterlessConstructor_Implicit1()
         {
             var ilSource = @"
@@ -330,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             emitOptions: TestEmitters.RefEmitBug);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void TestStructParameterlessConstructor_Implicit2()
         {
             var ilSource = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -1097,7 +1097,7 @@ namespace N1
             }
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_Simple()
         {
             var source1 = @"
@@ -1113,7 +1113,7 @@ public class Forwarded
             CheckForwarderEmit(source1, source2, "Forwarded");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_InNamespace()
         {
             var source1 = @"
@@ -1132,7 +1132,7 @@ namespace NS
             CheckForwarderEmit(source1, source2, "NS.Forwarded");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_OpenGeneric()
         {
             var source1 = @"
@@ -1148,7 +1148,7 @@ public class Forwarded<T>
             CheckForwarderEmit(source1, source2, "Forwarded`1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_ConstructedGeneric()
         {
             var source1 = @"
@@ -1164,7 +1164,7 @@ public class Forwarded<T>
             CheckForwarderEmit(source1, source2, "Forwarded`1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_OverlappingGeneric()
         {
             var source1 = @"
@@ -1182,7 +1182,7 @@ public class Forwarded<T>
             CheckForwarderEmit(source1, source2, "Forwarded`1");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_Nested()
         {
             var source1 = @"
@@ -1204,7 +1204,7 @@ namespace NS
             CheckForwarderEmit(source1, source2, "NS.Forwarded", "NS.Forwarded+Inner");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_Nested_Private()
         {
             var source1 = @"
@@ -1242,7 +1242,7 @@ namespace NS
             CheckForwarderEmit(source1, source2, "NS.Forwarded", "NS.Forwarded+Internal", "NS.Forwarded+Protected", "NS.Forwarded+ProtectedInternal");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_MultipleNested()
         {
             // Note the order: depth first, children in forward order.
@@ -1280,7 +1280,7 @@ public class Forwarded
             CheckForwarderEmit(source1, source2, "Forwarded", "Forwarded+A", "Forwarded+A+B", "Forwarded+A+C", "Forwarded+D", "Forwarded+D+E", "Forwarded+D+F");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_NestedGeneric()
         {
             var source1 = @"
@@ -1408,7 +1408,7 @@ namespace NS
         }
 
         [WorkItem(545911, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void EmitForwarder_WithModule()
         {
             var source0 = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using System.Linq;
@@ -2639,7 +2639,7 @@ class D : C
         }
 
         [WorkItem(545658, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void MethodConstructedFromOverrideWithCustomModifiers()
         {
             var il = @"
@@ -2841,7 +2841,8 @@ Base[G`1[System.Int32]].Meth(G`1[System.Int32],System.Int32)
 Base[C].Meth(C,System.Int32)");
         }
 
-        [Fact, WorkItem(546816, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(546816, "DevDiv")]
         public void Bug16887()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -272,7 +272,7 @@ public class LocalTypes3
 }
 ";
 
-        [Fact]
+        [ClrOnlyFact]
         public void HideLocalTypeDefinitions()
         {
             var LocalTypes1 = CreateCompilationWithMscorlib(s_sourceLocalTypes1_IL, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes1");
@@ -341,7 +341,7 @@ public class LocalTypes3
             Assert.Null(assemblies[1].GetTypeByMetadataName(fullName_S2.FullName));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LocalTypeSubstitution1_1()
         {
             var LocalTypes1 = CreateCompilationWithMscorlib(s_sourceLocalTypes1_IL, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes1");
@@ -638,7 +638,7 @@ public class LocalTypes3
             GC.KeepAlive(library1_9);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LocalTypeSubstitution1_2()
         {
             var LocalTypes1 = CreateCompilationWithMscorlib(s_sourceLocalTypes1, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes1",
@@ -937,7 +937,7 @@ public class LocalTypes3
             GC.KeepAlive(library1_9);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void LocalTypeSubstitution1_3()
         {
             var Pia1 = CreateCompilationWithMscorlib(s_sourcePia1, options: TestOptions.ReleaseDll, assemblyName: "Pia1");
@@ -1239,7 +1239,7 @@ public class LocalTypes3
             GC.KeepAlive(library1_9);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CyclicReference_1()
         {
             var mscorlibRef = TestReferences.SymbolsTests.MDTestLib1;
@@ -1264,7 +1264,7 @@ public class LocalTypes3
             GC.KeepAlive(tc2);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CyclicReference_2()
         {
             var mscorlibRef = TestReferences.SymbolsTests.MDTestLib1;
@@ -1290,7 +1290,7 @@ public class LocalTypes3
             GC.KeepAlive(tc2);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CyclicReference_3()
         {
             var mscorlibRef = TestReferences.SymbolsTests.MDTestLib1;
@@ -1320,7 +1320,7 @@ public class LocalTypes3
             GC.KeepAlive(tc2);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void GenericsClosedOverLocalTypes1_1()
         {
             var LocalTypes3 = CreateCompilationWithMscorlib(s_sourceLocalTypes3_IL, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes3");
@@ -1366,7 +1366,7 @@ public class LocalTypes3
             Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localTypes3.GetMembers("Test6").OfType<MethodSymbol>().Single().ReturnType);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void GenericsClosedOverLocalTypes1_2()
         {
             var LocalTypes3 = CreateCompilationWithMscorlib(s_sourceLocalTypes3, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes3",
@@ -1413,7 +1413,7 @@ public class LocalTypes3
             Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localTypes3.GetMembers("Test6").OfType<MethodSymbol>().Single().ReturnType);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void GenericsClosedOverLocalTypes1_3()
         {
             var Pia1 = CreateCompilationWithMscorlib(s_sourcePia1, options: TestOptions.ReleaseDll, assemblyName: "Pia1");
@@ -1463,7 +1463,7 @@ public class LocalTypes3
             Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localTypes3.GetMembers("Test6").OfType<MethodSymbol>().Single().ReturnType);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NestedType1()
         {
             string source =
@@ -1589,7 +1589,7 @@ public struct S1
             Assert.IsType<UnsupportedMetadataTypeSymbol>(args[1].Value);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NestedType2()
         {
             string source =
@@ -1714,7 +1714,7 @@ public struct S1
             Assert.IsType<UnsupportedMetadataTypeSymbol>(args[1].Value);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NestedType3()
         {
             string source =
@@ -1839,7 +1839,7 @@ public struct S1
             Assert.Equal("LocalTypes2", ((TypeSymbol)args[1].Value).ContainingAssembly.Name);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void NestedType4()
         {
             string piaSource =
@@ -1921,7 +1921,7 @@ interface AttrTest1
             Assert.IsType<UnsupportedMetadataTypeSymbol>(args[1].Value);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void GenericType1()
         {
             string source =
@@ -2047,7 +2047,8 @@ public struct S2<T>
             Assert.IsType<UnsupportedMetadataTypeSymbol>(args[1].Value);
         }
 
-        [Fact, WorkItem(685240, "DevDiv")]
+        [ClrOnlyFact]
+        [WorkItem(685240, "DevDiv")]
         public void Bug685240()
         {
             string piaSource = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -692,7 +692,7 @@ public class Derived2 : Derived
             Assert.False(derived2Indexer2.Parameters.Single().IsParams, "Derived2.Indexer2.IsParams should be false");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         [WorkItem(819774, "DevDiv")]
         public void Repro819774()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;
@@ -383,7 +383,7 @@ class c1
         }
 
         // The literal 0 implicitly converts to any enum type. 
-        [Fact]
+        [ClrOnlyFact]
         public void ZeroInEnum()
         {
             var source =
@@ -589,7 +589,7 @@ public enum Enum2 : byte { A2, B2 };
 
         [WorkItem(5030, "DevDiv_Projects/Roslyn")]
         // Operator on enum member 
-        [Fact]
+        [ClrOnlyFact]
         public void OperatorOnEnumMember()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -230,7 +230,7 @@ class C
         }
 
 
-        [Fact]
+        [ClrOnlyFact]
         public void EventInvocation()
         {
             var text =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Source
 {
     public sealed class ExpressionBodiedMethodTests : CSharpTestBase
     {
-        [Fact]
+        [ClrOnlyFact]
         public void PartialMethods()
         {
             var comp = CompileAndVerify(@"
@@ -298,7 +298,7 @@ class C : I, J, K
             Assert.False(method.IsExplicitInterfaceImplementation);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Emit01()
         {
             var comp = CreateCompilationWithMscorlib45(@"
@@ -341,7 +341,7 @@ foo
 foo8");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Emit02()
         {
             var comp = CreateCompilationWithMscorlib45(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using System;
 using Xunit;
 
@@ -399,7 +400,7 @@ class C : I, J, K
             Assert.True(prop.IsReadOnly);
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void Emit01()
         {
             var comp = CreateCompilationWithMscorlib45(@"
@@ -445,7 +446,7 @@ foo8
 18");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void AccessorInheritsVisibility()
         {
             var comp = CreateCompilationWithMscorlib45(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -419,7 +419,7 @@ class C1
             Assert.Equal("@out", dout.ToString());
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyNonDefaultAccessorNames()
         {
             var source = @"
@@ -505,7 +505,7 @@ class Program
         /// Properties should refer to methods
         /// in the type members collection.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void MethodsAndAccessorsSame()
         {
             var source =
@@ -605,7 +605,7 @@ class Program
         /// <summary>
         /// Calling bogus methods directly should be allowed.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void CallMethodsDirectly()
         {
             var source = @"
@@ -640,7 +640,7 @@ class Program
 ");
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void MethodsReferencedInMultipleProperties()
         {
             var source = @"
@@ -845,7 +845,7 @@ class C
         /// Properties where the property and accessor signatures differ by
         /// modopt only should be supported (as in the native compiler).
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void SignaturesDifferByModOptsOnly()
         {
             const string ilSource =
@@ -929,7 +929,7 @@ class C
         }
 
         [WorkItem(538956, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyAccessorDoesNotHideMethod()
         {
             const string cSharpSource = @"
@@ -952,7 +952,7 @@ class Program {
         }
 
         [WorkItem(538956, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyAccessorDoesNotConflictWithMethod()
         {
             const string cSharpSource = @"
@@ -1019,7 +1019,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "Program").WithArguments("Program", "type"));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void CanReadInstancePropertyWithStaticGetterAsStatic()
         {
             const string ilSource = @"
@@ -1760,7 +1760,7 @@ class C : N.I<int>
         }
 
         [WorkItem(539998, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void ImportDefaultPropertiesWithParameters()
         {
             var source = @"
@@ -1811,7 +1811,7 @@ class Program
         }
 
         [WorkItem(540342, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void NoSequencePointsForAutoPropertyAccessors()
         {
             var text = @"
@@ -1889,7 +1889,7 @@ class Test
         }
 
         [WorkItem(545682, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyWithParametersHidingMethod01()
         {
             var source1 =
@@ -1970,7 +1970,7 @@ End Class";
                 Diagnostic(ErrorCode.ERR_MethGrpToNonDel, "Q").WithArguments("Q", "object").WithLocation(8, 15));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyWithParametersHidingMethod02()
         {
             var source1 =
@@ -2024,7 +2024,7 @@ static class E
                 Diagnostic(ErrorCode.ERR_MethGrpToNonDel, "P").WithArguments("P", "object").WithLocation(6, 15));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyWithParametersHidingMethod03()
         {
             var source1 =
@@ -2161,7 +2161,7 @@ class D
                 Diagnostic(ErrorCode.ERR_NonInvocableMemberCalled, "P9").WithArguments("B.P9[object]").WithLocation(30, 15));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void PropertyWithParametersAndOtherErrors()
         {
             var source1 =
@@ -2204,7 +2204,7 @@ End Class";
                 Diagnostic(ErrorCode.ERR_BadAccess, "P3").WithArguments("A.P3[object]").WithLocation(8, 15));
         }
 
-        [Fact]
+        [ClrOnlyFact]
         public void SubstitutedPropertyWithParameters()
         {
             var source1 =
@@ -2625,7 +2625,7 @@ public interface IA
         /// When the output type is .winmdobj properties should emit put_Property methods instead
         /// of set_Property methods.
         /// </summary>
-        [Fact]
+        [ClrOnlyFact]
         public void WinRtPropertySet()
         {
             const string libSrc =
@@ -2742,7 +2742,7 @@ class C
         }
 
         [WorkItem(1073332, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void Bug1073332_01()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;
@@ -1375,7 +1375,7 @@ class NonGen
         }
 
         [WorkItem(545154, "DevDiv")]
-        [Fact]
+        [ClrOnlyFact]
         public void MultiDimArray()
         {
             var r = MetadataReference.CreateFromImage(TestResources.SymbolsTests.Methods.CSMethods.AsImmutableOrNull());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This modifies the failing tests form '[Fact]' to '[ClrOnlyFact]'. This disables them on the failing linux build until a fix can be applied.