### PR TITLE
Enable ResolveProjectReferences target to run

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -155,18 +155,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var mr in compilerInputs.References)
                 {
-                    var filePath = GetDocumentFilePath(mr);
+                    if (!IsProjectReferenceOutputAssembly(mr))
+                    {
+                        var filePath = GetDocumentFilePath(mr);
 
-                    var aliases = GetAliases(mr);
-                    if (aliases.IsDefaultOrEmpty)
-                    {
-                        args.Add("/r:\"" + filePath + "\"");
-                    }
-                    else
-                    {
-                        foreach (var alias in aliases)
+                        var aliases = GetAliases(mr);
+                        if (aliases.IsDefaultOrEmpty)
                         {
-                            args.Add("/r:" + alias + "=\"" + filePath + "\"");
+                            args.Add("/r:\"" + filePath + "\"");
+                        }
+                        else
+                        {
+                            foreach (var alias in aliases)
+                            {
+                                args.Add("/r:" + alias + "=\"" + filePath + "\"");
+                            }
                         }
                     }
                 }

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -57,11 +57,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
             // prepare for building
             var buildTargets = new BuildTargets(_loadedProject, "Compile");
 
-            // Don't execute this one. It will build referenced projects.
-            // Even when DesignTimeBuild is defined, it will still add the referenced project's output to the references list
-            // which we don't want.
-            buildTargets.Remove("ResolveProjectReferences");
-
             // don't execute anything after CoreCompile target, since we've
             // already done everything we need to compute compiler inputs by then.
             buildTargets.RemoveAfter("CoreCompile", includeTargetInRemoval: false);
@@ -180,6 +175,11 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
 
             return PathUtilities.GetFileName(assemblyName);
+        }
+
+        protected bool IsProjectReferenceOutputAssembly(MSB.Framework.ITaskItem item)
+        {
+            return item.GetMetadata("ReferenceOutputAssembly") == "true";
         }
 
         protected IEnumerable<ProjectFileReference> GetProjectReferences(ProjectInstance executedProject)

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
@@ -115,7 +115,6 @@ namespace Microsoft.CodeAnalysis.VisualBasic
 
             private void GetReferences(VisualBasicProjectFileLoader.VisualBasicProjectFile.VisualBasicCompilerInputs compilerInputs, ProjectInstance executedProject, ref IEnumerable<MetadataReference> metadataReferences, ref IEnumerable<AnalyzerReference> analyzerReferences)
             {
-
                 // use command line parser to compute references using common logic
                 List<string> list = new List<string>();
                 if (compilerInputs.LibPaths != null && compilerInputs.LibPaths.Count<string>() > 0)
@@ -126,8 +125,11 @@ namespace Microsoft.CodeAnalysis.VisualBasic
                 // metadata references
                 foreach (var current in compilerInputs.References)
                 {
-                    string documentFilePath = base.GetDocumentFilePath(current);
-                    list.Add("/r:\"" + documentFilePath + "\"");
+                    if (!IsProjectReferenceOutputAssembly(current))
+                    {
+                        string documentFilePath = base.GetDocumentFilePath(current);
+                        list.Add("/r:\"" + documentFilePath + "\"");
+                    }
                 }
 
                 // analyzer references

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -306,6 +306,16 @@
     <EmbeddedResource Include="TestFiles\CircularProjectReferences\CircularCSharpProject2.csproj" />
     <EmbeddedResource Include="TestFiles\CircularProjectReferences\CircularSolution.sln" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\CSharpProject_ReferencesPortableProject.csproj">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\CSharpProject_PortableProject.csproj">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Targets\VSL.Imports.targets" />
     <Import Project="..\..\..\build\VSL.Imports.Closed.targets" />

--- a/src/Workspaces/CoreTest/TestFiles/CSharpProject_PortableProject.csproj
+++ b/src/Workspaces/CoreTest/TestFiles/CSharpProject_PortableProject.csproj
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{f4261866-0652-4115-b022-0e4f4e4d903e}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Portly</RootNamespace>
+    <AssemblyName>Portly</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CSharpClass.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/CoreTest/TestFiles/CSharpProject_ReferencesPortableProject.csproj
+++ b/src/Workspaces/CoreTest/TestFiles/CSharpProject_ReferencesPortableProject.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{23293B02-BAAF-4BED-99F0-AC5C44199DEA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Bug2824</RootNamespace>
+    <AssemblyName>Bug2824</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="PortableProject.csproj">
+      <Project>{f4261866-0652-4115-b022-0e4f4e4d903e}</Project>
+      <Name>PortableProject</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -77,6 +77,26 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(5, compReferences.Count);
         }
 
+        [WorkItem(2824, "https://github.com/dotnet/roslyn/issues/2824")]
+        [Fact(Skip ="Needs target file update. Activate when we move to new base drop.")]
+        public void Test_OpenProjectReferencingPortableProject()
+        {
+            var files = new FileSet(new Dictionary<string, object>
+            {
+                { @"CSharpProject\ReferencesPortableProject.csproj", GetResourceText("CSharpProject_ReferencesPortableProject.csproj") },
+                { @"CSharpProject\Program.cs", GetResourceText("CSharpProject_CSharpClass.cs") },
+                { @"CSharpProject\PortableProject.csproj", GetResourceText("CSharpProject_PortableProject.csproj") },
+                { @"CSharpProject\CSharpClass.cs", GetResourceText("CSharpProject_CSharpClass.cs") }
+
+            });
+
+            CreateFiles(files);
+
+            var project = MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"CSharpProject\ReferencesPortableProject.csproj")).Result;
+            var hasFacades = project.MetadataReferences.OfType<PortableExecutableReference>().Any(r => r.FilePath.Contains("Facade"));
+            Assert.True(hasFacades);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void Test_SharedMetadataReferences()
         {


### PR DESCRIPTION
Fixes #2824 

This change enables MSBuildWorkspace to open projects that reference the Portable Class Libraries.

The technique used to remove assemblies associated with project references from the list of metadata references for the project being opened was disabling the MSBuild target that also did some shenanigans with portable class library references. The fix is to use a post-MSBuild filter to remove unwanted references instead of disabling some of the MSBuild targets.

@Pilchie @jasonmalinowski  please review