### PR TITLE
Use MetadataReference.CreateFromFile in Samples.sln

### DIFF
--- a/src/Samples/CSharp/APISampleUnitTests/Compilations.cs
+++ b/src/Samples/CSharp/APISampleUnitTests/Compilations.cs
@@ -35,7 +35,7 @@ namespace APISampleUnitTestsCS
                 "calc.dll",
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
                 syntaxTrees: new[] { tree },
-                references: new[] { MetadataReference.CreateFromAssembly(typeof(object).Assembly) });
+                references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
 
             Assembly compiledAssembly;
             using (var stream = new MemoryStream())
@@ -65,7 +65,7 @@ namespace APISampleUnitTestsCS
             var compilation = CSharpCompilation
                 .Create("program.exe")
                 .AddSyntaxTrees(tree)
-                .AddReferences(MetadataReference.CreateFromAssembly(typeof(object).Assembly));
+                .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
 
             IEnumerable<Diagnostic> errorsAndWarnings = compilation.GetDiagnostics();
             Assert.AreEqual(1, errorsAndWarnings.Count());

--- a/src/Samples/CSharp/APISampleUnitTests/FAQ.cs
+++ b/src/Samples/CSharp/APISampleUnitTests/FAQ.cs
@@ -40,7 +40,7 @@ namespace APISampleUnitTestsCS
             {
                 if (mscorlib == null)
                 {
-                    mscorlib = MetadataReference.CreateFromAssembly(typeof(object).Assembly);
+                    mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
                 }
 
                 return mscorlib;
@@ -2328,7 +2328,7 @@ class Program
                 .AddMetadataReference(projectId, Mscorlib)
                 .AddMetadataReference(projectId, AppDomain.CurrentDomain.GetAssemblies()
                     .Where(a => string.Compare(a.GetName().Name, "System", StringComparison.OrdinalIgnoreCase) == 0)
-                    .Select(MetadataReference.CreateFromAssembly).Single())
+                    .Select(a => MetadataReference.CreateFromFile(a.Location)).Single())
                 .AddDocument(documentId, "MyFile.cs", source);
             var document = solution.GetDocument(documentId);
 

--- a/src/Samples/CSharp/APISampleUnitTests/SymbolsAndSemantics.cs
+++ b/src/Samples/CSharp/APISampleUnitTests/SymbolsAndSemantics.cs
@@ -130,7 +130,7 @@ int index) {} }");
             string file2 = "class Cat : Animal { public override void MakeSound() { } }";
             var compilation = CSharpCompilation.Create("test")
                     .AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree(file1), SyntaxFactory.ParseSyntaxTree(file2))
-                    .AddReferences(MetadataReference.CreateFromAssembly(typeof(object).Assembly));
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
 
             var globalNamespace = compilation.SourceModule.GlobalNamespace;
 
@@ -310,7 +310,7 @@ class X
                 Compilation = CSharpCompilation
                     .Create("test")
                     .AddSyntaxTrees(SyntaxTree)
-                    .AddReferences(MetadataReference.CreateFromAssembly(typeof(object).Assembly));
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
 
                 SemanticModel = Compilation.GetSemanticModel(SyntaxTree);
             }

--- a/src/Samples/CSharp/AsyncPackage/Test/Backend/DiagnosticVerifier.Helper.cs
+++ b/src/Samples/CSharp/AsyncPackage/Test/Backend/DiagnosticVerifier.Helper.cs
@@ -20,10 +20,10 @@ namespace TestTemplate
     /// </summary>
     public abstract partial class DiagnosticVerifier
     {
-        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromAssembly(typeof(object).Assembly);
-        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromAssembly(typeof(Enumerable).Assembly);
-        private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromAssembly(typeof(CSharpCompilation).Assembly);
-        private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromAssembly(typeof(Compilation).Assembly);
+        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+        private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";

--- a/src/Samples/Shared/UnitTestFramework/CodeActionProviderTestFixture.cs
+++ b/src/Samples/Shared/UnitTestFramework/CodeActionProviderTestFixture.cs
@@ -25,7 +25,7 @@ namespace Roslyn.UnitTestFramework
 
             var references = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => simpleNames.Contains(a.GetName().Name, StringComparer.OrdinalIgnoreCase))
-                .Select(MetadataReference.CreateFromAssembly);
+                .Select(a => MetadataReference.CreateFromFile(a.Location));
 
             return new AdhocWorkspace().CurrentSolution
                 .AddProject(projectId, "TestProject", "TestProject", LanguageName)

--- a/src/Samples/VisualBasic/APISampleUnitTests/Compilations.vb
+++ b/src/Samples/VisualBasic/APISampleUnitTests/Compilations.vb
@@ -28,8 +28,8 @@ End Module
             "calc.dll",
             options:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
             syntaxTrees:={tree},
-            references:={MetadataReference.CreateFromAssembly(GetType(Object).Assembly),
-                        MetadataReference.CreateFromAssembly(GetType(CompilerServices.StandardModuleAttribute).Assembly)})
+            references:={MetadataReference.CreateFromFile(GetType(Object).Assembly.Location),
+                        MetadataReference.CreateFromFile(GetType(CompilerServices.StandardModuleAttribute).Assembly.Location)})
 
         Dim compiledAssembly As Assembly
         Using stream = New MemoryStream()
