### PR TITLE
Fix VB TypeInferrer after ArgumentList

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -342,6 +342,32 @@ End Class
             VerifyItemIsAbsent(markup, "e As E")
         End Sub
 
+        <WorkItem(3518, "https://github.com/dotnet/roslyn/issues/3518")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NotAfterInvocationWithCompletionListTagTypeAsFirstParameter()
+            Dim markup = <Text><![CDATA[
+Class C
+    Sub Test()
+        M(Type2.A)
+        $$
+    End Sub
+
+    Private Sub M(a As Type1)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+''' <completionlist cref="Type2"/>
+Public Class Type1
+End Class
+
+Public Class Type2
+    Public Shared A As Type1
+    Public Shared B As Type1
+End Class
+]]></Text>.Value
+            VerifyNoItemsExist(markup)
+        End Sub
+
         Friend Overrides Function CreateCompletionProvider() As ICompletionProvider
             Return New CompletionListTagCompletionProvider()
         End Function

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -710,5 +710,20 @@ Module M
 End Module"
             Test(text, "Global.System.Threading.Tasks.Task(Of System.Boolean)", testPosition:=True)
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        <WorkItem(3518, "https://github.com/dotnet/roslyn/issues/3518")>
+        Public Sub NoTypeAfterInvocationWithCompletionListTagTypeAsFirstParameter()
+            Dim text = "Class C
+    Sub Test()
+        M(5)
+        [|x|]
+    End Sub
+
+    Sub M(x As Integer)
+    End Sub
+End Class"
+            Test(text, "System.Object", testNode:=False, testPosition:=True)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -217,6 +217,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             index = GetArgumentListIndex(argumentList, previousToken)
                         End If
 
+                        If index < 0 Then
+                            Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
+                        End If
+
                         Dim info = _semanticModel.GetSymbolInfo(invocation)
                         ' Check all the methods that have at least enough arguments to support being
                         ' called with argument at this position.  Note: if they're calling an extension
@@ -259,6 +263,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Else
                                     index = GetArgumentListIndex(argumentList, previousToken)
                                 End If
+
+                                If index < 0 Then
+                                    Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
+                                End If
+
                                 Dim constructors = namedType.InstanceConstructors.Where(Function(m) m.Parameters.Length > index)
                                 Return InferTypeInArgument(argumentOpt, index, constructors)
                             End If
@@ -277,6 +286,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             index = attribute.ArgumentList.Arguments.IndexOf(argumentOpt)
                         Else
                             index = GetArgumentListIndex(argumentList, previousToken)
+                        End If
+
+                        If index < 0 Then
+                            Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
                         End If
 
                         Dim info = _semanticModel.GetSymbolInfo(attribute)
@@ -838,7 +851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim index = argumentList.Arguments.GetWithSeparators().IndexOf(previousToken)
-                Return (index + 1) \ 2
+                Return If(index >= 0, (index + 1) \ 2, -1)
             End Function
 
             Private Function InferTypeInCollectionInitializerExpression(


### PR DESCRIPTION
Fixes #3518 (related to the fix in PR #3519)

When trying to figure out which Argument of an ArgumentList was being
inferred, we found the index and then returned "(index + 1) \ 2" without
checking if the index was out of bounds. When the index is out of bounds
its value is -1, so the above expression results in an index of 0, and
the rest of the system continues as though we're really trying to infer
the type of the first Argument (but really, the token we've passed is
the close paren for the entire invocation).

Potential Reviewers: @Pilchie @rchande @jasonmalinowski @DustinCampbell @balajikris @basoundr @brettfo