### PR TITLE
Implement data flow analysis for interpolated expressions

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -2528,6 +2528,19 @@ lUnsplitAndFinish:
             Visit(node.Expression)
             Return Nothing
         End Function
+
+        Public Overrides Function VisitInterpolatedStringExpression(node As BoundInterpolatedStringExpression) As BoundNode
+            For Each item In node.Contents
+                Visit(item)
+            Next
+
+            Return Nothing
+        End Function
+
+        Public Overrides Function VisitInterpolation(node As BoundInterpolation) As BoundNode
+            Visit(node.Expression)
+            Return Nothing
+        End Function
 #End Region
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -2539,6 +2539,8 @@ lUnsplitAndFinish:
 
         Public Overrides Function VisitInterpolation(node As BoundInterpolation) As BoundNode
             Visit(node.Expression)
+            Visit(node.AlignmentOpt)
+            Visit(node.FormatStringOpt)
             Return Nothing
         End Function
 #End Region

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -1140,6 +1140,151 @@ BC30491: Expression does not produce a value.
         End Sub
 
         <Fact>
+        Public Sub FlowAnalysis_Warning_InterpoledVariableUsedBeforeBeingAssigned()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
+<compilation>
+    <%= _formattableStringSource %>
+    <file name="a.vb">
+Imports System
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Dim v As Object
+
+        Write($"{v}")
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            AssertTheseCompileDiagnostics(compilation,
+<expected>
+BC42104: Variable 'v' is used before it has been assigned a value. A null reference exception could result at runtime.
+        Write($"{v}")
+                 ~
+</expected>)
+
+        End Sub
+
+        <Fact>
+        Public Sub FlowAnalysis_InterpolatedLocalConstNotConsideredUnused()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
+<compilation>
+    <%= _formattableStringSource %>
+    <file name="a.vb">
+Imports System
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Const v As Object = Nothing
+
+        Write($"{v}")
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            AssertNoDiagnostics(compilation)
+
+        End Sub
+
+        <Fact>
+        Public Sub FlowAnalysis_AnalyzeDataFlowReportsCorrectResultsForVariablesUsedInInterpolations()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
+<compilation>
+    <%= _formattableStringSource %>
+    <file name="a.vb">
+Imports System
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Dim v As Object = Nothing
+
+        Write($"Expression {v} is not a value.")
+
+        WriteLine(v)
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            AssertNoDiagnostics(compilation)
+
+            Dim mainTree = Aggregate t In compilation.SyntaxTrees Where t.FilePath = "a.vb" Into [Single]()
+            Dim root = mainTree.GetRoot()
+            Dim sm = compilation.GetSemanticModel(mainTree)
+
+            Dim vSymbol = CType(sm.GetDeclaredSymbol(root.DescendantNodes().OfType(Of ModifiedIdentifierSyntax).Single()), ILocalSymbol)
+
+            Dim analysis = sm.AnalyzeDataFlow(root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First())
+
+            Assert.True(analysis.Succeeded)
+            Assert.DoesNotContain(vSymbol, analysis.AlwaysAssigned)
+            Assert.DoesNotContain(vSymbol, analysis.Captured)
+            Assert.Contains(vSymbol, analysis.DataFlowsIn)
+            Assert.DoesNotContain(vSymbol, analysis.DataFlowsOut)
+            Assert.Contains(vSymbol, analysis.ReadInside)
+            Assert.Contains(vSymbol, analysis.ReadOutside)
+            Assert.DoesNotContain(vSymbol, analysis.UnsafeAddressTaken)
+            Assert.DoesNotContain(vSymbol, analysis.VariablesDeclared)
+            Assert.DoesNotContain(vSymbol, analysis.WrittenInside)
+            Assert.Contains(vSymbol, analysis.WrittenOutside)
+
+        End Sub
+
+        <Fact>
+        Public Sub FlowAnalysis_AnalyzeDataFlowReportsCorrectResultsForVariablesCapturedInInterpolations()
+
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
+<compilation>
+    <%= _formattableStringSource %>
+    <file name="a.vb">
+Imports System
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Dim v As Object = Nothing
+
+        Write($"Expression {(Function() v)()} is not a value.")
+
+        WriteLine(v)
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            AssertNoDiagnostics(compilation)
+
+            Dim mainTree = Aggregate t In compilation.SyntaxTrees Where t.FilePath = "a.vb" Into [Single]()
+            Dim root = mainTree.GetRoot()
+            Dim sm = compilation.GetSemanticModel(mainTree)
+
+            Dim vSymbol = CType(sm.GetDeclaredSymbol(root.DescendantNodes().OfType(Of ModifiedIdentifierSyntax).Single()), ILocalSymbol)
+
+            Dim analysis = sm.AnalyzeDataFlow(root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First())
+
+            Assert.True(analysis.Succeeded)
+            Assert.DoesNotContain(vSymbol, analysis.AlwaysAssigned)
+            Assert.Contains(vSymbol, analysis.Captured)
+            Assert.Contains(vSymbol, analysis.DataFlowsIn)
+            Assert.DoesNotContain(vSymbol, analysis.DataFlowsOut)
+            Assert.Contains(vSymbol, analysis.ReadInside)
+            Assert.Contains(vSymbol, analysis.ReadOutside)
+            Assert.DoesNotContain(vSymbol, analysis.UnsafeAddressTaken)
+            Assert.DoesNotContain(vSymbol, analysis.VariablesDeclared)
+            Assert.DoesNotContain(vSymbol, analysis.WrittenInside)
+            Assert.Contains(vSymbol, analysis.WrittenOutside)
+
+        End Sub
+
+        <Fact>
         Public Sub Lowering_MissingFormattableStringDoesntProduceErrorIfFactoryMethodReturnsTypeConvertableToIFormattable()
 
             Dim verifier = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -1206,7 +1206,7 @@ Module Program
     Sub Main()
         Dim v As Object = Nothing
 
