### PR TITLE
C# SemanticModel.GetSymbolInfo - Properly handle explicit method group conversions.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
@@ -1568,6 +1568,11 @@ Module Program
         Dim v5 = F2(0) 'BIND13:"F2"
 
         x = C1.C()     'BIND14:"C1.C"
+
+        d = CType(addressof C1.B, Func(of byte)) 'BIND15:"C1.B"
+        d = DirectCast(addressof C1.B, Func(of byte)) 'BIND16:"C1.B"
+        d = TryCast(addressof C1.B, Func(of byte)) 'BIND17:"C1.B"
+
     End Sub
 
     Function F() As Func(Of Integer, Integer)
@@ -1588,6 +1593,21 @@ Module Program
 End Module
     </file>
     </compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC35000: Requested operation is not available because the runtime library function 'Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute..ctor' is not defined.
+Module Program
+       ~~~~~~~
+BC30454: Expression is not a method.
+        C1.A     'BIND:"C1.A"
+        ~~~~
+BC30545: Property access must assign to the property or use its value.
+        C1.C     'BIND2:"C1.C"
+        ~~~~
+BC42104: Variable 'o' is used before it has been assigned a value. A null reference exception could result at runtime.
+        Dim c = o.ToString(0) 'BIND7:"o.ToString"
+                ~
+                                               </expected>)
 
             Dim model = GetSemanticModel(compilation, "a.vb")
             Dim expressionSyntax = CompilationUtils.FindBindingText(Of MemberAccessExpressionSyntax)(compilation, "a.vb", 0)
@@ -1689,6 +1709,27 @@ End Module
             expressionSyntax = CompilationUtils.FindBindingText(Of MemberAccessExpressionSyntax)(compilation, "a.vb", 14)
             symbolInfo = model.GetSymbolInfo(expressionSyntax)
             Assert.Equal("C", symbolInfo.Symbol.Name)
+            typeInfo = model.GetTypeInfo(expressionSyntax)
+            Assert.Null(typeInfo.Type)
+
+            expressionSyntax = CompilationUtils.FindBindingText(Of MemberAccessExpressionSyntax)(compilation, "a.vb", 15)
+            symbolInfo = model.GetSymbolInfo(expressionSyntax)
+            Assert.Equal("Function C1.B() As System.Byte", symbolInfo.Symbol.ToTestDisplayString())
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
+            typeInfo = model.GetTypeInfo(expressionSyntax)
+            Assert.Null(typeInfo.Type)
+
+            expressionSyntax = CompilationUtils.FindBindingText(Of MemberAccessExpressionSyntax)(compilation, "a.vb", 16)
+            symbolInfo = model.GetSymbolInfo(expressionSyntax)
+            Assert.Equal("Function C1.B() As System.Byte", symbolInfo.Symbol.ToTestDisplayString())
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
+            typeInfo = model.GetTypeInfo(expressionSyntax)
+            Assert.Null(typeInfo.Type)
+
+            expressionSyntax = CompilationUtils.FindBindingText(Of MemberAccessExpressionSyntax)(compilation, "a.vb", 17)
+            symbolInfo = model.GetSymbolInfo(expressionSyntax)
+            Assert.Equal("Function C1.B() As System.Byte", symbolInfo.Symbol.ToTestDisplayString())
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             typeInfo = model.GetTypeInfo(expressionSyntax)
             Assert.Null(typeInfo.Type)
         End Sub

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -2054,7 +2054,7 @@ class C
     static void Main()
     {
         Action<string> g = null;
-        var h = (Foo<string>) + g;
+        var h = Foo + g;
     }
 
     static void Foo<T>(T y) { }


### PR DESCRIPTION
Fixes #3096.

@VSadov, @gafter, @agocke, @jaredpar, @khyperia Please review.