### PR TITLE
Classify exterior documentation trivia spans with trailing or inner whitespace

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
                 if (spanStart != null && char.IsWhiteSpace(ch))
                 {
-                    var span = TextSpan.FromBounds(spanStart.Value, spanStart.Value + index);
+                    var span = TextSpan.FromBounds(spanStart.Value, trivia.Span.Start + index);
                     AddClassification(span, ClassificationTypeNames.XmlDocCommentDelimiter);
                     spanStart = null;
                 }

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.DocumentationCommentClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.DocumentationCommentClassifier.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                     Dim ch = text(index)
 
                     If spanStart IsNot Nothing AndAlso Char.IsWhiteSpace(ch) Then
-                        Dim span = TextSpan.FromBounds(spanStart.Value, spanStart.Value + index)
+                        Dim span = TextSpan.FromBounds(spanStart.Value, trivia.Span.Start + index)
                         _worker.AddClassification(span, ClassificationTypeNames.XmlDocCommentDelimiter)
                         spanStart = Nothing
                     ElseIf spanStart Is Nothing AndAlso Not Char.IsWhiteSpace(ch) Then


### PR DESCRIPTION
If the exterior documentation had a trivia node with `whitespace nonwhitespace whitespace` or `whitespace nonwhitespace whitespace nonwhitespace`, the ending bound used for the nonwhitespace characters would be too high - potentially outside of the range of the node itself.  The index is relative to `trivia.Span.Start`, but it is added to `spanStart.Value` instead, which would effectively give the span a length of `index` instead of actually indicating the end bound.

This scenario is not created by the lexer currently.  The lexer at most generates exterior documentation trivia nodes with leading whitespace - which would hit the block that takes the span from the point where it found non-whitespace to the end of the token.