### PR TITLE
Use a JSON serializer for serializing strings to errorlog file

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -126,7 +126,7 @@ public class C
       }}
     }}
   ]
-}}", sourceFile);
+}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);
@@ -163,7 +163,7 @@ public class C
             var actualOutput = File.ReadAllText(errorLogFile).Trim();
 
             var expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd);
-            var expectedIssues = AnalyzerForErrorLogTest.GetExpectedErrorLogIssuesText(cmd.Compilation, outputFilePath);
+            var expectedIssues = AnalyzerForErrorLogTest.GetExpectedErrorLogIssuesText(cmd.Compilation);
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);
 

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Runtime.Serialization.Json;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -26,6 +27,8 @@ namespace Microsoft.CodeAnalysis
         private const char listEndChar = ']';
 
         private readonly StreamWriter _writer;
+        private readonly DataContractJsonSerializer _jsonStringSerializer;
+
         private string _currentIndent;
         private bool _reportedAnyIssues;
 
@@ -35,6 +38,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(stream.Position == 0);
 
             _writer = new StreamWriter(stream);
+            _jsonStringSerializer = new DataContractJsonSerializer(typeof(string));
             _currentIndent = string.Empty;
             _reportedAnyIssues = false;
 
@@ -272,7 +276,8 @@ namespace Microsoft.CodeAnalysis
 
         private void WriteValue(string value)
         {
-            _writer.Write($"\"{value}\"");
+            _writer.Flush();
+            _jsonStringSerializer.WriteObject(_writer.BaseStream, value);
         }
 
         private void WriteValue(int value)

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -132,7 +132,7 @@ End Class
       }}
     }}
   ]
-}}", sourceFilePath, Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)
@@ -174,7 +174,7 @@ End Class
             Dim actualOutput = File.ReadAllText(errorLogFile).Trim()
 
             Dim expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd)
-            Dim expectedIssues = AnalyzerForErrorLogTest.GetExpectedErrorLogIssuesText(cmd.Compilation, outputFilePath)
+            Dim expectedIssues = AnalyzerForErrorLogTest.GetExpectedErrorLogIssuesText(cmd.Compilation)
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)

--- a/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -85,11 +86,12 @@ namespace Microsoft.CodeAnalysis
                 return expectedText;
             }
 
-            public static string GetExpectedErrorLogIssuesText(Compilation compilation, string outputFilePath)
+            public static string GetExpectedErrorLogIssuesText(Compilation compilation)
             {
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
+                var filePath = EscapeDirectorySeparatorChar(tree.FilePath);
 
                 return @"
   ""issues"": [
@@ -99,7 +101,7 @@ namespace Microsoft.CodeAnalysis
         {
           ""analysisTarget"": [
             {
-              ""uri"": """ + tree.FilePath + @""",
+              ""uri"": """ + filePath + @""",
               ""region"": {
                 ""startLine"": " + expectedLineSpan.StartLinePosition.Line + @",
                 ""startColumn"": " + expectedLineSpan.StartLinePosition.Character + @",
@@ -145,6 +147,10 @@ namespace Microsoft.CodeAnalysis
 }";
             }
 
+            public static string EscapeDirectorySeparatorChar(string input)
+            {
+                return input.Replace(Path.DirectorySeparatorChar.ToString(), @"\" + Path.DirectorySeparatorChar);
+            }
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]


### PR DESCRIPTION
Fixes #3337 (errorlog JSON output should escape backslashes)