### PR TITLE
Fix VB Reports Application project template creation

### DIFF
--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -36,6 +36,11 @@ namespace Roslyn.Utilities
     {
         internal static void Initialize()
         {
+            // This method provides a way to force the static initializers of each type below
+            // to run. This ensures that the static field values will be computed eagerly
+            // rather than lazily on demand. If you add a new nested class below to access API
+            // surface area, be sure to "touch" the Type field here.
+
             Touch(Assembly.Type);
             Touch(Directory.Type);
             Touch(Encoding.Type);

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -34,6 +34,32 @@ namespace Roslyn.Utilities
     /// </summary>
     internal static class PortableShim
     {
+        internal static void Initialize()
+        {
+            Touch(Assembly.Type);
+            Touch(Directory.Type);
+            Touch(Encoding.Type);
+            Touch(Environment.Type);
+            Touch(File.Type);
+            Touch(FileAccess.Type);
+            Touch(FileMode.Type);
+            Touch(FileOptions.Type);
+            Touch(FileShare.Type);
+            Touch(FileStream.Type);
+            Touch(FileVersionInfo.Type);
+            Touch(MemoryStream.Type);
+            Touch(Path.Type);
+            Touch(RuntimeHelpers.Type);
+            Touch(SearchOption.Type);
+            Touch(Thread.Type);
+            Touch(XPath.Extensions.Type);
+        }
+
+        private static void Touch(Type type)
+        {
+            // Do nothing.
+        }
+
         private static class CoreNames
         {
             internal const string System_Diagnostics_FileVersionInfo = "System.Diagnostics.FileVersionInfo, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -54,6 +54,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             var method = compilerFailFast.GetMethod(nameof(FailFast.OnFatalException), BindingFlags.Static | BindingFlags.NonPublic);
             property.SetValue(null, Delegate.CreateDelegate(property.PropertyType, method));
 
+            InitializePortableShim(compilerAssembly);
+
             RegisterFindResultsLibraryManager();
 
             var componentModel = (IComponentModel)this.GetService(typeof(SComponentModel));
@@ -74,6 +76,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             LoadComponentsInUIContext();
 
             _solutionEventMonitor = new SolutionEventMonitor(_workspace);
+        }
+
+        private static void InitializePortableShim(Assembly compilerAssembly)
+        {
+            // We eagerly force all of the types to be loaded within the PortableShim because there are scenarios
+            // in which loading types can trigger the current AppDomain's AssemblyResolve or TypeResolve events.
+            // If handlers of those events do anything that would cause PortableShim to be accessed recursively,
+            // bad things can happen. In particular, this fixes the scenario described in TFS bug #1185842.
+            //
+            // Note that the fix below is written to be as defensive as possible to do no harm if it impacts other
+            // scenarios.
+
+            // Initialize the PortableShim linked into the Workspaces layer.
+            Roslyn.Utilities.PortableShim.Initialize();
+
+            // Initialize the PortableShim linekd into the Compilers layer via reflection.
+            var compilerPortableShim = compilerAssembly.GetType("Roslyn.Utilities.PortableShim", throwOnError: false);
+            var initializeMethod = compilerPortableShim?.GetMethod("Initialize", BindingFlags.Static | BindingFlags.NonPublic);
+            initializeMethod?.Invoke(null, null);
         }
 
         private void InitializeColors()

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             // Initialize the PortableShim linekd into the Compilers layer via reflection.
             var compilerPortableShim = compilerAssembly.GetType("Roslyn.Utilities.PortableShim", throwOnError: false);
-            var initializeMethod = compilerPortableShim?.GetMethod("Initialize", BindingFlags.Static | BindingFlags.NonPublic);
+            var initializeMethod = compilerPortableShim?.GetMethod(nameof(Roslyn.Utilities.PortableShim.Initialize), BindingFlags.Static | BindingFlags.NonPublic);
             initializeMethod?.Invoke(null, null);
         }
 

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
@@ -873,5 +873,70 @@ End Class
             End Try
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBAssignments_DontThrowWhenLeftHandSideDoesntBind()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <CompilationOptions RootNamespace="ClassLibrary1"/>
+        <Document>
+Public Class A
+    Public Property Prop As B
+End Class
+
+Public Class C
+    Dim x As New A
+
+    $$Sub M()
+        x.Prop.NestedProp = "Text"
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="9">
+        <Expression>
+            <Assignment>
+                <Expression>
+                    <NameRef variablekind="unknown">
+                        <Expression>
+                            <NameRef variablekind="property">
+                                <Expression>
+                                    <NameRef variablekind="field">
+                                        <Expression>
+                                            <ThisReference/>
+                                        </Expression>
+                                        <Name>x</Name>
+                                    </NameRef>
+                                </Expression>
+                                <Name>Prop</Name>
+                            </NameRef>
+                        </Expression>
+                        <Name>NestedProp</Name>
+                    </NameRef>
+                </Expression>
+                <Expression>
+                    <Literal>
+                        <String>Text</String>
+                    </Literal>
+                </Expression>
+            </Assignment>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Dim currentThread = Thread.CurrentThread
+            Dim oldCulture = currentThread.CurrentCulture
+            Try
+                currentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE")
+                Test(definition, expected)
+            Finally
+                currentThread.CurrentCulture = oldCulture
+            End Try
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
@@ -268,7 +268,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel.MethodXm
             Dim kind = MyBase.GetVariableKind(symbol)
 
             ' need to special case WithEvent properties. CodeModel wants them as fields.
-            If symbol.Kind = SymbolKind.Property Then
+            If symbol?.Kind = SymbolKind.Property Then
                 Dim propertySymbol = TryCast(symbol, IPropertySymbol)
                 If propertySymbol IsNot Nothing AndAlso propertySymbol.IsWithEvents Then
                     kind = VariableKind.Field


### PR DESCRIPTION
**Customer Scenario**: After starting Visual Studio, creating a new VB Reports Application results in a "white screen of darn" where the WinForms designer does not be load properly. Once this happens, VB Reports Application projects cannot be successfully created until Visual Studio is restarted. However, if the user creates or opens a different project first, creating a VB Reports Application will *likely* succeed, though possibly not -- depending on the project.

**Issue Description**: This problem is caused by a confluence of events. The root cause stems from the ```ProjectShim``` class which lazily gathers up types and constructors for several types that are not including in the .NET 4.5 portable surface area that the compiler needs (e.g. ```FileStream``` and it's friends).

Here's what happens in the customer scenario:

1. Assembly references are added while the project is created.
2. Loading those assembly references requires using file system APIs that are accessed via ```PortableShim```.
3. These first accesses to ```PortableShim``` causes the static field initializes to run, which loads several types.
4. Loading the types triggers the ```AssemblyResolve``` event on the current AppDomain (the default domain).
5. The ```AssemblyResolve``` event handler on the ```VSTypeResolveService``` calls into the VB project system which attempts a TempPE compile.
6. The TempPE compile creates a new Roslyn ```Compilation``` and adds assembly references to it.
7. Adding those assembly references causes the ```PortableShim``` to be accessed again *even though it's static initialization is not complete*. That means that several static fields are null and will throw if touched.
8. Because an exception was thrown during type initialization for ```PortableShim``` it's possible that it is has been left in a bad state, where some fields are null and will never get loaded properly.

**Fix Description**: Eagerly load the types in the ```ProjectShim``` class during the Roslyn package initialization. Moving this earlier in the process side-steps the issue entirely.

In addition, a null reference exception has been fixed in MethodXML generation for VB. Initially, it was assumed that this was the root cause of the problem. Ultimately, it turned out that the problem was that binding failed when metadata didn't load because ```PortableShim``` got busted. However, the null-check is safe and hardens against further problems.

**Testing Done**: At the moment, just manual verification. This is not an easy scenario to test. However, the fix has been written to be as defensive as possible so that it will do no harm if something goes wrong.

Reviewers: @jaredpar, @jasonmalinowski, @Pilchie, @pharring 

I need some buddy testing. Would @brettfo, @dpoeschl, @basoundr, @rchande or @balajikris be interested?