### PR TITLE
Sequence points, entry point, #Pdb stream

### DIFF
--- a/Src/PortablePdb/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
+++ b/Src/PortablePdb/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
@@ -253,17 +253,11 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public int GetUserEntryPoint(out int methodToken)
         {
-            var mdReader = MetadataReader;
-
-            foreach (var cdiHandle in mdReader.GetCustomDebugInformation(Handle.AssemblyDefinition))
+            var handle = MetadataReader.DebugMetadataHeader.EntryPoint;
+            if (!handle.IsNil)
             {
-                var cdi = mdReader.GetCustomDebugInformation(cdiHandle);
-                if (mdReader.GetGuid(cdi.Kind) == MetadataUtilities.CdiKindEntryPoint)
-                {
-                    var blobReader = mdReader.GetBlobReader(cdi.Value);
-                    methodToken = MetadataUtilities.MethodDefToken(blobReader.ReadCompressedInteger());
-                    return HResult.S_OK;
-                }
+                methodToken = MetadataTokens.GetToken(handle);
+                return HResult.S_OK;
             }
 
             methodToken = 0;

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" targetFramework="net45" />
   <package id="Microsoft.Net.RoslynDiagnostics" version="1.0.0-rc3-20150510-01" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00006" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00007" targetFramework="net45" />
   <package id="FakeSign" version="0.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -167,6 +167,7 @@
     <Compile Include="PDB\PDBTests.cs" />
     <Compile Include="PDB\PDBUsingTests.cs" />
     <Compile Include="PDB\PDBWinMdExpTests.cs" />
+    <Compile Include="PDB\PortablePdbTests.cs" />
     <Compile Include="Perf.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PortablePdbTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PortablePdbTests.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
+{
+    public class PortablePdbTests : CSharpPDBTestBase
+    {
+        [Fact]
+        public void SequencePointBlob()
+        {
+            string source = @"
+class C
+{
+    public static void Main()
+    {
+        if (F())
+        {
+            System.Console.WriteLine(1);
+        }
+    }
+
+    public static bool F() => false;
+}
+";
+            var c = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+
+            var pdbStream = new MemoryStream();
+            var peBlob = c.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb), pdbStream: pdbStream);
+
+            using (var peReader = new PEReader(peBlob))
+            using (var pdbMetadata = new PinnedMetadata(pdbStream.ToImmutable()))
+            {
+                var mdReader = peReader.GetMetadataReader();
+                var pdbReader = pdbMetadata.Reader;
+
+                foreach (var methodHandle in mdReader.MethodDefinitions)
+                {
+                    var method = mdReader.GetMethodDefinition(methodHandle);
+                    var methodBody = pdbReader.GetMethodBody(methodHandle);
+
+                    var name = mdReader.GetString(method.Name);
+
+                    var spReader = pdbReader.GetSequencePointsReader(methodBody.SequencePoints);
+
+                    TextWriter writer = new StringWriter();
+                    while (spReader.MoveNext())
+                    {
+                        var sp = spReader.Current;
+                        if (sp.IsHidden)
+                        {
+                            writer.WriteLine($"{sp.Offset}: <hidden>");
+                        }
+                        else
+                        {
+                            writer.WriteLine($"{sp.Offset}: ({sp.StartLine},{sp.StartColumn})-({sp.EndLine},{sp.EndColumn})");
+                        }
+                    }
+
+                    var spString = writer.ToString();
+                    var spBlob = pdbReader.GetBlobBytes(methodBody.SequencePoints);
+
+                    switch (name)
+                    {
+                        case "Main":
+                            AssertEx.AssertEqualToleratingWhitespaceDifferences(@"
+0: (5,5)-(5,6)
+1: (6,9)-(6,17)
+7: <hidden>
+10: (7,9)-(7,10)
+11: (8,13)-(8,41)
+18: (9,9)-(9,10)
+19: (10,5)-(10,6)
+", spString);
+                            AssertEx.Equal(new byte[] 
+                            {
+                                0x01, // local signature
+                                0x01, // document
+
+                                0x00, // IL offset
+                                0x00, // Delta Lines
+                                0x01, // Delta Columns
+                                0x05, // Start Line
+                                0x05, // Start Column
+
+                                0x01, // delta IL offset
+                                0x00, // Delta Lines
+                                0x08, // Delta Columns
+                                0x02, // delta Start Line (signed compressed)
+                                0x08, // delta Start Column (signed compressed)
+
+                                0x06, // delta IL offset
+                                0x00, // hidden
+                                0x00, // hidden
+
+                                0x03, // delta IL offset
+                                0x00, // Delta Lines
+                                0x01, // Delta Columns
+                                0x02, // delta Start Line (signed compressed)
+                                0x00, // delta Start Column (signed compressed)
+
+                                0x01, // delta IL offset
+                                0x00, // Delta Lines
+                                0x1C, // Delta Columns
+                                0x02, // delta Start Line (signed compressed)
+                                0x08, // delta Start Column (signed compressed)
+
+                                0x07, // delta IL offset
+                                0x00, // Delta Lines
+                                0x01, // Delta Columns
+                                0x02, // delta Start Line (signed compressed)
+                                0x79, // delta Start Column (signed compressed)
+
+                                0x01, // delta IL offset
+                                0x00, // Delta Lines
+                                0x01, // Delta Columns
+                                0x02, // delta Start Line (signed compressed)
+                                0x79, // delta Start Column (signed compressed)
+                            }, spBlob);
+                            break;
+
+                        case "F":
+                            AssertEx.AssertEqualToleratingWhitespaceDifferences("0: (12,31)-(12,36)", spString);
+                            AssertEx.Equal(new byte[] 
+                            {
+                                0x00, // local signature
+                                0x01, // document
+
+                                0x00, // delta IL offset
+                                0x00, // Delta Lines
+                                0x05, // Delta Columns
+                                0x0C, // Start Line
+                                0x1F  // Start Column
+                            }, spBlob);
+                            break;
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -231,11 +231,6 @@ namespace Microsoft.CodeAnalysis.Emit
             get { return _previousGeneration.EncId; }
         }
 
-        protected override bool CompressMetadataStream
-        {
-            get { return false; }
-        }
-
         protected override uint GetEventDefIndex(IEventDefinition def)
         {
             return _eventDefs[def];

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -605,9 +605,9 @@ namespace Microsoft.CodeAnalysis.Emit
             }
         }
 
-        protected override uint SerializeLocalVariablesSignature(IMethodBody body)
+        protected override int SerializeLocalVariablesSignature(IMethodBody body)
         {
-            uint result = 0;
+            int localSignatureRowId;
             var localVariables = body.LocalVariables;
             var encInfos = ArrayBuilder<EncLocalInfo>.GetInstance();
 
@@ -641,10 +641,12 @@ namespace Microsoft.CodeAnalysis.Emit
                 }
 
                 uint blobIndex = heaps.GetBlobIndex(writer.BaseStream);
-                uint signatureIndex = this.GetOrAddStandAloneSignatureIndex(blobIndex);
+                localSignatureRowId = (int)this.GetOrAddStandAloneSignatureIndex(blobIndex);
                 stream.Free();
-
-                result = 0x11000000 | signatureIndex;
+            }
+            else
+            {
+                localSignatureRowId = 0;
             }
 
             var method = body.MethodDefinition;
@@ -663,7 +665,7 @@ namespace Microsoft.CodeAnalysis.Emit
             }
 
             encInfos.Free();
-            return result;
+            return localSignatureRowId;
         }
 
         private EncLocalInfo CreateEncLocalInfo(ILocalDefinition localDef, byte[] signature)

--- a/src/Compilers/Core/Portable/MetadataReader/PortableCustomDebugInfoKinds.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PortableCustomDebugInfoKinds.cs
@@ -6,7 +6,6 @@ namespace Microsoft.CodeAnalysis
 {
     internal static class PortableCustomDebugInfoKinds
     {
-        public static readonly Guid EntryPoint = new Guid("22DEB650-BB47-4D8A-B2A4-1BBA47FEB7F1");
         public static readonly Guid StateMachineHoistedLocalScopes = new Guid("6DA9A61E-F8C7-4874-BE62-68BC5630DF71"); 
         public static readonly Guid DynamicLocalVariables = new Guid("83C563C4-B4F3-47D5-B824-BA5441477EA8");
         public static readonly Guid DefaultNamespace = new Guid("58b2eab6-209f-4e4e-a22c-b2d0f910c782");

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -111,11 +111,6 @@ namespace Microsoft.Cci
             get { return Guid.Empty; }
         }
 
-        protected override bool CompressMetadataStream
-        {
-            get { return true; }
-        }
-
         protected override bool TryGetTypeDefIndex(ITypeDefinition def, out uint index)
         {
             return _typeDefs.TryGetValue(def, out index);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataSizes.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataSizes.cs
@@ -394,10 +394,7 @@ namespace Microsoft.Cci
 
         internal int CalculateStandalonePdbStreamSize()
         {
-            int result = sizeof(byte) +       // MajorVersion
-                         sizeof(byte) +       // MinorVersion
-                         sizeof(short) +      // Reserved
-                         sizeof(int) +        // EntryPoint
+            int result = sizeof(int) +        // EntryPoint
                          sizeof(long);        // ReferencedTypeSystemTables
 
             // external table row counts

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -387,22 +387,6 @@ namespace Microsoft.Cci
             Debug.Assert(_importScopeTable.Count == ModuleImportScopeRid);
         }
 
-        private void DefineEntryPointCustomDebugInformation(int entryPointToken)
-        {
-            Debug.Assert(entryPointToken != 0);
-
-            MemoryStream blob = new MemoryStream();
-            BinaryWriter writer = new BinaryWriter(blob);
-            writer.WriteCompressedUInt((uint)(entryPointToken & 0x00ffffff));
-
-            _customDebugInformationTable.Add(new CustomDebugInformationRow
-            {
-                Parent = HasCustomDebugInformation(HasCustomDebugInformationTag.Assembly, 1),
-                Kind = debugHeapsOpt.GetGuidIndex(PortableCustomDebugInfoKinds.EntryPoint),
-                Value = debugHeapsOpt.GetBlobIndex(blob)
-            });
-        }
-
         private int GetImportScopeIndex(IImportScope scope, Dictionary<IImportScope, int> scopeIndex)
         {
             int scopeRid;

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2112,12 +2112,11 @@ namespace Microsoft.Cci
             if (IsFullMetadata && entryPoint?.GetResolvedMethod(Context) != null)
             {
                 entryPointToken = GetMethodToken(entryPoint);
-                nativePdbWriterOpt?.SetEntryPoint(entryPointToken);
 
-                if (debugHeapsOpt != null)
-                {
-                    DefineEntryPointCustomDebugInformation((int)entryPointToken);
-                }
+                // entry point can only be a MethodDef:
+                Debug.Assert((entryPointToken & 0xff000000) == 0x06000000);
+
+                nativePdbWriterOpt?.SetEntryPoint(entryPointToken);
             }
             else
             {

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3768,11 +3768,6 @@ namespace Microsoft.Cci
         {
             uint startPosition = writer.BaseStream.Position;
 
-            // TODO: Portable PDB format version
-            writer.WriteByte(0);
-            writer.WriteByte(1);
-
-            writer.WriteShort(0); // reserved
             writer.WriteUint(entryPointToken);
 
             writer.WriteUlong(metadataSizes.ExternalTablesMask);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -138,11 +138,6 @@ namespace Microsoft.Cci
         protected abstract Guid EncBaseId { get; }
 
         /// <summary>
-        /// Returns true if the metadata stream should be compressed.
-        /// </summary>
-        protected abstract bool CompressMetadataStream { get; }
-
-        /// <summary>
         /// Returns true and the 1-based index of the type definition
         /// if the type definition is recognized. Otherwise returns false.
         /// The index is into the full metadata.
@@ -425,7 +420,14 @@ namespace Microsoft.Cci
         private ReferenceIndexer _referenceVisitor;
 
         protected readonly MetadataHeapsBuilder heaps;
+
+        // A heap builder distinct from heaps if we are emitting debug information into a separate Portable PDB stream.
+        // Shared heap builder (reference equals heaps) if we are embedding Portable PDB into the metadata stream.
+        // Null otherwise.
         private readonly MetadataHeapsBuilder debugHeapsOpt;
+
+        private bool EmitStandaloneDebugMetadata => debugHeapsOpt != null && heaps != debugHeapsOpt;
+
         private readonly Dictionary<ICustomAttribute, uint> _customAttributeSignatureIndex = new Dictionary<ICustomAttribute, uint>();
         private readonly Dictionary<ITypeReference, uint> _typeSpecSignatureIndex = new Dictionary<ITypeReference, uint>();
         private readonly Dictionary<ITypeReference, uint> _exportedTypeIndex;
@@ -447,63 +449,57 @@ namespace Microsoft.Cci
 
         internal const int MappedFieldDataAlignment = 8;
 
-        private ImmutableArray<int> GetRowCounts(bool includeTypeSystemTables, bool includeDebugTables)
+        private ImmutableArray<int> GetRowCounts()
         {
             var rowCounts = new int[MetadataTokens.TableCount];
 
             // module row is in both debug and regular metadata
             rowCounts[(int)TableIndex.Module] = 1;
 
-            if (includeTypeSystemTables)
-            {
-                rowCounts[(int)TableIndex.Assembly] = (this.module.AsAssembly != null) ? 1 : 0;
-                rowCounts[(int)TableIndex.AssemblyRef] = _assemblyRefTable.Count;
-                rowCounts[(int)TableIndex.ClassLayout] = _classLayoutTable.Count;
-                rowCounts[(int)TableIndex.Constant] = _constantTable.Count;
-                rowCounts[(int)TableIndex.CustomAttribute] = _customAttributeTable.Count;
-                rowCounts[(int)TableIndex.DeclSecurity] = _declSecurityTable.Count;
-                rowCounts[(int)TableIndex.EncLog] = _encLogTable.Count;
-                rowCounts[(int)TableIndex.EncMap] = _encMapTable.Count;
-                rowCounts[(int)TableIndex.EventMap] = _eventMapTable.Count;
-                rowCounts[(int)TableIndex.Event] = _eventTable.Count;
-                rowCounts[(int)TableIndex.ExportedType] = _exportedTypeTable.Count;
-                rowCounts[(int)TableIndex.FieldLayout] = _fieldLayoutTable.Count;
-                rowCounts[(int)TableIndex.FieldMarshal] = _fieldMarshalTable.Count;
-                rowCounts[(int)TableIndex.FieldRva] = _fieldRvaTable.Count;
-                rowCounts[(int)TableIndex.Field] = _fieldDefTable.Count;
-                rowCounts[(int)TableIndex.File] = _fileTable.Count;
-                rowCounts[(int)TableIndex.GenericParamConstraint] = _genericParamConstraintTable.Count;
-                rowCounts[(int)TableIndex.GenericParam] = _genericParamTable.Count;
-                rowCounts[(int)TableIndex.ImplMap] = _implMapTable.Count;
-                rowCounts[(int)TableIndex.InterfaceImpl] = _interfaceImplTable.Count;
-                rowCounts[(int)TableIndex.ManifestResource] = _manifestResourceTable.Count;
-                rowCounts[(int)TableIndex.MemberRef] = _memberRefTable.Count;
-                rowCounts[(int)TableIndex.MethodImpl] = _methodImplTable.Count;
-                rowCounts[(int)TableIndex.MethodSemantics] = _methodSemanticsTable.Count;
-                rowCounts[(int)TableIndex.MethodSpec] = _methodSpecTable.Count;
-                rowCounts[(int)TableIndex.MethodDef] = _methodTable.Length;
-                rowCounts[(int)TableIndex.ModuleRef] = _moduleRefTable.Count;
-                rowCounts[(int)TableIndex.NestedClass] = _nestedClassTable.Count;
-                rowCounts[(int)TableIndex.Param] = _paramTable.Count;
-                rowCounts[(int)TableIndex.PropertyMap] = _propertyMapTable.Count;
-                rowCounts[(int)TableIndex.Property] = _propertyTable.Count;
-                rowCounts[(int)TableIndex.StandAloneSig] = GetStandAloneSignatures().Count;
-                rowCounts[(int)TableIndex.TypeDef] = _typeDefTable.Count;
-                rowCounts[(int)TableIndex.TypeRef] = _typeRefTable.Count;
-                rowCounts[(int)TableIndex.TypeSpec] = _typeSpecTable.Count;
-            }
-            
-            if (includeDebugTables)
-            {
-                rowCounts[(int)TableIndex.Document] = _documentTable.Count;
-                rowCounts[(int)TableIndex.MethodBody] = _methodBodyTable.Count;
-                rowCounts[(int)TableIndex.LocalScope] = _localScopeTable.Count;
-                rowCounts[(int)TableIndex.LocalVariable] = _localVariableTable.Count;
-                rowCounts[(int)TableIndex.LocalConstant] = _localConstantTable.Count;
-                rowCounts[(int)TableIndex.AsyncMethod] = _asyncMethodTable.Count;
-                rowCounts[(int)TableIndex.ImportScope] = _importScopeTable.Count;
-                rowCounts[(int)TableIndex.CustomDebugInformation] = _customDebugInformationTable.Count;
-            }
+            rowCounts[(int)TableIndex.Assembly] = (this.module.AsAssembly != null) ? 1 : 0;
+            rowCounts[(int)TableIndex.AssemblyRef] = _assemblyRefTable.Count;
+            rowCounts[(int)TableIndex.ClassLayout] = _classLayoutTable.Count;
+            rowCounts[(int)TableIndex.Constant] = _constantTable.Count;
+            rowCounts[(int)TableIndex.CustomAttribute] = _customAttributeTable.Count;
+            rowCounts[(int)TableIndex.DeclSecurity] = _declSecurityTable.Count;
+            rowCounts[(int)TableIndex.EncLog] = _encLogTable.Count;
+            rowCounts[(int)TableIndex.EncMap] = _encMapTable.Count;
+            rowCounts[(int)TableIndex.EventMap] = _eventMapTable.Count;
+            rowCounts[(int)TableIndex.Event] = _eventTable.Count;
+            rowCounts[(int)TableIndex.ExportedType] = _exportedTypeTable.Count;
+            rowCounts[(int)TableIndex.FieldLayout] = _fieldLayoutTable.Count;
+            rowCounts[(int)TableIndex.FieldMarshal] = _fieldMarshalTable.Count;
+            rowCounts[(int)TableIndex.FieldRva] = _fieldRvaTable.Count;
+            rowCounts[(int)TableIndex.Field] = _fieldDefTable.Count;
+            rowCounts[(int)TableIndex.File] = _fileTable.Count;
+            rowCounts[(int)TableIndex.GenericParamConstraint] = _genericParamConstraintTable.Count;
+            rowCounts[(int)TableIndex.GenericParam] = _genericParamTable.Count;
+            rowCounts[(int)TableIndex.ImplMap] = _implMapTable.Count;
+            rowCounts[(int)TableIndex.InterfaceImpl] = _interfaceImplTable.Count;
+            rowCounts[(int)TableIndex.ManifestResource] = _manifestResourceTable.Count;
+            rowCounts[(int)TableIndex.MemberRef] = _memberRefTable.Count;
+            rowCounts[(int)TableIndex.MethodImpl] = _methodImplTable.Count;
+            rowCounts[(int)TableIndex.MethodSemantics] = _methodSemanticsTable.Count;
+            rowCounts[(int)TableIndex.MethodSpec] = _methodSpecTable.Count;
+            rowCounts[(int)TableIndex.MethodDef] = _methodTable.Length;
+            rowCounts[(int)TableIndex.ModuleRef] = _moduleRefTable.Count;
+            rowCounts[(int)TableIndex.NestedClass] = _nestedClassTable.Count;
+            rowCounts[(int)TableIndex.Param] = _paramTable.Count;
+            rowCounts[(int)TableIndex.PropertyMap] = _propertyMapTable.Count;
+            rowCounts[(int)TableIndex.Property] = _propertyTable.Count;
+            rowCounts[(int)TableIndex.StandAloneSig] = GetStandAloneSignatures().Count;
+            rowCounts[(int)TableIndex.TypeDef] = _typeDefTable.Count;
+            rowCounts[(int)TableIndex.TypeRef] = _typeRefTable.Count;
+            rowCounts[(int)TableIndex.TypeSpec] = _typeSpecTable.Count;
+
+            rowCounts[(int)TableIndex.Document] = _documentTable.Count;
+            rowCounts[(int)TableIndex.MethodBody] = _methodBodyTable.Count;
+            rowCounts[(int)TableIndex.LocalScope] = _localScopeTable.Count;
+            rowCounts[(int)TableIndex.LocalVariable] = _localVariableTable.Count;
+            rowCounts[(int)TableIndex.LocalConstant] = _localConstantTable.Count;
+            rowCounts[(int)TableIndex.AsyncMethod] = _asyncMethodTable.Count;
+            rowCounts[(int)TableIndex.ImportScope] = _importScopeTable.Count;
+            rowCounts[(int)TableIndex.CustomDebugInformation] = _customDebugInformationTable.Count;
 
             return ImmutableArray.CreateRange(rowCounts);
         }
@@ -1946,45 +1942,66 @@ namespace Microsoft.Cci
             writer.WriteCompressedUInt(this.GetTypeDefOrRefCodedIndex(customModifier.GetModifier(Context), true));
         }
 
-        private void SerializeMetadataHeader(BinaryWriter writer, MetadataSizes metadataSizes, bool isPortablePdb)
+        private void SerializeMetadataHeader(BinaryWriter writer, MetadataSizes metadataSizes)
         {
             uint startOffset = writer.BaseStream.Position;
 
-            // Storage signature
-            writer.WriteUint(0x424A5342); // Signature 4
-            writer.WriteUshort(1); // metadata version major 6
-            writer.WriteUshort(1); // metadata version minor 8
-            writer.WriteUint(0); // reserved 12
+            // signature
+            writer.WriteUint(0x424A5342);
 
-            writer.WriteUint(12); // version must be 12 chars long (TODO: this observation is not supported by the standard or the ILAsm book). 16
-            string targetRuntimeVersion = isPortablePdb ? "PDB v0.1" : this.module.TargetRuntimeVersion;
+            // major version
+            writer.WriteUshort(1); 
 
-            int n = targetRuntimeVersion.Length;
-            for (int i = 0; i < 12 && i < n; i++)
+            // minor version
+            writer.WriteUshort(1);
+
+            // reserved
+            writer.WriteUint(0);
+
+            // metadata version length
+            writer.WriteUint(MetadataSizes.MetadataVersionPaddedLength); 
+
+            string targetRuntimeVersion = metadataSizes.IsStandaloneDebugMetadata ? "PDB v0.1" : module.TargetRuntimeVersion;
+
+            int n = Math.Min(MetadataSizes.MetadataVersionPaddedLength, targetRuntimeVersion.Length);
+            for (int i = 0; i < n; i++)
             {
                 writer.WriteByte((byte)targetRuntimeVersion[i]);
             }
 
-            for (int i = n; i < 12; i++)
+            for (int i = n; i < MetadataSizes.MetadataVersionPaddedLength; i++)
             {
-                writer.WriteByte(0); // 28
+                writer.WriteByte(0);
             }
 
-            // Storage header
-            writer.WriteByte(0); // flags 29
-            writer.WriteByte(0); // padding 30
-            writer.WriteUshort((ushort)(this.IsMinimalDelta ? 6 : 5)); // number of streams 32
+            // reserved
+            writer.WriteUshort(0);
 
-            // Stream headers
+            // number of streams
+            writer.WriteUshort((ushort)(5 + (metadataSizes.IsMinimalDelta ? 1 : 0) + (metadataSizes.IsStandaloneDebugMetadata ? 1 : 0)));
+
+            // stream headers
             int offsetFromStartOfMetadata = metadataSizes.MetadataHeaderSize;
-            SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.MetadataTableStreamSize, (this.CompressMetadataStream ? "#~" : "#-"), writer);
+
+            // Spec: Some compilers store metadata in a #- stream, which holds an uncompressed, or non-optimized, representation of metadata tables;
+            // this includes extra metadata -Ptr tables. Such PE files do not form part of ECMA-335 standard.
+            //
+            // Note: EnC delta is stored as uncompressed metadata stream.
+            SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.MetadataTableStreamSize, (metadataSizes.IsMetadataTableStreamCompressed ? "#~" : "#-"), writer);
+
             SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.GetAlignedHeapSize(HeapIndex.String), "#Strings", writer);
             SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.GetAlignedHeapSize(HeapIndex.UserString), "#US", writer);
             SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.GetAlignedHeapSize(HeapIndex.Guid), "#GUID", writer);
             SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.GetAlignedHeapSize(HeapIndex.Blob), "#Blob", writer);
