### PR TITLE
Down targetting C# shouldn't allow interpolated strings

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
 
             Debug.Assert(originalToken.ToFullString() == result.ToFullString()); // yield from text equals yield from node
-            return result;
+            return CheckFeatureAvailability(result, MessageID.IDS_FeatureInterpolatedStrings);
         }
 
         private InterpolationSyntax ParseInterpolation(string text, Lexer.Interpolation interpolation, bool isVerbatim)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -4367,6 +4367,45 @@ partial class X
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion2, "partial").WithArguments("partial method", "3"));
         }
 
+        [Fact]
+        public void InterpolatedStringBeforeCSharp6()
+        {
+            var text = @"
+class C
+{
+    string M()
+    {
+        return $""hello"";
+    }
+}";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
+            tree.GetCompilationUnitRoot().GetDiagnostics().Verify(
+                // (6,16): error CS8026: Feature 'interpolated strings' is not available in C# 5.  Please use language version 6 or greater.
+                //         return $"hello";
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, @"$""hello""").WithArguments("interpolated strings", "6").WithLocation(6, 16));
+        }
+
+        [Fact]
+        public void InterpolatedStringWithReplacementBeforeCSharp6()
+        {
+            var text = @"
+class C
+{
+    string M()
+    {
+        string other = ""world"";
+        return $""hello + {other}"";
+    }
+}";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
+            tree.GetCompilationUnitRoot().GetDiagnostics().Verify(
+            // (7,16): error CS8026: Feature 'interpolated strings' is not available in C# 5.  Please use language version 6 or greater.
+            //         return $"hello + {other}";
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, @"$""hello + {other}""").WithArguments("interpolated strings", "6").WithLocation(7, 16));
+        }
+
         [WorkItem(529870, "DevDiv")]
         [Fact]
         public void AsyncBeforeCSharp5()
@@ -4681,6 +4720,7 @@ class C
         }
 
         var s = o?.ToString(); // null propagating operator
+        var x = $""hello world"";
     }
 }";
             SyntaxFactory.ParseSyntaxTree(source, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6)).GetDiagnostics().Verify();
@@ -4709,7 +4749,10 @@ class C
     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "when").WithArguments("exception filter", "6").WithLocation(18, 32),
     // (21,17): error CS8026: Feature 'null propagating operator' is not available in C# 5.  Please use language version 6 or greater.
     //         var s = o?.ToString(); // null propagating operator
-    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "o?.ToString()").WithArguments("null propagating operator", "6").WithLocation(21, 17)
+    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "o?.ToString()").WithArguments("null propagating operator", "6").WithLocation(21, 17),
+    // (22,17): error CS8026: Feature 'interpolated strings' is not available in C# 5.  Please use language version 6 or greater.
+    //         var x = $"hello world";
+    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, @"$""hello world""").WithArguments("interpolated strings", "6").WithLocation(22, 17)
                 );
         }
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
@@ -89,10 +89,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 skipped = Nothing
             End If
 
-            Return SyntaxFactory.InterpolatedStringExpression(dollarSignDoubleQuoteToken,
+            Dim node = SyntaxFactory.InterpolatedStringExpression(dollarSignDoubleQuoteToken,
                                                               _pool.ToListAndFree(contentBuilder),
                                                               doubleQuoteToken)
-
+            Return CheckFeatureAvailability(Feature.InterpolatedStrings, node)
         End Function
 
         Private Function ParseInterpolatedStringInterpolation() As InterpolationSyntax

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -6000,8 +6000,14 @@ checkNullable:
                 Return node
             End If
 
-            Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
-            Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), featureName)
+            If feature = Feature.InterpolatedStrings Then
+                ' Bug: It is too late in the release cycle to update localized strings.  As a short term measure we will output 
+                ' an unlocalized string and fix this to be localized in the next release.
+                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), "interpolated strings")
+            Else
+                Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
+                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), featureName)
+            End If
         End Function
 
         Private Function CheckFeatureAvailability(feature As Feature) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         GlobalNamespace
         NullPropagatingOperator
         NameOfExpressions
+        InterpolatedStrings
     End Enum
 
     Friend Module FeatureExtensions
@@ -39,7 +40,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return LanguageVersion.VisualBasic11
 
                 Case Feature.NullPropagatingOperator,
-                     Feature.NameOfExpressions
+                     Feature.NameOfExpressions,
+                     Feature.InterpolatedStrings
                     Return LanguageVersion.VisualBasic14
 
                 Case Else

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseLanguageVersionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseLanguageVersionTests.vb
@@ -299,4 +299,23 @@ End Namespace"
         Next
     End Sub
 
+    <Fact>
+    Public Sub InterpolatedStrings()
+        Dim x = Nothing
+        ParseAndVerify(
+        <![CDATA[
+Module Module1
+    Function M() As String
+        Dim x1 = $"world"
+        Dim x2 = $"hello {x1}"
+        Return x2
+    End Function
+End Module
+        ]]>.Value,
+            LanguageVersion.VisualBasic12,
+            Diagnostic(ERRID.ERR_LanguageVersion, "$""world""").WithArguments("12.0", "interpolated strings").WithLocation(4, 18),
+            Diagnostic(ERRID.ERR_LanguageVersion, "$""hello {x1}""").WithArguments("12.0", "interpolated strings").WithLocation(5, 18))
+    End Sub
+
+
 End Class


### PR DESCRIPTION
Interpolated strings are a C# 6.0 feature and should result in an error
when used with any earlier language version switch.  The detection logic
was added to the compiler before but it attached the error to the
SyntaxToken.  Interopolated strings reparse this token and weren't
properly migrating the diagnostics to the resulting SyntaxNode.  This
resulted in the errors getting lost.