### PR TITLE
Avoid crashes calculating rename declaration conflicts

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3411,5 +3411,37 @@ class Program2
                 result.AssertLabeledSpansAre("conflict", "B", RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub
+
+        <WorkItem(2352, "https://github.com/dotnet/roslyn/issues/2352")>
+        <WorkItem(3303, "https://github.com/dotnet/roslyn/issues/3303")>
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub DeclarationConflictInFileWithoutReferences_PartialTypes()
+            Using result = RenameEngineResult.Create(
+                   <Workspace>
+                       <Project Language="C#" CommonReferences="true">
+                           <Document FilePath="Test1.cs">
+partial class C
+{
+    private static void [|$$M|]()
+    {
+        {|conflict:M|}();
+    }
+}
+                            </Document>
+                           <Document FilePath="Test2.cs">
+partial class C
+{
+    private static void {|conflict:Method|}()
+    {
+    }
+}
+                            </Document>
+                       </Project>
+                   </Workspace>, renameTo:="Method")
+
+                result.AssertLabeledSpansAre("conflict", "Method", RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -133,7 +133,15 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                 return _documentToModifiedSpansMap[documentId].First(t => t.Item1 == originalSpan).Item2;
             }
 
-            return _documentToComplexifiedSpansMap[documentId].First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
+            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            {
+                return _documentToComplexifiedSpansMap[documentId].First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
+            }
+            
+            // The RenamedSpansTracker doesn't currently track unresolved conflicts for
+            // unmodified locations.  If the document wasn't modified, we can just use the 
+            // original span as the new span.
+            return originalSpan;
         }
 
         /// <summary>


### PR DESCRIPTION
**Bug** Fixes #3303 Avoid crashes calculating rename declaration conflicts

**Customer Scenario**

The scenario is during inline rename if you introduce a method declaration conflict in a partial type in another file **and** the conflict location is in a document that is unchanged by the rename itself. For example, we crash when attempting to rename a method in a .xaml.cs file to "InitializeComponent". This can crash during inline rename even when typing *through* any method name declared in another part of the partial type (in another file), so renaming "a" to "abc" can crash if the intermediate state of "ab" conflicts with a member as described above (this is what actually happened in the customer report).

**Fix Description** (from commit message)

This is a very similar crash to the one from #2352. This change reverts
the specific fix that was done for that bug and instead generally
ensures that all potential declaration conflict spans are calculated
into reverseMappedLocations before calling AddDeclarationConflictsAsync
when processing the project that contains the rename symbol's
declaration.

This also updates the
RenamedSpansTracker.GetResolutionTextSpan(TextSpan, DocumentId) test
hook, which maps original spans to post-rename spans, to correctly
handle documents that were not changed during the rename operation. This
change is needed because the RenamedSpansTracker does not track
unresolved conflicts in unmodified locations (see the similar existing
comment in InlineRenameReplacementInfo.GetNonComplexifiedReplacements
for confirmation of this), and changing that for "1.0 (stable)" is
potentially risky as many things query the state of the
RenamedSpansTracker.

**Testing done** 

A unit test was added for this scenario, and all existing tests pass. I can also have someone buddy test if needed.

**Potential Reviewers**: @Pilchie @jasonmalinowski @rchande @balajikris @basoundr @brettfo @jmarolf 