-            if (this.IsMinimalDelta)
+
+            if (metadataSizes.IsMinimalDelta)
             {
                 SerializeStreamHeader(ref offsetFromStartOfMetadata, 0, "#JTD", writer);
+            }
+
+            if (metadataSizes.IsStandaloneDebugMetadata)
+            {
+                SerializeStreamHeader(ref offsetFromStartOfMetadata, metadataSizes.StandalonePdbStreamSize, "#Pdb", writer);
             }
 
             uint endOffset = writer.BaseStream.Position;
@@ -1994,7 +2011,7 @@ namespace Microsoft.Cci
         private static void SerializeStreamHeader(ref int offsetFromStartOfMetadata, int alignedStreamSize, string streamName, BinaryWriter writer)
         {
             // 4 for the first uint (offset), 4 for the second uint (padded size), length of stream name + 1 for null terminator (then padded)
-            int sizeOfStreamHeader = 8 + BitArithmeticUtilities.Align(streamName.Length + 1, 4);
+            int sizeOfStreamHeader = MetadataSizes.GetMetadataStreamHeaderSize(streamName);
             writer.WriteInt(offsetFromStartOfMetadata);
             writer.WriteInt(alignedStreamSize);
             foreach (char ch in streamName)
@@ -2072,9 +2089,6 @@ namespace Microsoft.Cci
             out uint entryPointToken,
             out MetadataSizes metadataSizes)
         {
-            bool emitSeparateDebugMetadata = debugHeapsOpt != null;
-            bool emitEmbeddedDebugMetadata = heaps == debugHeapsOpt;
-
             // Extract information from object model into tables, indices and streams
             CreateIndices();
 
@@ -2112,22 +2126,26 @@ namespace Microsoft.Cci
 
             heaps.Complete();
 
+            var tableRowCounts = GetRowCounts();
+
             metadataSizes = new MetadataSizes(
-                GetRowCounts(includeTypeSystemTables: true, includeDebugTables: emitEmbeddedDebugMetadata),
-                heaps.GetHeapSizes(),
+                rowCounts: tableRowCounts,
+                heapSizes: heaps.GetHeapSizes(),
                 ilStreamSize: (int)ilWriter.BaseStream.Length,
                 mappedFieldDataSize: (int)mappedFieldDataWriter.BaseStream.Length,
                 resourceDataSize: (int)managedResourceDataWriter.BaseStream.Length,
-                isMinimalDelta: IsMinimalDelta);
+                isMinimalDelta: IsMinimalDelta,
+                emitStandaloneDebugMetadata: EmitStandaloneDebugMetadata,
+                isStandaloneDebugMetadata: false);
 
             int methodBodyStreamRva = calculateMethodBodyStreamRva(metadataSizes);
             int mappedFieldDataStreamRva = calculateMappedFieldDataStreamRva(metadataSizes);
 
             uint guidHeapStartOffset;
