### PR TITLE
Calculate correct set of events in the VB navigation bar

### DIFF
--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -448,6 +448,207 @@ End Class
                      Item("CancelKeyPress", Glyph.EventPublic, hasNavigationSymbolId:=False)}))
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(1185589)>
+        Public Sub WithEventsField_EventsFromInheritedInterfaces()
+            AssertItemsAre(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Interface I1
+    Event I1Event(sender As Object, e As EventArgs)
+End Interface
+
+Interface I2
+    Event I2Event(sender As Object, e As EventArgs)
+End Interface
+
+Interface I3
+    Inherits I1, I2
+    Event I3Event(sender As Object, e As EventArgs)
+End Interface
+
+Class Test
+    WithEvents i3 As I3
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                Item("I1", Glyph.InterfaceInternal, bolded:=True, children:={
+                     Item("I1Event", Glyph.EventPublic, bolded:=True)}),
+                Item("I2", Glyph.InterfaceInternal, bolded:=True, children:={
+                     Item("I2Event", Glyph.EventPublic, bolded:=True)}),
+                Item("I3", Glyph.InterfaceInternal, bolded:=True, children:={
+                     Item("I3Event", Glyph.EventPublic, bolded:=True)}),
+                Item("Test", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item("i3", Glyph.FieldPrivate, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("I1Event", Glyph.EventPublic, hasNavigationSymbolId:=False),
+                     Item("I2Event", Glyph.EventPublic, hasNavigationSymbolId:=False),
+                     Item("I3Event", Glyph.EventPublic, hasNavigationSymbolId:=False)}))
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(1185589), WorkItem(530506)>
+        Public Sub DoNotIncludeShadowedEvents()
+            AssertItemsAre(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class B
+    Event E(sender As Object, e As EventArgs)
+End Class
+
+Class C
+    Inherits B
+
+    Shadows Event E(sender As Object, e As EventArgs)
+End Class
+
+Class Test
+    WithEvents c As C
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                Item("B", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False),
+                     Item("E", Glyph.EventPublic, bolded:=True)}),
+                Item(String.Format(VBEditorResources.Events, "B"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPublic, hasNavigationSymbolId:=False)}),
+                Item("C", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False),
+                     Item("E", Glyph.EventPublic, bolded:=True)}),
+                Item(String.Format(VBEditorResources.Events, "C"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPublic, hasNavigationSymbolId:=False)}), ' Only one E under the "(C Events)" node
+                Item("Test", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item("c", Glyph.FieldPrivate, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPublic, hasNavigationSymbolId:=False)})) ' Only one E for WithEvents handling
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(1185589), WorkItem(530506)>
+        Public Sub EventList_EnsureInternalEventsInEventListAndInInheritedEventList()
+            AssertItemsAre(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Event E()
+End Class
+
+Class D
+    Inherits C
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                Item("C", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False),
+                     Item("E", Glyph.EventPublic, bolded:=True)}),
+                Item(String.Format(VBEditorResources.Events, "C"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPublic, hasNavigationSymbolId:=False)}),
+                Item("D", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item(String.Format(VBEditorResources.Events, "D"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPublic, hasNavigationSymbolId:=False)}))
+
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(1185589), WorkItem(530506)>
+        Public Sub EventList_EnsurePrivateEventsInEventListButNotInInheritedEventList()
+            AssertItemsAre(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Private Event E()
+End Class
+
+Class D
+    Inherits C
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                Item("C", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False),
+                     Item("E", Glyph.EventPrivate, bolded:=True)}),
+                Item(String.Format(VBEditorResources.Events, "C"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E", Glyph.EventPrivate, hasNavigationSymbolId:=False)}),
+                Item("D", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}))
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(1185589), WorkItem(530506)>
+        Public Sub EventList_TestAccessibilityThroughNestedAndDerivedTypes()
+            AssertItemsAre(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Public Event E0()
+    Protected Event E1()
+    Private Event E2()
+
+    Class N1
+        Class N2
+            Inherits C
+
+        End Class
+    End Class
+End Class
+
+Class D2
+    Inherits C
+
+End Class
+
+Class T
+    WithEvents c As C
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                Item("C", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False),
+                     Item("E0", Glyph.EventPublic, bolded:=True),
+                     Item("E1", Glyph.EventProtected, bolded:=True),
+                     Item("E2", Glyph.EventPrivate, bolded:=True)}),
+                Item(String.Format(VBEditorResources.Events, "C"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E0", Glyph.EventPublic, hasNavigationSymbolId:=False),
+                     Item("E1", Glyph.EventProtected, hasNavigationSymbolId:=False),
+                     Item("E2", Glyph.EventPrivate, hasNavigationSymbolId:=False)}),
+                Item("D2", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item(String.Format(VBEditorResources.Events, "D2"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E0", Glyph.EventPublic, hasNavigationSymbolId:=False),
+                     Item("E1", Glyph.EventProtected, hasNavigationSymbolId:=False)}),
+                Item("N1 (C)", Glyph.ClassPublic, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item("N2 (C.N1)", Glyph.ClassPublic, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item(String.Format(VBEditorResources.Events, "N2"), Glyph.EventPublic, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E0", Glyph.EventPublic, hasNavigationSymbolId:=False),
+                     Item("E1", Glyph.EventProtected, hasNavigationSymbolId:=False),
+                     Item("E2", Glyph.EventPrivate, hasNavigationSymbolId:=False)}),
+                Item("T", Glyph.ClassInternal, bolded:=True, children:={
+                     Item(NavigationItemNew, Glyph.MethodPublic, hasNavigationSymbolId:=False),
+                     Item("Finalize", Glyph.MethodProtected, hasNavigationSymbolId:=False)}),
+                Item("c", Glyph.FieldPrivate, hasNavigationSymbolId:=False, indent:=1, children:={
+                     Item("E0", Glyph.EventPublic, hasNavigationSymbolId:=False)}))
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar)>
         Public Sub GenerateEventHandler()
             AssertGeneratedResultIs(

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
             Contract.ThrowIfNull(semanticModel)
 
-            Dim types = GetTypesInFile(semanticModel, cancellationToken)
+            Dim typesAndDeclarations = GetTypesAndDeclarationsInFile(semanticModel, cancellationToken)
 
             Dim typeItems As New List(Of NavigationBarItem)
             Dim typeSymbolIndexProvider As New NavigationBarSymbolIdIndexProvider(caseSensitive:=False)
@@ -53,8 +53,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Dim symbolDeclarationService = document.GetLanguageService(Of ISymbolDeclarationService)
             Dim workspaceSupportsDocumentChanges = document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument)
 
