### PR TITLE
Further refinement for GetCurrentBlock in Script code...

### DIFF
--- a/src/VisualStudio/Core/Test/LanguageBlockTests.vb
+++ b/src/VisualStudio/Core/Test/LanguageBlockTests.vb
@@ -205,21 +205,24 @@ namespace N
     <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock)>
     Public Sub GetCurrentBlock_NotInGlobalCode_CS()
         VerifyNoBlock("
-S$$ystem.Console.WriteLine(""Hello"");
+var message = ""Hello"";
+System.Console$$.WriteLine(message);
 ", LanguageNames.CSharp, SourceCodeKind.Script)
     End Sub
 
     <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock)>
     Public Sub GetCurrentBlock_NotInGlobalCode_VB()
         VerifyNoBlock("
-S$$ystem.Console.WriteLine(""Hello"")
+Dim message = ""Hello""
+System.Console$$.WriteLine(message)
 ", LanguageNames.VisualBasic, SourceCodeKind.Script)
     End Sub
 
     Private Sub VerifyNoBlock(markup As String, languageName As String, Optional sourceCodeKind As SourceCodeKind = SourceCodeKind.Regular)
         Dim xml = <Workspace>
                       <Project Language=<%= languageName %> CommonReferences="True">
-                          <Document Kind=<%= sourceCodeKind %>>
+                          <Document>
+                              <ParseOptions Kind=<%= sourceCodeKind %>/>
                               <%= markup %>
                           </Document>
                       </Project>

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -724,7 +724,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (useFullSpan || node.Span.Contains(position))
                 {
-                    if (node is MemberDeclarationSyntax)
+                    if ((node.Kind() != SyntaxKind.GlobalStatement) && (node is MemberDeclarationSyntax))
                     {
                         return node;
                     }


### PR DESCRIPTION
It turns out my test wasn't doing what I thought it was (it was parsing as SourceCodeKind.Regular).  We don't want to treat top level statments in scripting as a containing member for the purposes of calculating the current block.