-            SerializeMetadata(metadataWriter, metadataSizes, methodBodyStreamRva, mappedFieldDataStreamRva, out guidHeapStartOffset, isPortablePdb: false);
+            SerializeMetadata(metadataWriter, metadataSizes, methodBodyStreamRva, mappedFieldDataStreamRva, entryPointToken, out guidHeapStartOffset);
             moduleVersionIdOffsetInMetadataStream = GetModuleVersionGuidOffsetInMetadataStream(guidHeapStartOffset);
 
-            if (!emitSeparateDebugMetadata)
+            if (!EmitStandaloneDebugMetadata)
             {
                 return;
             }
@@ -2138,14 +2156,16 @@ namespace Microsoft.Cci
             debugHeapsOpt.Complete();
 
             var debugMetadataSizes = new MetadataSizes(
-                GetRowCounts(includeTypeSystemTables: false, includeDebugTables: true),
-                debugHeapsOpt.GetHeapSizes(),
+                rowCounts: tableRowCounts,
+                heapSizes: debugHeapsOpt.GetHeapSizes(),
                 ilStreamSize: 0,
                 mappedFieldDataSize: 0,
                 resourceDataSize: 0,
-                isMinimalDelta: IsMinimalDelta);
+                isMinimalDelta: IsMinimalDelta,
+                emitStandaloneDebugMetadata: true,
+                isStandaloneDebugMetadata: true);
 
