### PR TITLE
Object Creation Preselection special case

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -225,5 +225,38 @@ class Foo
 ";
             VerifyItemExists(markup, "Location");
         }
+
+        [WorkItem(1090377)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void AfterNewFollowedByAssignment_GrandParentIsSimpleAssignment()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Program p = new $$
+        bool b = false;
+    }
+}";
+            VerifyItemExists(markup, "Program");
+        }
+
+        [WorkItem(2836, "https://github.com/dotnet/roslyn/issues/2836")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void AfterNewFollowedByAssignment_GrandParentIsEqualsValueClause()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        bool b;
+        Program p = new $$
+        b = false;
+    }
+}";
+            VerifyItemExists(markup, "Program");
+        }
     }
 }


### PR DESCRIPTION
Fixes #2836.

There are cases in broken code scenarios where the new keyword in
objectcreationexpression appears to be a part of a subsequent
assignment.

This was originally addressed in #2537. This commit addresses #2836
which is a special case of the same class of problem.

E.g:
```C#
bool b;
Program p = new $$
b = false;
```

Per the parser, the new token here belongs to the second assignment and
hence type inferrer recommends `bool`.  However, that is not helpful.
The IDE detects this and correctly infers the type `Program` which is
what the user expects.