### PR TITLE
Allow await in top-level expressions in C# interactive

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case SymbolKind.Method:
                         // global statements
-                        return ((MethodSymbol)containingMember).IsScriptConstructor;
+                        return ((MethodSymbol)containingMember).IsScriptInitializer;
 
                     case SymbolKind.NamedType:
                         // script variable initializers

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -20,33 +19,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal static void BindFieldInitializers(
-            SourceMemberContainerTypeSymbol typeSymbol,
-            MethodSymbol scriptCtor,
+            CSharpCompilation compilation,
+            SynthesizedInteractiveInitializerMethod scriptInitializerOpt,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> fieldInitializers,
             DiagnosticBag diagnostics,
-            ref ProcessedFieldInitializers processedInitializers) //by ref so that we can store the results of lowering
+            bool setReturnType, // Remove once static fields are errors in submissions.
+            ref ProcessedFieldInitializers processedInitializers)
         {
-            DiagnosticBag diagsForInstanceInitializers = DiagnosticBag.GetInstance();
-            try
+            if (setReturnType && ((object)scriptInitializerOpt != null))
             {
-                ImportChain firstImportChain;
-
-                processedInitializers.BoundInitializers = BindFieldInitializers(typeSymbol, scriptCtor, fieldInitializers,
-                    diagsForInstanceInitializers, out firstImportChain);
-
-                processedInitializers.HasErrors = diagsForInstanceInitializers.HasAnyErrors();
-                processedInitializers.FirstImportChain = firstImportChain;
+                SetScriptInitializerReturnType(compilation, scriptInitializerOpt, fieldInitializers, diagnostics);
             }
-            finally
-            {
-                diagnostics.AddRange(diagsForInstanceInitializers);
-                diagsForInstanceInitializers.Free();
-            }
+
+            var diagsForInstanceInitializers = DiagnosticBag.GetInstance();
+            ImportChain firstImportChain;
+            processedInitializers.BoundInitializers = BindFieldInitializers(compilation, scriptInitializerOpt, fieldInitializers, diagsForInstanceInitializers, out firstImportChain);
+            processedInitializers.HasErrors = diagsForInstanceInitializers.HasAnyErrors();
+            processedInitializers.FirstImportChain = firstImportChain;
+            diagnostics.AddRange(diagsForInstanceInitializers);
+            diagsForInstanceInitializers.Free();
         }
 
-        internal static ImmutableArray<BoundInitializer> BindFieldInitializers(
-            SourceMemberContainerTypeSymbol containingType,
-            MethodSymbol scriptCtor,
+        private static ImmutableArray<BoundInitializer> BindFieldInitializers(
+            CSharpCompilation compilation,
+            SynthesizedInteractiveInitializerMethod scriptInitializerOpt,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
             DiagnosticBag diagnostics,
             out ImportChain firstImportChain)
@@ -57,26 +53,88 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ImmutableArray<BoundInitializer>.Empty;
             }
 
-            CSharpCompilation compilation = containingType.DeclaringCompilation;
-            ArrayBuilder<BoundInitializer> boundInitializers = ArrayBuilder<BoundInitializer>.GetInstance();
-
-            if ((object)scriptCtor == null)
+            var boundInitializers = ArrayBuilder<BoundInitializer>.GetInstance();
+            if ((object)scriptInitializerOpt == null)
             {
                 BindRegularCSharpFieldInitializers(compilation, initializers, boundInitializers, diagnostics, out firstImportChain);
             }
             else
             {
-                BindScriptFieldInitializers(compilation, scriptCtor, initializers, boundInitializers, diagnostics, out firstImportChain);
+                BindScriptFieldInitializers(compilation, scriptInitializerOpt, initializers, boundInitializers, diagnostics, out firstImportChain);
+            }
+            return boundInitializers.ToImmutableAndFree();
+        }
+
+        private static void SetScriptInitializerReturnType(
+            CSharpCompilation compilation,
+            SynthesizedInteractiveInitializerMethod scriptInitializer,
+            ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> fieldInitializers,
+            DiagnosticBag diagnostics)
+        {
+            bool isAsync = scriptInitializer.IsSubmissionInitializer && fieldInitializers.Any(i => i.Any(ContainsAwaitsVisitor.ContainsAwait));
+            var resultType = scriptInitializer.ResultType;
+            TypeSymbol returnType;
+
+            if ((object)resultType == null)
+            {
+                Debug.Assert(!isAsync);
+                returnType = compilation.GetSpecialType(SpecialType.System_Void);
+            }
+            else if (!isAsync)
+            {
+                returnType = resultType;
+            }
+            else
+            {
+                var taskT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+                var useSiteDiagnostic = taskT.GetUseSiteDiagnostic();
+                if (useSiteDiagnostic != null)
+                {
+                    diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton);
+                }
+                returnType = taskT.Construct(resultType);
             }
 
-            return boundInitializers.ToImmutableAndFree();
+            scriptInitializer.SetReturnType(isAsync, returnType);
+        }
+
+        private sealed class ContainsAwaitsVisitor : CSharpSyntaxWalker
+        {
+            private bool _containsAwait;
+
+            internal static bool ContainsAwait(FieldOrPropertyInitializer initializer)
+            {
+                var syntax = initializer.Syntax.GetSyntax();
+                var visitor = new ContainsAwaitsVisitor();
+                visitor.Visit(syntax);
+                return visitor._containsAwait;
+            }
+
+            public override void VisitAwaitExpression(AwaitExpressionSyntax node)
+            {
+                _containsAwait = true;
+            }
+
+            public override void DefaultVisit(SyntaxNode node)
+            {
+                switch (node.Kind())
+                {
+                    case SyntaxKind.SimpleLambdaExpression:
+                    case SyntaxKind.ParenthesizedLambdaExpression:
+                        // Do not walk into lambdas.
+                        break;
+                    default:
+                        base.DefaultVisit(node);
+                        break;
+                }
+            }
         }
 
         /// <summary>
         /// In regular C#, all field initializers are assignments to fields and the assigned expressions
         /// may not reference instance members.
         /// </summary>