-            SerializeMetadata(debugMetadataWriterOpt, debugMetadataSizes, 0, 0, out guidHeapStartOffset, isPortablePdb: true);
+            SerializeMetadata(debugMetadataWriterOpt, debugMetadataSizes, 0, 0, entryPointToken, out guidHeapStartOffset);
         }
 
         private void SerializeMetadata(
@@ -2153,8 +2173,8 @@ namespace Microsoft.Cci
             MetadataSizes metadataSizes, 
             int methodBodyStreamRva, 
             int mappedFieldDataStreamRva,
-            out uint guidHeapStartOffset,
-            bool isPortablePdb)
+            uint entryPointToken,
+            out uint guidHeapStartOffset)
         {
             uint metadataStartOffset = metadataWriter.BaseStream.Position;
 
@@ -2163,16 +2183,22 @@ namespace Microsoft.Cci
             metadataWriter.BaseStream.Position = metadataStartOffset + (uint)metadataSizes.MetadataHeaderSize;
 
             // #~ or #- stream:
-            this.SerializeMetadataTables(metadataWriter, metadataSizes, methodBodyStreamRva, mappedFieldDataStreamRva, isPortablePdb);
+            SerializeMetadataTables(metadataWriter, metadataSizes, methodBodyStreamRva, mappedFieldDataStreamRva);
 
             // #Strings, #US, #Guid and #Blob streams:
-            (isPortablePdb ? debugHeapsOpt : heaps).WriteTo(metadataWriter.BaseStream, out guidHeapStartOffset);
-            
+            (metadataSizes.IsStandaloneDebugMetadata ? debugHeapsOpt : heaps).WriteTo(metadataWriter.BaseStream, out guidHeapStartOffset);
+
+            // #Pdb stream
+            if (metadataSizes.IsStandaloneDebugMetadata)
+            {
+                SerializeStandalonePdbStream(metadataWriter, metadataSizes, entryPointToken);
+            }
+
             uint metadataSize = metadataWriter.BaseStream.Position;
 
             // write header at the start of the metadata stream:
             metadataWriter.BaseStream.Position = 0;
-            this.SerializeMetadataHeader(metadataWriter, metadataSizes, isPortablePdb);
+            SerializeMetadataHeader(metadataWriter, metadataSizes);
 
             metadataWriter.BaseStream.Position = metadataSize;
         }