@@ -58,8 +58,8 @@ End Module
         Dim comp = VisualBasicCompilation.Create(
             "program.exe",
             syntaxTrees:={tree},
-            references:={MetadataReference.CreateFromAssembly(GetType(Object).Assembly),
-                        MetadataReference.CreateFromAssembly(GetType(CompilerServices.StandardModuleAttribute).Assembly)})
+            references:={MetadataReference.CreateFromFile(GetType(Object).Assembly.Location),
+                        MetadataReference.CreateFromFile(GetType(CompilerServices.StandardModuleAttribute).Assembly.Location)})
 
         Dim errorsAndWarnings = comp.GetDiagnostics()
         Assert.AreEqual(1, errorsAndWarnings.Count())

--- a/src/Samples/VisualBasic/APISampleUnitTests/FAQ.vb
+++ b/src/Samples/VisualBasic/APISampleUnitTests/FAQ.vb
@@ -42,7 +42,7 @@ Namespace APISampleUnitTestsVB
         Public ReadOnly Property Mscorlib As MetadataReference
             Get
                 If _Mscorlib Is Nothing Then
-                    _Mscorlib = MetadataReference.CreateFromAssembly(GetType(Object).Assembly)
+                    _Mscorlib = MetadataReference.CreateFromFile(GetType(Object).Assembly.Location)
                 End If
                 Return _Mscorlib
             End Get
@@ -66,7 +66,7 @@ Module Program
     End Sub
 End Module
 </text>.Value)
-            Dim vbRuntime = MetadataReference.CreateFromAssembly(GetType(CompilerServices.StandardModuleAttribute).Assembly)
+            Dim vbRuntime = MetadataReference.CreateFromFile(GetType(CompilerServices.StandardModuleAttribute).Assembly.Location)
             Dim comp = VisualBasicCompilation.Create("MyCompilation", syntaxTrees:={tree}, references:={Mscorlib, vbRuntime})
             Dim model = comp.GetSemanticModel(tree)
 
@@ -624,7 +624,7 @@ Module Program
 End Module
 </text>.Value)
 
-            Dim vbRuntime = MetadataReference.CreateFromAssembly(GetType(CompilerServices.StandardModuleAttribute).Assembly)
+            Dim vbRuntime = MetadataReference.CreateFromFile(GetType(CompilerServices.StandardModuleAttribute).Assembly.Location)
             Dim comp = VisualBasicCompilation.Create("MyCompilation", syntaxTrees:={tree}, references:={Mscorlib, vbRuntime})
             Dim results = New StringBuilder()
 
@@ -2230,7 +2230,7 @@ End Module
             Dim newRoot = CType(rewriter.Visit(oldRoot), CompilationUnitSyntax)
             newRoot = newRoot.NormalizeWhitespace() ' normalize all the whitespace to make it legible
             Dim newTree = tree.WithRootAndOptions(newRoot, tree.Options)
-            Dim vbRuntime = MetadataReference.CreateFromAssembly(GetType(CompilerServices.StandardModuleAttribute).Assembly)
+            Dim vbRuntime = MetadataReference.CreateFromFile(GetType(CompilerServices.StandardModuleAttribute).Assembly.Location)
             Dim comp = VisualBasicCompilation.Create("MyCompilation", syntaxTrees:={newTree}, references:={Mscorlib, vbRuntime})
             Dim output As String = Execute(comp)
 
@@ -2377,7 +2377,7 @@ End Module
             Dim _documentId = DocumentId.CreateNewId(_projectId)
 
             Dim systemReference = AppDomain.CurrentDomain.GetAssemblies().Where(Function(x) String.Equals(x.GetName().Name, "System", StringComparison.OrdinalIgnoreCase)).
-                Select(AddressOf MetadataReference.CreateFromAssembly).Single()
+                Select(Function(a) MetadataReference.CreateFromFile(a.Location)).Single()
 
             Dim vbOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithEmbedVbCoreRuntime(True)
 

--- a/src/Samples/VisualBasic/APISampleUnitTests/SymbolsAndSemantics.vb
+++ b/src/Samples/VisualBasic/APISampleUnitTests/SymbolsAndSemantics.vb
@@ -146,7 +146,7 @@ End Class
         Dim comp = VisualBasicCompilation.Create(
             "test",
             syntaxTrees:={SyntaxFactory.ParseSyntaxTree(file1), SyntaxFactory.ParseSyntaxTree(file2)},
-            references:={MetadataReference.CreateFromAssembly(GetType(Object).Assembly)})
+            references:={MetadataReference.CreateFromFile(GetType(Object).Assembly.Location)})
 
         Dim globalNamespace = comp.SourceModule.GlobalNamespace
 

--- a/src/Samples/VisualBasic/APISampleUnitTests/TestCodeContainer.vb
+++ b/src/Samples/VisualBasic/APISampleUnitTests/TestCodeContainer.vb
@@ -39,7 +39,7 @@ Class TestCodeContainer
         Me.Compilation = VisualBasicCompilation.Create(
             "test",
             syntaxTrees:={Me.SyntaxTree},
-            references:={MetadataReference.CreateFromAssembly(GetType(Object).Assembly)})
+            references:={MetadataReference.CreateFromFile(GetType(Object).Assembly.Location)})
 
         Me.SemanticModel = Compilation.GetSemanticModel(Me.SyntaxTree)
     End Sub


### PR DESCRIPTION
Replace usage of MetadataReference.CreateFromAssembly with
MetadataReference.CreateFromFile

MetadataReference.CreateFromAssembly was made obsolete in #3344, but the references in Samples.sln were not updated to use CreateFromFile, so our internal builds are failing (including the signed build)

@tmat @tmeschter