### PR TITLE
Move intermediate build output to the Binaries directory

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -118,9 +118,9 @@
     </Reference>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(OutDir)' == ''">
-    <!-- If we don't already have an OutDir, set one-->
-    <OutDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\$(Configuration)'))\</OutDir>
+  <PropertyGroup>
+    <OutDir Condition="'$(OutDire)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\$(Configuration)'))\</OutDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\Obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
+++ b/src/Tools/Microsoft.CodeAnalysis.Toolset.Open/Targets/VSL.Settings.targets
@@ -119,7 +119,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <OutDir Condition="'$(OutDire)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\$(Configuration)'))\</OutDir>
+    <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\$(Configuration)'))\</OutDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\Binaries\Obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Program.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Program.cs
@@ -10,18 +10,17 @@ namespace BoundTreeGenerator
 {
     internal class Program
     {
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
-            var nonSwitches = args.Where(a => !a.StartsWith("/", StringComparison.Ordinal)).ToArray();
             string language;
             string infilename;
             string outfilename;
             TargetLanguage targetLanguage;
 
-            if (nonSwitches.Length != 3)
+            if (args.Length != 3)
             {
-                Console.WriteLine("Usage: \"{0} <language> <input> <output>\", where <language> is \"VB\" or \"CSharp\"", Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]));
-                return;
+                Console.Error.WriteLine("Usage: \"{0} <language> <input> <output>\", where <language> is \"VB\" or \"CSharp\"", Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]));
+                return 1;
             }
 
             language = args[0];
@@ -38,8 +37,8 @@ namespace BoundTreeGenerator
                     targetLanguage = TargetLanguage.CSharp;
                     break;
                 default:
-                    Console.WriteLine("Language must be \"VB\" or \"CSharp\"");
-                    return;
+                    Console.Error.WriteLine("Language must be \"VB\" or \"CSharp\"");
+                    return 1;
             }
 
             var serializer = new XmlSerializer(typeof(Tree));
@@ -58,6 +57,8 @@ namespace BoundTreeGenerator
             {
                 BoundNodeClassWriter.Write(outfile, tree, targetLanguage);
             }
+
+            return 0;
         }
 
         private static void serializer_UnreferencedObject(object sender, UnreferencedObjectEventArgs e)


### PR DESCRIPTION
Our build system currently generates our final output to the Binaries directory but
puts the intermediate output into the source tree in obj directories.  This change unifies
the behavior by putting both intermediate and final output into Binaries.