@@ -2192,15 +2218,14 @@ namespace Microsoft.Cci
             BinaryWriter writer, 
             MetadataSizes metadataSizes, 
             int methodBodyStreamRva, 
-            int mappedFieldDataStreamRva,
-            bool isPortablePdb)
+            int mappedFieldDataStreamRva)
         {
             uint startPosition = writer.BaseStream.Position;
 
             this.SerializeTablesHeader(writer, metadataSizes);
 
-            Debug.Assert(!metadataSizes.IsEmpty(TableIndex.Module));
-            if (isPortablePdb)
+            Debug.Assert(metadataSizes.IsPresent(TableIndex.Module));
+            if (metadataSizes.IsStandaloneDebugMetadata)
             {
                 SerializeModuleTable(writer, metadataSizes, debugHeapsOpt, ref _debugModuleRow);
             }
@@ -2209,219 +2234,219 @@ namespace Microsoft.Cci
                 SerializeModuleTable(writer, metadataSizes, heaps, ref _moduleRow);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.TypeRef))
+            if (metadataSizes.IsPresent(TableIndex.TypeRef))
             {
                 this.SerializeTypeRefTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.TypeDef))
+            if (metadataSizes.IsPresent(TableIndex.TypeDef))
             {
                 this.SerializeTypeDefTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Field))
