### PR TITLE
Classify trailing trivia in xml docs

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
                 if (token.HasTrailingTrivia)
                 {
-                    ClassifyXmlTrivia(token.LeadingTrivia, whitespaceClassificationType: ClassificationTypeNames.XmlDocCommentText);
+                    ClassifyXmlTrivia(token.TrailingTrivia, whitespaceClassificationType: ClassificationTypeNames.XmlDocCommentText);
                 }
             }
         }


### PR DESCRIPTION
The lexer and parser currently do not put trailing trivia on `XmlText` tokens, but if something did, it would end up trying to classify the leading trivia (again) instead.

With this change, the trailing trivia is classified (if present).  The equivalent VB code already calls `ClassifyXmlTrivia` on the respective trivia.