-            For Each typeSymbol In types
-                typeItems.AddRange(CreateItemsForType(typeSymbol, typeSymbolIndexProvider.GetIndexForSymbolId(typeSymbol.GetSymbolKey()), semanticModel, workspaceSupportsDocumentChanges, symbolDeclarationService, cancellationToken))
+            For Each typeAndDeclaration In typesAndDeclarations
+                Dim type = typeAndDeclaration.Item1
+                Dim position = typeAndDeclaration.Item2.SpanStart
+                typeItems.AddRange(CreateItemsForType(type, position, typeSymbolIndexProvider.GetIndexForSymbolId(type.GetSymbolKey()), semanticModel, workspaceSupportsDocumentChanges, symbolDeclarationService, cancellationToken))
             Next
 
             Return typeItems
@@ -65,23 +67,23 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Return TypeOf item IsNot AbstractGenerateCodeItem
         End Function
 
-        Private Function GetTypesInFile(semanticModel As SemanticModel, cancellationToken As CancellationToken) As IEnumerable(Of INamedTypeSymbol)
+        Private Function GetTypesAndDeclarationsInFile(semanticModel As SemanticModel, cancellationToken As CancellationToken) As IEnumerable(Of Tuple(Of INamedTypeSymbol, SyntaxNode))
             Try
-                Dim types As New HashSet(Of INamedTypeSymbol)
+                Dim typesAndDeclarations As New Dictionary(Of INamedTypeSymbol, SyntaxNode)
                 Dim nodesToVisit As New Stack(Of SyntaxNode)
 
                 nodesToVisit.Push(DirectCast(semanticModel.SyntaxTree.GetRoot(cancellationToken), SyntaxNode))
 
                 Do Until nodesToVisit.IsEmpty
                     If cancellationToken.IsCancellationRequested Then
-                        Return SpecializedCollections.EmptyEnumerable(Of INamedTypeSymbol)()
+                        Return SpecializedCollections.EmptyEnumerable(Of Tuple(Of INamedTypeSymbol, SyntaxNode))()
                     End If
 
                     Dim node = nodesToVisit.Pop()
                     Dim type = TryCast(semanticModel.GetDeclaredSymbol(node, cancellationToken), INamedTypeSymbol)
 
                     If type IsNot Nothing Then
-                        types.Add(type)
+                        typesAndDeclarations(type) = node
                     End If
 
                     If TypeOf node Is MethodBlockBaseSyntax OrElse
