### PR TITLE
Add DebuggerHiddenAttribute to BaseMethodWrapper...

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -650,6 +650,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 AssignTypeMapAndTypeParameters(typeMap, typeParameters);
             }
+
+            internal override void AddSynthesizedAttributes(ModuleCompilationState compilationState, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+            {
+                base.AddSynthesizedAttributes(compilationState, ref attributes);
+
+                AddSynthesizedAttribute(ref attributes, this.DeclaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
+            }
         }
     }
 }


### PR DESCRIPTION
These methods are an implementation detail and do not have pdb information associated with them.  Therefore, you cannot navigate to their implementation, and we should hide them in the Call Stack Window.

**Note:**  VB already adds the attribute correctly in ```SynthesizedWrapperMethod```, albeit only when ``` OptimizationLevel <> OptimizationLevel.Debug```

(fixes #431)