-        private static void BindRegularCSharpFieldInitializers(
+        internal static void BindRegularCSharpFieldInitializers(
             CSharpCompilation compilation,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
             ArrayBuilder<BoundInitializer> boundInitializers,
@@ -133,12 +191,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// In script C#, some field initializers are assignments to fields and others are global
         /// statements.  There are no restrictions on accessing instance members.
         /// </summary>
-        private static void BindScriptFieldInitializers(CSharpCompilation compilation, MethodSymbol scriptCtor,
-            ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers, ArrayBuilder<BoundInitializer> boundInitializers, DiagnosticBag diagnostics,
+        private static void BindScriptFieldInitializers(
+            CSharpCompilation compilation,
+            SynthesizedInteractiveInitializerMethod scriptInitializer,
+            ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
+            ArrayBuilder<BoundInitializer> boundInitializers,
+            DiagnosticBag diagnostics,
             out ImportChain firstDebugImports)
         {
-            Debug.Assert((object)scriptCtor != null);
-
             firstDebugImports = null;
 
             for (int i = 0; i < initializers.Length; i++)
@@ -179,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         firstDebugImports = scriptClassBinder.ImportChain;
                     }
 
-                    Binder parentBinder = new ExecutableCodeBinder((CSharpSyntaxNode)syntaxRef.SyntaxTree.GetRoot(), scriptCtor, scriptClassBinder);
+                    Binder parentBinder = new ExecutableCodeBinder((CSharpSyntaxNode)syntaxRef.SyntaxTree.GetRoot(), scriptInitializer, scriptClassBinder);
 
                     BoundInitializer boundInitializer;
                     if ((object)fieldSymbol != null)
@@ -215,13 +275,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // the result of the last global expression is assigned to the result storage for submission result:
             if (binder.Compilation.IsSubmission && isLast && boundStatement.Kind == BoundKind.ExpressionStatement && !boundStatement.HasAnyErrors)
             {
-                var submissionReturnType = binder.Compilation.GetSubmissionReturnType();
-
                 // insert an implicit conversion for the submission return type (if needed):
                 var expression = ((BoundExpressionStatement)boundStatement).Expression;
                 if ((object)expression.Type == null || expression.Type.SpecialType != SpecialType.System_Void)
                 {
-                    expression = binder.GenerateConversionForAssignment(submissionReturnType, expression, diagnostics);
+                    var submissionResultType = binder.Compilation.GetSubmissionInitializer().ResultType;
+                    expression = binder.GenerateConversionForAssignment(submissionResultType, expression, diagnostics);
                     boundStatement = new BoundExpressionStatement(boundStatement.Syntax, expression, expression.HasErrors);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionStatement = new BoundExpressionStatement(node, expression);
             }
 
-            CheckForUnobservedAwaitable(expressionStatement, diagnostics);
+            CheckForUnobservedAwaitable(expression, diagnostics);
 
             return expressionStatement;
         }
@@ -441,46 +441,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>
         /// The checks here are equivalent to StatementBinder::CheckForUnobservedAwaitable() in the native compiler.
         /// </remarks>
-        private void CheckForUnobservedAwaitable(BoundExpressionStatement expressionStatement, DiagnosticBag diagnostics)
+        private void CheckForUnobservedAwaitable(BoundExpression expression, DiagnosticBag diagnostics)
         {
-            if (expressionStatement == null)
-            {
-                return;
-            }
-
-            BoundExpression expression = expressionStatement.Expression;
-
-            // If we don't have an expression or it doesn't have a type, just bail out
-            // now. Also, the dynamic type is always awaitable in an async method and
-            // could generate a lot of noise if we warned on it. Finally, we only want
-            // to warn on method calls, not other kinds of expressions.
-
-            if (expression == null
-                || expression.Kind != BoundKind.Call
-                || (object)expression.Type == null
-                || expression.Type.IsDynamic()
-                || expression.Type.SpecialType == SpecialType.System_Void)
-            {
-                return;
-            }
-
-            var call = (BoundCall)expression;
-
-            // First check if the target method is async.
-            if ((object)call.Method != null && call.Method.IsAsync)
-            {
-                Error(diagnostics, ErrorCode.WRN_UnobservedAwaitableExpression, expression.Syntax);
-                return;
-            }
-
-            // Then check if the method call returns a WinRT async type.
-            if (ImplementsWinRTAsyncInterface(call.Type))
-            {
-                Error(diagnostics, ErrorCode.WRN_UnobservedAwaitableExpression, expression.Syntax);
-                return;
-            }
-
-            // Finally, if we're in an async method, and the expression could be be awaited, report that it is instead discarded.
             if (CouldBeAwaited(expression))
             {
                 Error(diagnostics, ErrorCode.WRN_UnobservedAwaitableExpression, expression.Syntax);
@@ -3195,7 +3157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Don't mark compiler generated so that the rewriter generates sequence points
                     var expressionStatement = new BoundExpressionStatement(syntax, expression, errors);
 
-                    CheckForUnobservedAwaitable(expressionStatement, diagnostics);
+                    CheckForUnobservedAwaitable(expression, diagnostics);
                     statement = expressionStatement;
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -110,6 +110,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal bool IsSubmissionClass
+        {
+            get { return (_container.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsSubmissionClass; }
+        }
+
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<Symbol> basesBeingResolved)
         {
             var type = _container as NamedTypeSymbol;
@@ -165,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(result.IsClear);
 
-            if (_container.IsSubmissionClass)
+            if (IsSubmissionClass)
             {
                 this.LookupMembersInternal(result, _container, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
                 return;
@@ -201,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.AddMemberLookupSymbolsInfo(result, _container, options, originalBinder);
 
             // if we are looking only for labels we do not need to search through the imports
-            if (!_container.IsSubmissionClass && ((options & LookupOptions.LabelsOnly) == 0))
+            if (!IsSubmissionClass && ((options & LookupOptions.LabelsOnly) == 0))
             {
                 var imports = GetImports(basesBeingResolved: null);
 

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -709,6 +709,7 @@
     <Compile Include="Symbols\Synthesized\SynthesizedStaticConstructor.cs" />
     <Compile Include="Symbols\Synthesized\SynthesizedStringHashFunctionSymbol.cs" />
     <Compile Include="Symbols\Synthesized\SynthesizedSubmissionConstructor.cs" />
+    <Compile Include="Symbols\Synthesized\SynthesizedInteractiveInitializerMethod.cs" />
     <Compile Include="Symbols\Synthesized\SynthesizedSubstitutedTypeParameterSymbol.cs" />
     <Compile Include="Symbols\Synthesized\TypeSubstitutedLocalSymbol.cs" />
     <Compile Include="Symbols\TypedConstantExtensions.cs" />

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1305,17 +1305,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _lazyHostObjectTypeSymbol;
         }
 
-        internal TypeSymbol GetSubmissionReturnType()
+        internal SynthesizedInteractiveInitializerMethod GetSubmissionInitializer()
         {
-            if (IsSubmission && (object)ScriptClass != null)
-            {
-                // the second parameter of Script class instance constructor is the submission return value:
-                return ((MethodSymbol)ScriptClass.GetMembers(WellKnownMemberNames.InstanceConstructorName)[0]).Parameters[1].Type;
-            }
-            else
-            {
-                return null;
-            }
+            return (IsSubmission && (object)ScriptClass != null) ?
+                ScriptClass.GetScriptInitializer() :
+                null;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -183,15 +183,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal static MethodSymbol GetEntryPoint(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuilt, bool hasDeclarationErrors, DiagnosticBag diagnostics, CancellationToken cancellationToken)
+        private static MethodSymbol GetEntryPoint(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuilt, bool hasDeclarationErrors, DiagnosticBag diagnostics, CancellationToken cancellationToken)
         {
             CSharpCompilationOptions options = compilation.Options;
             if (!options.OutputKind.IsApplication())
             {
                 Debug.Assert(compilation.GetEntryPointAndDiagnostics(default(CancellationToken)) == null);
-                return compilation.IsSubmission
-                    ? DefineScriptEntryPoint(compilation, moduleBeingBuilt, compilation.GetSubmissionReturnType(), hasDeclarationErrors, diagnostics)
-                    : null;
+                var submissionInitializer = compilation.GetSubmissionInitializer();
+                if ((object)submissionInitializer == null)
+                {
+                    return null;
+                }
+                var returnType = submissionInitializer.IsAsync ? submissionInitializer.ReturnType : compilation.GetSpecialType(SpecialType.System_Object);
+                return DefineScriptEntryPoint(compilation, moduleBeingBuilt, returnType, hasDeclarationErrors, diagnostics);
             }
 
             Debug.Assert(!compilation.IsSubmission);
@@ -212,9 +216,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return entryPoint.MethodSymbol;
         }
 
-        internal static MethodSymbol DefineScriptEntryPoint(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuilt, TypeSymbol returnType, bool hasDeclarationErrors, DiagnosticBag diagnostics)
+        private static MethodSymbol DefineScriptEntryPoint(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuilt, TypeSymbol returnType, bool hasDeclarationErrors, DiagnosticBag diagnostics)
         {
-            var scriptEntryPoint = new SynthesizedEntryPointSymbol(compilation.ScriptClass, returnType, diagnostics);
+            var scriptClass = compilation.ScriptClass;
+            var scriptEntryPoint = SynthesizedEntryPointSymbol.Create(scriptClass, returnType, diagnostics);
             if (moduleBeingBuilt != null && !hasDeclarationErrors && !diagnostics.HasAnyErrors())
             {
                 var body = scriptEntryPoint.CreateBody();
@@ -236,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     emittingPdb: false);
 
                 moduleBeingBuilt.SetMethodBody(scriptEntryPoint, emittedBody);
-                moduleBeingBuilt.AddSynthesizedDefinition(compilation.ScriptClass, scriptEntryPoint);
+                moduleBeingBuilt.AddSynthesizedDefinition(scriptClass, scriptEntryPoint);
             }
 
             return scriptEntryPoint;
@@ -347,39 +352,42 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }), _cancellationToken);
         }
 
-        private void CompileNamedType(NamedTypeSymbol symbol)
+        private void CompileNamedType(NamedTypeSymbol containingType)
         {
-            TypeCompilationState compilationState = new TypeCompilationState(symbol, _compilation, _moduleBeingBuiltOpt);
+            var compilationState = new TypeCompilationState(containingType, _compilation, _moduleBeingBuiltOpt);
 
             _cancellationToken.ThrowIfCancellationRequested();
 
             // Find the constructor of a script class.
-            MethodSymbol scriptCtor = null;
-            int submissionCtorOrdinal = -1;
-            if (symbol.IsScriptClass)
+            SynthesizedInstanceConstructor scriptCtor = null;
+            SynthesizedInteractiveInitializerMethod scriptInitializer = null;
+            int scriptCtorOrdinal = -1;
+            if (containingType.IsScriptClass)
             {
                 // The field initializers of a script class could be arbitrary statements,
                 // including blocks.  Field initializers containing blocks need to
                 // use a MethodBodySemanticModel to build up the appropriate tree of binders, and
                 // MethodBodySemanticModel requires an "owning" method.  That's why we're digging out
                 // the constructor - it will own the field initializers.
-                scriptCtor = symbol.InstanceConstructors[0];
+                scriptCtor = containingType.GetScriptConstructor();
+                scriptInitializer = containingType.GetScriptInitializer();
                 Debug.Assert((object)scriptCtor != null);
+                Debug.Assert((object)scriptInitializer != null);
             }
 
-            var synthesizedSubmissionFields = symbol.IsSubmissionClass ? new SynthesizedSubmissionFields(_compilation, symbol) : null;
+            var synthesizedSubmissionFields = containingType.IsSubmissionClass ? new SynthesizedSubmissionFields(_compilation, containingType) : null;
             var processedStaticInitializers = new Binder.ProcessedFieldInitializers();
             var processedInstanceInitializers = new Binder.ProcessedFieldInitializers();
 
-            var sourceTypeSymbol = symbol as SourceMemberContainerTypeSymbol;
+            var sourceTypeSymbol = containingType as SourceMemberContainerTypeSymbol;
 
             if ((object)sourceTypeSymbol != null)
             {
                 _cancellationToken.ThrowIfCancellationRequested();
-                Binder.BindFieldInitializers(sourceTypeSymbol, scriptCtor, sourceTypeSymbol.StaticInitializers, _diagnostics, ref processedStaticInitializers);
+                Binder.BindFieldInitializers(_compilation, scriptInitializer, sourceTypeSymbol.StaticInitializers, _diagnostics, false, ref processedStaticInitializers);
 
                 _cancellationToken.ThrowIfCancellationRequested();
-                Binder.BindFieldInitializers(sourceTypeSymbol, scriptCtor, sourceTypeSymbol.InstanceInitializers, _diagnostics, ref processedInstanceInitializers);
+                Binder.BindFieldInitializers(_compilation, scriptInitializer, sourceTypeSymbol.InstanceInitializers, _diagnostics, true, ref processedInstanceInitializers);
 
                 if (compilationState.Emitting)
                 {
@@ -391,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // so we can decide to synthesize a static constructor.
             bool hasStaticConstructor = false;
 
-            var members = symbol.GetMembers();
+            var members = containingType.GetMembers();
             for (int memberOrdinal = 0; memberOrdinal < members.Length; memberOrdinal++)
             {
                 var member = members[memberOrdinal];
@@ -411,10 +419,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SymbolKind.Method:
                         {
                             MethodSymbol method = (MethodSymbol)member;
-                            if (method.IsSubmissionConstructor)
+                            if (method.IsScriptConstructor)
                             {
-                                Debug.Assert(submissionCtorOrdinal == -1);
-                                submissionCtorOrdinal = memberOrdinal;
+                                Debug.Assert(scriptCtorOrdinal == -1);
+                                scriptCtorOrdinal = memberOrdinal;
                                 continue;
                             }
 
@@ -433,7 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
 
                             Binder.ProcessedFieldInitializers processedInitializers =
-                                method.MethodKind == MethodKind.Constructor ? processedInstanceInitializers :
+                                (method.MethodKind == MethodKind.Constructor || method.IsScriptInitializer)? processedInstanceInitializers :
                                 method.MethodKind == MethodKind.StaticConstructor ? processedStaticInitializers :
                                 default(Binder.ProcessedFieldInitializers);
 
@@ -494,13 +502,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert(symbol.TypeKind != TypeKind.Submission || ((object)scriptCtor != null && scriptCtor.IsSubmissionConstructor));
+            Debug.Assert(containingType.IsScriptClass == (scriptCtorOrdinal >= 0));
 
             // process additional anonymous type members
-            if (AnonymousTypeManager.IsAnonymousTypeTemplate(symbol))
+            if (AnonymousTypeManager.IsAnonymousTypeTemplate(containingType))
             {
                 var processedInitializers = default(Binder.ProcessedFieldInitializers);
-                foreach (var method in AnonymousTypeManager.GetAnonymousTypeHiddenMethods(symbol))
+                foreach (var method in AnonymousTypeManager.GetAnonymousTypeHiddenMethods(containingType))
                 {
                     CompileMethod(method, -1, ref processedInitializers, synthesizedSubmissionFields, compilationState);
                 }
@@ -528,11 +536,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // compile submission constructor last so that synthesized submission fields are collected from all script methods:
-            if (synthesizedSubmissionFields != null && compilationState.Emitting)
+            if (scriptCtor != null && compilationState.Emitting)
             {
-                Debug.Assert(scriptCtor.IsSubmissionConstructor);
-                CompileMethod(scriptCtor, submissionCtorOrdinal, ref processedInstanceInitializers, synthesizedSubmissionFields, compilationState);
-                synthesizedSubmissionFields.AddToType(scriptCtor.ContainingType, compilationState.ModuleBuilderOpt);
+                Debug.Assert(scriptCtorOrdinal >= 0);
+                var processedInitializers = new Binder.ProcessedFieldInitializers() { BoundInitializers = ImmutableArray<BoundInitializer>.Empty };
+                CompileMethod(scriptCtor, scriptCtorOrdinal, ref processedInitializers, synthesizedSubmissionFields, compilationState);
+                if (synthesizedSubmissionFields != null)
+                {
+                    synthesizedSubmissionFields.AddToType(containingType, compilationState.ModuleBuilderOpt);
+                }
             }
 
             // Emit synthesized methods produced during lowering if any
@@ -548,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(_moduleBeingBuiltOpt != null);
 
-            TypeCompilationState compilationState = new TypeCompilationState(null, _compilation, _moduleBeingBuiltOpt);
+            var compilationState = new TypeCompilationState(null, _compilation, _moduleBeingBuiltOpt);
             foreach (MethodSymbol method in privateImplClass.GetMethods(new EmitContext(_moduleBeingBuiltOpt, null, diagnostics)))
             {
                 Debug.Assert(method.SynthesizesLoweredBoundBody);
@@ -563,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var additionalType in additionalTypes)
             {
-                TypeCompilationState compilationState = new TypeCompilationState(additionalType, _compilation, _moduleBeingBuiltOpt);
+                var compilationState = new TypeCompilationState(additionalType, _compilation, _moduleBeingBuiltOpt);
                 foreach (var method in additionalType.GetMethodsToEmit())
                 {
                     method.GenerateMethodBody(compilationState, diagnostics);
@@ -824,8 +836,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (methodSymbol.IsScriptConstructor)
                 {
+                    body = new BoundBlock(methodSymbol.GetNonNullSyntaxNode(), ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty) { WasCompilerGenerated = true };
+                    includeInitializersInBody = false;
+                    importChain = null;
+                }
+                else if (methodSymbol.IsScriptInitializer)
+                {
                     // rewrite top-level statements and script variable declarations to a list of statements and assignments, respectively:
-                    BoundTypeOrInstanceInitializers initializerStatements = InitializerRewriter.Rewrite(processedInitializers.BoundInitializers, methodSymbol);
+                    var submissionResultType = ((SynthesizedInteractiveInitializerMethod)methodSymbol).ResultType;
+                    BoundTypeOrInstanceInitializers initializerStatements = InitializerRewriter.Rewrite(processedInitializers.BoundInitializers, methodSymbol, submissionResultType);
 
                     // the lowered script initializers should not be treated as initializers anymore but as a method body:
                     body = new BoundBlock(initializerStatements.Syntax, ImmutableArray<LocalSymbol>.Empty, initializerStatements.Statements) { WasCompilerGenerated = true };
@@ -836,8 +855,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // Do not emit initializers if we are invoking another constructor of this class.
-
-                    SourceMemberContainerTypeSymbol container = methodSymbol.ContainingType as SourceMemberContainerTypeSymbol;
                     includeInitializersInBody = !processedInitializers.BoundInitializers.IsDefaultOrEmpty &&
                                                 !HasThisConstructorInitializer(methodSymbol);
 
@@ -849,10 +866,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // appended to its body.
                     if (includeInitializersInBody && processedInitializers.LoweredInitializers == null)
                     {
-                        analyzedInitializers = InitializerRewriter.Rewrite(processedInitializers.BoundInitializers, methodSymbol);
+                        analyzedInitializers = InitializerRewriter.Rewrite(processedInitializers.BoundInitializers, methodSymbol, submissionResultTypeOpt: null);
                         processedInitializers.HasErrors = processedInitializers.HasErrors || analyzedInitializers.HasAnyErrors;
 
-                        if (body != null && container.IsStructType() && !methodSymbol.IsImplicitConstructor)
+                        if (body != null && methodSymbol.ContainingType.IsStructType() && !methodSymbol.IsImplicitConstructor)
                         {
                             // In order to get correct diagnostics, we need to analyze initializers and the body together.
                             body = body.Update(body.Locals, body.Statements.Insert(0, analyzedInitializers));
@@ -994,7 +1011,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             if (analyzedInitializers != null)
                             {
-                                StateMachineTypeSymbol initializerStateMachineTypeOpt = null;
+                                StateMachineTypeSymbol initializerStateMachineTypeOpt;
 
                                 processedInitializers.LoweredInitializers = (BoundStatementList)LowerBodyOrInitializer(
                                     methodSymbol,
@@ -1654,26 +1671,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // The constructor is implicit. We need to get the binder for the body
                 // of the enclosing class. 
                 CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
-                SyntaxToken bodyToken;
-                if (containerNode.Kind() == SyntaxKind.ClassDeclaration)
-                {
-                    bodyToken = ((ClassDeclarationSyntax)containerNode).OpenBraceToken;
-                }
-                else if (containerNode.Kind() == SyntaxKind.StructDeclaration)
-                {
-                    bodyToken = ((StructDeclarationSyntax)containerNode).OpenBraceToken;
-                }
-                else if (containerNode.Kind() == SyntaxKind.EnumDeclaration)
-                {
-                    // We're not going to find any non-default ctors, but we'll look anyway.
-                    bodyToken = ((EnumDeclarationSyntax)containerNode).OpenBraceToken;
-                }
-                else
-                {
-                    Debug.Assert(false, "How did we get an implicit constructor added to something that is neither a class nor a struct?");
-                    bodyToken = containerNode.GetFirstToken();
-                }
-
+                SyntaxToken bodyToken = GetImplicitConstructorBodyToken(containerNode);
                 outerBinder = compilation.GetBinderFactory(containerNode.SyntaxTree).GetBinder(containerNode, bodyToken.Position);
             }
             else if (initializerArgumentListOpt == null)
@@ -1693,6 +1691,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor);
 
             return initializerBinder.BindConstructorInitializer(initializerArgumentListOpt, constructor, diagnostics);
+        }
+
+        private static SyntaxToken GetImplicitConstructorBodyToken(CSharpSyntaxNode containerNode)
+        {
+            var kind = containerNode.Kind();
+            switch (kind)
+            {
+                case SyntaxKind.ClassDeclaration:
+                    return ((ClassDeclarationSyntax)containerNode).OpenBraceToken;
+                case SyntaxKind.StructDeclaration:
+                    return ((StructDeclarationSyntax)containerNode).OpenBraceToken;
+                case SyntaxKind.EnumDeclaration:
+                    // We're not going to find any non-default ctors, but we'll look anyway.
+                    return ((EnumDeclarationSyntax)containerNode).OpenBraceToken;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(kind);
+            }
         }
 
         internal static BoundCall GenerateObjectConstructorInitializer(MethodSymbol constructor, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private sealed class AwaitInFinallyAnalysis : LabelCollector
         {
-            // all try blocks with yields in them and complete set of lables inside those trys
+            // all try blocks with yields in them and complete set of labels inside those trys
             // NOTE: non-yielding Trys are transparently ignored - i.e. their labels are included
             //       in the label set of the nearest yielding-try parent  
             private Dictionary<BoundTryStatement, HashSet<LabelSymbol>> _labelsInInterestingTry;
@@ -848,7 +848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // proxy labels for branches leaving the frame. 
             // we build this on demand once we encounter leaving branches.
             // subsequent leaves to an already proxied label redirected to the proxy.
-            // At the proxy lable we will execute finally and forward the control flow 
+            // At the proxy label we will execute finally and forward the control flow 
             // to the actual destination. (which could be proxied again in the parent)
             public Dictionary<LabelSymbol, LabelSymbol> proxyLabels;
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
@@ -19,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private AsyncRewriter(
             BoundStatement body,
-            SourceMethodSymbol method,
+            MethodSymbol method,
             int methodOrdinal,
             AsyncStateMachine stateMachineType,
             VariableSlotAllocator slotAllocatorOpt,
@@ -66,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             stateMachineType = new AsyncStateMachine(slotAllocatorOpt, compilationState, method, methodOrdinal, typeKind);
             compilationState.ModuleBuilderOpt.CompilationState.SetStateMachineType(method, stateMachineType);
-            var rewriter = new AsyncRewriter(bodyWithAwaitLifted, (SourceMethodSymbol)method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics);
+            var rewriter = new AsyncRewriter(bodyWithAwaitLifted, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics);
             if (!rewriter._constructedSuccessfully)
             {
                 return body;

--- a/src/Compilers/CSharp/Portable/Lowering/InitializerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/InitializerRewriter.cs
@@ -4,18 +4,19 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal static class InitializerRewriter
     {
-        internal static BoundTypeOrInstanceInitializers Rewrite(ImmutableArray<BoundInitializer> boundInitializers, MethodSymbol constructor)
+        internal static BoundTypeOrInstanceInitializers Rewrite(ImmutableArray<BoundInitializer> boundInitializers, MethodSymbol method, TypeSymbol submissionResultTypeOpt)
         {
             Debug.Assert(!boundInitializers.IsDefault);
+            Debug.Assert(method.IsSubmissionInitializer == ((object)submissionResultTypeOpt != null));
 
             var boundStatements = ArrayBuilder<BoundStatement>.GetInstance(boundInitializers.Length);
+            BoundExpression submissionResult = null;
 
             for (int i = 0; i < boundInitializers.Length; i++)
             {
@@ -28,33 +29,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
 
                     case BoundKind.GlobalStatementInitializer:
-                        var stmtInit = (BoundGlobalStatementInitializer)init;
-
-                        // the value of the last expression statement (if any) is stored to a ref parameter of the submission constructor:
-                        if (constructor.IsSubmissionConstructor && i == boundInitializers.Length - 1 && stmtInit.Statement.Kind == BoundKind.ExpressionStatement)
+                        var statement = ((BoundGlobalStatementInitializer)init).Statement;
+                        // The value of the last expression statement (if any) is returned from the submission initializer.
+                        if ((object)submissionResultTypeOpt != null &&
+                            i == boundInitializers.Length - 1 &&
+                            statement.Kind == BoundKind.ExpressionStatement)
                         {
-                            var syntax = stmtInit.Syntax;
-                            var submissionResultVariable = new BoundParameter(syntax, constructor.Parameters[1]);
-                            var expr = ((BoundExpressionStatement)stmtInit.Statement).Expression;
-
-                            // The expression is converted to the submission result type when the initializer is bound, 
-                            // so we just need to assign it to the out parameter:
+                            var expr = ((BoundExpressionStatement)statement).Expression;
                             if ((object)expr.Type != null && expr.Type.SpecialType != SpecialType.System_Void)
                             {
-                                boundStatements.Add(
-                                    new BoundExpressionStatement(syntax,
-                                        new BoundAssignmentOperator(syntax,
-                                            submissionResultVariable,
-                                            expr,
-                                            expr.Type
-                                        )
-                                    ));
-
+                                submissionResult = expr;
                                 break;
                             }
                         }
-
-                        boundStatements.Add(stmtInit.Statement);
+                        boundStatements.Add(statement);
                         break;
 
                     default:
@@ -62,21 +50,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert(boundStatements.Count == boundInitializers.Length);
+            var sourceMethod = method as SourceMethodSymbol;
+            var syntax = ((object)sourceMethod != null) ? sourceMethod.SyntaxNode : method.GetNonNullSyntaxNode();
 
-            CSharpSyntaxNode listSyntax;
-
-            SourceMethodSymbol sourceConstructor = constructor as SourceMethodSymbol;
-            if ((object)sourceConstructor != null)
+            if ((object)submissionResultTypeOpt != null)
             {
-                listSyntax = sourceConstructor.SyntaxNode;
-            }
-            else
-            {
-                listSyntax = constructor.GetNonNullSyntaxNode();
+                if (submissionResult == null)
+                {
+                    // Return null if submission does not have a trailing expression.
+                    Debug.Assert(submissionResultTypeOpt.IsReferenceType);
+                    submissionResult = new BoundLiteral(syntax, ConstantValue.Null, submissionResultTypeOpt);
+                }
+
+                Debug.Assert((object)submissionResult.Type != null);
+                Debug.Assert(submissionResult.Type.SpecialType != SpecialType.System_Void);
+
+                // The expression is converted to the submission result type when the initializer is bound.
+                boundStatements.Add(new BoundReturnStatement(submissionResult.Syntax, submissionResult));
             }
 
-            return new BoundTypeOrInstanceInitializers(listSyntax, boundStatements.ToImmutableAndFree());
+            return new BoundTypeOrInstanceInitializers(syntax, boundStatements.ToImmutableAndFree());
         }
 
         private static BoundStatement RewriteFieldInitializer(BoundFieldInitializer fieldInit)

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.IteratorFinallyFrame.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.IteratorFinallyFrame.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // proxy labels for branches leaving the frame. 
             // we build this on demand once we encounter leaving branches.
             // subsequent leaves to an already proxied label redirected to the proxy.
-            // At the proxy lable we will execute finally and forward the control flow 
+            // At the proxy label we will execute finally and forward the control flow 
             // to the actual destination. (which could be proxied again in the parent)
             public Dictionary<LabelSymbol, LabelSymbol> proxyLabels;
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.YieldsInTryAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.YieldsInTryAnalysis.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private class YieldsInTryAnalysis : LabelCollector
         {
-            // all try blocks with yields in them and complete set of lables inside those trys
+            // all try blocks with yields in them and complete set of labels inside those trys
             // NOTE: non-yielding Trys are transparently ignored - i.e. their labels are included
             //       in the label set of the nearest yielding-try parent  
             private Dictionary<BoundTryStatement, HashSet<LabelSymbol>> _labelsInYieldingTrys;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8195,7 +8195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private bool IsPossibleAwaitExpressionStatement()
         {
-            return this.IsInAsync && this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
+            return (this.IsInteractive || this.IsInAsync) && this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
         }
 
         private bool IsAwaitExpression()

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -513,6 +513,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal virtual bool IsScriptInitializer
+        {
+            get { return false; }
+        }
+
         /// <summary>
         /// Returns if the method is implicit constructor (normal and static)
         /// </summary>
@@ -543,6 +548,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return IsScriptConstructor && ContainingAssembly.IsInteractive;
+            }
+        }
+
+        internal bool IsSubmissionInitializer
+        {
+            get
+            {
+                return IsScriptInitializer && ContainingAssembly.IsInteractive;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -416,6 +416,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal bool IsSubmissionClass
+        {
+            get
+            {
+                return TypeKind == TypeKind.Submission;
+            }
+        }
+
+        internal SynthesizedInstanceConstructor GetScriptConstructor()
+        {
+            Debug.Assert(IsScriptClass);
+            return (SynthesizedInstanceConstructor)InstanceConstructors.Single();
+        }
+
+        internal SynthesizedInteractiveInitializerMethod GetScriptInitializer()
+        {
+            Debug.Assert(IsScriptClass);
+            return (SynthesizedInteractiveInitializerMethod)GetMembers(SynthesizedInteractiveInitializerMethod.InitializerName).Single();
+        }
+
         /// <summary>
         /// Returns true if the type is the implicit class that holds onto invalid global members (like methods or
         /// statements in a non script file).

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -46,14 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal bool IsSubmissionClass
-        {
-            get
-            {
-                return IsType && ((TypeSymbol)this).TypeKind == TypeKind.Submission;
-            }
-        }
-
         /// <summary>
         /// Returns true if this symbol is "virtual", has an implementation, and does not override a
         /// base class member; i.e., declared with the "virtual" modifier. Does not return true for

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1,18 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -2791,52 +2789,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            // constants don't count, since they do not exist as fields at runtime
-            // NOTE: even for decimal constants (which require field initializers), 
-            // we do not create .cctor here since a static constructor implicitly created for a decimal 
-            // should not appear in the list returned by public API like GetMembers().
-            var hasStaticInitializer = HasNonConstantInitializer(staticInitializers);
-
             // NOTE: Per section 11.3.8 of the spec, "every struct implicitly has a parameterless instance constructor".
             // We won't insert a parameterless constructor for a struct if there already is one.
             // We don't expect anything to be emitted, but it should be in the symbol table.
             if ((!hasParameterlessInstanceConstructor && this.IsStructType()) || (!hasInstanceConstructor && !this.IsStatic))
             {
-                if (this.TypeKind == TypeKind.Submission)
-                {
-                    members.Add(new SynthesizedSubmissionConstructor(this, diagnostics));
-                }
-                else
-                {
-                    members.Add(new SynthesizedInstanceConstructor(this));
-                }
+                members.Add((this.TypeKind == TypeKind.Submission) ?
+                    new SynthesizedSubmissionConstructor(this, diagnostics) :
+                    new SynthesizedInstanceConstructor(this));
             }
 
-            if (!hasStaticConstructor && hasStaticInitializer)
+            // constants don't count, since they do not exist as fields at runtime
+            // NOTE: even for decimal constants (which require field initializers), 
+            // we do not create .cctor here since a static constructor implicitly created for a decimal 
+            // should not appear in the list returned by public API like GetMembers().
+            if (!hasStaticConstructor && HasNonConstantInitializer(staticInitializers))
             {
                 // Note: we don't have to put anything in the method - the binder will
                 // do that when processing field initializers.
                 members.Add(new SynthesizedStaticConstructor(this));
             }
+
+            if (this.IsScriptClass)
+            {
+                members.Add(new SynthesizedInteractiveInitializerMethod(this, diagnostics));
+            }
         }
 
         private static bool HasNonConstantInitializer(ArrayBuilder<ImmutableArray<FieldOrPropertyInitializer>> initializers)
         {
-            if (initializers != null)
-            {
-                foreach (var siblings in initializers)
-                {
-                    foreach (var initializer in siblings)
-                    {
-                        if (!initializer.FieldOpt.IsConst)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
+            return initializers.Any(siblings => siblings.Any(initializer => !initializer.FieldOpt.IsConst));
         }
 
         private void AddNonTypeMembers(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -375,9 +375,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else
                             {
-                                // synthesized constructors are the exception, but they should have been weeded out by the caller
-                                var isNew = ((SourceMethodSymbol)method).IsNew;
-                                CheckNonOverrideMember(method, isNew, method.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                var sourceMethod = method as SourceMethodSymbol;
+                                if ((object)sourceMethod != null) // skip submission initializer
+                                {
+                                    var isNew = sourceMethod.IsNew;
+                                    CheckNonOverrideMember(method, isNew, method.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                }
                             }
                         }
                         else if (method.MethodKind == MethodKind.Destructor)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -4,9 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -14,41 +11,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Represents an interactive code entry point that is inserted into the compilation if there is not an existing one. 
     /// </summary>
-    internal sealed class SynthesizedEntryPointSymbol : MethodSymbol
+    internal abstract class SynthesizedEntryPointSymbol : MethodSymbol
     {
         private readonly NamedTypeSymbol _containingType;
-        private readonly ImmutableArray<ParameterSymbol> _parameters;
         private readonly TypeSymbol _returnType;
-        private readonly string _name;
 
-        internal SynthesizedEntryPointSymbol(NamedTypeSymbol containingType, TypeSymbol returnType, DiagnosticBag diagnostics)
+        internal static SynthesizedEntryPointSymbol Create(NamedTypeSymbol containingType, TypeSymbol returnType, DiagnosticBag diagnostics)
         {
-            Debug.Assert((object)containingType != null);
-            _containingType = containingType;
-
+            var compilation = containingType.DeclaringCompilation;
             if (containingType.ContainingAssembly.IsInteractive)
             {
-                var submissionArrayType = this.DeclaringCompilation.CreateArrayTypeSymbol(this.DeclaringCompilation.GetSpecialType(SpecialType.System_Object));
+                var submissionArrayType = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Object));
                 var useSiteDiagnostic = submissionArrayType.GetUseSiteDiagnostic();
                 if (useSiteDiagnostic != null)
                 {
-                    Symbol.ReportUseSiteDiagnostic(useSiteDiagnostic, diagnostics, NoLocation.Singleton);
+                    ReportUseSiteDiagnostic(useSiteDiagnostic, diagnostics, NoLocation.Singleton);
                 }
-
-                _parameters = ImmutableArray.Create<ParameterSymbol>(new SynthesizedParameterSymbol(this, submissionArrayType, 0, RefKind.None, "submissionArray"));
-                _name = "<Factory>";
+                return new SubmissionEntryPoint(containingType, returnType, submissionArrayType);
             }
             else
             {
-                _parameters = ImmutableArray<ParameterSymbol>.Empty;
-                _name = "<Main>";
+                return new ScriptEntryPoint(containingType, returnType);
             }
+        }
 
-            if (this.DeclaringCompilation.IsSubmission)
-            {
-                returnType = this.DeclaringCompilation.GetSpecialType(SpecialType.System_Object);
-            }
+        private SynthesizedEntryPointSymbol(NamedTypeSymbol containingType, TypeSymbol returnType)
+        {
+            Debug.Assert((object)containingType != null);
+            Debug.Assert((object)returnType != null);
 
+            _containingType = containingType;
             _returnType = returnType;
         }
 
@@ -57,108 +49,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal BoundBlock CreateBody()
-        {
-            return this.DeclaringCompilation.IsSubmission ? CreateSubmissionFactoryBody() : CreateScriptBody();
-        }
-
-        // Generates:
-        //
-        // private static void {Main}()
-        // {
-        //     new {ThisScriptClass}();
-        // }
-        private BoundBlock CreateScriptBody()
-        {
-            Debug.Assert(_containingType.IsScriptClass);
-
-            SyntaxTree syntaxTree = CSharpSyntaxTree.Dummy;
-            CSharpSyntaxNode syntax = (CSharpSyntaxNode)syntaxTree.GetRoot();
-
-            return new BoundBlock(syntax,
-                ImmutableArray<LocalSymbol>.Empty,
-                ImmutableArray.Create<BoundStatement>(
-                    new BoundExpressionStatement(syntax,
-                        new BoundObjectCreationExpression(
-                            syntax,
-                            _containingType.InstanceConstructors.Single())
-                        { WasCompilerGenerated = true })
-                    { WasCompilerGenerated = true },
-                    new BoundReturnStatement(syntax, null) { WasCompilerGenerated = true })
-            );
-        }
-
-        // Generates:
-        // 
-        // private static T {Factory}(InteractiveSession session) 
-        // {
-        //    T submissionResult;
-        //    new {ThisScriptClass}(session, out submissionResult);
-        //    return submissionResult;
-        // }
-        private BoundBlock CreateSubmissionFactoryBody()
-        {
-            Debug.Assert(_containingType.TypeKind == TypeKind.Submission);
-
-            SyntaxTree syntaxTree = CSharpSyntaxTree.Dummy;
-            CSharpSyntaxNode syntax = (CSharpSyntaxNode)syntaxTree.GetRoot();
-
-            var interactiveSessionParam = new BoundParameter(syntax, _parameters[0]) { WasCompilerGenerated = true };
-
-            var ctor = _containingType.InstanceConstructors.Single();
-            Debug.Assert(ctor is SynthesizedInstanceConstructor);
-            Debug.Assert(ctor.ParameterCount == 2);
-
-            var submissionResultType = ctor.Parameters[1].Type;
-
-            var resultLocal = new SynthesizedLocal(ctor, submissionResultType, SynthesizedLocalKind.LoweringTemp);
-            var localReference = new BoundLocal(syntax, resultLocal, null, submissionResultType) { WasCompilerGenerated = true };
-
-            BoundExpression submissionResult = localReference;
-            if (submissionResultType.IsStructType() && _returnType.SpecialType == SpecialType.System_Object)
-            {
-                submissionResult = new BoundConversion(syntax, submissionResult, Conversion.Boxing, false, true, ConstantValue.NotAvailable, _returnType)
-                { WasCompilerGenerated = true };
-            }
-
-            return new BoundBlock(syntax,
-                // T submissionResult;
-                ImmutableArray.Create<LocalSymbol>(resultLocal),
-                ImmutableArray.Create<BoundStatement>(
-                    // new Submission(interactiveSession, out submissionResult);
-                    new BoundExpressionStatement(syntax,
-                        new BoundObjectCreationExpression(
-                            syntax,
-                            ctor,
-                            ImmutableArray.Create<BoundExpression>(interactiveSessionParam, localReference),
-                            ImmutableArray<string>.Empty,
-                            ImmutableArray.Create<RefKind>(RefKind.None, RefKind.Ref),
-                            false,
-                            default(ImmutableArray<int>),
-                            null,
-                            null,
-                            _containingType
-                        )
-                        { WasCompilerGenerated = true })
-                    { WasCompilerGenerated = true },
-                    // return submissionResult;
-                    new BoundReturnStatement(syntax, submissionResult) { WasCompilerGenerated = true }))
-            { WasCompilerGenerated = true };
-        }
+        internal abstract BoundBlock CreateBody();
 
         public override Symbol ContainingSymbol
         {
             get { return _containingType; }
         }
 
-        public override string Name
+        public abstract override string Name
         {
-            get { return _name; }
+            get;
         }
 
         internal override bool HasSpecialName
         {
-            get { return false; }
+            get { return true; }
         }
 
         internal override System.Reflection.MethodImplAttributes ImplementationAttributes
@@ -179,11 +84,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<TypeParameterSymbol> TypeParameters
         {
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
-        }
-
-        public override ImmutableArray<ParameterSymbol> Parameters
-        {
-            get { return _parameters; }
         }
 
         public override Accessibility DeclaredAccessibility
@@ -355,6 +255,194 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {
             throw ExceptionUtilities.Unreachable;
+        }
+
+        private CSharpSyntaxNode GetSyntax()
+        {
+            var syntaxTree = CSharpSyntaxTree.Dummy;
+            return (CSharpSyntaxNode)syntaxTree.GetRoot();
+        }
+
+        private sealed class ScriptEntryPoint : SynthesizedEntryPointSymbol
+        {
+            internal ScriptEntryPoint(NamedTypeSymbol containingType, TypeSymbol returnType) :
+                base(containingType, returnType)
+            {
+                Debug.Assert(containingType.IsScriptClass);
+                Debug.Assert(returnType.SpecialType == SpecialType.System_Void);
+            }
+
+            public override string Name
+            {
+                get { return "<Main>"; }
+            }
+
+            public override ImmutableArray<ParameterSymbol> Parameters
+            {
+                get { return ImmutableArray<ParameterSymbol>.Empty; }
+            }
+
+            // private static void <Main>()
+            // {
+            //     var script = new Script();
+            //     script.<Initialize>();
+            // }
+            internal override BoundBlock CreateBody()
+            {
+                var syntax = this.GetSyntax();
+
+                var ctor = _containingType.GetScriptConstructor();
+                Debug.Assert(ctor.ParameterCount == 0);
+
+                var initializer = _containingType.GetScriptInitializer();
+                Debug.Assert(initializer.ParameterCount == 0);
+
+                var submissionLocal = new BoundLocal(
+                    syntax,
+                    new SynthesizedLocal(this, _containingType, SynthesizedLocalKind.LoweringTemp),
+                    null,
+                    _containingType)
+                { WasCompilerGenerated = true };
+
+                return new BoundBlock(syntax,
+                    ImmutableArray.Create<LocalSymbol>(submissionLocal.LocalSymbol),
+                    ImmutableArray.Create<BoundStatement>(
+                        // var script = new Script();
+                        new BoundExpressionStatement(
+                            syntax,
+                            new BoundAssignmentOperator(
+                                syntax,
+                                submissionLocal,
+                                new BoundObjectCreationExpression(
+                                    syntax,
+                                    ctor)
+                                { WasCompilerGenerated = true },
+                                _containingType)
+                            { WasCompilerGenerated = true })
+                        { WasCompilerGenerated = true },
+                        // script.<Initialize>();
+                        new BoundExpressionStatement(
+                            syntax,
+                            new BoundCall(
+                                syntax,
+                                submissionLocal,
+                                initializer,
+                                ImmutableArray<BoundExpression>.Empty,
+                                default(ImmutableArray<string>),
+                                default(ImmutableArray<RefKind>),
+                                isDelegateCall: false,
+                                expanded: false,
+                                invokedAsExtensionMethod: false,
+                                argsToParamsOpt: default(ImmutableArray<int>),
+                                resultKind: LookupResultKind.Viable,
+                                type: initializer.ReturnType)
+                            { WasCompilerGenerated = true })
+                        { WasCompilerGenerated = true },
+                        // return;
+                        new BoundReturnStatement(
+                            syntax,
+                            null)
+                        { WasCompilerGenerated = true }))
+                { WasCompilerGenerated = true };
+            }
+        }
+
+        private sealed class SubmissionEntryPoint : SynthesizedEntryPointSymbol
+        {
+            private readonly ImmutableArray<ParameterSymbol> _parameters;
+
+            internal SubmissionEntryPoint(NamedTypeSymbol containingType, TypeSymbol returnType, TypeSymbol submissionArrayType) :
+                base(containingType, returnType)
+            {
+                Debug.Assert(containingType.IsSubmissionClass);
+                _parameters = ImmutableArray.Create<ParameterSymbol>(new SynthesizedParameterSymbol(this, submissionArrayType, 0, RefKind.None, "submissionArray"));
+            }
+
+            public override string Name
+            {
+                get { return "<Factory>"; }
+            }
+
+            public override ImmutableArray<ParameterSymbol> Parameters
+            {
+                get { return _parameters; }
+            }
+
+            // private static T <Factory>(object[] submissionArray) 
+            // {
+            //     var submission = new Submission#N(submissionArray);
+            //     return submission.<Initialize>();
+            // }
+            internal override BoundBlock CreateBody()
+            {
+                var syntax = this.GetSyntax();
+
+                var ctor = _containingType.GetScriptConstructor();
+                Debug.Assert(ctor.ParameterCount == 1);
+
+                var initializer = _containingType.GetScriptInitializer();
+                Debug.Assert(initializer.ParameterCount == 0);
+
+                var submissionArrayParameter = new BoundParameter(syntax, _parameters[0]) { WasCompilerGenerated = true };
+                var submissionLocal = new BoundLocal(
+                    syntax,
+                    new SynthesizedLocal(this, _containingType, SynthesizedLocalKind.LoweringTemp),
+                    null,
+                    _containingType)
+                { WasCompilerGenerated = true };
+
+                // var submission = new Submission#N(submissionArray);
+                var submissionAssignment = new BoundExpressionStatement(
+                    syntax,
+                    new BoundAssignmentOperator(
+                        syntax,
+                        submissionLocal,
+                        new BoundObjectCreationExpression(
+                            syntax,
+                            ctor,
+                            ImmutableArray.Create<BoundExpression>(submissionArrayParameter),
+                            default(ImmutableArray<string>),
+                            default(ImmutableArray<RefKind>),
+                            false,
+                            default(ImmutableArray<int>),
+                            null,
+                            null,
+                            _containingType)
+                        { WasCompilerGenerated = true },
+                        _containingType)
+                    { WasCompilerGenerated = true })
+                { WasCompilerGenerated = true };
+
+                // return submission.<Initialize>();
+                BoundExpression initializeResult = new BoundCall(
+                    syntax,
+                    submissionLocal,
+                    initializer,
+                    ImmutableArray<BoundExpression>.Empty,
+                    default(ImmutableArray<string>),
+                    default(ImmutableArray<RefKind>),
+                    isDelegateCall: false,
+                    expanded: false,
+                    invokedAsExtensionMethod: false,
+                    argsToParamsOpt: default(ImmutableArray<int>),
+                    resultKind: LookupResultKind.Viable,
+                    type: initializer.ReturnType)
+                { WasCompilerGenerated = true };
+                if (initializeResult.Type.IsStructType() && (_returnType.SpecialType == SpecialType.System_Object))
+                {
+                    initializeResult = new BoundConversion(syntax, initializeResult, Conversion.Boxing, false, true, ConstantValue.NotAvailable, _returnType)
+                    { WasCompilerGenerated = true };
+                }
+                var returnStatement = new BoundReturnStatement(
+                    syntax,
+                    initializeResult)
+                { WasCompilerGenerated = true };
+
+                return new BoundBlock(syntax,
+                    ImmutableArray.Create<LocalSymbol>(submissionLocal.LocalSymbol),
+                    ImmutableArray.Create<BoundStatement>(submissionAssignment, returnStatement))
+                { WasCompilerGenerated = true };
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -3,12 +3,11 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal class SynthesizedImplementationMethod : SynthesizedInstanceMethodSymbol
+    internal abstract class SynthesizedImplementationMethod : SynthesizedInstanceMethodSymbol
     {
         //inputs
         private readonly MethodSymbol _interfaceMethod;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedInteractiveInitializerMethod : SynthesizedInstanceMethodSymbol
+    {
+        internal const string InitializerName = "<Initialize>";
+
+        private readonly SourceMemberContainerTypeSymbol _containingType;
+        private readonly TypeSymbol _resultType;
+        private ReturnTypeState _lazyReturnType;
+
+        private sealed class ReturnTypeState
+        {
+            internal ReturnTypeState(bool isAsync, TypeSymbol returnType)
+            {
+                this.IsAsync = isAsync;
+                this.ReturnType = returnType;
+            }
+
+            internal readonly bool IsAsync;
+            internal readonly TypeSymbol ReturnType;
+        }
+
+        internal SynthesizedInteractiveInitializerMethod(SourceMemberContainerTypeSymbol containingType, DiagnosticBag diagnostics)
+        {
+            Debug.Assert(containingType.IsScriptClass);
+
+            _containingType = containingType;
+
+            var compilation = containingType.DeclaringCompilation;
+            var submissionReturnType = compilation.SubmissionReturnType;
+            _resultType = (submissionReturnType == null) ?
+                null :
+                compilation.GetTypeByReflectionType(submissionReturnType, diagnostics);
+        }
+
+        public override string Name
+        {
+            get { return InitializerName; }
+        }
+
+        internal override bool IsScriptInitializer
+        {
+            get { return true; }
+        }
+
+        public override int Arity
+        {
+            get { return this.TypeParameters.Length; }
+        }
+
+        public override Symbol AssociatedSymbol
+        {
+            get { return null; }
+        }
+
+        public override Symbol ContainingSymbol
+        {
+            get { return _containingType; }
+        }
+
+        public override Accessibility DeclaredAccessibility
+        {
+            get { return Accessibility.Friend; }
+        }
+
+        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
+        {
+            get { return ImmutableArray<MethodSymbol>.Empty; }
+        }
+
+        public override bool HidesBaseMethodsByName
+        {
+            get { return false; }
+        }
+
+        public override bool IsAbstract
+        {
+            get { return false; }
+        }
+
+        public override bool IsAsync
+        {
+            get { return _lazyReturnType.IsAsync; }
+        }
+
+        public override bool IsExtensionMethod
+        {
+            get { return false; }
+        }
+
+        public override bool IsExtern
+        {
+            get { return false; }
+        }
+
+        public override bool IsOverride
+        {
+            get { return false; }
+        }
+
+        public override bool IsSealed
+        {
+            get { return false; }
+        }
+
+        public override bool IsStatic
+        {
+            get { return false; }
+        }
+
+        public override bool IsVararg
+        {
+            get { return false; }
+        }
+
+        public override bool IsVirtual
+        {
+            get { return false; }
+        }
+
+        public override ImmutableArray<Location> Locations
+        {
+            get { return _containingType.Locations; }
+        }
+
+        public override MethodKind MethodKind
+        {
+            get { return MethodKind.Ordinary; }
+        }
+
+        public override ImmutableArray<ParameterSymbol> Parameters
+        {
+            get { return ImmutableArray<ParameterSymbol>.Empty; }
+        }
+
+        public override bool ReturnsVoid
+        {
+            get { return ReturnType.SpecialType == SpecialType.System_Void; }
+        }
+
+        public override TypeSymbol ReturnType
+        {
+            get { return _lazyReturnType.ReturnType; }
+        }
+
+        public override ImmutableArray<CustomModifier> ReturnTypeCustomModifiers
+        {
+            get { return ImmutableArray<CustomModifier>.Empty; }
+        }
+
+        public override ImmutableArray<TypeSymbol> TypeArguments
+        {
+            get { return ImmutableArray<TypeSymbol>.Empty; }
+        }
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters
+        {
+            get { return ImmutableArray<TypeParameterSymbol>.Empty; }
+        }
+
+        internal override Cci.CallingConvention CallingConvention
+        {
+            get
+            {
+                Debug.Assert(!this.IsStatic);
+                Debug.Assert(!this.IsGenericMethod);
+                return Cci.CallingConvention.HasThis;
+            }
+        }
+
+        internal override bool GenerateDebugInfo
+        {
+            get { return true; }
+        }
+
+        internal override bool HasDeclarativeSecurity
+        {
+            get { return false; }
+        }
+
+        internal override bool HasSpecialName
+        {
+            get { return true; }
+        }
+
+        internal override MethodImplAttributes ImplementationAttributes
+        {
+            get { return default(MethodImplAttributes); }
+        }
+
+        internal override bool RequiresSecurityObject
+        {
+            get { return false; }
+        }
+
+        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
+        {
+            get { return null; }
+        }
+
+        public override DllImportData GetDllImportData()
+        {
+            return null;
+        }
+
+        internal override ImmutableArray<string> GetAppliedConditionalSymbols()
+        {
+            return ImmutableArray<string>.Empty;
+        }
+
+        internal override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        {
+            return false;
+        }
+
+        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
+        {
+            return false;
+        }
+
+        internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+        {
+            return _containingType.CalculateSyntaxOffsetInSynthesizedConstructor(localPosition, localTree, isStatic: false);
+        }
+
+        internal TypeSymbol ResultType
+        {
+            get { return _resultType; }
+        }
+
+        internal void SetReturnType(bool isAsync, TypeSymbol returnType)
+        {
+            Debug.Assert((_lazyReturnType == null) || (_lazyReturnType.ReturnType == returnType));
+            Interlocked.CompareExchange(ref _lazyReturnType, new ReturnTypeState(isAsync, returnType), null);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubmissionConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubmissionConstructor.cs
@@ -2,9 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -27,13 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(useSiteError, NoLocation.Singleton);
             }
 
-            // resolve return type:
-            TypeSymbol returnType = compilation.GetTypeByReflectionType(compilation.SubmissionReturnType, diagnostics);
-
             _parameters = ImmutableArray.Create<ParameterSymbol>(
-                new SynthesizedParameterSymbol(this, submissionArrayType, 0, RefKind.None, "submissionArray"),
-                new SynthesizedParameterSymbol(this, returnType, 1, RefKind.Ref, "submissionResult")
-            );
+                new SynthesizedParameterSymbol(this, submissionArrayType, 0, RefKind.None, "submissionArray"));
         }
 
         public override ImmutableArray<ParameterSymbol> Parameters

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenAsyncTests : EmitMetadataTestBase
     {
-        private CSharpCompilation CreateCompilation(string source, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null)
+        private static CSharpCompilation CreateCompilation(string source, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null)
         {
             SynchronizationContext.SetSynchronizationContext(null);
 
@@ -31,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         {
             SynchronizationContext.SetSynchronizationContext(null);
 
-            var compilation = this.CreateCompilation(source, references: references, options: options);
+            var compilation = CreateCompilation(source, references: references, options: options);
             return base.CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 
@@ -3362,6 +3361,53 @@ class Program
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             CompileAndVerify(comp);
             CompileAndVerify(comp.WithOptions(TestOptions.ReleaseExe));
+        }
+
+        [Fact]
+        public void AwaitInScript()
+        {
+            var source =
+@"int x = await System.Threading.Tasks.Task.Run(() => 1);
+System.Console.WriteLine(x);";
+            var compilation = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics(
+                // (1,9): error CS1992: The 'await' operator can only be used when contained within a method or lambda expression marked with the 'async' modifier
+                // int x = await System.Threading.Tasks.Task.Run(() => 1);
+                Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsync, "await System.Threading.Tasks.Task.Run(() => 1)").WithLocation(1, 9));
+        }
+
+        [Fact]
+        public void AwaitInInteractive()
+        {
+            var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
+            var source0 =
+@"static async System.Threading.Tasks.Task<int> F()
+{
+    return await System.Threading.Tasks.Task.FromResult(2);
+}";
+            var source1 =
+@"await F()";
+            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive), references);
+            var s1 = CSharpCompilation.CreateSubmission("s1.dll", SyntaxFactory.ParseSyntaxTree(source1, options: TestOptions.Interactive), references, previousSubmission: s0);
+            s1.VerifyDiagnostics();
+        }
+
+        /// <summary>
+        /// await should be disallowed in static field initializer
+        /// since the static initialization of the class should
+        /// complete before other members are used.
+        /// </summary>
+        [Fact(Skip = "Not handled")]
+        public void AwaitInStaticInitializer()
+        {
+            var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
+            var source =
+@"static int x = await System.Threading.Tasks.Task.FromResult(1);";
+            var compilation = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Interactive), references);
+            compilation.VerifyDiagnostics(
+                // (1,16): error CS1992: The 'await' operator can only be used when contained within a method or lambda expression marked with the 'async' modifier
+                // static int x = await System.Threading.Tasks.Task.FromResult(1);
+                Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsync, "await System.Threading.Tasks.Task.FromResult(1)").WithLocation(1, 16));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -7190,47 +7190,45 @@ dynamic x = Color.F((dynamic)1);
 ";
             var script = CreateCompilationWithMscorlib(Parse(sourceScript, options: TestOptions.Script), new[] { new CSharpCompilationReference(lib), SystemCoreRef, CSharpRef });
 
-            CompileAndVerify(script).VerifyIL(".ctor", @"
+            CompileAndVerify(script).VerifyIL("<Initialize>", @"
 {
-  // Code size      110 (0x6e)
+  // Code size      104 (0x68)
   .maxstack  10
   IL_0000:  ldarg.0
-  IL_0001:  call       ""object..ctor()""
-  IL_0006:  ldarg.0
-  IL_0007:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
-  IL_000c:  brtrue.s   IL_0048
-  IL_000e:  ldc.i4.0
-  IL_000f:  ldstr      ""F""
-  IL_0014:  ldnull
-  IL_0015:  ldtoken    ""Script""
-  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_001f:  ldc.i4.2
-  IL_0020:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_0025:  dup
-  IL_0026:  ldc.i4.0
-  IL_0027:  ldc.i4.1
-  IL_0028:  ldnull
-  IL_0029:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_002e:  stelem.ref
-  IL_002f:  dup
-  IL_0030:  ldc.i4.1
-  IL_0031:  ldc.i4.0
-  IL_0032:  ldnull
-  IL_0033:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_0038:  stelem.ref
-  IL_0039:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_003e:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0043:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
-  IL_0048:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
-  IL_004d:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Target""
-  IL_0052:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
-  IL_0057:  ldarg.0
-  IL_0058:  ldfld      """"
-  IL_005d:  ldc.i4.1
-  IL_005e:  box        ""int""
-  IL_0063:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, Color, object)""
-  IL_0068:  stfld      """"
-  IL_006d:  ret
+  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+  IL_0006:  brtrue.s   IL_0042
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldstr      ""F""
+  IL_000e:  ldnull
+  IL_000f:  ldtoken    ""Script""
+  IL_0014:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0019:  ldc.i4.2
+  IL_001a:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_001f:  dup
+  IL_0020:  ldc.i4.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  ldnull
+  IL_0023:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0028:  stelem.ref
+  IL_0029:  dup
+  IL_002a:  ldc.i4.1
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldnull
+  IL_002d:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0032:  stelem.ref
+  IL_0033:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_0038:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_003d:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+  IL_0042:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+  IL_0047:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Target""
+  IL_004c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+  IL_0051:  ldarg.0
+  IL_0052:  ldfld      ""Color Script.Color""
+  IL_0057:  ldc.i4.1
+  IL_0058:  box        ""int""
+  IL_005d:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, Color, object)""
+  IL_0062:  stfld      ""dynamic Script.x""
+  IL_0067:  ret
 }
 ", realIL: true);
         }
@@ -7263,7 +7261,7 @@ void Foo()
 {
   // Code size       99 (0x63)
   .maxstack  9
-  IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__1.<>p__0""
+  IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
   IL_0005:  brtrue.s   IL_0041
   IL_0007:  ldc.i4.0
   IL_0008:  ldstr      ""F""
@@ -7286,10 +7284,10 @@ void Foo()
   IL_0031:  stelem.ref
   IL_0032:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
   IL_0037:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_003c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__1.<>p__0""
-  IL_0041:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__1.<>p__0""
+  IL_003c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
+  IL_0041:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
   IL_0046:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Target""
-  IL_004b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__1.<>p__0""
+  IL_004b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__2.<>p__0""
   IL_0050:  ldarg.0
   IL_0051:  ldfld      ""Color Script.Color""
   IL_0056:  ldc.i4.1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FieldInitializerBindingTests.cs
@@ -285,24 +285,17 @@ class C
         private static ImmutableArray<BoundInitializer> BindInitializersWithoutDiagnostics(SourceNamedTypeSymbol typeSymbol, ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers)
         {
             DiagnosticBag diagnostics = DiagnosticBag.GetInstance();
-            try
-            {
-                ImportChain unused;
-                var boundInitializers = Binder.BindFieldInitializers(
-                    containingType: typeSymbol,
-                    scriptCtor: null,
-                    initializers: initializers,
-                    diagnostics: diagnostics,
-                    firstImportChain: out unused);
-
-                diagnostics.Verify();
-
-                return boundInitializers;
-            }
-            finally
-            {
-                diagnostics.Free();
-            }
+            ImportChain unused;
+            var boundInitializers = ArrayBuilder<BoundInitializer>.GetInstance();
+            Binder.BindRegularCSharpFieldInitializers(
+                typeSymbol.DeclaringCompilation,
+                initializers,
+                boundInitializers,
+                diagnostics,
+                firstDebugImports: out unused);
+            diagnostics.Verify();
+            diagnostics.Free();
+            return boundInitializers.ToImmutableAndFree();
         }
 
         private class ExpectedInitializer

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -19,9 +20,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Test;
-using Microsoft.CodeAnalysis.Scripting.CSharp;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -150,9 +149,9 @@ namespace Foo
         public void NamespaceWithBothInteractiveAndNoninteractiveImplicitTypes()
         {
             string test = @"
-namespace Foo { void foo() { } }
-void bar() { }
-bar();
+namespace Foo { void F() { } }
+void G() { }
+G();
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
@@ -178,20 +177,15 @@ bar();
                 if (cls.IsScriptClass)
                 {
                     Assert.False(cls.IsImplicitClass);
-                    Assert.Equal(2, methods.Length);
-                    Assert.Equal("bar", methods[0].Name);
-                    Assert.Equal(WellKnownMemberNames.InstanceConstructorName, methods[1].Name);
+                    AssertEx.SetEqual(new[] { "<Initialize>", "G", ".ctor" }, methods.Select(m => m.Name));
                 }
                 else
                 {
                     Assert.False(cls.IsScriptClass);
                     Assert.Equal(TypeSymbol.ImplicitTypeName, member.Name);
-                    Assert.Equal(2, methods.Length);
-                    Assert.Equal("foo", methods[0].Name);
-                    Assert.Equal(".ctor", methods[1].Name);
-                    Assert.IsAssignableFrom(typeof(MethodSymbol), methods[0]);
-                    Assert.IsAssignableFrom(typeof(MethodSymbol), methods[1]);
+                    AssertEx.SetEqual(new[] { "F", ".ctor" }, methods.Select(m => m.Name));
                 }
+                Assert.True(methods.All(m => m is MethodSymbol));
             }
         }
 
@@ -2686,6 +2680,65 @@ this[1]
             Assert.Equal(TypeKind.Error, summary.ConvertedType.TypeKind);
             Assert.Equal(Conversion.Identity, summary.ImplicitConversion);
             Assert.Equal(0, summary.MethodGroup.Length);
+        }
+
+        [Fact]
+        public void NoAwait()
+        {
+            var engine = new CSharpScriptEngine();
+            var session = engine.CreateSession();
+            // No await. The return value is Task<int> rather than Task<object>.
+            var result = (Task<int>)session.Execute("System.Threading.Tasks.Task.FromResult(1)");
+            Assert.Equal(1, result.Result);
+        }
+
+        /// <summary>
+        /// 'await' expression at top-level.
+        /// </summary>
+        [Fact]
+        public void Await()
+        {
+            var engine = new CSharpScriptEngine();
+            var session = engine.CreateSession();
+            var result = (Task<object>)session.Execute("await System.Threading.Tasks.Task.FromResult(2)");
+            Assert.Equal(2, result.Result);
+        }
+
+        /// <summary>
+        /// 'await' in sub-expression.
+        /// </summary>
+        [Fact]
+        public void AwaitSubExpression()
+        {
+            var engine = new CSharpScriptEngine();
+            var session = engine.CreateSession();
+            var result = (Task<object>)session.Execute("0 + await System.Threading.Tasks.Task.FromResult(3)");
+            Assert.Equal(3, result.Result);
+        }
+
+        /// <summary>
+        /// 'await' in lambda should be ignored.
+        /// </summary>
+        [Fact]
+        public void AwaitInLambda()
+        {
+            var engine = new CSharpScriptEngine();
+            var session = engine.CreateSession();
+            session.Execute(
+@"using System;
+using System.Threading.Tasks;
+static T F<T>(Func<Task<T>> f)
+{
+    return f().Result;
+}
+static T G<T>(T t, Func<T, Task<T>> f)
+{
+    return f(t).Result;
+}");
+            var result = session.Execute("F(async () => await Task.FromResult(4))");
+            Assert.Equal(4, result);
+            result = session.Execute("G(5, async x => await Task.FromResult(x))");
+            Assert.Equal(5, result);
         }
 
         #endregion

--- a/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
@@ -268,8 +268,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     return ILBuilderVisualizer.ILBuilderToString(methodData.ILBuilder, markers: markers);
                 }
 
-                var module = this.GetModuleSymbolForEmittedImage();
-                return module != null ? _test.VisualizeRealIL(module, methodData, markers) : null;
+                if (_lazyModuleSymbol == null)
+                {
+                    _lazyModuleSymbol = GetModuleSymbolForEmittedImage(EmittedAssemblyData, MetadataImportOptions.All);
+                }
+
+                return _lazyModuleSymbol != null ? _test.VisualizeRealIL(_lazyModuleSymbol, methodData, markers) : null;
             }
 
             public CompilationVerifier VerifyMemberInIL(string methodName, bool expected)
@@ -286,28 +290,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             public IModuleSymbol GetModuleSymbolForEmittedImage()
             {
-                return GetModuleSymbolForEmittedImage(ref _lazyModuleSymbol, EmittedAssemblyData);
+                return GetModuleSymbolForEmittedImage(EmittedAssemblyData, _compilation.Options.MetadataImportOptions);
             }
 
-            private IModuleSymbol GetModuleSymbolForEmittedImage(ref IModuleSymbol moduleSymbol, ImmutableArray<byte> peImage)
+            private IModuleSymbol GetModuleSymbolForEmittedImage(ImmutableArray<byte> peImage, MetadataImportOptions importOptions)
             {
                 if (peImage.IsDefault)
                 {
                     return null;
                 }
 
-                if (moduleSymbol == null)
-                {
-                    Debug.Assert(!peImage.IsDefault);
-
-                    var targetReference = LoadTestEmittedExecutableForSymbolValidation(peImage, _compilation.Options.OutputKind, display: _compilation.AssemblyName);
-                    var references = _compilation.References.Concat(new[] { targetReference });
-                    var assemblies = _test.ReferencesToModuleSymbols(references, _compilation.Options.MetadataImportOptions);
-                    var module = assemblies.Last();
-                    moduleSymbol = module;
-                }
-
-                return moduleSymbol;
+                var targetReference = LoadTestEmittedExecutableForSymbolValidation(peImage, _compilation.Options.OutputKind, display: _compilation.AssemblyName);
+                var references = _compilation.References.Concat(new[] { targetReference });
+                var assemblies = _test.ReferencesToModuleSymbols(references, importOptions);
+                return assemblies.Last();
             }
 
             private static MetadataReference LoadTestEmittedExecutableForSymbolValidation(


### PR DESCRIPTION
Top-level statements in Interactive are now executed in an Initialize method rather than in the Script or Submission .ctor. This allows interactive submissions to contain 'await' expressions since the expressions can be rewritten as state machines. For now, 'await' is allowed in interactive only, not in scripting. (In interactive, the host will be responsible for ensuring previous submissions complete before subsequent submissions are started. In scripting, the script is compiled to non-async Main method.) 