### PR TITLE
Implement IAccurateTagger<TTag> on asynchronous taggers

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractAggregatedDiagnosticsTagSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractAggregatedDiagnosticsTagSource.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -51,6 +52,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         protected abstract TagSpan<TTag> CreateTagSpan(SnapshotSpan span, DiagnosticData diagnostic);
 
         public override ITagSpanIntervalTree<TTag> GetTagIntervalTreeForBuffer(ITextBuffer buffer)
+        {
+            return GetAccurateTagIntervalTreeForBuffer(buffer, CancellationToken.None);
+        }
+
+        public override ITagSpanIntervalTree<TTag> GetAccurateTagIntervalTreeForBuffer(ITextBuffer buffer, CancellationToken cancellationToken)
         {
             if (buffer == this.SubjectBuffer)
             {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.TagSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 return new TagSpan<ClassificationTag>(span, s_tag);
             }
 
-            public override ITagSpanIntervalTree<ClassificationTag> GetTagIntervalTreeForBuffer(ITextBuffer buffer)
+            public override ITagSpanIntervalTree<ClassificationTag> GetAccurateTagIntervalTreeForBuffer(ITextBuffer buffer, CancellationToken cancellationToken)
             {
                 // when contrast changed, tagger will refresh itself if host support high contrast mode. (VS does)
                 if (HighContrastChecker.IsHighContrast)
@@ -63,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     return null;
                 }
 
-                return base.GetTagIntervalTreeForBuffer(buffer);
+                return base.GetAccurateTagIntervalTreeForBuffer(buffer, cancellationToken);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/ReferenceHighlightingTagSource.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/ReferenceHighlightingTagSource.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
 
             var tagSpans = SpecializedCollections.EmptyEnumerable<ITagSpan<AbstractNavigatableReferenceHighlightingTag>>();
 
-            var map = ConvertToTagTree(tagSpans, spansToTag);
+            var map = ConvertToTagTree(tagSpans, spansToTag, cancellationToken);
 
             // here we call base.ProcessNewTags so that we can clear tags without setting last solution version
             // clear tags is a special update mechanism where it represents clearing tags not updating tags.

--- a/src/EditorFeatures/Core/Shared/Tagging/TagSources/TagSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/TagSources/TagSource.cs
@@ -69,9 +69,16 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public event EventHandler Resumed;
 
         /// <summary>
-        /// implemented by derived types to return interval tree associated with the buffer
+        /// Implemented by derived types to return interval tree associated with the buffer.
+        /// This method may return incomplete or partial results.
         /// </summary>
         public abstract ITagSpanIntervalTree<TTag> GetTagIntervalTreeForBuffer(ITextBuffer buffer);
+
+        /// <summary>
+        /// Implemented by derived types to return interval tree associated with the buffer.
+        /// This method must return complete results for the buffer because it is called from <see cref="IAccurateTagger{T}.GetAllTags(NormalizedSnapshotSpanCollection, CancellationToken)"/>.
+        /// </summary>
+        public abstract ITagSpanIntervalTree<TTag> GetAccurateTagIntervalTreeForBuffer(ITextBuffer buffer, CancellationToken cancellationToken);
 
         /// <summary>
         /// Implemented by derived types to start recalculate tags

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -103,16 +103,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
 
                 var document = workspace.Documents.First();
                 var textBuffer = document.TextBuffer;
-                var tagger = tagProvider.CreateTagger<IOutliningRegionTag>(textBuffer);
+                var tagger = tagProvider.CreateTagger<IOutliningRegionTag>(textBuffer) as IAccurateTagger<IOutliningRegionTag>;
 
                 using (var disposable = (IDisposable)tagger)
                 {
                     ProducerPopulatedTagSource<IOutliningRegionTag> tagSource = null;
                     tagProvider.TryRetrieveTagSource(null, textBuffer, out tagSource);
-                    tagSource.ComputeTagsSynchronouslyIfNoAsynchronousComputationHasCompleted = true;
 
                     // The very first all to get tags should return the single outlining span.
-                    var tags = tagger.GetTags(new NormalizedSnapshotSpanCollection(textBuffer.CurrentSnapshot.GetFullSpan()));
+                    var tags = tagger.GetAllTags(new NormalizedSnapshotSpanCollection(textBuffer.CurrentSnapshot.GetFullSpan()), CancellationToken.None);
                     Assert.Equal(1, tags.Count());
                 }
             }

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -103,14 +103,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
 
                 var document = workspace.Documents.First();
                 var textBuffer = document.TextBuffer;
