### PR TITLE
port interactive fixes to stabilization

### DIFF
--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindow.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindow.cs
@@ -4,6 +4,7 @@
 // #define DUMP_COMMANDS
 
 using System;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
 using Microsoft.VisualStudio;
@@ -30,6 +31,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
     /// VsInteractiveWindowEditorsFactoryService which handles all of the mapping of VS commands to API calls
     /// on the interactive window.
     /// </summary>
+    [Guid(Guids.InteractiveToolWindowIdString)]
     internal sealed class VsInteractiveWindow : ToolWindowPane, IVsFindTarget, IOleCommandTarget, IVsInteractiveWindow
     {
         private readonly IComponentModel _componentModel;
@@ -72,7 +74,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     out frame
                 )
             );
-
+            var guid = GetType().GUID;
+            ErrorHandler.ThrowOnFailure(frame.SetGuidProperty((int)__VSFPROPID.VSFPROPID_CmdUIGuid, ref guid));
             this.Frame = frame;
         }
 

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -276,15 +276,19 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     case CommandIds.HistoryPrevious:
                     case CommandIds.SearchHistoryNext:
                     case CommandIds.SearchHistoryPrevious:
+                    case CommandIds.SmartExecute: 
                         // TODO: Submit?
                         prgCmds[0].cmdf = _window.CurrentLanguageBuffer != null ? CommandEnabled : CommandDisabled;
-                        break;
+                        prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
+                        return VSConstants.S_OK;
                     case CommandIds.AbortExecution:
                         prgCmds[0].cmdf = _window.IsRunning ? CommandEnabled : CommandDisabled;
-                        break;
+                        prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
+                        return VSConstants.S_OK;
                     case CommandIds.Reset:
                         prgCmds[0].cmdf = !_window.IsResetting ? CommandEnabled : CommandDisabled;
-                        break;
+                        prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
+                        return VSConstants.S_OK;
                     default:
                         prgCmds[0].cmdf = CommandEnabled;
                         break;


### PR DESCRIPTION
https://github.com/Microsoft/PTVS/issues/227
https://github.com/Microsoft/PTVS/issues/287

This fixes the following issues:
 History search doesn't work (type a prefix, and then hit Ctrl-Alt-Up/Ctrl-Alt-Down). This is because the interactive window is not responding properly to the QueryStatus calls for its own commands
 SubmitOrPaste doesn't work: This command is useful for always submitting an input when you're in an active input buffer, but also allows you to submit a previously entered input by navigating to it and then pressing Ctrl-Enter. This is because the interactive window is picking up the tool windows command guid instead of its own. Therefore commands that belong to the interactive window aren't being routed to it properly.

Both of these were reported by users of PTVS and they represent regressions from the previous interactive window. While not all users will use these commands many find them extremely useful.
