### PR TITLE
use Build as BuildTool even for live error

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetErrorSource(_factory._buildTool);
                                 return true;
                             case StandardTableKeyNames.BuildTool:
-                                content = _factory._buildTool;
+                                content = GetBuildTool(_factory._buildTool);
                                 return content != null;
                             case StandardTableKeyNames.Text:
                                 content = item.Message;
@@ -198,6 +198,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = null;
                                 return false;
                         }
+                    }
+
+                    private string GetBuildTool(string buildTool)
+                    {
+                        if (buildTool == PredefinedBuildTools.Compiler)
+                        {
+                            return PredefinedBuildTools.Build;
+                        }
+
+                        return _factory._buildTool;
                     }
 
                     private ErrorSource GetErrorSource(string buildTool)


### PR DESCRIPTION
porting #3369

Customer Scenario: The error list now has a Build tool column that is present by default. The value of this column is supposed to be the name of the tool that produced the error\warning. For compiler errors\warnings, we are currently showing the string "Live" when the error is produced by the IDE's background live analysis and "Compiler" when it is produced by the build. This is confusing. 

Fix: This change simply makes the tool name be "Compiler" in both cases.
