### PR TITLE
made us to re-analyze some part of solution when assembly name have c…

### DIFF
--- a/src/Features/Core/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/SolutionCrawler/WorkCoordinator.cs
@@ -512,7 +512,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 if (projectChanges.GetAddedMetadataReferences().Any() || projectChanges.GetAddedProjectReferences().Any() || projectChanges.GetAddedAnalyzerReferences().Any() ||
                     projectChanges.GetRemovedMetadataReferences().Any() || projectChanges.GetRemovedProjectReferences().Any() || projectChanges.GetRemovedAnalyzerReferences().Any() ||
-                    !object.Equals(oldProject.CompilationOptions, newProject.CompilationOptions))
+                    !object.Equals(oldProject.CompilationOptions, newProject.CompilationOptions) ||
+                    !object.Equals(oldProject.AssemblyName, newProject.AssemblyName))
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);
                 }


### PR DESCRIPTION
…hanged.

Customer Impact:
User changed assembly name (hence assembly identity), but all internal visible types are not re-analyzed. which ends up us to either incorrectly not report inaccessible internal types or report inaccessible internal types which just became accessible.

the fix should let diagnostic service to correctly track p2p dependencies and re-analyze those projects on assembly name change.
