### PR TITLE
Introduced NewLinesForBracesInProperties c# formatting option.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -77,6 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
         public static readonly Option<bool> NewLinesForBracesInMethods = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInMethods", defaultValue: true);
 
+        public static readonly Option<bool> NewLinesForBracesInProperties = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInProperties", defaultValue: true);
+
         public static readonly Option<bool> NewLinesForBracesInAnonymousMethods = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInAnonymousMethods", defaultValue: true);
 
         public static readonly Option<bool> NewLinesForBracesInControlBlocks = new Option<bool>(NewLineFormattingFeatureName, "NewLinesForBracesInControlBlocks", defaultValue: true);

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -88,7 +88,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null &&
                (currentTokenParentParent is MemberDeclarationSyntax || currentTokenParentParent is AccessorDeclarationSyntax))
             {
-                if (!optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
+                if (!optionSet.GetOption(currentTokenParentParent is BasePropertyDeclarationSyntax || currentTokenParentParent is AccessorDeclarationSyntax ?
+                    CSharpFormattingOptions.NewLinesForBracesInProperties : CSharpFormattingOptions.NewLinesForBracesInMethods))
                 {
                     operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
                 }
@@ -257,7 +258,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.Kind() == SyntaxKind.OpenBraceToken &&
                 currentTokenParentParent != null && (currentTokenParentParent is MemberDeclarationSyntax || currentTokenParentParent is AccessorDeclarationSyntax))
             {
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
+                if (optionSet.GetOption(currentTokenParentParent is BasePropertyDeclarationSyntax || currentTokenParentParent is AccessorDeclarationSyntax ?
+                    CSharpFormattingOptions.NewLinesForBracesInProperties : CSharpFormattingOptions.NewLinesForBracesInMethods))
                 {
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6249,4 +6249,38 @@ class Program
             AssertFormat(code, code);
         }
     }
+
+    [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+    public void NewLinesForBracesInPropertiesTest()
+    {
+        var changingOptions = new Dictionary<OptionKey, object>();
+        changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInProperties, false);
+        AssertFormat(@"class Class2
+{
+    int Foo
+    {
+        get
+        {
+            return 1;
+        }
+    }
+
+    int MethodFoo()
+    {
+        return 42; 
+    }
+}", @"class Class2
+{
+    int Foo {
+        get {
+            return 1;
+        }
+    }
+
+    int MethodFoo()
+    {
+        return 42; 
+    }
+}", false, changingOptions);
+    }
 }


### PR DESCRIPTION
Allows formatting for property like constructs to be independent from method like constructs.

Fixes issue #84
https://github.com/dotnet/roslyn/issues/84