-        Write($"Expression {v} is not a value.")
+        WriteLine($"{v}")
 
         WriteLine(v)
     End Sub
@@ -1222,7 +1222,10 @@ End Module
 
             Dim vSymbol = CType(sm.GetDeclaredSymbol(root.DescendantNodes().OfType(Of ModifiedIdentifierSyntax).Single()), ILocalSymbol)
 
-            Dim analysis = sm.AnalyzeDataFlow(root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First())
+            Dim writeLineCall = root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First()
+            Assert.Equal("WriteLine($""{v}"")", writeLineCall.ToString())
+
+            Dim analysis = sm.AnalyzeDataFlow(writeLineCall)
 
             Assert.True(analysis.Succeeded)
             Assert.DoesNotContain(vSymbol, analysis.AlwaysAssigned)
@@ -1252,7 +1255,7 @@ Module Program
     Sub Main()
         Dim v As Object = Nothing
 
-        Write($"Expression {(Function() v)()} is not a value.")
+        WriteLine($"{(Function() v)()}")
 
         WriteLine(v)
     End Sub
@@ -1268,7 +1271,10 @@ End Module
 
             Dim vSymbol = CType(sm.GetDeclaredSymbol(root.DescendantNodes().OfType(Of ModifiedIdentifierSyntax).Single()), ILocalSymbol)
 
