### PR TITLE
Remove contradictory ProjectReference properties

### DIFF
--- a/src/Diagnostics/FxCop/Setup/AnalyzerPowerPack.Setup.csproj
+++ b/src/Diagnostics/FxCop/Setup/AnalyzerPowerPack.Setup.csproj
@@ -64,7 +64,6 @@
     <ProjectReference Include="..\Core\AnalyzerPowerPack.Common.csproj">
       <Project>{36755424-5267-478c-9434-37a507e22711}</Project>
       <Name>AnalyzerPowerPack.Common</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
@@ -72,7 +71,6 @@
     <ProjectReference Include="..\CSharp\AnalyzerPowerPack.CSharp.csproj">
       <Project>{3ba13187-2a3b-4b08-9199-c11fda1d5ad0}</Project>
       <Name>AnalyzerPowerPack.CSharp</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>

--- a/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
@@ -98,7 +98,6 @@
     <ProjectReference Include="..\..\Interactive\Features\InteractiveFeatures.csproj">
       <Project>{8E2A252E-A140-45A6-A81A-2652996EA589}</Project>
       <Name>InteractiveFeatures</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
@@ -106,7 +105,6 @@
     <ProjectReference Include="..\InteractiveServices\VisualStudioInteractiveServices.csproj">
       <Project>{A31228BB-F05C-4D4A-B98A-0E681D876B7C}</Project>
       <Name>VisualStudioInteractiveServices</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>


### PR DESCRIPTION
It doesn't make sense to have both ReferenceOutputAssembly=false and
IncludeOutputGroupsInVSIX=BuildProjectOutputGroup.  (The upshot is that
the affected references end up in the VSIX unsigned.)