### PR TITLE
Propagate CharSet for structs implementing fixed buffers from the field's containing type.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -188,6 +188,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override CharSet MarshallingCharSet
+        {
+            get
+            {
+                // We manually propagate the CharSet field of StructLayout attribute for fabricated structs implementing fixed buffers.
+                // See void AttrBind::EmitStructLayoutAttributeCharSet(AttributeNode *attr) in native codebase.
+                return _field.ContainingType.MarshallingCharSet;
+            }
+        }
         internal override FieldSymbol FixedElementField
         {
             get { return _internalField; }


### PR DESCRIPTION
Fixes #3392.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.