### PR TITLE
Fix ITextBuffer leak after RenameTracking commit

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
@@ -137,7 +137,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                 // When this action is undone (the user has undone twice), restore the state
                 // machine to so that they can continue their original rename tracking session.
-                UpdateWorkspaceForResetOfTypedIdentifier(workspace, renameTrackingSolutionSet.OriginalSolution);
+
+                var trackingSessionId = _stateMachine.StoreCurrentTrackingSessionAndGenerateId();
+                UpdateWorkspaceForResetOfTypedIdentifier(workspace, renameTrackingSolutionSet.OriginalSolution, trackingSessionId);
 
                 // Now that the solution is back in its original state, notify third parties about
                 // the coming rename operation.
@@ -164,7 +166,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 }
 
                 // Undo/redo on this action must always clear the state machine
-                UpdateWorkspaceForGlobalIdentifierRename(workspace, finalSolution, workspace.CurrentSolution, _displayText, changedDocuments, renameTrackingSolutionSet.Symbol, newName);
+                UpdateWorkspaceForGlobalIdentifierRename(
+                    workspace, 
+                    finalSolution, 
+                    workspace.CurrentSolution, 
+                    _displayText, 
+                    changedDocuments, 
+                    renameTrackingSolutionSet.Symbol, 
+                    newName,
+                    trackingSessionId);
 
                 RenameTrackingDismisser.DismissRenameTracking(workspace, changedDocuments);
                 return true;
@@ -209,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 return tokenRenameInfo.HasSymbols ? tokenRenameInfo.Symbols.First() : null;
             }
 
-            private void UpdateWorkspaceForResetOfTypedIdentifier(Workspace workspace, Solution newSolution)
+            private void UpdateWorkspaceForResetOfTypedIdentifier(Workspace workspace, Solution newSolution, int trackingSessionId)
             {
                 AssertIsForeground();
 
@@ -219,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 var undoHistory = _undoHistoryRegistry.RegisterHistory(_stateMachine.Buffer);
                 using (var localUndoTransaction = undoHistory.CreateTransaction(EditorFeaturesResources.TextBufferChange))
                 {
-                    var undoPrimitiveBefore = new UndoPrimitive(_stateMachine, shouldRestoreStateOnUndo: true);
+                    var undoPrimitiveBefore = new UndoPrimitive(_stateMachine.Buffer, trackingSessionId, shouldRestoreStateOnUndo: true);
                     localUndoTransaction.AddUndo(undoPrimitiveBefore);
 
                     if (!workspace.TryApplyChanges(newSolution))
@@ -228,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     }
 
                     // Never resume tracking session on redo
-                    var undoPrimitiveAfter = new UndoPrimitive(_stateMachine, shouldRestoreStateOnUndo: false);
+                    var undoPrimitiveAfter = new UndoPrimitive(_stateMachine.Buffer, trackingSessionId, shouldRestoreStateOnUndo: false);
                     localUndoTransaction.AddUndo(undoPrimitiveAfter);
 
                     localUndoTransaction.Complete();
@@ -242,7 +252,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 string undoName,
                 IEnumerable<DocumentId> changedDocuments,
                 ISymbol symbol,
-                string newName)
+                string newName,
+                int trackingSessionId)
             {
                 AssertIsForeground();
 
@@ -254,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 using (var workspaceUndoTransaction = workspace.OpenGlobalUndoTransaction(undoName))
                 using (var localUndoTransaction = undoHistory.CreateTransaction(undoName))
                 {
-                    var undoPrimitiveBefore = new UndoPrimitive(_stateMachine, shouldRestoreStateOnUndo: false);
+                    var undoPrimitiveBefore = new UndoPrimitive(_stateMachine.Buffer, trackingSessionId, shouldRestoreStateOnUndo: false);
                     localUndoTransaction.AddUndo(undoPrimitiveBefore);
 
                     if (!workspace.TryApplyChanges(newSolution))
@@ -272,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     }
 
                     // Never resume tracking session on redo
-                    var undoPrimitiveAfter = new UndoPrimitive(_stateMachine, shouldRestoreStateOnUndo: false);
+                    var undoPrimitiveAfter = new UndoPrimitive(_stateMachine.Buffer, trackingSessionId, shouldRestoreStateOnUndo: false);
                     localUndoTransaction.AddUndo(undoPrimitiveAfter);
 
                     localUndoTransaction.Complete();


### PR DESCRIPTION
Fixes #830

When a rename tracking session is committed, we create 4
ITextUndoPrimitives to facilitate the two-phase undo system that can
clear or restore an earlier TrackingSession. These UndoPrimitives can
live beyond the lifetime of the buffer in which the TrackingSession
occurred (when they are grouped into a global undo transaction), so it's
important that they do not contain any strong references to the
ITextBuffer.

The UndoPrimitive class previously held a strong reference to the
StateMachine, which directly referenced the ITextBuffer. Instead of
directly referencing the StateMachine, the UndoPrimitive class now holds
a WeakReference to the ITextBuffer, from which we can retrieve the
StateMachine (via its property bag). If the ITextBuffer has gone away
but the UndoPrimitive still exists as part of a global undo, then
undo/redo will not be able to retrieve the StateMachine and will
therefore have no effect (as expected, because the only purpose of the
custom UndoPrimitives is to provide custom experiences in the
ITextBuffer that's already been GC'd).

The UndoPrimitive class also previously referenced the TrackingSession
that it needs to restore on undo, which then contains an ITrackingSpan
that references the ITextBuffer. Instead, the StateMachine itself now
keeps a list of all of the committed TrackingSessions, and the
UndoPrimitive simply stores the index of it's target TrackingSpan into
that list. Because the StateMachine is only held alive in the
ITextBuffer's property bag, the StateMachine itself and all of the
previously committed TrackingSessions will be collected when the
ITextBuffer goes away.

Potential Reviewers: @Pilchie @brettfo @jasonmalinowski @balajikris @rchande @basoundr @jmarolf