### PR TITLE
Allow projects to be created with no SDK path

### DIFF
--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/MockCompilerHost.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/MockCompilerHost.vb
@@ -20,6 +20,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
             End Get
         End Property
 
+        Public Shared ReadOnly Property NoSdkCompilerHost As MockCompilerHost
+            Get
+                Return New MockCompilerHost("")
+            End Get
+        End Property
+
         Public Function GetWellKnownDllName(fileName As String) As String
             Return Path.Combine(_sdkPath, fileName)
         End Function
@@ -28,8 +34,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
             Throw New NotImplementedException()
         End Sub
 
-        Public Function GetSdkPath() As <MarshalAs(UnmanagedType.BStr)> String Implements IVbCompilerHost.GetSdkPath
-            Return _sdkPath
+        Public Function GetSdkPath(ByRef sdkPath As String) As Integer Implements IVbCompilerHost.GetSdkPath
+            sdkPath = _sdkPath
+
+            If String.IsNullOrEmpty(sdkPath) Then
+                Return VSConstants.E_NOTIMPL
+            Else
+                Return VSConstants.S_OK
+            End If
         End Function
 
         Public Function GetTargetLibraryType() As VBTargetLibraryType Implements IVbCompilerHost.GetTargetLibraryType

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
@@ -6,9 +6,9 @@ Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fram
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.VisualBasicHelpers
     Friend Module VisualBasicHelpers
-        Public Function CreateVisualBasicProject(environment As TestEnvironment, projectName As String) As VisualBasicProjectShimWithServices
+        Public Function CreateVisualBasicProject(environment As TestEnvironment, projectName As String, Optional compilerHost As IVbCompilerHost = Nothing) As VisualBasicProjectShimWithServices
             Return New VisualBasicProjectShimWithServices(environment.ProjectTracker,
-                                                          MockCompilerHost.FullFrameworkCompilerHost,
+                                                          If(compilerHost, MockCompilerHost.FullFrameworkCompilerHost),
                                                           projectName,
                                                           environment.CreateHierarchy(projectName, "VB"),
                                                           environment.ServiceProvider)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
@@ -96,6 +96,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
+        <Fact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        <WorkItem(3477, "https://github.com/dotnet/roslyn/issues/3477")>
+        Public Sub ProjectWithEmptySdkPathHasNoReferences()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test", compilerHost:=MockCompilerHost.NoSdkCompilerHost)
+
+                project.SetCompilerOptions(CreateMinimalCompilerOptions(project))
+
+                ' We should have no references
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Assert.Empty(workspaceProject.MetadataReferences)
+
+                project.Disconnect()
+            End Using
+        End Sub
 
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/Interop/IVbCompilerHost.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/Interop/IVbCompilerHost.vb
@@ -15,7 +15,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.
         ''' Returns the system SDK directory, where mscorlib.dll and Microsoft.VisualBasic.dll is
         ''' located.
         ''' </summary>
-        Function GetSdkPath() As <MarshalAs(UnmanagedType.BStr)> String
+        <PreserveSig>
+        Function GetSdkPath(<MarshalAs(UnmanagedType.BStr), Out> ByRef sdkPath As String) As Integer
 
         ''' <summary>
         ''' Get the target library type.


### PR DESCRIPTION
When there is an empty SDK path returned from a project flavor, the project system presents us with a E_NOTIMPL when we call IVbCompilerHost.GetSdkPath. In this case, simply don't try doing any magic for mscorlib.dll.

Code review: @Pilchie, @rchande, @davkean