### PR TITLE
TypeScript Contained Language 2

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -119,6 +119,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
         private async Task<SyntaxToken> FindTokenInLinkedDocument(SyntaxToken token, Document linkedDocument, CancellationToken cancellationToken)
         {
+            if (!linkedDocument.SupportsSyntaxTree)
+            {
+                return default(SyntaxToken);
+            }
+
             var root = await linkedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Don't search trivia because we want to ignore inactive regions

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -113,8 +114,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
         private Task<IEnumerable<Location>> GetAdditionalReferencesAsync(
             Document document, ISymbol symbol, CancellationToken cancellationToken)
         {
-            return document.Project.LanguageServices.GetService<IReferenceHighlightingAdditionalReferenceProvider>()
-                .GetAdditionalReferencesAsync(document, symbol, cancellationToken);
+            var additionalReferenceProvider = document.Project.LanguageServices.GetService<IReferenceHighlightingAdditionalReferenceProvider>();
+            if (additionalReferenceProvider != null)
+            {
+                return additionalReferenceProvider.GetAdditionalReferencesAsync(document, symbol, cancellationToken);
+            }
+
+            return Task.FromResult<IEnumerable<Location>>(Array.Empty<Location>());
         }
 
         private async Task<IEnumerable<DocumentHighlights>> CreateSpansAsync(

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
                 return additionalReferenceProvider.GetAdditionalReferencesAsync(document, symbol, cancellationToken);
             }
 
-            return Task.FromResult<IEnumerable<Location>>(Array.Empty<Location>());
+            return Task.FromResult<IEnumerable<Location>>(SpecializedCollections.EmptyEnumerable<Location>());
         }
 
         private async Task<IEnumerable<DocumentHighlights>> CreateSpansAsync(

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -43,6 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private const string NewLineReplacementString = @"{|n|}";
 
         private const string HTML = "HTML";
+        private const string HTMLX = "HTMLX";
         private const string Razor = "Razor";
         private const string XOML = "XOML";
 
@@ -136,7 +137,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var projectionBuffer = _containedLanguage.DataBuffer as IProjectionBuffer;
             if (projectionBuffer != null)
             {
-                if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(HTML)))
+                // For TypeScript hosted in HTML the source buffers will have type names
+                // HTMLX and TypeScript. RazorCSharp has an HTMLX base type but should 
+                // not be associated with the HTML host type. Use ContentType.TypeName 
+                // instead of ContentType.IsOfType for HTMLX to ensure the Razor host 
+                // type is identified correctly.
+                if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(HTML) ||
+                    string.Compare(HTMLX, b.ContentType.TypeName, StringComparison.OrdinalIgnoreCase) == 0))
                 {
                     return HostType.HTML;
                 }
@@ -801,6 +808,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             var snapshot = subjectBuffer.CurrentSnapshot;
             var document = _workspace.CurrentSolution.GetDocument(this.Id);
+            if (!document.SupportsSyntaxTree)
+            {
+                return;
+            }
+
             var originalText = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
             Contract.Requires(object.ReferenceEquals(originalText, snapshot.AsText()));
 


### PR DESCRIPTION
A few changes to enable editing JavaScript blocks using TypeScript and Roslyn.

Creating a new pull request as the last one (https://github.com/dotnet/roslyn/pull/3354) had a commit that was not attributed correctly to my username.

Based on @jasonmalinowski, @Pilchie  CR comments I've removed the .html -> .html.js extension mapping out of Roslyn and instead we now handle it from the TypeScript language service.  

Adding other reviewers that were also on the previous pull request:
 @balajikris, @basoundr, @brettfo, @davkean, @DustinCampbell, @dpoeschl, @CyrusNajmabadi 