### PR TITLE
Fix DeclarePublicAPIAnalyzer

### DIFF
--- a/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Diagnostics/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -89,7 +89,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             MethodKind.EventRemove
         };
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DeclareNewApiRule, RemoveDeletedApiRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DeclareNewApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType);
 
         public override void Initialize(AnalysisContext context)
         {


### PR DESCRIPTION
The analyzer can report three different diagnostics, but currently only
returns two from the `SupportedDiagnostics` property.

This is the first step in addressing #3626. The second step is moving to a new build of the Roslyn diagnostics once it has been checked in.