### PR TITLE
Remove the term "whitelist"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyChecker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyChecker.cs
@@ -17,16 +17,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     internal sealed class AnalyzerDependencyChecker
     {
         private readonly HashSet<string> _analyzerFilePaths;
-        private readonly List<IAssemblyWhiteList> _assemblyWhiteLists;
+        private readonly List<IIgnorableAssemblyList> _ignorableAssemblyLists;
         private readonly IBindingRedirectionService _bindingRedirectionService;
 
-        public AnalyzerDependencyChecker(IEnumerable<string> analyzerFilePaths, IEnumerable<IAssemblyWhiteList> assemblyWhiteLists, IBindingRedirectionService bindingRedirectionService = null)
+        public AnalyzerDependencyChecker(IEnumerable<string> analyzerFilePaths, IEnumerable<IIgnorableAssemblyList> ignorableAssemblyLists, IBindingRedirectionService bindingRedirectionService = null)
         {
             Debug.Assert(analyzerFilePaths != null);
-            Debug.Assert(assemblyWhiteLists != null);
+            Debug.Assert(ignorableAssemblyLists != null);
 
             _analyzerFilePaths = new HashSet<string>(analyzerFilePaths, StringComparer.OrdinalIgnoreCase);
-            _assemblyWhiteLists = assemblyWhiteLists.ToList();
+            _ignorableAssemblyLists = ignorableAssemblyLists.ToList();
             _bindingRedirectionService = bindingRedirectionService;
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 }
             }
 
-            _assemblyWhiteLists.Add(new AssemblyIdentityWhiteList(analyzerInfos.Select(info => info.Identity)));
+            _ignorableAssemblyLists.Add(new IgnorableAssemblyIdentityList(analyzerInfos.Select(info => info.Identity)));
 
             // First check for analyzers with the same identity but different
             // contents (that is, different MVIDs).
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                         ? _bindingRedirectionService.ApplyBindingRedirects(reference)
                         : reference;
 
