### PR TITLE
Pass (IntPtr)(-1) to ThrowExceptionForHR calls to ignore existing error info

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Utilities/Exceptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/Exceptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
     {
         public static Exception ThrowEFail()
         {
-            Marshal.ThrowExceptionForHR(VSConstants.E_FAIL);
+            Marshal.ThrowExceptionForHR(VSConstants.E_FAIL, new IntPtr(-1));
 
             // never reached...
             return null;
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
 
         public static Exception ThrowEInvalidArg()
         {
-            Marshal.ThrowExceptionForHR(VSConstants.E_INVALIDARG);
+            Marshal.ThrowExceptionForHR(VSConstants.E_INVALIDARG, new IntPtr(-1));
 
             // never reached...
             return null;
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
 
         public static Exception ThrowENotImpl()
         {
-            Marshal.ThrowExceptionForHR(VSConstants.E_NOTIMPL);
+            Marshal.ThrowExceptionForHR(VSConstants.E_NOTIMPL, new IntPtr(-1));
 
             // never reached...
             return null;
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
 
         public static Exception ThrowEUnexpected()
         {
-            Marshal.ThrowExceptionForHR(VSConstants.E_UNEXPECTED);
+            Marshal.ThrowExceptionForHR(VSConstants.E_UNEXPECTED, new IntPtr(-1));
 
             // never reached...
             return null;


### PR DESCRIPTION
Fixes TFS bug 961110

__Customer scenario:__
Customer has a VS package which hooks the "OnBeginBuild" event in order to generate a unique name for every build. It does this by renaming one of the source files.
 In Dev12 this works. In Dev14, this throws an exception with the confusing message "The data necessary to complete this operation is not yet available."

__Root cause__
As part of the rename, the project system asks for an Intellisense build but, since we've just started a full build, MSBuild throws a ComException with the HRESULT of E_PENDING. This HRESULT is ignored, but then the project system calls into Roslyn FileCodeModel to make the rename. Roslyn's FileCodeModel, for compatibility reasons, attempts to return E_NOTIMPL to the caller by calling Marshal.ThrowExceptionForHR(E_NOTIMPL). However, since there's already an unreported exception on this thread, the runtime ignores E_NOTIMPL and returns E_PENDING instead. E_NOTIMPL is handled very specially by the project system (ultimately resulting in S_OK), but E_PENDING is not, so that result is returned to the caller.

__Fix__
The fix is to call the 2-argument overload of ThrowExceptionForHR and pass (IntPtr)(-1) for the 2nd arg which tells the runtime to ignore any existing IErrorInfo and use the HRESULT passed in the 1st arg.

__Testing__
Manual testing so far.
