### PR TITLE
Report rude edit when partially executed active statement is deleted

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -7687,6 +7687,33 @@ class C
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "Console.WriteLine(40);"));
         }
 
+        [Fact]
+        public void PartiallyExecutedActiveStatement_Deleted()
+        {
+            string src1 = @"
+class C
+{
+    public static void F()
+    {
+        <AS:0>Console.WriteLine(1);</AS:0> 
+    }
+}";
+            string src2 = @"
+class C
+{
+    public static void F()
+    { 
+    <AS:0>}</AS:0>
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            active.OldSpans[0] = new ActiveStatementSpan(ActiveStatementFlags.PartiallyExecuted | ActiveStatementFlags.LeafFrame, active.OldSpans[0].Span);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.PartiallyExecutedActiveStatementDelete, "{"));
+        }
+
         #endregion
     }
 }

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
             {
                 RudeEditKind.ActiveStatementUpdate,
                 RudeEditKind.PartiallyExecutedActiveStatementUpdate,
+                RudeEditKind.PartiallyExecutedActiveStatementDelete,
                 RudeEditKind.DeleteActiveStatement,
                 RudeEditKind.UpdateExceptionHandlerOfActiveTry,
                 RudeEditKind.UpdateTryOrCatchWithActiveFinally,

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -5014,5 +5014,29 @@ End Class
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "Console.WriteLine(20)"),
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "Console.WriteLine(40)"))
         End Sub
+
+        <Fact>
+        Public Sub PartiallyExecutedActiveStatement_Delete()
+            Dim src1 As String = "
+Class C
+    Sub F()
+        <AS:0>Console.WriteLine(1)</AS:0> 
+    End Sub
+End Class
+"
+            Dim src2 As String = "
+Class C
+    Sub F()
+    <AS:0>End Sub</AS:0> 
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            active.OldSpans(0) = New ActiveStatementSpan(ActiveStatementFlags.PartiallyExecuted Or ActiveStatementFlags.LeafFrame, active.OldSpans(0).Span)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.PartiallyExecutedActiveStatementDelete, "Sub F()"))
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1079,11 +1079,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     newSpan = GetDeletedNodeActiveSpan(match.Matches, oldStatementSyntax);
 
-                    if (!isLeaf)
+                    if (!isLeaf || isPartiallyExecuted)
                     {
                         // rude edit: internal active statement deleted
                         diagnostics.Add(
-                            new RudeEditDiagnostic(RudeEditKind.DeleteActiveStatement,
+                            new RudeEditDiagnostic(isLeaf ? RudeEditKind.PartiallyExecutedActiveStatementDelete : RudeEditKind.DeleteActiveStatement,
                             GetDeletedNodeDiagnosticSpan(match.Matches, oldStatementSyntax)));
                     }
                 }

--- a/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.ActiveStatementLambdaRemoved,              FeaturesResources.RemovingThatContainsActiveStatement) },
             // TODO: change the error message to better explain what's going on
             { GetDescriptorPair(RudeEditKind.PartiallyExecutedActiveStatementUpdate,    FeaturesResources.UpdatingAnActiveStatement) },
+            { GetDescriptorPair(RudeEditKind.PartiallyExecutedActiveStatementDelete,    FeaturesResources.AnActiveStatementHasBeenRemoved) },
             { GetDescriptorPair(RudeEditKind.InsertFile,                                FeaturesResources.AddingANewFile) },
 
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.ModifyingAWhichContainsComplexQuery) },

--- a/src/Features/Core/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditKind.cs
@@ -88,6 +88,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertHandlesClause = 70,
         InsertFile = 71,
         PartiallyExecutedActiveStatementUpdate = 72,
+        PartiallyExecutedActiveStatementDelete = 73,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,


### PR DESCRIPTION
Fixes #3295.

**Scenario**
F5, comment out "Stop" statement, F10:

```VB
Module Module1                
Sub Main()                          
   Stop                                
   Console.WriteLine(1)       
   Console.WriteLine(2)          
End Sub
End Module
```

The debugger skips "Console.WriteLine(1)" and ends up stopping on "Console.WriteLine(2)".

**Fix**
#3295 was addressed before on Roslyn side but a fix on debugger side was needed as well in order to fix the E2E scenario. Now that both fixes are in place the validation of E2E scenario is possible. The scenario is still not working -- a check is missing in Roslyn EnC logic. Only one out of two code paths were covered by the previous fix. This fix takes care of the other code path as well.

**Testing**
Unit test and E2E validation on the latest D14Rel bits.

@ManishJayaswal 