+            if (metadataSizes.IsPresent(TableIndex.Field))
             {
                 this.SerializeFieldTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MethodDef))
+            if (metadataSizes.IsPresent(TableIndex.MethodDef))
             {
                 this.SerializeMethodDefTable(writer, metadataSizes, methodBodyStreamRva);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Param))
+            if (metadataSizes.IsPresent(TableIndex.Param))
             {
                 this.SerializeParamTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.InterfaceImpl))
+            if (metadataSizes.IsPresent(TableIndex.InterfaceImpl))
             {
                 this.SerializeInterfaceImplTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MemberRef))
+            if (metadataSizes.IsPresent(TableIndex.MemberRef))
             {
                 this.SerializeMemberRefTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Constant))
+            if (metadataSizes.IsPresent(TableIndex.Constant))
             {
                 this.SerializeConstantTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.CustomAttribute))
+            if (metadataSizes.IsPresent(TableIndex.CustomAttribute))
             {
                 this.SerializeCustomAttributeTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.FieldMarshal))
+            if (metadataSizes.IsPresent(TableIndex.FieldMarshal))
             {
                 this.SerializeFieldMarshalTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.DeclSecurity))
+            if (metadataSizes.IsPresent(TableIndex.DeclSecurity))
             {
                 this.SerializeDeclSecurityTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ClassLayout))
+            if (metadataSizes.IsPresent(TableIndex.ClassLayout))
             {
                 this.SerializeClassLayoutTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.FieldLayout))
+            if (metadataSizes.IsPresent(TableIndex.FieldLayout))
             {
                 this.SerializeFieldLayoutTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.StandAloneSig))
+            if (metadataSizes.IsPresent(TableIndex.StandAloneSig))
             {
                 this.SerializeStandAloneSigTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.EventMap))
+            if (metadataSizes.IsPresent(TableIndex.EventMap))
             {
                 this.SerializeEventMapTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Event))
+            if (metadataSizes.IsPresent(TableIndex.Event))
             {
                 this.SerializeEventTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.PropertyMap))
+            if (metadataSizes.IsPresent(TableIndex.PropertyMap))
             {
                 this.SerializePropertyMapTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Property))
+            if (metadataSizes.IsPresent(TableIndex.Property))
             {
                 this.SerializePropertyTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MethodSemantics))
+            if (metadataSizes.IsPresent(TableIndex.MethodSemantics))
             {
                 this.SerializeMethodSemanticsTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MethodImpl))
+            if (metadataSizes.IsPresent(TableIndex.MethodImpl))
             {
                 this.SerializeMethodImplTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ModuleRef))
+            if (metadataSizes.IsPresent(TableIndex.ModuleRef))
             {
                 this.SerializeModuleRefTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.TypeSpec))
+            if (metadataSizes.IsPresent(TableIndex.TypeSpec))
             {
                 this.SerializeTypeSpecTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ImplMap))
+            if (metadataSizes.IsPresent(TableIndex.ImplMap))
             {
                 this.SerializeImplMapTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.FieldRva))
+            if (metadataSizes.IsPresent(TableIndex.FieldRva))
             {
                 this.SerializeFieldRvaTable(writer, metadataSizes, mappedFieldDataStreamRva);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.EncLog))
+            if (metadataSizes.IsPresent(TableIndex.EncLog))
             {
                 this.SerializeEncLogTable(writer);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.EncMap))
+            if (metadataSizes.IsPresent(TableIndex.EncMap))
             {
                 this.SerializeEncMapTable(writer);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.Assembly))
+            if (metadataSizes.IsPresent(TableIndex.Assembly))
             {
                 this.SerializeAssemblyTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.AssemblyRef))
+            if (metadataSizes.IsPresent(TableIndex.AssemblyRef))
             {
                 this.SerializeAssemblyRefTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.File))
+            if (metadataSizes.IsPresent(TableIndex.File))
             {
                 this.SerializeFileTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ExportedType))
+            if (metadataSizes.IsPresent(TableIndex.ExportedType))
             {
                 this.SerializeExportedTypeTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ManifestResource))
+            if (metadataSizes.IsPresent(TableIndex.ManifestResource))
             {
                 this.SerializeManifestResourceTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.NestedClass))
+            if (metadataSizes.IsPresent(TableIndex.NestedClass))
             {
                 this.SerializeNestedClassTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.GenericParam))
+            if (metadataSizes.IsPresent(TableIndex.GenericParam))
             {
                 this.SerializeGenericParamTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MethodSpec))
+            if (metadataSizes.IsPresent(TableIndex.MethodSpec))
             {
                 this.SerializeMethodSpecTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.GenericParamConstraint))
+            if (metadataSizes.IsPresent(TableIndex.GenericParamConstraint))
             {
                 this.SerializeGenericParamConstraintTable(writer, metadataSizes);
             }
 
             // debug tables
 
-            if (!metadataSizes.IsEmpty(TableIndex.Document))
+            if (metadataSizes.IsPresent(TableIndex.Document))
             {
                 this.SerializeDocumentTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.MethodBody))
+            if (metadataSizes.IsPresent(TableIndex.MethodBody))
             {
                 this.SerializeMethodBodyTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.LocalScope))
