### PR TITLE
make sure we lock before changing shared state.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
@@ -49,7 +49,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 
             public void ClearImplicitCache()
             {
-                _implicitCache.Clear();
+                lock (_gate)
+                {
+                    _implicitCache.Clear();
+                }
             }
 
             public IDisposable EnableCaching(ProjectId key)


### PR DESCRIPTION
Customer Scenario: user closed a solution, and sometimes VS crashes a bit later the user closed the solution.

issue is we have a field we clear after solution close but it wasn't properly guarded by a lock. so when condition is met, we cleared the field, while it is being used by other thread and we crash.


fixes devdiv 1183411
