### PR TITLE
Bail on rename session when entering debug run mode

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            internal void Disconnect(bool documentIsClosed)
+            internal void Disconnect(bool documentIsClosed, bool rollbackTemporaryEdits)
             {
                 AssertIsForeground();
 
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // Remove any old read only regions we had
                 UpdateReadOnlyRegions(removeOnly: true);
 
-                if (!documentIsClosed)
+                if (rollbackTemporaryEdits && !documentIsClosed)
                 {
                     _session.UndoManager.UndoTemporaryEdits(_subjectBuffer, disconnect: true);
                 }

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1263,6 +1263,8 @@ class C
                 Dim renameService = workspace.GetService(Of IInlineRenameService)()
                 Assert.NotNull(renameService.ActiveSession)
 
+                VerifyTagsAreCorrect(workspace, "BarFoo")
+
                 ' Simulate starting a debugging session
                 Dim editAndContinueWorkspaceService = workspace.Services.GetService(Of IEditAndContinueWorkspaceService)
                 editAndContinueWorkspaceService.OnBeforeDebuggingStateChanged(DebuggingState.Design, DebuggingState.Run)
@@ -1303,6 +1305,9 @@ class C
                 ' Make sure the RenameService's ActiveSession is still there
                 Dim renameService = workspace.GetService(Of IInlineRenameService)()
                 Assert.NotNull(renameService.ActiveSession)
+
+
+                VerifyTagsAreCorrect(workspace, "BarFoo")
 
                 ' Simulate ending break mode in the debugger (by stepping or continuing)
                 Dim editAndContinueWorkspaceService = workspace.Services.GetService(Of IEditAndContinueWorkspaceService)


### PR DESCRIPTION
Bail on rename session when entering debug run mode

Fixes internal bug #1176673

If a debug session enters run mode while an inline rename session is active, then we must abandon the rename session in its current state because we can neither commit the session (which may cause further changes) nor cancel the session (which will roll back to the original state). Allowing any of these edits through can at best prevent debugging data tips from working correctly, or at worst it can crash the process.

Ideally we would get notified that run mode is about to be entered while there's still time to adjust the sources, but that ability doesn't exist today.

Potential Reviewers: @Pilchie @DustinCampbell @jasonmalinowski @brettfo @rchande @balajikris @basoundr @jmarolf @tmat