+            if (metadataSizes.IsPresent(TableIndex.LocalScope))
             {
                 this.SerializeLocalScopeTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.LocalVariable))
+            if (metadataSizes.IsPresent(TableIndex.LocalVariable))
             {
                 this.SerializeLocalVariableTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.LocalConstant))
+            if (metadataSizes.IsPresent(TableIndex.LocalConstant))
             {
                 this.SerializeLocalConstantTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.ImportScope))
+            if (metadataSizes.IsPresent(TableIndex.ImportScope))
             {
                 this.SerializeImportScopeTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.AsyncMethod))
+            if (metadataSizes.IsPresent(TableIndex.AsyncMethod))
             {
                 this.SerializeAsyncMethodTable(writer, metadataSizes);
             }
 
-            if (!metadataSizes.IsEmpty(TableIndex.CustomDebugInformation))
+            if (metadataSizes.IsPresent(TableIndex.CustomDebugInformation))
             {
                 this.SerializeCustomDebugInformationTable(writer, metadataSizes);
             }
@@ -2471,7 +2496,7 @@ namespace Microsoft.Cci
             // This table is populated after the others because it depends on the order of the entries of the generic parameter table.
             this.PopulateCustomAttributeTableRows();
 
-            ImmutableArray<int> rowCounts = GetRowCounts(includeTypeSystemTables: true, includeDebugTables: true);
+            ImmutableArray<int> rowCounts = GetRowCounts();
             Debug.Assert(rowCounts[(int)TableIndex.EncLog] == 0 && rowCounts[(int)TableIndex.EncMap] == 0);
 
             this.PopulateEncLogTableRows(_encLogTable, rowCounts);
@@ -3725,48 +3750,50 @@ namespace Microsoft.Cci
                 heapSizes |= (HeapSizeFlag.EnCDeltas | HeapSizeFlag.DeletedMarks);
             }
 
-            ulong validTables;
-            ulong sortedTables;
-            ComputeValidAndSortedMasks(metadataSizes, out validTables, out sortedTables);
+            const ulong sortedTables = 0x16003301fa00;
 
             writer.WriteUint(0); // reserved
-            writer.WriteByte(this.module.MetadataFormatMajorVersion);
-            writer.WriteByte(this.module.MetadataFormatMinorVersion);
+            writer.WriteByte(module.MetadataFormatMajorVersion);
+            writer.WriteByte(module.MetadataFormatMinorVersion);
             writer.WriteByte((byte)heapSizes);
             writer.WriteByte(1); // reserved
-            writer.WriteUlong(validTables);
+            writer.WriteUlong(metadataSizes.PresentTablesMask);
             writer.WriteUlong(sortedTables);
-            SerializeRowCounts(writer, metadataSizes);
+            SerializeRowCounts(writer, metadataSizes.RowCounts, metadataSizes.PresentTablesMask);
 
             uint endPosition = writer.BaseStream.Position;
             Debug.Assert(metadataSizes.CalculateTableStreamHeaderSize() == endPosition - startPosition);
         }
 
-        private static void ComputeValidAndSortedMasks(MetadataSizes metadataSizes, out ulong validTables, out ulong sortedTables)
+        private static void SerializeStandalonePdbStream(BinaryWriter writer, MetadataSizes metadataSizes, uint entryPointToken)
         {
-            validTables = 0;
-            ulong validBit = 1;
+            uint startPosition = writer.BaseStream.Position;
 
-            foreach (int rowCount in metadataSizes.RowCounts)
-            {
-                if (rowCount > 0)
-                {
-                    validTables |= validBit;
-                }
+            // TODO: Portable PDB format version
+            writer.WriteByte(0);
+            writer.WriteByte(1);
 
-                validBit <<= 1;
-            }
+            writer.WriteShort(0); // reserved
+            writer.WriteUint(entryPointToken);
 
-            sortedTables = 0x16003301fa00/* & validTables*/;
+            writer.WriteUlong(metadataSizes.ExternalTablesMask);
+            SerializeRowCounts(writer, metadataSizes.RowCounts, metadataSizes.ExternalTablesMask);
+
+            uint endPosition = writer.BaseStream.Position;
+            Debug.Assert(metadataSizes.CalculateStandalonePdbStreamSize() == endPosition - startPosition);
         }
 
