### PR TITLE
remove subscription to IWorkspaceCacheService from non host workspace.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioProjectCacheHostServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioProjectCacheHostServiceFactory.cs
@@ -29,12 +29,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         {
             var projectCacheService = new ProjectCacheService(workspaceServices.Workspace, ImplicitCacheTimeoutInMS);
 
-            var workspaceCacheService = workspaceServices.GetService<IWorkspaceCacheService>();
-            if (workspaceCacheService != null)
-            {
-                workspaceCacheService.CacheFlushRequested += (s, e) => projectCacheService.ClearImplicitCache();
-            }
-
             // Also clear the cache when the solution is cleared or removed.
             workspaceServices.Workspace.WorkspaceChanged += (s, e) =>
             {


### PR DESCRIPTION
IWorkspaceCacheService is non-factory MEF workspace service which means it leaves forever. so anything subscribed to it will live forever as well.

this made some temporary workspace to live longer than expected.