### PR TITLE
Rename should kick out in bad syntax

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -427,14 +427,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                             expressionOfInvocation = DirectCast(expressionOfInvocation, ParenthesizedExpressionSyntax).Expression
                         Case SyntaxKind.MeExpression
                             Exit While
-                        Case SyntaxKind.SingleLineSubLambdaExpression,
-                                SyntaxKind.SingleLineFunctionLambdaExpression,
-                                SyntaxKind.MultiLineSubLambdaExpression,
-                                SyntaxKind.MultiLineFunctionLambdaExpression,
-                                SyntaxKind.InvocationExpression
-                            Return Nothing
                         Case Else
-                            ExceptionUtilities.UnexpectedValue(expressionOfInvocation.Kind)
+                            ' This isn't actually an invocation, so there's no member name to check.
+                            Return Nothing
                     End Select
                 End While
 


### PR DESCRIPTION
...rather than looping infinitely.  This parallels the C# behavior.

Fixes #3316.

Impact: Without this fix, VB rename can loop infinitely in bad code.  (Mitigation: the user can click Cancel.)