@@ -99,13 +101,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                     Next
                 Loop
 
-                Return types.OrderBy(Function(t) t.Name)
+                Return typesAndDeclarations.Select(Function(kvp) Tuple.Create(kvp.Key, kvp.Value)).OrderBy(Function(t) t.Item1.Name)
             Catch ex As Exception When FatalError.ReportUnlessCanceled(ex)
                 Throw ExceptionUtilities.Unreachable
             End Try
         End Function
 
         Private Function CreateItemsForType(type As INamedTypeSymbol,
+                                            position As Integer,
                                             typeSymbolIdIndex As Integer,
                                             semanticModel As SemanticModel,
                                             workspaceSupportsDocumentChanges As Boolean,
@@ -120,6 +123,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                 If type.TypeKind <> TypeKind.Interface Then
                     Dim typeEvents = CreateItemForEvents(
                         type,
+                        position,
                         type,
                         eventContainer:=Nothing,
                         semanticModel:=semanticModel,
@@ -139,6 +143,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                             items.Add(
                                 CreateItemForEvents(
                                     type,
+                                    position,
                                     propertySymbol.Type,
                                     propertySymbol,
                                     semanticModel,
@@ -279,6 +284,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
         ''' <param name="eventContainer">If this is an entry for a WithEvents member, the WithEvents
         ''' property itself.</param>
         Private Function CreateItemForEvents(containingType As INamedTypeSymbol,
+                                             position As Integer,
                                              eventType As ITypeSymbol,
                                              eventContainer As IPropertySymbol,
                                              semanticModel As SemanticModel,
@@ -288,10 +294,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 
             Dim rightHandMemberItems As New List(Of NavigationBarItem)
 
-            ' Get all of the events and methods implementing them. We must include events from base
-            ' types, as well as static events.
-            Dim allEvents = eventType.GetBaseTypesAndThis().SelectMany(Function(t) t.GetMembers()).OfType(Of IEventSymbol)().OrderBy(Function(e) e.Name)
-            Dim accessibleEvents = allEvents.Where(Function(e) e.IsAccessibleWithin(containingType))
+            Dim accessibleEvents = semanticModel.LookupSymbols(position, eventType).OfType(Of IEventSymbol).OrderBy(Function(e) e.Name)
+
             Dim methodsImplementingEvents = containingType.GetMembers().OfType(Of IMethodSymbol) _
                                                           .Where(Function(m) m.HandledEvents.Any(Function(he) Object.Equals(he.EventContainer, eventContainer)))
 
@@ -299,10 +303,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 
             For Each method In methodsImplementingEvents
                 For Each handledEvent In method.HandledEvents
-                    Dim list As list(Of IMethodSymbol) = Nothing
+                    Dim list As List(Of IMethodSymbol) = Nothing
 
                     If Not eventToImplementingMethods.TryGetValue(handledEvent.EventSymbol, list) Then
-                        list = New list(Of IMethodSymbol)
+                        list = New List(Of IMethodSymbol)
                         eventToImplementingMethods.Add(handledEvent.EventSymbol, list)
                     End If
 


### PR DESCRIPTION
Fixes internal bugs #1185589 (currently active in "1.0 (stable)") and #530506

**ShipRoom** info <a href = "#issuecomment-111359084">available below</a>.

There are two places in VB where we display custom lists of events in the navigation bar:
1. In a type declaration with declared events (directly or in any base type or interface), the middle dropdown shows a "(&lt;Type> Events)" node that then lists all of its events in the right dropdown.
2. WithEvents fields are each shown as a separate node in the middle dropdown, which then list all of the accessible events on that type (or its base types or interfaces) in the right dropdown.

In either case, selecting an event from the right dropdown generates a method that Handles the event (or navigates to an existing method that Handles the event).

To calculate the list the events to show for code generation, we previously iterated through its BaseType chain gathering up IEventSymbols with the needed accessibility levels. This approach had two known problems:

1. It was not considering interface implementation, only BaseTypes. This would cause events to be omitted. (#1185589)
2. It incorrectly included shadowed events. This would cause either duplicate entries resulting in the same Handles method generation (#530506) or completely invalid entries that would generate invalid code (if the shadowing event uses a different name)

Instead of manually constructing this list of events by navigating around the type hierarchy, we now use LookupSymbols to rely on the compiler's knowledge of what events are available (and which are not available due to shadowing).

Potential reviewers: @jasonmalinowski @Pilchie @brettfo @balajikris @rchande @jmarolf @basoundr