### PR TITLE
Do not attempt to prepare for an event hookup for a Handles clause in an invalid context.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -758,13 +758,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim methodSym = DirectCast(implementingMember, SourceMemberMethodSymbol)
 
                     Dim diagbag = DiagnosticBag.GetInstance()
-                    Dim boundClause = methodSym.BindSingleHandlesClause(handlesClause,
-                                                                        binder,
-                                                                        diagbag,
-                                                                        eventSymbolBuilder,
-                                                                        containerSymbolBuilder,
-                                                                        propertySymbolBuilder,
-                                                                        resultKind)
+                    methodSym.BindSingleHandlesClause(handlesClause,
+                                                      binder,
+                                                      diagbag,
+                                                      eventSymbolBuilder,
+                                                      containerSymbolBuilder,
+                                                      propertySymbolBuilder,
+                                                      resultKind)
 
                     diagbag.Free()
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
@@ -743,6 +743,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagBag)
             End If
 
+            Select Case ContainingType.TypeKind
+                Case TypeKind.Interface, TypeKind.Structure, TypeKind.Enum, TypeKind.Delegate
+                    ' Handles clause is invalid in this context. 
+                    Return Nothing
+
+                Case TypeKind.Class, TypeKind.Module
+                    ' Valid context
+
+                Case Else
+                    Debug.Assert(False)
+            End Select
+
             Dim receiverOpt As BoundExpression = Nothing
 
             ' synthesize delegate creation (may involve relaxation)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
@@ -2100,5 +2100,114 @@ End Structure
 }
 ]]>)
         End Sub
+
+        <Fact, WorkItem(3448, "https://github.com/dotnet/roslyn/issues/3448")>
+        Public Sub HandlesInAnInterface()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Interface I
+    Event E()
+    Sub M() Handles Me.E
+End Interface
+    ]]></file>
+</compilation>, options:=TestOptions.DebugDll)
+
+            Dim expected = <expected>
+BC30270: 'Handles' is not valid on an interface method declaration.
+    Sub M() Handles Me.E
+            ~~~~~~~~~~~~
+                           </expected>
+
+            compilation.AssertTheseDiagnostics(expected)
+            compilation.AssertTheseEmitDiagnostics(expected)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(n) n.Identifier.ValueText = "E").Single()
+
+            Assert.Equal("Me.E", node.Parent.ToString())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+            Assert.Equal("Event I.E()", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem(3448, "https://github.com/dotnet/roslyn/issues/3448")>
+        Public Sub HandlesInAStruct()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Structure S
+    Event E()
+    Sub M() Handles Me.E
+    End Sub
+End Structure
+    ]]></file>
+</compilation>, options:=TestOptions.DebugDll)
+
+            Dim expected = <expected>
+BC30728: Methods declared in structures cannot have 'Handles' clauses.
+    Sub M() Handles Me.E
+        ~
+                           </expected>
+
+            compilation.AssertTheseDiagnostics(expected)
+            compilation.AssertTheseEmitDiagnostics(expected)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(n) n.Identifier.ValueText = "E").Single()
+
+            Assert.Equal("Me.E", node.Parent.ToString())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+            Assert.Equal("Event S.E()", symbolInfo.Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem(3448, "https://github.com/dotnet/roslyn/issues/3448")>
+        Public Sub HandlesInAnEnum()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Enum E1
+    'Event E()
+    Sub M() Handles Me.E
+    End Sub
+End Enum
+    ]]></file>
+</compilation>, options:=TestOptions.DebugDll)
+
+            Dim expected = <expected>
+BC30185: 'Enum' must end with a matching 'End Enum'.
+Enum E1
+~~~~~~~
+BC30280: Enum 'E1' must contain at least one member.
+Enum E1
+     ~~
+BC30619: Statement cannot appear within an Enum body. End of Enum assumed.
+    Sub M() Handles Me.E
+    ~~~~~~~~~~~~~~~~~~~~
+BC30590: Event 'E' cannot be found.
+    Sub M() Handles Me.E
+                       ~
+BC30184: 'End Enum' must be preceded by a matching 'Enum'.
+End Enum
+~~~~~~~~
+                           </expected>
+
+            compilation.AssertTheseDiagnostics(expected)
+            compilation.AssertTheseEmitDiagnostics(expected)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of IdentifierNameSyntax)().Where(Function(n) n.Identifier.ValueText = "E").Single()
+
+            Assert.Equal("Me.E", node.Parent.ToString())
+
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim symbolInfo = semanticModel.GetSymbolInfo(node)
+            Assert.Null(symbolInfo.Symbol)
+            Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #3448.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.