### PR TITLE
Remove extra files from OpenSourceDebug.vsix

### DIFF
--- a/src/Tools/Source/OpenSourceDebug/OpenSourceDebug.csproj
+++ b/src/Tools/Source/OpenSourceDebug/OpenSourceDebug.csproj
@@ -75,7 +75,7 @@
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.$(VisualStudioVersion)" />
+    <Reference Include="Microsoft.VisualStudio.Shell.$(VisualStudioVersion)"><Private>false</Private></Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0"><Private>false</Private></Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0"><Private>false</Private></Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0"><Private>false</Private></Reference>

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.Build.Tasks.$(MSBuildAssemblyNameFragment), Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Tasks.$(MSBuildAssemblyNameFragment), Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>


### PR DESCRIPTION
These two changes should have been included in https://github.com/dotnet/roslyn/commit/8c9ed547c5bc6ad5a9842945688da9b2f189ac8c but,

1. The references didn't match any of the extraneous VSIX names because they inline variables.
2. OpenSourceDebug.csproj doesn't drop a VSIX in the output folder, so it was missed by my validation pass.

The net effect is to remove Microsoft.Build.Tasks.Core.dll, Microsoft.Build.Utilities.Core.dll, and Microsoft.VisualStudio.Shell.14.0.dll from OpenSourceDebug.vsix.