### PR TITLE
Reconcile SemanticModel behavior for imports/using aliases with errors across VB and C#.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1699,15 +1699,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var builder = ArrayBuilder<Symbol>.GetInstance();
                     foreach (var s in symbols)
                     {
-                        var originalErrorSymbol = s.OriginalDefinition as ErrorTypeSymbol;
-                        if ((object)originalErrorSymbol != null)
-                        {
-                            builder.AddRange(originalErrorSymbol.CandidateSymbols);
-                        }
-                        else
-                        {
-                            builder.Add(s);
-                        }
+                        AddUnwrappingErrorTypes(builder, s);
                     }
 
                     symbols = builder.ToImmutableAndFree();
@@ -1727,6 +1719,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return SymbolInfo.None;
+        }
+
+        private static void AddUnwrappingErrorTypes(ArrayBuilder<Symbol> builder, Symbol s)
+        {
+            var originalErrorSymbol = s.OriginalDefinition as ErrorTypeSymbol;
+            if ((object)originalErrorSymbol != null)
+            {
+                builder.AddRange(originalErrorSymbol.CandidateSymbols);
+            }
+            else
+            {
+                builder.Add(s);
+            }
         }
 
         private static bool IsUserDefinedTrueOrFalse(BoundUnaryOperator @operator)
@@ -1972,7 +1977,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<Symbol> builder = ArrayBuilder<Symbol>.GetInstance();
             foreach (Symbol sym in symbols)
             {
-                builder.Add(UnwrapAlias(sym));
+                // Caas clients don't want ErrorTypeSymbol in the symbols, but the best guess
+                // instead. If no best guess, then nothing is returned.
+                AddUnwrappingErrorTypes(builder, UnwrapAlias(sym));
             }
 
             return builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
@@ -320,7 +320,7 @@ namespace prog
             var discarded = comp.GetDiagnostics();
         }
 
-        [Fact, WorkItem(2805, "https://github.com/dotnet/roslyn/issues/2805")]
+        [ClrOnlyFact, WorkItem(2805, "https://github.com/dotnet/roslyn/issues/2805")]
         public void AliasWithAnError()
         {
             var text =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Source
@@ -318,5 +319,51 @@ namespace prog
             CSharpCompilation comp = CreateCompilationWithMscorlib(syntaxTree);
             var discarded = comp.GetDiagnostics();
         }