-            Dim analysis = sm.AnalyzeDataFlow(root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First())
+            Dim writeLineCall = root.DescendantNodes().OfType(Of ExpressionStatementSyntax).First()
+            Assert.Equal("WriteLine($""{(Function() v)()}"")", writeLineCall.ToString())
+
+            Dim analysis = sm.AnalyzeDataFlow(writeLineCall)
 
             Assert.True(analysis.Succeeded)
             Assert.DoesNotContain(vSymbol, analysis.AlwaysAssigned)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -116,14 +116,36 @@ NewLines("Module M \n Sub Main() \n Dim x = 0 \n Do While {|Rename:NewMethod|}(x
         Public Sub TestInInterpolation1()
             Test(
 NewLines("Module M \n Sub Main() \n Dim v As New Object \n [|System.Console.WriteLine($""{v}"")|] \n System.Console.WriteLine(v) \n End Sub \n End Module"),
-NewLines("Module M \n Sub Main() \n Dim v As New Object \n {|Rename:NewMethod|}(v) \n System.Console.WriteLine(v) \n End Sub \n Private Sub NewMethod(v As Object) \n System.Console.WriteLine($""{v}"") \n End Sub \n End Module"))
+NewLines("Module M
+    Sub Main()
+        Dim v As New Object
+        {|Rename:NewMethod|}(v)
+        System.Console.WriteLine(v)
+    End Sub
+
+    Private Sub NewMethod(v As Object)
+        System.Console.WriteLine($""{v}"")
+    End Sub
+End Module"),
+compareTokens:=False)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInInterpolation2()
             Test(
 NewLines("Module M \n Sub Main() \n Dim v As New Object \n System.Console.WriteLine([|$""{v}""|]) \n System.Console.WriteLine(v) \n End Sub \n End Module"),
-NewLines("Module M \n Sub Main() \n Dim v As New Object \n System.Console.WriteLine({|Rename:NewMethod|}(v)) \n System.Console.WriteLine(v) \n End Sub \n Private Function NewMethod(v As Object) As Object \n Return $""{v}"" \n End Function \n End Module"))
+NewLines("Module M
+    Sub Main()
+        Dim v As New Object
+        System.Console.WriteLine({|Rename:NewMethod|}(v))
+        System.Console.WriteLine(v)
+    End Sub
+
+    Private Function NewMethod(v As Object) As String
+        Return $""{v}""
+    End Function
+End Module"),
+compareTokens:=False)
         End Sub
 
         <WorkItem(545829)>

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -112,6 +112,20 @@ NewLines("Module M \n Sub Main() \n Dim x = 0 \n Do While [|x * x < 100|] \n x +
 NewLines("Module M \n Sub Main() \n Dim x = 0 \n Do While {|Rename:NewMethod|}(x) \n x += 1 \n Loop \n End Sub \n Private Function NewMethod(x As Integer) As Boolean \n Return x * x < 100 \n End Function \n End Module"))
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        Public Sub TestInInterpolation1()
+            Test(
+NewLines("Module M \n Sub Main() \n Dim v As New Object \n [|System.Console.WriteLine($""{v}"")|] \n System.Console.WriteLine(v) \n End Sub \n End Module"),
+NewLines("Module M \n Sub Main() \n Dim v As New Object \n {|Rename:NewMethod|}(v) \n System.Console.WriteLine(v) \n End Sub \n Private Sub NewMethod(v As Object) \n System.Console.WriteLine($""{v}"") \n End Sub \n End Module"))
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        Public Sub TestInInterpolation2()
+            Test(
+NewLines("Module M \n Sub Main() \n Dim v As New Object \n System.Console.WriteLine([|$""{v}""|]) \n System.Console.WriteLine(v) \n End Sub \n End Module"),
+NewLines("Module M \n Sub Main() \n Dim v As New Object \n System.Console.WriteLine({|Rename:NewMethod|}(v)) \n System.Console.WriteLine(v) \n End Sub \n Private Function NewMethod(v As Object) As Object \n Return $""{v}"" \n End Function \n End Module"))
+        End Sub
+
         <WorkItem(545829)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestMissingOnImplicitMemberAccess()


### PR DESCRIPTION
Fixes bug #3381.

**Customer scenario**
1) VB developers using unassigned local variables exclusively inside of interpolations will receive false negatives for warning **BC42014: Variable is used before it has been assigned**.

``` VB.NET
Module Program
    Sub Main()
        Dim v As Object
        WriteLine($"{v.ToString()}") ' There should be a warning here.
    End Sub
End Module
```
2) VB developers using unassigned local variables and _assigned_ constants exclusively inside of interpolations will receive false positives for warnings **BC42024: Unused local variable** and **BC42099: Unused local constant**. This is the original customer issue.

``` VB.NET
Module Program
    Sub Main()
        Dim v As Integer ' False warning.
        Const c As Integer = 1 ' False warning.
        WriteLine($"{v}{c}")
    End Sub
End Module
```
3) VB developers invoking the extract method refactoring (and any other tooling dependent on flow analysis) of a region where local variables are exclusively used inside of interpolations will end up with broken code.

_Before:_
``` VB.NET
Module Program
    Sub Main()
        Dim v As Integer = 1
        WriteLine($"{v}") ' Extract this line.
    End Sub
End Module
```
_After:_
``` VB.NET
Module Program
    Sub Main()
        Dim v As Integer = 1
        NewMethod()
    End Sub

    Private Sub NewMethod()
        WriteLine($"{v}") ' 'v' is not defined.
    End Sub
End Module
```
**Description of fix**
The VB flow analysis visitor needs to know how to traverse interpolated string and interpolation bound nodes. The fix is to override the appropriate methods so that expressions used inside of interpolations are properly visited.

**Testing done**
Unit tests were added for the above 3 scenarios and all existing tests pass.

**Potential reviewers:** @gafter, @AlekseyTs, @VSadov, @jaredpar, @heejaechang. 
