### PR TITLE
return correct ProjectGuid for build only filter

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -286,8 +286,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = GetProjectName(_factory._workspace, item.ProjectId);
                                 return content != null;
                             case StandardTableKeyNames.ProjectGuid:
-                                content = GetProjectGuid(_factory._workspace, item.ProjectId);
-                                return ProjectGuid != Guid.Empty;
+                                var guid = GetProjectGuid(_factory._workspace, item.ProjectId);
+                                content = guid;
+                                return guid != Guid.Empty;
                             default:
                                 content = null;
                                 return false;


### PR DESCRIPTION
Customer Impact.

In the Error list, when both BuildOnly and Current Project filters are selected, this bug prevents any error to show up. There is a common workflow that this affects  - I have a project with a lot of errors and I have scoped the filter down to the current project and then right-click on my project and build just that one. With this bug, no errors will show up in the error list. This bug also cause errors not show up in the build order when build only filter is on.

The fix is to correctly filter out only non-current project errors.

Testing done: Tested all combinations of filters with the buildonly mode.
