### PR TITLE
Change detection of double 0.0 to use BitConverter.DoubleToInt64Bits

### DIFF
--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue Create(float value)
         {
-            if (value == 0 && 1 / value > 0)
+            if (BitConverter.DoubleToInt64Bits(value) == 0)
             {
                 return ConstantValueDefault.Single;
             }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue CreateSingle(double value)
         {
-            if (value == 0 && 1 / value > 0)
+            if (BitConverter.DoubleToInt64Bits(value) == 0)
             {
                 return ConstantValueDefault.Single;
             }
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue Create(double value)
         {
-            if (value == 0 && 1 / value > 0)
+            if (BitConverter.DoubleToInt64Bits(value) == 0)
             {
                 return ConstantValueDefault.Double;
             }


### PR DESCRIPTION
Underneath BitConverter just casts 64bit double to a 64bit int with the same bit pattern, making it a simpler operation.