### PR TITLE
Associate PropertyComment with Target on AttributeListSyntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2313,10 +2313,11 @@
         <summary>Gets the open bracket token.</summary>
       </PropertyComment>
     </Field>
-    <Field Name="Target" Type="AttributeTargetSpecifierSyntax" Optional="true"/>
-    <PropertyComment>
-      <summary>Gets the optional construct targeted by the attribute.</summary>
-    </PropertyComment>
+    <Field Name="Target" Type="AttributeTargetSpecifierSyntax" Optional="true">
+      <PropertyComment>
+        <summary>Gets the optional construct targeted by the attribute.</summary>
+      </PropertyComment>
+    </Field>
     <Field Name="Attributes" Type="SeparatedSyntaxList&lt;AttributeSyntax&gt;">
       <PropertyComment>
         <summary>Gets the attribute declaration list.</summary>


### PR DESCRIPTION
The `PropertyComment` for the `Target` property/field isn't nested inside of its corresponding `Field` element.  As a result, the documentation comment is ignored.

This moves the `PropertyComment` under the `Field`, so its xml documentation is generated.