### PR TITLE
Fix VB TypeInferrer after ArgumentList

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -342,6 +342,32 @@ End Class
             VerifyItemIsAbsent(markup, "e As E")
         End Sub
 
+        <WorkItem(3518, "https://github.com/dotnet/roslyn/issues/3518")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NotAfterInvocationWithCompletionListTagTypeAsFirstParameter()
+            Dim markup = <Text><![CDATA[
+Class C
+    Sub Test()
+        M(Type2.A)
+        $$
+    End Sub
+
+    Private Sub M(a As Type1)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+''' <completionlist cref="Type2"/>
+Public Class Type1
+End Class
+
+Public Class Type2
+    Public Shared A As Type1
+    Public Shared B As Type1
+End Class
+]]></Text>.Value
+            VerifyNoItemsExist(markup)
+        End Sub
+
         Friend Overrides Function CreateCompletionProvider() As ICompletionProvider
             Return New CompletionListTagCompletionProvider()
         End Function

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -710,5 +710,20 @@ Module M
 End Module"
             Test(text, "Global.System.Threading.Tasks.Task(Of System.Boolean)", testPosition:=True)
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        <WorkItem(3518, "https://github.com/dotnet/roslyn/issues/3518")>
+        Public Sub NoTypeAfterInvocationWithCompletionListTagTypeAsFirstParameter()
+            Dim text = "Class C
+    Sub Test()
+        M(5)
+        [|x|]
+    End Sub
+
+    Sub M(x As Integer)
+    End Sub
+End Class"
+            Test(text, "System.Object", testNode:=False, testPosition:=True)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -217,6 +217,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             index = GetArgumentListIndex(argumentList, previousToken)
                         End If
 
+                        If index < 0 Then
+                            Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
+                        End If
+
                         Dim info = _semanticModel.GetSymbolInfo(invocation)
                         ' Check all the methods that have at least enough arguments to support being
                         ' called with argument at this position.  Note: if they're calling an extension
@@ -259,6 +263,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Else
                                     index = GetArgumentListIndex(argumentList, previousToken)
                                 End If
+
+                                If index < 0 Then
+                                    Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
+                                End If
+
                                 Dim constructors = namedType.InstanceConstructors.Where(Function(m) m.Parameters.Length > index)
                                 Return InferTypeInArgument(argumentOpt, index, constructors)
                             End If
@@ -277,6 +286,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             index = attribute.ArgumentList.Arguments.IndexOf(argumentOpt)
                         Else
                             index = GetArgumentListIndex(argumentList, previousToken)
+                        End If
+
+                        If index < 0 Then
+                            Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
                         End If
 
                         Dim info = _semanticModel.GetSymbolInfo(attribute)
@@ -838,7 +851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim index = argumentList.Arguments.GetWithSeparators().IndexOf(previousToken)
-                Return (index + 1) \ 2
+                Return If(index >= 0, (index + 1) \ 2, -1)
             End Function
 
             Private Function InferTypeInCollectionInitializerExpression(


### PR DESCRIPTION
Fixes #3518 (related to the fix in PR #3519)

**Note**: There are two PRs for the same bug here -- this one and #3519. This fix has more potential risk, but also fixes the bug in the non-comment case.

**User scenario**: The user is typing in VB after an invocation where the first parameter is of an enum type. On the next line, enum preselection will kick in inappropriately, causing unexpected items to be committed. 

If the enum preselection is happening due to the ```completionlist``` doc comment tag, then this can even occur within comments (the specific case for which a fix is proposed in #3519).

**Issue description**: The VB TypeInferrer reports the type of the first parameter of the method invoked in the previous statement as the inferred type at any position between the end of that statement and the beginning of the next statement.

**Fix**: The long description is in the commit message, but basically we were assuming the PreviousToken at the provided position would be in the ArgumentListSyntax, but when it wasn't (in the case of the trailing parenthesis) we took its "index" (of -1) and returned "(index + 1) \ 2" which accidentally turned it into index 0. We now more carefully handle the -1 case, but I'm mostly relying on our tests to prove that nobody was depending on this behavior.

**Testing done**: Manual verification, unit testing. Relying on Jenkins to run all tests...

Potential Reviewers: @Pilchie @rchande @jasonmalinowski @DustinCampbell @balajikris @basoundr @brettfo