-                var tagger = tagProvider.CreateTagger<IOutliningRegionTag>(textBuffer) as IAccurateTagger<IOutliningRegionTag>;
+                var tagger = (IAccurateTagger<IOutliningRegionTag>)tagProvider.CreateTagger<IOutliningRegionTag>(textBuffer);
 
                 using (var disposable = (IDisposable)tagger)
                 {
-                    ProducerPopulatedTagSource<IOutliningRegionTag> tagSource = null;
-                    tagProvider.TryRetrieveTagSource(null, textBuffer, out tagSource);
-
-                    // The very first all to get tags should return the single outlining span.
                     var tags = tagger.GetAllTags(new NormalizedSnapshotSpanCollection(textBuffer.CurrentSnapshot.GetFullSpan()), CancellationToken.None);
                     Assert.Equal(1, tags.Count());
                 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
@@ -134,25 +134,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 var viewEx = textView as IVsTextViewEx;
                 if (viewEx != null)
                 {
-                    // We need to get our outlining tag source to notify it to start blocking
-                    var outliningTaggerProvider = this.Package.ComponentModel.GetService<OutliningTaggerProvider>();
-                    ProducerPopulatedTagSource<IOutliningRegionTag> tagSource;
-                    if (outliningTaggerProvider.TryRetrieveTagSource(wpfTextView, wpfTextView.TextBuffer, out tagSource))
+                    // If this file is a metadata-from-source file, we want to force-collapse
+                    if (isOpenMetadataAsSource)
                     {
-                        // If this file is a metadata-from-source file, we want to force-collapse
-                        if (isOpenMetadataAsSource)
-                        {
-                            outliningManager.CollapseAll(new SnapshotSpan(wpfTextView.TextBuffer.CurrentSnapshot,
-                                                                          start: 0,
-                                                                          length: wpfTextView.TextBuffer.CurrentSnapshot.Length),
-                                                         c => c.Tag.IsImplementation);
-                        }
-                        else
-                        {
-                            // Set the initial outlining state by reading from the suo file, this operation requires
-                            // us to synchronously compute the outlining region tags.
-                            viewEx.PersistOutliningState();
-                        }
+                        outliningManager.CollapseAll(new SnapshotSpan(wpfTextView.TextBuffer.CurrentSnapshot,
+                                                                      start: 0,
+                                                                      length: wpfTextView.TextBuffer.CurrentSnapshot.Length),
+                                                     c => c.Tag.IsImplementation);
+                    }
+                    else
+                    {
+                        // Set the initial outlining state by reading from the suo file, this operation requires
+                        // us to synchronously compute the outlining region tags.
+                        viewEx.PersistOutliningState();
                     }
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
@@ -139,28 +139,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     ProducerPopulatedTagSource<IOutliningRegionTag> tagSource;
                     if (outliningTaggerProvider.TryRetrieveTagSource(wpfTextView, wpfTextView.TextBuffer, out tagSource))
                     {
-                        tagSource.ComputeTagsSynchronouslyIfNoAsynchronousComputationHasCompleted = true;
-
-                        try
+                        // If this file is a metadata-from-source file, we want to force-collapse
+                        if (isOpenMetadataAsSource)
                         {
-                            // If this file is a metadata-from-source file, we want to force-collapse
-                            if (isOpenMetadataAsSource)
-                            {
-                                outliningManager.CollapseAll(new SnapshotSpan(wpfTextView.TextBuffer.CurrentSnapshot,
-                                                                              start: 0,
-                                                                              length: wpfTextView.TextBuffer.CurrentSnapshot.Length),
-                                                             c => c.Tag.IsImplementation);
-                            }
-                            else
-                            {
-                                // Set the initial outlining state by reading from the suo file, this operation requires
-                                // us to synchronously compute the outlining region tags.
-                                viewEx.PersistOutliningState();
-                            }
+                            outliningManager.CollapseAll(new SnapshotSpan(wpfTextView.TextBuffer.CurrentSnapshot,
+                                                                          start: 0,
+                                                                          length: wpfTextView.TextBuffer.CurrentSnapshot.Length),
+                                                         c => c.Tag.IsImplementation);
                         }
-                        finally
+                        else
                         {
-                            tagSource.ComputeTagsSynchronouslyIfNoAsynchronousComputationHasCompleted = false;
+                            // Set the initial outlining state by reading from the suo file, this operation requires
+                            // us to synchronously compute the outlining region tags.
+                            viewEx.PersistOutliningState();
                         }
                     }
                 }


### PR DESCRIPTION
Address "open file" performance by making our outlining tagger asynchronous.
We implement ```IAccurateTagger<TTag>``` on ```TagSource```
The ```GetAllTags``` is now the "block until all tags are computed" API and the original ```GetTags``` method is the "give me what you've got" API. As a result the ```ComputeTagsSynchronouslyIfNoAsynchronousComputationHasCompleted``` property on ```ProducerPopulatedTagSource``` went away. I verified that the editor code will call us via ```IAccurateTagger.GetAllTags``` in the case where there is non-default persisted outlining information in the .suo file.