### PR TITLE
No exceptions for missing rule set includes

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -441,8 +441,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(ruleSet.Includes.First().IncludePath, "foo.ruleset");
         }
 
-        [WorkItem(156)]
-        [Fact(Skip = "156")]
+        [WorkItem(1184500, "DevDiv 1184500")]
+        [Fact]
         public void TestRuleSetInclude1()
         {
             string source = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -453,7 +453,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
   </Rules>
 </RuleSet>
 ";
-            VerifyRuleSetError(source, () => string.Format(CodeAnalysisResources.InvalidRuleSetInclude, "foo.ruleset", string.Format(CodeAnalysisResources.FailedToResolveRuleSetName, "foo.ruleset")), otherSources: new string[] { "" });
+            var dir = Temp.CreateDirectory();
+            var file = dir.CreateFile("a.ruleset");
+            file.WriteAllText(source);
+
+            var ruleSet = RuleSet.LoadEffectiveRuleSetFromFile(file.Path);
+
+            Assert.Equal(ReportDiagnostic.Default, ruleSet.GeneralDiagnosticOption);
+            Assert.Contains("CA1013", ruleSet.SpecificDiagnosticOptions.Keys);
+            Assert.Equal(ReportDiagnostic.Warn, ruleSet.SpecificDiagnosticOptions["CA1013"]);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/RuleSet/RuleSetInclude.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSetInclude.cs
@@ -57,6 +57,12 @@ namespace Microsoft.CodeAnalysis
                 path = GetIncludePath(parent);
                 ruleSet = RuleSetProcessor.LoadFromFile(path);
             }
+            catch (FileNotFoundException)
+            {
+                // The compiler uses the same rule set files as FxCop, but doesn't have all of
+                // the same logic for resolving included files. For the moment, just ignore any
+                // includes we can't resolve.
+            }
             catch (Exception e)
             {
                 throw new InvalidRuleSetException(string.Format(CodeAnalysisResources.InvalidRuleSetInclude, path, e.Message));


### PR DESCRIPTION
**Bug:** Fixes DevDiv bug 1184500

**Customer Scenario**
Customer has an existing solution that uses FxCop, and uses a custom rule set that includes one of the "built in" FxCop rule sets, such as MinimumRecommendedRules.ruleset. When building this solution with Roslyn compilers, his build will fail with errors about MinimumRecommendedRules.ruleset not being found.

**Fix Description**
The issue is that the Roslyn compilers use the same rule set files as FxCop, but do not have all the same logic for resolving included files. They can find included rule sets at absolute paths, and at paths relative to the parent rule set, but they do not know about the extra directories FxCop checks after that. The fix here is to simply ignore any included rule set files that cannot be found.

We've made this fix before, actually, but it was lost in the code shuffle of commit 7e277f66.

**Testing done**
We had an existing unit test covering this scenario, but it was skipped. I updated the test and un-skipped it. I validated that it failed without my fix, and passed with the fix.