### PR TITLE
Fix binding redirect range

### DIFF
--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -164,18 +164,18 @@ using Microsoft.VisualStudio.Shell;
 
 internal class Constants
 {
+    public const string OldVersionLowerBound = "0.7.0.0";
+    public const string OldVersionUpperBound = "1.1.0.0";
+    
 #if OFFICIAL_BUILD
     // If this is an official build we want to generate binding
     // redirects from our old versions to the release version 
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "0.7.0.0";
     public const string NewVersion = "1.1.0.0";
 #else
     // Non-official builds get redirects to local 42.42.42.42,
     // which will only be built locally
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "1.1.0.0";
     public const string NewVersion = "42.42.42.42";
 #endif
+
     public const string PublicKeyToken = "31BF3856AD364E35";
 }


### PR DESCRIPTION
Fix the binding redirection range. For official builds we were only
redirection version 0.7.0.0 to version 1.1.0.0, rather than redirecting
everything in the range 0.7.0.0-1.1.0.0.

Also, since the old version bounds are always going to be the same, we
should just define them once.