### PR TITLE
Avoid assembly name resolution when loading analyzer type

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -277,7 +277,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 Type type;
                 try
                 {
-                    type = Type.GetType(typeName + ", " + analyzerAssembly.FullName, throwOnError: true);
+                    // TODO: Once we move to CoreCLR we should just call GetType(typeName, throwOnError: true, ignoreCase: false) directly.
+                    // For now we fall back to reflection shim in order to report good error message (type load exception).
+                    const bool throwOnError = true;
+                    const bool ignoreCase = false;
+                    type = PortableShim.Assembly.GetType_string_bool_bool(analyzerAssembly, typeName, throwOnError, ignoreCase);
                 }
                 catch (Exception e)
                 {

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -43,6 +43,7 @@ namespace Roslyn.Utilities
             internal const string System_Runtime_Extensions = "System.Runtime.Extensions, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
             internal const string System_Threading_Thread = "System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
             internal const string System_Xml_XPath_XDocument = "System.Xml.XPath.XDocument, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+            internal const string System_Reflection = "System.Reflection, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
         }
 
         private static class DesktopNames
@@ -433,6 +434,20 @@ namespace Roslyn.Utilities
                 var thread = Thread.CurrentThread.GetValue(null);
                 Thread.CurrentUICulture.SetValue(thread, cultureInfo);
             }
+        }
+
+        internal static class Assembly
+        {
+            private const string TypeName = "System.Reflection.Assembly";
+
+            internal static readonly Type Type = ReflectionUtil.GetTypeFromEither(
+                contractName: $"{TypeName}, {CoreNames.System_Reflection}",
+                desktopName: TypeName);
+
+            internal static readonly Func<System.Reflection.Assembly, string, bool, bool, Type> GetType_string_bool_bool = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod("GetType", typeof(string), typeof(bool), typeof(bool))
+                .CreateDelegate<Func<System.Reflection.Assembly, string, bool, bool, Type>>();
         }
     }
 }

--- a/src/Test/Utilities/TempDirectory.cs
+++ b/src/Test/Utilities/TempDirectory.cs
@@ -59,6 +59,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         }
 
         /// <summary>
+        /// Creates a file in this directory that is a copy of the specified file.
+        /// </summary>
+        public TempFile CopyFile(string originalPath)
+        {
+            string name = System.IO.Path.GetFileName(originalPath);
+            string filePath = System.IO.Path.Combine(_path, name);
+            File.Copy(originalPath, filePath);
+            return _root.AddFile(new DisposableFile(filePath));
+        }
+
+        /// <summary>
         /// Creates a subdirectory in this directory.
         /// </summary>
         /// <param name="name">Directory name or unrooted directory path.</param>


### PR DESCRIPTION
Fixes #3347.

**Scenario**
TypeScript got broken by my previous change in analyzer loading logic. I didn't realize that we load analyzers to "load-from" context which is not where Type.GetType(assembly-qualified-name) is looking for assemblies. 

**Fix**
The purpose of the previous change was to communicate the load exception to the user. Unfortunately, portable profile 7 doesn't have the overload of Assembly.GetType that throws (hence the change to Type.GetType, which does). Turns out that the method is actually available on CoreCLR, so we can use the PortableShim to invoke it thru reflection to retrieve a good error message.

**Testing**
Added unit tests and verified that TS analyzer works as expected.

@ManishJayaswal 