### PR TITLE
Refine DisplayNames for GlobalStatements...

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Debugging/LocationInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/LocationInfoGetter.cs
@@ -24,7 +24,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
             var syntaxFactsService = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
             var memberDeclaration = syntaxFactsService.GetContainingMemberDeclaration(root, position, useFullSpan: true);
 
-            if (memberDeclaration == null)
+            // It might be reasonable to return an empty Name and a LineOffset from the beginning of the
+            // file for GlobalStatements.  However, the only known caller (Breakpoints Window) doesn't
+            // appear to consume this information, so we'll just return the simplest thing (no location).
+            if ((memberDeclaration == null) || (memberDeclaration.Kind() == SyntaxKind.GlobalStatement))
             {
                 return default(DebugLocationInfo);
             }

--- a/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.VisualStudio.LanguageServices.CSharp.Debugging;
 using Roslyn.Test.Utilities;
@@ -12,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 {
     public class LocationInfoGetterTests
     {
-        private void Test(string markup, string expectedName, int expectedLineOffset)
+        private void Test(string markup, string expectedName, int expectedLineOffset, CSharpParseOptions parseOptions = null)
         {
-            using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromLines(markup))
+            using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromLines(new[] { markup }, parseOptions))
             {
                 var testDocument = workspace.Documents.Single();
                 var position = testDocument.CursorPosition.Value;
@@ -468,7 +469,7 @@ class C1
         {
             Test(
 @"$$int f1;
-", "f1", 0);
+", "f1", 0, new CSharpParseOptions(kind: SourceCodeKind.Script));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
@@ -478,7 +479,17 @@ class C1
 @"int M1(int x)
 {
 $$}
-", "M1(int x)", 2);
+", "M1(int x)", 2, new CSharpParseOptions(kind: SourceCodeKind.Script));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingLocationName)]
+        public void TopLevelStatement()
+        {
+            Test(
+@"
+
+$$System.Console.WriteLine(""Hello"")
+", null, 0, new CSharpParseOptions(kind: SourceCodeKind.Interactive));
         }
     }
 }

--- a/src/VisualStudio/Core/Test/LanguageBlockTests.vb
+++ b/src/VisualStudio/Core/Test/LanguageBlockTests.vb
@@ -202,10 +202,24 @@ namespace N
         VerifyNoBlock("$$", languageName:="NoCompilation")
     End Sub
 
-    Private Sub VerifyNoBlock(markup As String, languageName As String)
+    <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock)>
+    Public Sub GetCurrentBlock_NotInGlobalCode_CS()
+        VerifyNoBlock("
+S$$ystem.Console.WriteLine(""Hello"");
+", LanguageNames.CSharp, SourceCodeKind.Script)
+    End Sub
+
+    <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock)>
+    Public Sub GetCurrentBlock_NotInGlobalCode_VB()
+        VerifyNoBlock("
+S$$ystem.Console.WriteLine(""Hello"")
+", LanguageNames.VisualBasic, SourceCodeKind.Script)
+    End Sub
+
+    Private Sub VerifyNoBlock(markup As String, languageName As String, Optional sourceCodeKind As SourceCodeKind = SourceCodeKind.Regular)
         Dim xml = <Workspace>
                       <Project Language=<%= languageName %> CommonReferences="True">
-                          <Document>
+                          <Document Kind=<%= sourceCodeKind %>>
                               <%= markup %>
                           </Document>
                       </Project>


### PR DESCRIPTION
Previously, I didn't realize that GlobalStatements in C# were separate from top level declarations with an initializer.  The old code handled GlobalStatements, but it was doing a lot of unnecessary work.  Also, I didn't have tests for this case.