+
+        [Fact, WorkItem(2805, "https://github.com/dotnet/roslyn/issues/2805")]
+        public void AliasWithAnError()
+        {
+            var text =
+@"
+namespace NS
+{
+    using Short = LongNamespace;
+    class Test
+    {
+        public object Method1()
+        {
+            return (new Short.MyClass()).Prop;
+        }
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib(text);
+
+            compilation.VerifyDiagnostics(
+    // (4,19): error CS0246: The type or namespace name 'LongNamespace' could not be found (are you missing a using directive or an assembly reference?)
+    //     using Short = LongNamespace;
+    Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "LongNamespace").WithArguments("LongNamespace").WithLocation(4, 19)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Short").Skip(1).Single();
+
+            Assert.Equal("Short.MyClass", node.Parent.ToString());
+
+            var model = compilation.GetSemanticModel(tree);
+
+            var alias = model.GetAliasInfo(node);
+            Assert.Equal("Short=LongNamespace", alias.ToTestDisplayString());
+            Assert.Equal(SymbolKind.ErrorType, alias.Target.Kind);
+            Assert.Equal("LongNamespace", alias.Target.ToTestDisplayString());
+
+            var symbolInfo = model.GetSymbolInfo(node);
+
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If aliasTarget.Kind <> SymbolKind.ErrorType Then
                             Dim useSiteErrorInfo As DiagnosticInfo = aliasTarget.GetUseSiteErrorInfo()
 
-                            If ReportUseSiteErrorForAlias(useSiteErrorInfo) Then
+                            If ShouldReportUseSiteErrorForAlias(useSiteErrorInfo) Then
                                 Binder.ReportDiagnostic(diagBag, aliasImportSyntax, useSiteErrorInfo)
                             End If
                         End If
@@ -133,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' Checks use site error and returns True in case it should be reported for the alias. 
             ''' In current implementation checks for errors #36924 and #36925
             ''' </summary>
-            Private Shared Function ReportUseSiteErrorForAlias(useSiteErrorInfo As DiagnosticInfo) As Boolean
+            Private Shared Function ShouldReportUseSiteErrorForAlias(useSiteErrorInfo As DiagnosticInfo) As Boolean
                 Return useSiteErrorInfo IsNot Nothing AndAlso
                        useSiteErrorInfo.Code <> ERRID.ERR_CannotUseGenericTypeAcrossAssemblyBoundaries AndAlso
                        useSiteErrorInfo.Code <> ERRID.ERR_CannotUseGenericBaseTypeAcrossAssemblyBoundaries

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
@@ -90,56 +90,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
                 End If
 
-                If aliasTarget.Kind <> SymbolKind.ErrorType Then
-                    Dim aliasIdentifier = aliasImportSyntax.Alias.Identifier
-                    Dim aliasText = aliasIdentifier.ValueText
-                    ' Parser checks for type characters on alias text, so don't need to check again here.
+                Dim aliasIdentifier = aliasImportSyntax.Alias.Identifier
+                Dim aliasText = aliasIdentifier.ValueText
+                ' Parser checks for type characters on alias text, so don't need to check again here.
 
-                    ' Check for duplicate symbol.
-                    If data.Aliases.ContainsKey(aliasText) Then
-                        Binder.ReportDiagnostic(diagBag, aliasIdentifier, ERRID.ERR_DuplicateNamedImportAlias1, aliasText)
-                    Else
-                        ' Make sure that the Import's alias doesn't have the same name as a type or a namespace in the global namespace
-                        Dim conflictsWith = binder.Compilation.GlobalNamespace.GetMembers(aliasText)
+                ' Check for duplicate symbol.
+                If data.Aliases.ContainsKey(aliasText) Then
+                    Binder.ReportDiagnostic(diagBag, aliasIdentifier, ERRID.ERR_DuplicateNamedImportAlias1, aliasText)
+                Else
+                    ' Make sure that the Import's alias doesn't have the same name as a type or a namespace in the global namespace
+                    Dim conflictsWith = binder.Compilation.GlobalNamespace.GetMembers(aliasText)
 
-                        If Not conflictsWith.IsEmpty Then
-                            ' TODO: Note that symbol's name in this error message is supposed to include Class/Namespace word at the beginning.
-                            '       Might need to use special format for that parameter in the error message. 
-                            Binder.ReportDiagnostic(diagBag,
+                    If Not conflictsWith.IsEmpty Then
+                        ' TODO: Note that symbol's name in this error message is supposed to include Class/Namespace word at the beginning.
+                        '       Might need to use special format for that parameter in the error message. 
+                        Binder.ReportDiagnostic(diagBag,
                                                     aliasImportSyntax,
                                                     ERRID.ERR_ImportAliasConflictsWithType2,
                                                     aliasText,
                                                     conflictsWith(0))
-                        Else
-                            ' NOTE: we are mimicing Dev10 behavior where referencing type symbol in 
-                            '       alias 'declaration' fails in case the symbol has errors.
+                    Else
+                        If aliasTarget.Kind <> SymbolKind.ErrorType Then
                             Dim useSiteErrorInfo As DiagnosticInfo = aliasTarget.GetUseSiteErrorInfo()
-                            If Not AllowAliasWithUseSiteError(useSiteErrorInfo) Then
+
+                            If ReportUseSiteErrorForAlias(useSiteErrorInfo) Then
                                 Binder.ReportDiagnostic(diagBag, aliasImportSyntax, useSiteErrorInfo)
-                                ' NOTE: Do not create an alias!!!
-
-                            Else
-                                Dim aliasSymbol = New AliasSymbol(binder.Compilation,
-                                                                 binder.ContainingNamespaceOrType,
-                                                                 aliasText,
-                                                                 aliasTarget,
-                                                                 If(binder.BindingLocation = BindingLocation.ProjectImportsDeclaration, NoLocation.Singleton, aliasIdentifier.GetLocation()))
-
-                                data.AddAlias(binder.GetSyntaxReference(aliasImportSyntax), aliasText, aliasSymbol, aliasImportSyntax.SpanStart)
                             End If
                         End If
+
+                        Dim aliasSymbol = New AliasSymbol(binder.Compilation,
+                                                             binder.ContainingNamespaceOrType,
+                                                             aliasText,
+                                                             aliasTarget,
+                                                             If(binder.BindingLocation = BindingLocation.ProjectImportsDeclaration, NoLocation.Singleton, aliasIdentifier.GetLocation()))
+
+                        data.AddAlias(binder.GetSyntaxReference(aliasImportSyntax), aliasText, aliasSymbol, aliasImportSyntax.SpanStart)
                     End If
                 End If
             End Sub
 
             ''' <summary>
-            ''' Checks use site error and returns True in case the alias should still be created for the
-            ''' type with this site error. In current implementation checks for errors ##36924, 36925
+            ''' Checks use site error and returns True in case it should be reported for the alias. 
+            ''' In current implementation checks for errors #36924 and #36925
             ''' </summary>
-            Private Shared Function AllowAliasWithUseSiteError(useSiteErrorInfo As DiagnosticInfo) As Boolean
-                Return useSiteErrorInfo Is Nothing OrElse
-                        useSiteErrorInfo.Code = ERRID.ERR_CannotUseGenericTypeAcrossAssemblyBoundaries OrElse
-                        useSiteErrorInfo.Code = ERRID.ERR_CannotUseGenericBaseTypeAcrossAssemblyBoundaries
+            Private Shared Function ReportUseSiteErrorForAlias(useSiteErrorInfo As DiagnosticInfo) As Boolean
+                Return useSiteErrorInfo IsNot Nothing AndAlso
+                       useSiteErrorInfo.Code <> ERRID.ERR_CannotUseGenericTypeAcrossAssemblyBoundaries AndAlso
+                       useSiteErrorInfo.Code <> ERRID.ERR_CannotUseGenericBaseTypeAcrossAssemblyBoundaries
             End Function
 
             ' Bind a members imports clause. If it is OK, and also unique, add it to the members imports set.

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
@@ -1628,13 +1628,19 @@ Imports VB6 = Microsoft.VisualBasic
     </file>
 </compilation>, options)
 
+            compilation.AssertTheseDiagnostics(<expected>
+BC40056: Namespace or type specified in the Imports 'Microsoft.VisualBasic' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
+Imports VB6 = Microsoft.VisualBasic
+              ~~~~~~~~~~~~~~~~~~~~~
+                                               </expected>)
+
             Dim treeA = CompilationUtils.GetTree(compilation, "a.vb")
             Dim bindingsA = compilation.GetSemanticModel(treeA)
             Dim node = treeA.GetCompilationUnitRoot().FindToken(treeA.GetCompilationUnitRoot().ToFullString().IndexOf("VB6", StringComparison.Ordinal)).Parent.Parent
             Dim symbol = bindingsA.GetDeclaredSymbol(node)
 
             Assert.Equal(SyntaxKind.SimpleImportsClause, node.Kind)
-            Assert.Null(symbol)
+            Assert.Equal("VB6=Microsoft.VisualBasic", symbol.ToTestDisplayString())
 
         End Sub
 


### PR DESCRIPTION
This change is related to issue #2805.

When an alias target cannot be resolved,
GetSymbolInfo(<alias reference node>) – returns Nothing in VB, but returns an ErrorTypeSymbol in C#
GetAliasInfo(<alias reference node>) – returns Nothing in VB, but returns corresponding AliasSymbol in C#.

GetSymbolInfo should never return error types, so VB behavior is correct and this change adjusts C# behavior accordingly.
GetAliasInfo should return an AliasSymbol even if the alias target cannot be resolved, so C# behavior is correct. VB behavior was caused by the fact that, if target couldn’t be resolved, the AliasSymbol wasn’t even created. This change ensures that the AliasSymbols are created.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.