-                    if (!_assemblyWhiteLists.Any(whiteList => whiteList.Includes(redirectedReference)))
+                    if (!_ignorableAssemblyLists.Any(ignorableAssemblyList => ignorableAssemblyList.Includes(redirectedReference)))
                     {
                         builder.Add(new MissingAnalyzerDependency(
                             analyzerInfo.Path,

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependencyCheckingService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     internal sealed class AnalyzerDependencyCheckingService
     {
         private static readonly object s_dependencyConflictErrorId = new object();
-        private static readonly IAssemblyWhiteList s_systemPrefixWhiteList = new AssemblyNamePrefixWhiteList("System");
+        private static readonly IIgnorableAssemblyList s_systemPrefixList = new IgnorableAssemblyNamePrefixList("System");
 
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly HostDiagnosticUpdateSource _updateSource;
@@ -194,10 +194,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _task = _task.SafeContinueWith(_ =>
             {
                 IEnumerable<AssemblyIdentity> loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(assembly => AssemblyIdentity.FromAssemblyDefinition(assembly));
-                AssemblyIdentityWhiteList loadedAssembliesWhiteList = new AssemblyIdentityWhiteList(loadedAssemblies);
-                IAssemblyWhiteList[] whiteLists = new[] { s_systemPrefixWhiteList, loadedAssembliesWhiteList };
+                IgnorableAssemblyIdentityList loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
+                IIgnorableAssemblyList[] ignorableAssemblyLists = new[] { s_systemPrefixList, loadedAssembliesList };
 
-                return new AnalyzerDependencyChecker(currentAnalyzerPaths, whiteLists, _bindingRedirectionService).Run(_cancellationTokenSource.Token);
+                return new AnalyzerDependencyChecker(currentAnalyzerPaths, ignorableAssemblyLists, _bindingRedirectionService).Run(_cancellationTokenSource.Token);
             },
             TaskScheduler.Default);
 

--- a/src/VisualStudio/Core/Def/Implementation/IIgnorableAssemblyList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IIgnorableAssemblyList.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    internal interface IAssemblyWhiteList
+    internal interface IIgnorableAssemblyList
     {
         bool Includes(AssemblyIdentity assemblyIdentity);
     }

--- a/src/VisualStudio/Core/Def/Implementation/IgnorableAssemblyIdentityList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IgnorableAssemblyIdentityList.cs
@@ -6,11 +6,11 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    internal sealed class AssemblyIdentityWhiteList : IAssemblyWhiteList
+    internal sealed class IgnorableAssemblyIdentityList : IIgnorableAssemblyList
     {
         private readonly HashSet<AssemblyIdentity> _assemblyIdentities;
 
-        public AssemblyIdentityWhiteList(IEnumerable<AssemblyIdentity> assemblyIdentities)
+        public IgnorableAssemblyIdentityList(IEnumerable<AssemblyIdentity> assemblyIdentities)
         {
             Debug.Assert(assemblyIdentities != null);
 

--- a/src/VisualStudio/Core/Def/Implementation/IgnorableAssemblyNamePrefixList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IgnorableAssemblyNamePrefixList.cs
@@ -5,11 +5,11 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    internal sealed class AssemblyNamePrefixWhiteList : IAssemblyWhiteList
+    internal sealed class IgnorableAssemblyNamePrefixList : IIgnorableAssemblyList
     {
         private readonly string _prefix;
 
-        public AssemblyNamePrefixWhiteList(string prefix)
+        public IgnorableAssemblyNamePrefixList(string prefix)
         {
             Debug.Assert(prefix != null);
 

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -32,12 +32,12 @@
     <Compile Include="Implementation\AnalyzerDependencyChecker.cs" />
     <Compile Include="Implementation\AnalyzerDependencyCheckingService.cs" />
     <Compile Include="Implementation\AnalyzerDependencyConflict.cs" />
-    <Compile Include="Implementation\AssemblyIdentityWhiteList.cs" />
-    <Compile Include="Implementation\AssemblyNamePrefixWhiteList.cs" />
+    <Compile Include="Implementation\IgnorableAssemblyIdentityList.cs" />
+    <Compile Include="Implementation\IgnorableAssemblyNamePrefixList.cs" />
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
     <Compile Include="Implementation\EditAndContinue\Interop\NativeMethods.cs" />
-    <Compile Include="Implementation\IAssemblyWhiteList.cs" />
+    <Compile Include="Implementation\IIgnorableAssemblyList.cs" />
     <Compile Include="Implementation\IBindingRedirectionService.cs" />
     <Compile Include="Implementation\LanguageService\AbstractLanguageService`2.IVsLanguageBlock.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs" />

--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -33,11 +33,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         Private Shared s_CSharpCompilerExecutable As String = Path.Combine(MSBuildDirectory, "csc.exe")
         Private Shared s_mscorlibDisplayName As String = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
 
-        Private Shared Function GetWhiteLists() As IEnumerable(Of IAssemblyWhiteList)
+        Private Shared Function GetIgnorableAssemblyLists() As IEnumerable(Of IIgnorableAssemblyList)
             Dim mscorlib As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib)
 
-            Return {New AssemblyIdentityWhiteList({mscorlib})}
+            Return {New IgnorableAssemblyIdentityList({mscorlib})}
         End Function
 
         <Fact, WorkItem(1064914)>
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -76,7 +76,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -108,7 +108,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -149,7 +149,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -191,7 +191,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory2, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory2, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -232,7 +232,7 @@ public class B
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -273,7 +273,7 @@ public class B
                 Dim libraryC2 = directory2.CreateFile("C.dll").CopyContentFrom(libraryC1).Path
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.Conflicts)
@@ -325,7 +325,7 @@ public class C
                 Dim libraryCPrime = BuildLibrary(directory2, sourceCPrime, "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryCPrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryCPrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Dim conflicts = results.Conflicts
@@ -396,7 +396,7 @@ public class D
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Dim conflicts = results.Conflicts
@@ -475,7 +475,7 @@ public class E
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -527,7 +527,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryA2 = directory2.CreateFile("A.dll").CopyContentFrom(libraryA1).Path
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA1, libraryA2, libraryB, libraryBPrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA1, libraryA2, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -591,7 +591,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -642,7 +642,7 @@ public class B
                 Dim libraryB2 = directory2.CreateFile("B.dll").CopyContentFrom(libraryB1).Path
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB1, libraryB2}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB1, libraryB2}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
                 Dim conflicts = results.Conflicts
 
@@ -722,7 +722,7 @@ public class D
                 Dim libraryDPrimePrime = BuildLibrary(directory3, sourceDPrimePrime, "D")
                 Dim libraryC = BuildLibrary(directory3, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Equal(expected:=3, actual:=results.Conflicts.Length)
@@ -737,7 +737,7 @@ public class D
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
 
                 Assert.Empty(results.MissingDependencies)
@@ -764,7 +764,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA}, GetWhiteLists())
+                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA}, GetIgnorableAssemblyLists())
                 Dim results = dependencyChecker.Run()
                 Dim missingDependencies = results.MissingDependencies
 
@@ -777,59 +777,59 @@ public class A
         End Sub
 
         <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
-        Public Sub AssemblyIdentityWhiteList_IncludesItem()
+        Public Sub IgnorableAssemblyIdentityList_IncludesItem()
             Dim mscorlib1 As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib1)
 
-            Dim whiteList = New AssemblyIdentityWhiteList({mscorlib1})
+            Dim ignorableAssemblyList = New IgnorableAssemblyIdentityList({mscorlib1})
 
             Dim mscorlib2 As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib2)
 