-        private static void SerializeRowCounts(BinaryWriter writer, MetadataSizes tableSizes)
+        private static void SerializeRowCounts(BinaryWriter writer, ImmutableArray<int> rowCounts, ulong includeTables)
         {
-            foreach (int rowCount in tableSizes.RowCounts)
+            for (int i = 0; i < rowCounts.Length; i++)
             {
-                if (rowCount > 0)
+                if (((1UL << i) & includeTables) != 0)
                 {
-                    writer.WriteInt(rowCount);
+                    int rowCount = rowCounts[i];
+                    if (rowCount > 0)
+                    {
+                        writer.WriteInt(rowCount);
+                    }
                 }
             }
         }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -4208,7 +4208,7 @@ namespace Microsoft.Cci
                     if (body != null)
                     {
                         localSignatureRid = this.SerializeLocalVariablesSignature(body);
-                        uint localSignatureToken = (uint)(0x11000000 | localSignatureRid);
+                        uint localSignatureToken = (localSignatureRid != 0) ? (uint)(0x11000000 | localSignatureRid) : 0;
 
                         // TODO: consider parallelizing these (local signature tokens can be piped into IL serialization & debug info generation)
                         rva = this.SerializeMethodBody(body, writer, localSignatureToken);

--- a/src/CrossPlatform.sln
+++ b/src/CrossPlatform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22725.0
+VisualStudioVersion = 14.0.23004.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -92,16 +92,19 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vbc2", "Compilers\VisualBas
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vbc", "Compilers\VisualBasic\vbc\vbc.csproj", "{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Debugging", "Debugging", "{5EFE4D73-9608-4E19-83A5-963B02413164}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DiaSymReader.PortablePdb", "PortablePdb\Microsoft.DiaSymReader.PortablePdb\Microsoft.DiaSymReader.PortablePdb.csproj", "{F83343BA-B4EA-451C-B6DB-5D645E6171BC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DiaSymReader.PortablePdb.UnitTests", "PortablePdb\Microsoft.DiaSymReader.PortablePdb.Tests\Microsoft.DiaSymReader.PortablePdb.UnitTests.csproj", "{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{edc68a0e-c68d-4a74-91b7-bf38ec909888}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
 		Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
-		Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{a1bcd0ce-6c2f-4f8c-9a48-d9d93928e26d}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
 		Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
-		Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{3973b09a-4fbf-44a5-8359-3d22ceb71f71}*SharedItemsImports = 4
 		Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		Compilers\Core\SharedCollections\SharedCollections.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
@@ -643,6 +646,38 @@ Global
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.ActiveCfg = Release|x64
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.Build.0 = Release|x64
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|x64.Build.0 = Debug|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|ARM.Build.0 = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|x64.ActiveCfg = Release|Any CPU
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Release|x64.Build.0 = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|ARM.Build.0 = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Debug|x64.Build.0 = Debug|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|ARM.ActiveCfg = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|ARM.Build.0 = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|x64.ActiveCfg = Release|Any CPU
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -677,19 +712,16 @@ Global
 		{288089C5-8721-458E-BE3E-78990DAB5E2E} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{288089C5-8721-458E-BE3E-78990DAB5E2D} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{6AA96934-D6B7-4CC8-990D-DB6B9DD56E34} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
-		{E195A63F-B5A4-4C5A-96BD-8E7ED6A181B7} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
-		{E3FDC65F-568D-4E2D-A093-5132FD3793B7} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{909B656F-6095-4AC2-A5AB-C3F032315C45} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
-		{2E87FA96-50BB-4607-8676-46521599F998} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{21B239D0-D144-430F-A394-C066D58EE267} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
-		{687DAFFD-9BD9-4331-96B7-483B941EDEAA} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
-		{E637AD92-8397-4337-A9CD-9F2570078E59} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{D0BC9BE7-24F6-40CA-8DC6-FCB93BD44B34} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
 		{C1930979-C824-496B-A630-70F5369A636F} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
 		{FCFA8808-A1B6-48CC-A1EA-0B8CA8AEDA8E} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
 		{C545216D-8CBA-4460-810D-D3DC7EFF8373} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
 		{21446697-E359-41D9-B39D-40ADA2B20823} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
+		{F83343BA-B4EA-451C-B6DB-5D645E6171BC} = {5EFE4D73-9608-4E19-83A5-963B02413164}
+		{DEB3D675-5A3C-46DA-8945-F2EFAB135EA0} = {5EFE4D73-9608-4E19-83A5-963B02413164}
 	EndGlobalSection
 EndGlobal

--- a/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
@@ -599,6 +599,23 @@ namespace Roslyn.Test.MetadataUtilities
             return $"IL_{sequencePoint.Offset:X4}: " + range;
         }
 
+        public void VisualizeHeaders()
+        {
+            _reader = _readers[0];
+
+            _writer.WriteLine("MetadataVersion: {0}", _reader.MetadataVersion);
+
+            if (_reader.DebugMetadataHeader != null)
+            {
+                if (!_reader.DebugMetadataHeader.EntryPoint.IsNil)
+                {
+                    _writer.WriteLine("EntryPoint: {0}", Token(_reader.DebugMetadataHeader.EntryPoint));
+                }
+            }
+
+            _writer.WriteLine();
+        }
+
         private void WriteModule()
         {
             var def = _reader.GetModuleDefinition();

--- a/src/Test/Utilities/CompilationExtensions.cs
+++ b/src/Test/Utilities/CompilationExtensions.cs
@@ -19,13 +19,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             this Compilation compilation,
             EmitOptions options = null,
             CompilationTestData testData = null,
-            DiagnosticDescription[] expectedWarnings = null)
+            DiagnosticDescription[] expectedWarnings = null,
+            Stream pdbStream = null)
         {
             var stream = new MemoryStream();
-            MemoryStream pdbStream = 
-                (compilation.Options.OptimizationLevel == OptimizationLevel.Debug) && !CLRHelpers.IsRunningOnMono() 
-                ? new MemoryStream() 
-                : null;
+
+            if (pdbStream == null && compilation.Options.OptimizationLevel == OptimizationLevel.Debug)
+            {
+                if (CLRHelpers.IsRunningOnMono())
+                {
+                    options = options.WithDebugInformationFormat(DebugInformationFormat.PortablePdb);
+                }
+
+                pdbStream = new MemoryStream();
+            }
 
             var emitResult = compilation.Emit(
                 peStream: stream,

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -27,7 +27,7 @@
     <SystemCollectionsImmutableAssemblyVersion Condition="'$(SystemCollectionsImmutableAssemblyVersion)' == ''">1.1.36</SystemCollectionsImmutableAssemblyVersion>
     <NuGetCommandLineAssemblyVersion Condition="'$(NuGetCommandLineAssemblyVersion)' == ''">2.8.5</NuGetCommandLineAssemblyVersion>
     <MicrosoftCompositionAssemblyVersion Condition="'$(MicrosoftCompositionAssemblyVersion)' == ''">1.0.27</MicrosoftCompositionAssemblyVersion>
-    <SystemReflectionMetadataVersion>$(SystemReflectionMetadataAssemblyVersion)-alpha-00006</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>$(SystemReflectionMetadataAssemblyVersion)-alpha-00007</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>$(SystemCollectionsImmutableAssemblyVersion)</SystemCollectionsImmutableVersion>
     <NuGetCommandLineVersion>$(NuGetCommandLineAssemblyVersion)</NuGetCommandLineVersion>
     <MicrosoftCompositionVersion>$(MicrosoftCompositionAssemblyVersion)</MicrosoftCompositionVersion>

--- a/src/Tools/Source/MetadataVisualizer/Program.cs
+++ b/src/Tools/Source/MetadataVisualizer/Program.cs
@@ -164,6 +164,8 @@ internal class Program : IDisposable
             var generation = generations[generationIndex];
             var mdReader = generation.MetadataReader;
 
+            visualizer.VisualizeHeaders();
+
             _writer.WriteLine(">>>");
             _writer.WriteLine(string.Format(">>> Generation {0}:", generationIndex));
             _writer.WriteLine(">>>");


### PR DESCRIPTION
Fixes encoding of sequence point deltas in presence of hidden sequence points.
Adds local signature token to method body, so that PDB readers have access to them without loading IL stream.
Adds a new #Pdb stream to standalone debug metadata that includes sizes of type-system tables referenced by the debug metadata tables. 
Replaces entry point CDI with an entry in #Pdb stream.