### PR TITLE
Do run ResolveProjectReferences in MSBuildWorkspace

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -57,11 +57,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
             // prepare for building
             var buildTargets = new BuildTargets(_loadedProject, "Compile");
 
-            // Don't execute this one. It will build referenced projects.
-            // Even when DesignTimeBuild is defined, it will still add the referenced project's output to the references list
-            // which we don't want.
-            buildTargets.Remove("ResolveProjectReferences");
-
             // don't execute anything after CoreCompile target, since we've
             // already done everything we need to compute compiler inputs by then.
             buildTargets.RemoveAfter("CoreCompile", includeTargetInRemoval: false);


### PR DESCRIPTION
Things like ImplicitlyExpandFacadeReferences depend on it being
set.

Fixes #2824.