-            Assert.True(whiteList.Includes(mscorlib2))
+            Assert.True(ignorableAssemblyList.Includes(mscorlib2))
         End Sub
 
         <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
-        Public Sub AssemblyIdentityWhiteList_DoesNotIncludeItem()
+        Public Sub IgnorableAssemblyIdentityList_DoesNotIncludeItem()
             Dim mscorlib As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib)
 
-            Dim whiteList = New AssemblyIdentityWhiteList({mscorlib})
+            Dim ignorableAssemblyList = New IgnorableAssemblyIdentityList({mscorlib})
 
             Dim alpha As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
 
-            Assert.False(whiteList.Includes(alpha))
+            Assert.False(ignorableAssemblyList.Includes(alpha))
         End Sub
 
         <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
-        Public Sub AssemblyNamePrefixWhiteList_IncludesItem_Prefix()
-            Dim whiteList = New AssemblyNamePrefixWhiteList("Alpha")
+        Public Sub IgnorableAssemblyNamePrefixList_IncludesItem_Prefix()
+            Dim ignorableAssemblyList = New IgnorableAssemblyNamePrefixList("Alpha")
 
             Dim alphaBeta As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName("Alpha.Beta, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alphaBeta)
 
-            Assert.True(whiteList.Includes(alphaBeta))
+            Assert.True(ignorableAssemblyList.Includes(alphaBeta))
         End Sub
 
         <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
-        Public Sub AssemblyNamePrefixWhiteList_IncludesItem_WholeName()
-            Dim whiteList = New AssemblyNamePrefixWhiteList("Alpha")
+        Public Sub IgnorableAssemblyNamePrefixList_IncludesItem_WholeName()
+            Dim ignorableAssemblyList = New IgnorableAssemblyNamePrefixList("Alpha")
 
             Dim alpha As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
 
-            Assert.True(whiteList.Includes(alpha))
+            Assert.True(ignorableAssemblyList.Includes(alpha))
         End Sub
 
         <Fact, WorkItem(3020, "https://github.com/dotnet/roslyn/issues/3020")>
-        Public Sub AssemblyNamePrefixWhiteList_DoesNotIncludeItem()
-            Dim whiteList = New AssemblyNamePrefixWhiteList("Beta")
+        Public Sub IgnorableAssemblyNamePrefixList_DoesNotIncludeItem()
+            Dim ignorableAssemblyList = New IgnorableAssemblyNamePrefixList("Beta")
 
             Dim alpha As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName("Alpha, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", alpha)
 
-            Assert.False(whiteList.Includes(alpha))
+            Assert.False(ignorableAssemblyList.Includes(alpha))
         End Sub
 
         Private Function BuildLibrary(directory As DisposableDirectory, fileContents As String, libraryName As String, ParamArray referenceNames As String()) As String


### PR DESCRIPTION
*Note that this fix has been to ship room before and was approved (request #3457); I then discovered I had created the pull request against master instead of stabilization. This is the same change, against stabilization.*

**Bug:** Fixes DevDiv Bug 1185799

**Customer Scenario**
No customer scenario, per se.

There are a number of places where we use the term "whitelist", and one of them (a code comment) was flagged by Policheck. Given that our code is open I've gone ahead and simply fixed them all.

**Fix**
Several internal types were updated with new names, as well as various fields, locals, and a comment.

**Testing**
After the fix, the code still passes all of our unit and integration tests.

@ManishJayaswal This is ready to go to ship room.