### PR TITLE
Fix Class View/Object Browser search for Web Site projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
@@ -776,21 +776,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             while (stack.Count > 0)
             {
                 var namespaceSymbol = stack.Pop();
+                var typeListItems = GetTypeListItems(namespaceSymbol, compilation, projectId, searchString, fullyQualified: true);
 
-                if (!namespaceSymbol.IsGlobalNamespace)
+                foreach (var typeListItem in typeListItems)
                 {
-                    var typeListItems = GetTypeListItems(namespaceSymbol, compilation, projectId, searchString, fullyQualified: true);
-
-                    foreach (var typeListItem in typeListItems)
+                    if (searchString == null)
                     {
-                        if (searchString == null)
-                        {
-                            builder.Add(typeListItem);
-                        }
-                        else if (typeListItem.SearchText.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0)
-                        {
-                            builder.Add(typeListItem);
-                        }
+                        builder.Add(typeListItem);
+                    }
+                    else if (typeListItem.SearchText.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        builder.Add(typeListItem);
                     }
                 }
 
@@ -813,24 +809,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             while (namespaceStack.Count > 0)
             {
                 var namespaceSymbol = namespaceStack.Pop();
+                var types = GetAccessibleTypes(namespaceSymbol, compilation);
 
-                if (!namespaceSymbol.IsGlobalNamespace)
+                foreach (var type in types)
                 {
-                    var types = GetAccessibleTypes(namespaceSymbol, compilation);
-
-                    foreach (var type in types)
+                    var memberListItems = GetMemberListItems(type, compilation, projectId, fullyQualified: true);
+                    foreach (var memberListItem in memberListItems)
                     {
-                        var memberListItems = GetMemberListItems(type, compilation, projectId, fullyQualified: true);
-                        foreach (var memberListItem in memberListItems)
+                        if (searchString == null)
                         {
-                            if (searchString == null)
-                            {
-                                builder.Add(memberListItem);
-                            }
-                            else if (memberListItem.SearchText.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0)
-                            {
-                                builder.Add(memberListItem);
-                            }
+                            builder.Add(memberListItem);
+                        }
+                        else if (memberListItem.SearchText.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            builder.Add(memberListItem);
                         }
                     }
                 }


### PR DESCRIPTION
Creating a new PR against master since this isn't going to make stabilization.

**Customer scenario**: Create a Web Site project and add a class to the App_Code folder. Bring up either the Class View or Object Browser and search for the class name. It should be found, but it isn't.

**Description of fix:**: Really, search in Web Site projects was working fine. The problem was that the default class template, when added to an App_Code folder does not contain a namespace declaration. So, the class ends up in the global namespace, which the search skipped.

**Testing done**: Manual verification