### PR TITLE
Add initial documentation on Additional Files

### DIFF
--- a/docs/analyzers/Analyzer Samples.md
+++ b/docs/analyzers/Analyzer Samples.md
@@ -1,10 +1,10 @@
-﻿**Samples Location:**
+**Samples Location:**
 
 Sample analyzers to demonstrate recommended implementation models for different analysis scenarios have been added to [CSharpAnalyzers.sln](..//..//src//Samples//CSharp//Analyzers//CSharpAnalyzers.sln) and [BasicAnalyzers.sln](..//..//src//Samples//VisualBasic//Analyzers//BasicAnalyzers.sln).
 
 **Description:**
 
-Analyzers have been broadly categorized into the following two buckets based on the kind of analysis performed:
+Analyzers have been broadly categorized into the following three buckets based on the kind of analysis performed:
   1. Stateless analyzers: Analyzers that report diagnostics about a specific code unit, such as a symbol, syntax node, code block, compilation, etc. Most analyzers would fall into this bucket.
      These analyzers register one or more actions, that:
      1. Do not require maintaining state across analyzer actions and are
@@ -13,6 +13,7 @@ Analyzers have been broadly categorized into the following two buckets based on 
      These analyzers require at least one of the following kind of state manipulation for analysis:
      1. Access to immutable state object(s) for the enclosing code unit, such as a compilation or the code block. For example, access to certain well known types defined in a compilation.
      2. Perform analysis over the enclosing code unit, with mutable state defined and initialized in a start action for the enclosing code unit, intermediate actions that access and/or update this state, and an end action to report diagnostic on the individual code units.
+  3. Additional File analyzers: Analyzers that read data from non-source text files included in the project.
 		
 **Contents:**
 	
@@ -28,3 +29,6 @@ Following sample analyzers, with simple unit tests, are provided:
      1. CodeBlockStartedAnalyzer: Analyzer to demonstrate code block wide analysis.
      2. CompilationStartedAnalyzer: Analyzer to demonstrate analysis within a compilation, for example analysis that depends on certain well-known symbol(s).
      3. CompilationStartedAnalyzerWithCompilationWideAnalysis: Analyzer to demonstrate compilation-wide analysis.
+  3. Additional File analyzers:
+     1. SimpleAdditionalFileAnalyzer: Demonstrates reading an additional file line-by-line and using the data in analysis.
+     2. XmlAdditionalFileAnalyzer: Demonstrates writing an additional file out to a `Stream` so that it can be read back as a structured document (in this case, XML).

--- a/docs/analyzers/Using Additional Files.md
+++ b/docs/analyzers/Using Additional Files.md
@@ -1,0 +1,231 @@
+Introduction
+============
+
+This document covers the following:
+
+* Uses of Additional Files
+* Passing Additional Files on the command line
+* Specifying an individual item as an `AdditionalFile` in an MSBuild project
+* Specifying an entire set of items as `AdditionalFile`s in an MSBuild project
+* Accessing and reading additional files through the `AnalyzerOptions` type
+* Includes sample analyzers that read additional files
+
+Uses
+====
+
+Sometimes an analyzer needs access to information that is not available through normal compiler inputs--source files, references, and options. To support these scenarios the C# and Visual Basic compilers can accept additional, non-source text files as inputs.
+
+On the Command Line
+===================
+
+On the command line, additional files can be passed using the `/additionalfile` option. For example:
+```
+csc.exe alpha.cs /additionalfile:terms.txt
+```
+
+In a Project File
+=================
+
+Passing an Individual File
+--------------------------
+
+To specify an individual project item as an additional file, set the item type to `AdditionalFile`:
+
+``` XML
+<ItemGroup>
+  <AdditionalFile Include="terms.txt" />
+</ItemGroup>
+```
+
+Passing a Group of Files
+------------------------
+
+Sometimes it isn't possible to change the item type, or a whole set of items need to be passed as additional files. In this situation you can update the `AdditionalFileItemNames` property to specify which item types to include. For example, if your analyzer needs access to all .resx files in the project, you can do the following:
+``` XML
+<PropertyGroup>
+  <!-- Update the property to include all EmbeddedResource files -->
+  <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+</PropertyGroup>
+<ItemGroup>
+  <!-- Existing resource file -->
+  <EmbeddedResource Include="Terms.resx">
+    ...
+  </EmbeddedResource>
+</ItemGroup>
+```
+
+Accessing Additional Files
+==========================
+
+The set of additional files can be accessed via the `Options` property of the context object passed to a diagnostic action. For example:
+```C#
+CompilationAnalysisContext context = ...;
+ImmutableArray<AdditionalText> additionFiles = context.Options.AdditionalFiles;
+```
+
+From an `AdditionalText` instance, you can access the path to the file or the contents as a `SourceText`:
+``` C#
+AdditionText additionalFile = ...;
+string path = additionalFile.Path;
+SourceText contents = additionaFile.GetText();
+```
+
+Samples
+=======
+
+Reading a File Line-by-Line
+---------------------------
+
+This sample reads a simple text file for a set of terms--one per line--that should not be used in type names.
+
+``` C#
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class CheckTermsAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "CheckTerms001";
+
+    private const string Title = "Type name contains invalid term";
+    private const string MessageFormat = "The term '{0}' is not allowed in a type name.";
+    private const string Category = "Policy";
+
+    private static DiagnosticDescriptor Rule =
+        new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterCompilationStartAction(compilationStartContext =>
+        {
+            // Find the file with the invalid terms.
+            ImmutableArray<AdditionalText> additionalFiles = compilationStartContext.Options.AdditionalFiles;
+            AdditionalText termsFile = additionalFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.txt"));
+
+            if (termsFile != null)
+            {
+                HashSet<string> terms = new HashSet<string>();
+
+                // Read the file line-by-line to get the terms.
+                SourceText fileText = termsFile.GetText(compilationStartContext.CancellationToken);
+                foreach (TextLine line in fileText.Lines)
+                {
+                    terms.Add(line.ToString());
+                }
+
+                // Check every named type for the invalid terms.
+                compilationStartContext.RegisterSymbolAction(symbolAnalysisContext =>
+                {
+                    INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                    string symbolName = namedTypeSymbol.Name;
+
+                    foreach (string term in terms)
+                    {
+                        if (symbolName.Contains(term))
+                        {
+                            symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], term));
+                        }
+                    }
+                },
+                SymbolKind.NamedType);
+            }
+        });
+    }
+}
+
+```
+
+Converting a File to a Stream
+-----------------------------
+
+In cases where an additional file contains structured data (e.g., XML or JSON) the line-by-line access provided by the `SourceText` may not be desirable. This sample demonstrates how to convert a `SourceText` to a `Stream` for consumption by other libraries.
+
+``` C#
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class CheckTermsXMLAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "CheckTerms001";
+
+    private const string Title = "Type name contains invalid term";
+    private const string MessageFormat = "The term '{0}' is not allowed in a type name.";
+    private const string Category = "Policy";
+
+    private static DiagnosticDescriptor Rule =
+        new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterCompilationStartAction(compilationStartContext =>
+        {
+            // Find the file with the invalid terms.
+            ImmutableArray<AdditionalText> additionalFiles = compilationStartContext.Options.AdditionalFiles;
+            AdditionalText termsFile = additionalFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.xml"));
+
+            if (termsFile != null)
+            {
+                HashSet<string> terms = new HashSet<string>();
+                SourceText fileText = termsFile.GetText(compilationStartContext.CancellationToken);
+
+                MemoryStream stream = new MemoryStream();
+                using (StreamWriter writer = new StreamWriter(stream))
+                {
+                    fileText.Write(writer);
+                }
+
+                // Read all the <Term> elements to get the terms.
+                XDocument document = XDocument.Load(stream);
+                foreach (XElement termElement in document.Descendants("Term"))
+                {
+                    terms.Add(termElement.Value);
+                }
+
+                // Check every named type for the invalid terms.
+                compilationStartContext.RegisterSymbolAction(symbolAnalysisContext =>
+                {
+                    INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                    string symbolName = namedTypeSymbol.Name;
+
+                    foreach (string term in terms)
+                    {
+                        if (symbolName.Contains(term))
+                        {
+                            symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], term));
+                        }
+                    }
+                },
+                SymbolKind.NamedType);
+            }
+        });
+    }
+}
+```

--- a/docs/analyzers/Using Additional Files.md
+++ b/docs/analyzers/Using Additional Files.md
@@ -159,7 +159,7 @@ In cases where an additional file contains structured data (e.g., XML or JSON) t
 <Terms>
   <Term>frob</Term>
   <Term>wizbang</Term>
-  <Term>orange</Term
+  <Term>orange</Term>
 </Terms>
 ```
 

--- a/docs/analyzers/Using Additional Files.md
+++ b/docs/analyzers/Using Additional Files.md
@@ -15,6 +15,8 @@ Uses
 
 Sometimes an analyzer needs access to information that is not available through normal compiler inputs--source files, references, and options. To support these scenarios the C# and Visual Basic compilers can accept additional, non-source text files as inputs.
 
+For example, an analyzer may enforce that a set of banned terms is not used within a project, or that every source file has a certain copyright header. The terms or copyright header could be passed to the analyzer as an additional file, rather than being hard-coded in the analyzer itself.
+
 On the Command Line
 ===================
 
@@ -29,11 +31,11 @@ In a Project File
 Passing an Individual File
 --------------------------
 
-To specify an individual project item as an additional file, set the item type to `AdditionalFile`:
+To specify an individual project item as an additional file, set the item type to `AdditionalFiles`:
 
 ``` XML
 <ItemGroup>
-  <AdditionalFile Include="terms.txt" />
+  <AdditionalFiles Include="terms.txt" />
 </ItemGroup>
 ```
 
@@ -151,7 +153,15 @@ public class CheckTermsAnalyzer : DiagnosticAnalyzer
 Converting a File to a Stream
 -----------------------------
 
-In cases where an additional file contains structured data (e.g., XML or JSON) the line-by-line access provided by the `SourceText` may not be desirable. This sample demonstrates how to convert a `SourceText` to a `Stream` for consumption by other libraries.
+In cases where an additional file contains structured data (e.g., XML or JSON) the line-by-line access provided by the `SourceText` may not be desirable. This sample demonstrates how to convert a `SourceText` to a `Stream` for consumption by other libraries. The terms file is assumed to have the following format:
+
+``` XML
+<Terms>
+  <Term>frob</Term>
+  <Term>wizbang</Term>
+  <Term>orange</Term
+</Terms>
+```
 
 ``` C#
 using System.Collections.Generic;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Helpers/DiagnosticResult.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Helpers/DiagnosticResult.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using System;
 
 namespace TestHelper

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Properties/AssemblyInfo.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CodeBlockAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CodeBlockAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CodeBlockStartedAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CodeBlockStartedAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationStartedAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationStartedAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationStartedAnalyzerWithCompilationWideAnalysisUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/CompilationStartedAnalyzerWithCompilationWideAnalysisUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SemanticModelAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SemanticModelAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SymbolAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SymbolAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SyntaxNodeAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SyntaxNodeAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SyntaxTreeAnalyzerUnitTests.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Tests/SyntaxTreeAnalyzerUnitTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace CSharpAnalyzers
+{
+    /// <summary>
+    /// Analyzer to demonstrate reading an additional file line-by-line.
+    /// It looks for an additional file named "Terms.txt" and extracts a set of
+    /// terms, one per line. It then detects type names that use those terms and
+    /// reports diagnostics.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    class SimpleAdditionalFileAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Title = "Type name contains invalid term";
+        private const string MessageFormat = "The term '{0}' is not allowed in a type name.";
+
+        private static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(
+                DiagnosticIds.SimpleAdditionalFileAnalyzerRuleId,
+                Title,
+                MessageFormat,
+                DiagnosticCategories.AdditionalFile,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return ImmutableArray.Create(Rule);
+            }
+        }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(compilationStartContext =>
+            {
+                // Find the additional file with the terms.
+                ImmutableArray<AdditionalText> additionFiles = compilationStartContext.Options.AdditionalFiles;
+                AdditionalText termsFile = additionFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.txt"));
+
+                if (termsFile != null)
+                {
+                    HashSet<string> terms = new HashSet<string>();
+
+                    // Read the file line-by-line to get the terms.
+                    SourceText fileText = termsFile.GetText(compilationStartContext.CancellationToken);
+                    foreach (TextLine line in fileText.Lines)
+                    {
+                        terms.Add(line.ToString());
+                    }
+
+                    // Check every named type for the invalid terms.
+                    compilationStartContext.RegisterSymbolAction(symbolAnalysisContext =>
+                    {
+                        INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                        string symbolName = namedTypeSymbol.Name;
+
+                        foreach (string term in terms)
+                        {
+                            if (symbolName.Contains(term))
+                            {
+                                symbolAnalysisContext.ReportDiagnostic(
+                                    Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], term));
+                            }
+                        }
+                    },
+                    SymbolKind.NamedType);
+                }
+            });
+        }
+    }
+}

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
@@ -42,8 +42,8 @@ namespace CSharpAnalyzers
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 // Find the additional file with the terms.
-                ImmutableArray<AdditionalText> additionFiles = compilationStartContext.Options.AdditionalFiles;
-                AdditionalText termsFile = additionFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.txt"));
+                ImmutableArray<AdditionalText> additionalFiles = compilationStartContext.Options.AdditionalFiles;
+                AdditionalText termsFile = additionalFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.txt"));
 
                 if (termsFile != null)
                 {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace CSharpAnalyzers
+{
+    /// <summary>
+    /// Analyzer to demonstrate reading an additional file line-by-line.
+    /// It looks for an additional file named "Terms.xml" and dumps it to a stream
+    /// so that it can be loaded into an <see cref="XDocument"/>. It then extracts
+    /// terms from the XML, detects type names that use those terms and reports
+    /// diagnostics on them.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    class XmlAdditionalFileAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Title = "Type name contains invalid term";
+        private const string MessageFormat = "The term '{0}' is not allowed in a type name.";
+
+        private static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(
+                DiagnosticIds.XmlAdditionalFileAnalyzerRuleId,
+                Title,
+                MessageFormat,
+                DiagnosticCategories.AdditionalFile,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return ImmutableArray.Create(Rule);
+            }
+        }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(compilationStartContext =>
+            {
+                // Find the additional file with the terms.
+                ImmutableArray<AdditionalText> additionFiles = compilationStartContext.Options.AdditionalFiles;
+                AdditionalText termsFile = additionFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.xml"));
+
+                if (termsFile != null)
+                {
+                    HashSet<string> terms = new HashSet<string>();
+                    SourceText fileText = termsFile.GetText(compilationStartContext.CancellationToken);
+
+                    // Write the additional file back to a stream.
+                    MemoryStream stream = new MemoryStream();
+                    using (StreamWriter writer = new StreamWriter(stream))
+                    {
+                        fileText.Write(writer);
+                    }
+
+                    // Read all the <Term> elements to get the terms.
+                    XDocument document = XDocument.Load(stream);
+                    foreach (XElement termElement in document.Descendants("Term"))
+                    {
+                        terms.Add(termElement.Value);
+                    }
+
+                    // Check every named type for the invalid terms.
+                    compilationStartContext.RegisterSymbolAction(symbolAnalysisContext =>
+                    {
+                        INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                        string symbolName = namedTypeSymbol.Name;
+
+                        foreach (string term in terms)
+                        {
+                            if (symbolName.Contains(term))
+                            {
+                                symbolAnalysisContext.ReportDiagnostic(
+                                    Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], term));
+                            }
+                        }
+                    },
+                    SymbolKind.NamedType);
+                }
+            });
+        }
+    }
+}

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace CSharpAnalyzers
 {
     /// <summary>
-    /// Analyzer to demonstrate reading an additional file line-by-line.
+    /// Analyzer to demonstrate reading an additional file with a structured format.
     /// It looks for an additional file named "Terms.xml" and dumps it to a stream
     /// so that it can be loaded into an <see cref="XDocument"/>. It then extracts
     /// terms from the XML, detects type names that use those terms and reports
@@ -44,8 +44,8 @@ namespace CSharpAnalyzers
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 // Find the additional file with the terms.
-                ImmutableArray<AdditionalText> additionFiles = compilationStartContext.Options.AdditionalFiles;
-                AdditionalText termsFile = additionFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.xml"));
+                ImmutableArray<AdditionalText> additionalFiles = compilationStartContext.Options.AdditionalFiles;
+                AdditionalText termsFile = additionalFiles.FirstOrDefault(file => Path.GetFileName(file.Path).Equals("Terms.xml"));
 
                 if (termsFile != null)
                 {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
@@ -78,8 +78,8 @@
     <PackagesDir Condition="'$(PackagesDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\..\..\packages'))</PackagesDir>
   </PropertyGroup>
   <ItemGroup>
-    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\portable50\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\portable50\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
@@ -32,6 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AdditionalFileAnalyzers\SimpleAdditionalFileAnalyzer.cs" />
+    <Compile Include="AdditionalFileAnalyzers\XmlAdditionalFileAnalyzer.cs" />
     <Compile Include="DiagnosticCategories.cs" />
     <Compile Include="DiagnosticIds.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticCategories.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticCategories.cs
@@ -1,4 +1,6 @@
-﻿namespace CSharpAnalyzers
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace CSharpAnalyzers
 {
     public static class DiagnosticCategories
     {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticCategories.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticCategories.cs
@@ -4,5 +4,6 @@
     {
         public const string Stateless = "SampleStatelessAnalyzers";
         public const string Stateful = "SampleStatefulAnalyzers";
+        public const string AdditionalFile = "SampleAdditionalFileAnalyzers";
     }
 }

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticIds.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticIds.cs
@@ -1,4 +1,6 @@
-﻿namespace CSharpAnalyzers
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace CSharpAnalyzers
 {
     public static class DiagnosticIds
     {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticIds.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/DiagnosticIds.cs
@@ -14,5 +14,9 @@
         public const string CodeBlockStartedAnalyzerRuleId = "CSS0101";
         public const string CompilationStartedAnalyzerRuleId = "CSS0102";
         public const string CompilationStartedAnalyzerWithCompilationWideAnalysisRuleId = "CSS0103";
+
+        // Additional File analyzer IDs.
+        public const string SimpleAdditionalFileAnalyzerRuleId = "CSS0201";
+        public const string XmlAdditionalFileAnalyzerRuleId = "CSS0202";
     }
 }

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/Properties/AssemblyInfo.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzerWithCompilationWideAnalysis.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzerWithCompilationWideAnalysis.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CompilationAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CompilationAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SemanticModelAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SemanticModelAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SymbolAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SymbolAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SyntaxNodeAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SyntaxNodeAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SyntaxTreeAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/SyntaxTreeAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis;

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Helpers/DiagnosticResult.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Helpers/DiagnosticResult.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 
 Namespace TestHelper
 

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Text

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CodeBlockAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CodeBlockAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CodeBlockStartedAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CodeBlockStartedAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationStartedAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationStartedAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationStartedAnalyzerWithCompilationWideAnalysisUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/CompilationStartedAnalyzerWithCompilationWideAnalysisUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SemanticModelAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SemanticModelAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SymbolAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SymbolAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SyntaxNodeAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SyntaxNodeAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports TestHelper

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SyntaxTreeAnalyzerUnitTests.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Tests/SyntaxTreeAnalyzerUnitTests.vb
@@ -1,4 +1,6 @@
-﻿
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Verifiers/DiagnosticVerifier.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/Verifiers/DiagnosticVerifier.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports System.Text

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.vb
@@ -1,0 +1,71 @@
+﻿Imports System.IO
+
+Namespace BasicAnalyzers
+
+    ''' <summary>
+    ''' Analyzer to demonstrate reading an additional file line-by-line.
+    ''' It looks for an additional file named "Terms.txt" and extracts a set of
+    ''' terms, one per line. It then detects type names that use those terms and
+    ''' reports diagnostics.
+    ''' </summary>
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic, LanguageNames.CSharp)>
+    Public Class SimpleAdditionalFileAnalyzer
+        Inherits DiagnosticAnalyzer
+
+        Private Const Title As String = "Type name contains invalid term"
+        Private Const MessageFormat As String = "The term '{0}' is not allowed in a type name."
+
+        Private Shared Rule As DiagnosticDescriptor =
+            New DiagnosticDescriptor(
+                DiagnosticIds.SimpleAdditionalFileAnalyzerRuleId,
+                Title,
+                MessageFormat,
+                DiagnosticCategories.AdditionalFile,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault:=True)
+
+        Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+            Get
+                Return ImmutableArray.Create(Rule)
+            End Get
+        End Property
+
+        Public Overrides Sub Initialize(context As AnalysisContext)
+            context.RegisterCompilationStartAction(
+                Sub(compilationStartContext)
+                    ' Find the additional file with the terms.
+                    Dim additionalFiles As ImmutableArray(Of AdditionalText) = compilationStartContext.Options.AdditionalFiles
+                    Dim termsFile As AdditionalText = additionalFiles.FirstOrDefault(
+                        Function(file)
+                            Return Path.GetFileName(file.Path).Equals("Terms.txt")
+                        End Function)
+
+                    If termsFile IsNot Nothing Then
+                        Dim terms As HashSet(Of String) = New HashSet(Of String)
+
+                        ' Read the file line-by-line to get the terms.
+                        Dim fileText As SourceText = termsFile.GetText(compilationStartContext.CancellationToken)
+                        For Each line As TextLine In fileText.Lines
+                            terms.Add(line.ToString())
+                        Next
+
+                        ' Check every named type for the invalid terms.
+                        compilationStartContext.RegisterSymbolAction(
+                            Sub(symbolAnalysisContext)
+                                Dim namedTypeSymbol As INamedTypeSymbol = DirectCast(symbolAnalysisContext.Symbol, INamedTypeSymbol)
+                                Dim symbolName As String = namedTypeSymbol.Name
+
+                                For Each term As String In terms
+                                    If symbolName.Contains(term) Then
+                                        symbolAnalysisContext.ReportDiagnostic(
+                                        Diagnostic.Create(Rule, namedTypeSymbol.Locations(0), term))
+                                    End If
+                                Next
+                            End Sub,
+                            SymbolKind.NamedType)
+                    End If
+
+                End Sub)
+        End Sub
+    End Class
+End Namespace

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/SimpleAdditionalFileAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports System.IO
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.IO
 
 Namespace BasicAnalyzers
 

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.vb
@@ -1,0 +1,79 @@
+﻿Imports System.IO
+
+Namespace BasicAnalyzers
+
+    ''' <summary>
+    ''' Analyzer to demonstrate reading an additional file with a structed format.
+    ''' It looks for an additional file named "Terms.xml" and dumps it to a stream
+    ''' so that it can be loaded into an <see cref="XDocument"/>. It then extracts
+    ''' terms from the XML, detects type names that use those terms and reports
+    ''' diagnostics on them.
+    ''' </summary>
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic, LanguageNames.CSharp)>
+    Public Class XmlAdditionalFileAnalyzer
+        Inherits DiagnosticAnalyzer
+
+        Private Const Title As String = "Type name contains invalid term"
+        Private Const MessageFormat As String = "The term '{0}' is not allowed in a type name."
+
+        Private Shared Rule As DiagnosticDescriptor =
+            New DiagnosticDescriptor(
+                DiagnosticIds.XmlAdditionalFileAnalyzerRuleId,
+                Title,
+                MessageFormat,
+                DiagnosticCategories.AdditionalFile,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault:=True)
+
+        Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+            Get
+                Return ImmutableArray.Create(Rule)
+            End Get
+        End Property
+
+        Public Overrides Sub Initialize(context As AnalysisContext)
+            context.RegisterCompilationStartAction(
+                Sub(compilationStartContext)
+                    ' Find the additional file with the terms.
+                    Dim additionalFiles As ImmutableArray(Of AdditionalText) = compilationStartContext.Options.AdditionalFiles
+                    Dim termsFile As AdditionalText = additionalFiles.FirstOrDefault(
+                        Function(file)
+                            Return Path.GetFileName(file.Path).Equals("Terms.txt")
+                        End Function)
+
+                    If termsFile IsNot Nothing Then
+                        Dim terms As HashSet(Of String) = New HashSet(Of String)
+                        Dim fileText As SourceText = termsFile.GetText(compilationStartContext.CancellationToken)
+
+                        ' Write the additional file back to a stream.
+                        Dim stream As MemoryStream = New MemoryStream()
+                        Using writer As StreamWriter = New StreamWriter(stream)
+                            fileText.Write(writer)
+                        End Using
+
+                        ' Read all the <Term> elements to get the terms.
+                        Dim document As XDocument = XDocument.Load(stream)
+                        For Each termElement As XElement In document.Descendants("Term")
+                            terms.Add(termElement.Value)
+                        Next
+
+                        ' Check every named type for the invalid terms.
+                        compilationStartContext.RegisterSymbolAction(
+                            Sub(symbolAnalysisContext)
+                                Dim namedTypeSymbol As INamedTypeSymbol = DirectCast(symbolAnalysisContext.Symbol, INamedTypeSymbol)
+                                Dim symbolName As String = namedTypeSymbol.Name
+
+                                For Each term As String In terms
+                                    If symbolName.Contains(term) Then
+                                        symbolAnalysisContext.ReportDiagnostic(
+                                        Diagnostic.Create(Rule, namedTypeSymbol.Locations(0), term))
+                                    End If
+                                Next
+                            End Sub,
+                            SymbolKind.NamedType)
+                    End If
+
+                End Sub)
+        End Sub
+    End Class
+End Namespace

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/AdditionalFileAnalyzers/XmlAdditionalFileAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports System.IO
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.IO
 
 Namespace BasicAnalyzers
 

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
@@ -115,8 +115,8 @@
     <PackagesDir Condition="'$(PackagesDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\..\..\packages'))</PackagesDir>
   </PropertyGroup>
   <ItemGroup>
-    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\portable50\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\portable50\vb\Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll" />
+    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\vb\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="$(PackagesDir)\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\vb\Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
@@ -68,6 +68,8 @@
     <Import Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdditionalFileAnalyzers\SimpleAdditionalFileAnalyzer.vb" />
+    <Compile Include="AdditionalFileAnalyzers\XmlAdditionalFileAnalyzer.vb" />
     <Compile Include="DiagnosticCategories.vb" />
     <Compile Include="DiagnosticIds.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticCategories.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticCategories.vb
@@ -2,5 +2,6 @@
     Public Module DiagnosticCategories
         Public Const Stateless As String = "SampleStatelessAnalyzers"
         Public Const Stateful As String = "SampleStatefulAnalyzers"
+        Public Const AdditionalFile As String = "SampleAdditionalFileAnalyzers"
     End Module
 End Namespace

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticCategories.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticCategories.vb
@@ -1,4 +1,6 @@
-﻿Namespace BasicAnalyzers
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace BasicAnalyzers
     Public Module DiagnosticCategories
         Public Const Stateless As String = "SampleStatelessAnalyzers"
         Public Const Stateful As String = "SampleStatefulAnalyzers"

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticIds.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticIds.vb
@@ -12,5 +12,9 @@
         Public Const CodeBlockStartedAnalyzerRuleId As String = "VBS0101"
         Public Const CompilationStartedAnalyzerRuleId As String = "VBS0102"
         Public Const CompilationStartedAnalyzerWithCompilationWideAnalysisRuleId As String = "VBS0103"
+
+        ' Additional File analyzer IDs.
+        Public Const SimpleAdditionalFileAnalyzerRuleId = "VBS0201"
+        Public Const XmlAdditionalFileAnalyzerRuleId = "VBS0202"
     End Module
 End Namespace

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticIds.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/DiagnosticIds.vb
@@ -1,4 +1,6 @@
-﻿Namespace BasicAnalyzers
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace BasicAnalyzers
     Public Module DiagnosticIds
         ' Stateless analyzer IDs.
         Public Const SymbolAnalyzerRuleId As String = "VBS0001"

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzerWithCompilationWideAnalysis.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CompilationStartedAnalyzerWithCompilationWideAnalysis.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/CompilationAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/CompilationAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SemanticModelAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SemanticModelAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports System.IO
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.IO
 Imports My.Resources
 
 Namespace BasicAnalyzers

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SymbolAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SymbolAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SyntaxNodeAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SyntaxNodeAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports My.Resources
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports My.Resources
 
 Namespace BasicAnalyzers
     ''' <summary>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SyntaxTreeAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatelessAnalyzers/SyntaxTreeAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports System.IO
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.IO
 Imports My.Resources
 
 Namespace BasicAnalyzers


### PR DESCRIPTION
This commit covers the following:

* Uses of Additional Files
* Passing Additional Files on the command line
* Specifying an individual item as an `AdditionalFile` in an MSBuild project
* Specifying an entire set of items as `AdditionalFile`s in an MSBuild project
* Accessing and reading additional files through the `AnalyzerOptions` type
* Includes sample analyzers that read additional files

Fixes #3543.