### PR TITLE
Suppress Add Watch when it would be invalid

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.TypeNames.cs
@@ -14,8 +14,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(identifier) != SyntaxKind.None;
         }
 
-        protected override void AppendIdentifierEscapingPotentialKeywords(StringBuilder builder, string identifier)
+        protected override void AppendIdentifierEscapingPotentialKeywords(StringBuilder builder, string identifier, out bool sawInvalidIdentifier)
         {
+            sawInvalidIdentifier = !IsValidIdentifier(identifier);
             if (IsPotentialKeyword(identifier))
             {
                 builder.Append('@');
@@ -30,8 +31,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             DynamicFlagsCustomTypeInfo dynamicFlags,
             ref int index,
             int arity, 
-            bool escapeKeywordIdentifiers)
+            bool escapeKeywordIdentifiers,
+            out bool sawInvalidIdentifier)
         {
+            sawInvalidIdentifier = false;
             builder.Append('<');
             for (int i = 0; i < arity; i++)
             {
@@ -41,7 +44,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 }
 
                 Type typeArgument = typeArguments[typeArgumentOffset + i];
-                AppendQualifiedTypeName(builder, typeArgument, dynamicFlags, ref index, escapeKeywordIdentifiers);
+                bool sawSingleInvalidIdentifier;
+                AppendQualifiedTypeName(builder, typeArgument, dynamicFlags, ref index, escapeKeywordIdentifiers, out sawSingleInvalidIdentifier);
+                sawInvalidIdentifier |= sawSingleInvalidIdentifier;
             }
             builder.Append('>');
         }
@@ -55,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             builder.Append(']');
         }
 
-        protected override bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic, bool escapeKeywordIdentifiers)
+        protected override bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic)
         {
             if (isDynamic)
             {
@@ -67,12 +72,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (type.IsPredefinedType())
             {
                 builder.Append(type.GetPredefinedTypeName()); // Not an identifier, does not require escaping.
-                return true;
-            }
-
-            if (type.IsGenericParameter)
-            {
-                AppendIdentifier(builder, escapeKeywordIdentifiers, type.Name);
                 return true;
             }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -18,10 +18,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (typeToDisplayOpt != null)
             {
                 // We're showing the type of a value, so "dynamic" does not apply.
+                bool unused;
                 int index = 0;
-                AppendQualifiedTypeName(builder, typeToDisplayOpt, default(DynamicFlagsCustomTypeInfo), ref index, escapeKeywordIdentifiers: true);
+                AppendQualifiedTypeName(builder, typeToDisplayOpt, default(DynamicFlagsCustomTypeInfo), ref index, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out unused);
                 builder.Append('.');
-                AppendIdentifierEscapingPotentialKeywords(builder, name);
+                AppendIdentifierEscapingPotentialKeywords(builder, name, sawInvalidIdentifier: out unused);
             }
             else
             {
@@ -46,7 +47,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             builder.Append('{');
 
             // We're showing the type of a value, so "dynamic" does not apply.
-            builder.Append(GetTypeName(new TypeAndCustomInfo(lmrType))); // NOTE: call our impl directly, since we're coupled anyway.
+            bool unused;
+            builder.Append(GetTypeName(new TypeAndCustomInfo(lmrType), escapeKeywordIdentifiers: false, sawInvalidIdentifier: out unused)); // NOTE: call our impl directly, since we're coupled anyway.
 
             var numSizes = sizes.Count;
 

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -22,6 +22,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
         }
 
+        internal override bool IsValidIdentifier(string name)
+        {
+            return SyntaxFacts.IsValidIdentifier(name);
+        }
+
         internal override bool IsIdentifierPartCharacter(char c)
         {
             return SyntaxFacts.IsIdentifierPartCharacter(c);

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -1259,14 +1259,14 @@ class C
                 EvalResult(rootExpr, "{A}", "A", rootExpr, DkmEvaluationResultFlags.Expandable));
             var children = GetChildren(evalResult);
             Verify(children,
-                EvalResult("1<>", "null", "object", "(new A()).1<>"),
-                EvalResult("@", "null", "object", "(new A()).@"),
-                EvalResult("CS<>7__8", "null", "object", "(new A()).CS<>7__8"),
+                EvalResult("1<>", "null", "object", fullName: null),
+                EvalResult("@", "null", "object", fullName: null),
+                EvalResult("CS<>7__8", "null", "object", fullName: null),
                 EvalResult("Static members", null, "", "A", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class));
             children = GetChildren(children[children.Length - 1]);
             Verify(children,
-                EvalResult(">", "null", "object", "A.>"),
-                EvalResult("><", "null", "object", "A.><"));
+                EvalResult(">", "null", "object", fullName: null),
+                EvalResult("><", "null", "object", fullName: null));
 
             type = assembly.GetType("B");
             rootExpr = "new B()";
@@ -1276,14 +1276,14 @@ class C
                 EvalResult(rootExpr, "{B}", "B", rootExpr, DkmEvaluationResultFlags.Expandable));
             children = GetChildren(evalResult);
             Verify(children,
-                EvalResult("1<>", "null", "object", "(new B()).1<>", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("@", "null", "object", "(new B()).@", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("VB<>7__8", "null", "object", "(new B()).VB<>7__8", DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("1<>", "null", "object", fullName: null, flags: DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("@", "null", "object", fullName: null, flags: DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("VB<>7__8", "null", "object", fullName: null, flags: DkmEvaluationResultFlags.ReadOnly),
                 EvalResult("Static members", null, "", "B", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class));
             children = GetChildren(children[children.Length - 1]);
             Verify(children,
-                EvalResult(">", "null", "object", "B.>", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("><", "null", "object", "B.><", DkmEvaluationResultFlags.ReadOnly));
+                EvalResult(">", "null", "object", fullName: null, flags: DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("><", "null", "object", fullName: null, flags: DkmEvaluationResultFlags.ReadOnly));
         }
 
         /// <summary>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Helpers/TestTypeExtensions.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
@@ -14,7 +15,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public static string GetTypeName(this System.Type type, DkmClrCustomTypeInfo typeInfo, bool escapeKeywordIdentifiers = false)
         {
-            return CSharpFormatter.Instance.GetTypeName(new TypeAndCustomInfo((TypeImpl)type, typeInfo), escapeKeywordIdentifiers);
+            bool sawInvalidIdentifier;
+            var result = CSharpFormatter.Instance.GetTypeName(new TypeAndCustomInfo((TypeImpl)type, typeInfo), escapeKeywordIdentifiers, out sawInvalidIdentifier);
+            Assert.False(sawInvalidIdentifier);
+            return result;            
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DebuggerTypeProxyExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DebuggerTypeProxyExpansion.cs
@@ -121,9 +121,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 formatter);
             if (proxyMembers != null)
             {
-                var proxyMemberFullNamePrefix = (childFullNamePrefix == null) ?
-                    null :
-                    formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true), childFullNamePrefix);
+                string proxyMemberFullNamePrefix = null;
+                if (childFullNamePrefix != null)
+                {
+                    bool sawInvalidIdentifier;
+                    var proxyTypeName = formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier);
+                    if (!sawInvalidIdentifier)
+                    {
+                        proxyMemberFullNamePrefix = formatter.GetObjectCreationExpression(proxyTypeName, childFullNamePrefix);
+                    }
+                }
                 _proxyItem = new EvalResultDataItem(
                     ExpansionKind.Default,
                     name: string.Empty,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DynamicViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DynamicViewExpansion.cs
@@ -89,11 +89,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var proxyTypeAndInfo = new TypeAndCustomInfo(_proxyValue.Type);
             var isRootExpression = parent == null;
             Debug.Assert(isRootExpression != (name == Resources.DynamicView));
-            var fullName = (!isRootExpression) ? parent.ChildFullNamePrefix : name;
+            var fullName = isRootExpression ? name : parent.ChildFullNamePrefix;
+            var sawInvalidIdentifier = false;
             var childFullNamePrefix = (fullName == null) ?
                 null :
-                formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true), fullName);
-            var formatSpecifiers = (!isRootExpression) ? parent.FormatSpecifiers : Formatter.NoFormatSpecifiers;
+                formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier), fullName);
+            Debug.Assert(!sawInvalidIdentifier); // Expected type name is "Microsoft.CSharp.RuntimeBinder.DynamicMetaObjectProviderDebugView".
+            var formatSpecifiers = isRootExpression ? Formatter.NoFormatSpecifiers : parent.FormatSpecifiers;
             return new EvalResultDataItem(
                 ExpansionKind.DynamicView,
                 name,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -382,7 +382,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 Expansion expansion)
             {
                 var formatter = resultProvider.Formatter;
-                var fullName = formatter.GetTypeName(declaredTypeAndInfo, escapeKeywordIdentifiers: true);
+                bool sawInvalidIdentifier;
+                var fullName = formatter.GetTypeName(declaredTypeAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier);
+                if (sawInvalidIdentifier)
+                {
+                    fullName = null;
+                }
                 return new EvalResultDataItem(
                     ExpansionKind.StaticMembers,
                     name: formatter.StaticMembersString,
@@ -421,14 +426,17 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 ? dynamicFlagsMap.SubstituteDynamicFlags(typeDeclaringMember.GetInterfaceListEntry(member.DeclaringType), originalDynamicFlags: default(DynamicFlagsCustomTypeInfo)).GetCustomTypeInfo()
                 : null;
             var formatter = resultProvider.Formatter;
-            memberName = formatter.GetIdentifierEscapingPotentialKeywords(memberName);
-            var fullName = MakeFullName(
-                formatter,
-                memberName,
-                new TypeAndCustomInfo(typeDeclaringMember, typeDeclaringMemberInfo), // Note: Won't include DynamicAttribute.
-                member.RequiresExplicitCast,
-                member.IsStatic,
-                parent);
+            bool sawInvalidIdentifier;
+            memberName = formatter.GetIdentifierEscapingPotentialKeywords(memberName, out sawInvalidIdentifier);
+            var fullName = sawInvalidIdentifier 
+                ? null 
+                : MakeFullName(
+                    formatter,
+                    memberName,
+                    new TypeAndCustomInfo(typeDeclaringMember, typeDeclaringMemberInfo), // Note: Won't include DynamicAttribute.
+                    member.RequiresExplicitCast,
+                    member.IsStatic,
+                    parent);
             return resultProvider.CreateDataItem(
                 inspectionContext,
                 memberName,
@@ -471,16 +479,26 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 parentFullName = $"({parentFullName})";
             }
 
-            if (!typeDeclaringMemberAndInfo.Type.IsInterface)
+            bool sawInvalidIdentifier;
+            var typeDeclaringMember = typeDeclaringMemberAndInfo.Type;
+            if (!typeDeclaringMember.IsInterface)
             {
                 string qualifier;
                 if (memberIsStatic)
                 {
-                    qualifier = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: false);
+                    qualifier = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier);
+                    if (sawInvalidIdentifier)
+                    {
+                        return null; // FullName wouldn't be parseable.
+                    }
                 }
                 else if (memberAccessRequiresExplicitCast)
                 {
-                    var typeName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
+                    var typeName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier);
+                    if (sawInvalidIdentifier)
+                    {
+                        return null; // FullName wouldn't be parseable.
+                    }
                     qualifier = formatter.GetCastExpression(
                         parentFullName,
                         typeName,
@@ -497,20 +515,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // NOTE: This should never interact with debugger proxy types:
                 //   1) Interfaces cannot have debugger proxy types.
                 //   2) Debugger proxy types cannot be interfaces.
-                if (typeDeclaringMemberAndInfo.Type.Equals(parent.DeclaredTypeAndInfo.Type))
+                if (typeDeclaringMember.Equals(parent.DeclaredTypeAndInfo.Type))
                 {
-                    var memberAccessTemplate = parent.ChildShouldParenthesize
-                        ? "({0}).{1}"
-                        : "{0}.{1}";
-                    return string.Format(memberAccessTemplate, parent.ChildFullNamePrefix, name);
+                    return $"{parentFullName}.{name}";
                 }
                 else
                 {
-                    var interfaceName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
-                    var memberAccessTemplate = parent.ChildShouldParenthesize
-                        ? "(({0})({1})).{2}"
-                        : "(({0}){1}).{2}";
-                    return string.Format(memberAccessTemplate, interfaceName, parent.ChildFullNamePrefix, name);
+                    var interfaceName = formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier);
+                    if (sawInvalidIdentifier)
+                    {
+                        return null; // FullName wouldn't be parseable.
+                    }
+                    return $"(({interfaceName}){parentFullName}).{name}";
                 }
             }
         }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/PointerDereferenceExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/PointerDereferenceExpansion.cs
@@ -50,19 +50,20 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var expansion = wasExceptionThrown ?
                 null :
                 resultProvider.GetTypeExpansion(inspectionContext, elementTypeAndInfo, value, ExpansionFlags.None);
-            var fullName = string.Format("*{0}", parent.ChildFullNamePrefix);
+            var parentFullName = parent.ChildFullNamePrefix;
+            var fullName = parentFullName == null ? null : $"*{parentFullName}";
             var editableValue = resultProvider.Formatter.GetEditableValue(value, inspectionContext);
 
             // NB: Full name is based on the real (i.e. not DebuggerDisplay) name.  This is a change from dev12, 
             // which used the DebuggerDisplay name, causing surprising results in "Add Watch" scenarios.
             return new EvalResultDataItem(
                 ExpansionKind.PointerDereference,
-                name: fullName,
+                name: fullName ?? $"*{parent.Name}",
                 typeDeclaringMemberAndInfo: default(TypeAndCustomInfo),
                 declaredTypeAndInfo: elementTypeAndInfo,
                 parent: null,
                 value: value,
-                displayValue: wasExceptionThrown ? string.Format(Resources.InvalidPointerDereference, fullName) : null,
+                displayValue: wasExceptionThrown ? string.Format(Resources.InvalidPointerDereference, fullName ?? parent.Name) : null,
                 expansion: expansion,
                 childShouldParenthesize: true,
                 fullName: fullName,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
@@ -212,9 +212,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Debug.Assert(parent != null);
             var proxyTypeAndInfo = new TypeAndCustomInfo(_proxyValue.Type);
             var fullName = parent.ChildFullNamePrefix;
+            var sawInvalidIdentifier = false;
             var childFullNamePrefix = (fullName == null) ?
                 null :
-                formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true), fullName);
+                formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier), fullName);
+            Debug.Assert(!sawInvalidIdentifier); // Expected proxy type name is "System.Linq.SystemCore_EnumerableDebugView".
             return new EvalResultDataItem(
                 ExpansionKind.ResultsView,
                 Resources.ResultsView,
@@ -249,7 +251,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 formatSpecifiers = Formatter.AddFormatSpecifier(formatSpecifiers, ResultsFormatSpecifier);
             }
-            var childFullNamePrefix = formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true), fullName);
+            bool sawInvalidIdentifier;
+            var childFullNamePrefix = formatter.GetObjectCreationExpression(formatter.GetTypeName(proxyTypeAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out sawInvalidIdentifier), fullName);
+            Debug.Assert(!sawInvalidIdentifier); // Expected proxy type name is "System.Linq.SystemCore_EnumerableDebugView".
             return new EvalResultDataItem(
                 ExpansionKind.Default,
                 name,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
@@ -4,7 +4,6 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -14,7 +13,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         /// <returns>The qualified name (i.e. including containing types and namespaces) of a named,
         /// pointer, or array type.</returns>
-        internal string GetTypeName(TypeAndCustomInfo typeAndInfo, bool escapeKeywordIdentifiers = false)
+        internal string GetTypeName(TypeAndCustomInfo typeAndInfo, bool escapeKeywordIdentifiers, out bool sawInvalidIdentifier)
         {
             var type = typeAndInfo.Type;
             if (type == null)
@@ -25,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var dynamicFlags = DynamicFlagsCustomTypeInfo.Create(typeAndInfo.Info);
             var index = 0;
             var pooled = PooledStringBuilder.GetInstance();
-            AppendQualifiedTypeName(pooled.Builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers);
+            AppendQualifiedTypeName(pooled.Builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, out sawInvalidIdentifier);
             return pooled.ToStringAndFree();
         }
 
@@ -41,7 +40,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// This is fortunate, since we don't have a good way to recognize them in metadata.
         /// Does not call itself (directly).
         /// </remarks>
-        protected void AppendQualifiedTypeName(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers)
+        protected void AppendQualifiedTypeName(
+            StringBuilder builder, 
+            Type type, 
+            DynamicFlagsCustomTypeInfo dynamicFlags, 
+            ref int index, 
+            bool escapeKeywordIdentifiers, 
+            out bool sawInvalidIdentifier)
         {
             Type originalType = type;
 
@@ -74,7 +79,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Debug.Assert(pointerCount == 0 || nullableCount == 0, "Benign: pointer to nullable?");
 
             int oldLength = builder.Length;
-            AppendQualifiedTypeNameInternal(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers);
+            AppendQualifiedTypeNameInternal(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, out sawInvalidIdentifier);
             string name = builder.ToString(oldLength, builder.Length - oldLength);
 
             builder.Append('?', nullableCount);
@@ -99,16 +104,29 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// <remarks>
         /// Does not call itself or <see cref="AppendQualifiedTypeName"/> (directly).
         /// </remarks>
-        private void AppendQualifiedTypeNameInternal(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers)
+        private void AppendQualifiedTypeNameInternal(
+            StringBuilder builder, 
+            Type type, 
+            DynamicFlagsCustomTypeInfo dynamicFlags, 
+            ref int index, 
+            bool escapeKeywordIdentifiers, 
+            out bool sawInvalidIdentifier)
         {
             var isDynamic = dynamicFlags[index++] && type.IsObject();
-            if (AppendSpecialTypeName(builder, type, isDynamic, escapeKeywordIdentifiers))
+            if (AppendSpecialTypeName(builder, type, isDynamic))
             {
+                sawInvalidIdentifier = false;
                 return;
             }
-            Debug.Assert(!isDynamic, $"Dynamic should have been handled by {nameof(AppendSpecialTypeName)}");
 
+            Debug.Assert(!isDynamic, $"Dynamic should have been handled by {nameof(AppendSpecialTypeName)}");
             Debug.Assert(!IsPredefinedType(type));
+
+            if (type.IsGenericParameter)
+            {
+                AppendIdentifier(builder, escapeKeywordIdentifiers, type.Name, out sawInvalidIdentifier);
+                return;
+            }
 
             // Note: in the Reflection/LMR object model, all type arguments are on the most nested type.
             var hasTypeArguments = type.IsGenericType;
@@ -119,6 +137,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var numTypeArguments = hasTypeArguments ? typeArguments.Length : 0;
 
+            sawInvalidIdentifier = false;
+            bool sawSingleInvalidIdentifier;
             if (type.IsNested)
             {
                 // Push from inside, out.
@@ -134,7 +154,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 var lastContainingTypeIndex = stack.Count - 1;
 
-                AppendNamespacePrefix(builder, stack[lastContainingTypeIndex], escapeKeywordIdentifiers);
+                AppendNamespacePrefix(builder, stack[lastContainingTypeIndex], escapeKeywordIdentifiers, out sawSingleInvalidIdentifier);
+                sawInvalidIdentifier |= sawSingleInvalidIdentifier;
 
                 var typeArgumentOffset = 0;
 
@@ -146,7 +167,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     // ACASEY: I explored the type in the debugger and couldn't find the arity stored/exposed separately.
                     int arity = hasTypeArguments ? containingType.GetGenericArguments().Length - typeArgumentOffset : 0;
 
-                    AppendUnqualifiedTypeName(builder, containingType, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, arity);
+                    AppendUnqualifiedTypeName(builder, containingType, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, arity, out sawSingleInvalidIdentifier);
+                    sawInvalidIdentifier |= sawSingleInvalidIdentifier;
                     builder.Append('.');
 
                     typeArgumentOffset += arity;
@@ -154,12 +176,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 stack.Free();
 
-                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, numTypeArguments - typeArgumentOffset);
+                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, typeArgumentOffset, numTypeArguments - typeArgumentOffset, out sawSingleInvalidIdentifier);
+                sawInvalidIdentifier |= sawSingleInvalidIdentifier;
             }
             else
             {
-                AppendNamespacePrefix(builder, type, escapeKeywordIdentifiers);
-                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, 0, numTypeArguments);
+                AppendNamespacePrefix(builder, type, escapeKeywordIdentifiers, out sawSingleInvalidIdentifier);
+                sawInvalidIdentifier |= sawSingleInvalidIdentifier;
+                AppendUnqualifiedTypeName(builder, type, dynamicFlags, ref index, escapeKeywordIdentifiers, typeArguments, 0, numTypeArguments, out sawSingleInvalidIdentifier);
+                sawInvalidIdentifier |= sawSingleInvalidIdentifier;
             }
         }
 
@@ -167,20 +192,24 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// Helper for appending the qualified name of the containing namespace of a type.
         /// NOTE: Unless the qualified name is empty, there will always be a trailing dot.
         /// </summary>
-        private void AppendNamespacePrefix(StringBuilder builder, Type type, bool escapeKeywordIdentifiers)
+        private void AppendNamespacePrefix(StringBuilder builder, Type type, bool escapeKeywordIdentifiers, out bool sawInvalidIdentifier)
         {
+            sawInvalidIdentifier = false;
+
             var @namespace = type.Namespace;
             if (!string.IsNullOrEmpty(@namespace))
             {
-                if (escapeKeywordIdentifiers && @namespace.Contains("."))
+                if (@namespace.Contains("."))
                 {
+                    bool sawSingleInvalidIdentifier;
                     var pooled = PooledStringBuilder.GetInstance();
                     var identifierBuilder = pooled.Builder;
                     foreach (var ch in @namespace)
                     {
                         if (ch == '.')
                         {
-                            AppendIdentifier(builder, escapeKeywordIdentifiers, identifierBuilder.ToString());
+                            AppendIdentifier(builder, escapeKeywordIdentifiers, identifierBuilder.ToString(), out sawSingleInvalidIdentifier);
+                            sawInvalidIdentifier |= sawSingleInvalidIdentifier;
                             builder.Append(ch);
                             identifierBuilder.Clear();
                         }
@@ -189,12 +218,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                             identifierBuilder.Append(ch);
                         }
                     }
-                    AppendIdentifier(builder, escapeKeywordIdentifiers, identifierBuilder.ToString());
+                    AppendIdentifier(builder, escapeKeywordIdentifiers, identifierBuilder.ToString(), out sawSingleInvalidIdentifier);
+                    sawInvalidIdentifier |= sawSingleInvalidIdentifier;
                     pooled.Free();
                 }
                 else
                 {
-                    AppendIdentifier(builder, escapeKeywordIdentifiers, @namespace);
+                    AppendIdentifier(builder, escapeKeywordIdentifiers, @namespace, out sawInvalidIdentifier);
                 }
                 builder.Append('.');
             }
@@ -220,59 +250,62 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// <param name="arity">
         /// The number of type parameters of <paramref name="type"/>, from a C# perspective.
         /// </param>
+        /// <param name="sawInvalidIdentifier">True if the name includes an invalid identifier (see <see cref="IsValidIdentifier"/>); false otherwise.</param>
         /// <remarks>
         /// We're passing the full array plus bounds, rather than a tailored array, to avoid creating a lot of short-lived
         /// temporary arrays.
         /// </remarks>
-        private void AppendUnqualifiedTypeName(StringBuilder builder, Type type, DynamicFlagsCustomTypeInfo dynamicFlags, ref int index, bool escapeKeywordIdentifiers, Type[] typeArguments, int typeArgumentOffset, int arity)
+        private void AppendUnqualifiedTypeName(
+            StringBuilder builder, 
+            Type type, 
+            DynamicFlagsCustomTypeInfo dynamicFlags, 
+            ref int index, 
+            bool escapeKeywordIdentifiers, 
+            Type[] typeArguments, 
+            int typeArgumentOffset, 
+            int arity, 
+            out bool sawInvalidIdentifier)
         {
             if (typeArguments == null || arity == 0)
             {
-                AppendIdentifier(builder, escapeKeywordIdentifiers, type.Name);
+                AppendIdentifier(builder, escapeKeywordIdentifiers, type.Name, out sawInvalidIdentifier);
                 return;
             }
 
             var mangledName = type.Name;
             var separatorIndex = mangledName.IndexOf('`');
-            AppendIdentifier(builder, escapeKeywordIdentifiers, mangledName, separatorIndex);
+            var unmangledName = separatorIndex < 0 ? mangledName : mangledName.Substring(0, separatorIndex);
+            AppendIdentifier(builder, escapeKeywordIdentifiers, unmangledName, out sawInvalidIdentifier);
 
-            AppendGenericTypeArgumentList(builder, typeArguments, typeArgumentOffset, dynamicFlags, ref index, arity, escapeKeywordIdentifiers);
+            bool argumentsSawInvalidIdentifier;
+            AppendGenericTypeArgumentList(builder, typeArguments, typeArgumentOffset, dynamicFlags, ref index, arity, escapeKeywordIdentifiers, out argumentsSawInvalidIdentifier);
+            sawInvalidIdentifier |= argumentsSawInvalidIdentifier;
         }
 
-        protected void AppendIdentifier(StringBuilder builder, bool escapeKeywordIdentifiers, string identifier, int length = -1)
+        protected void AppendIdentifier(StringBuilder builder, bool escapeKeywordIdentifiers, string identifier, out bool sawInvalidIdentifier)
         {
-            Debug.Assert(length < 0 || (0 <= length && length <= identifier.Length));
-
             if (escapeKeywordIdentifiers)
             {
-                if (length >= 0)
-                {
-                    identifier = identifier.Substring(0, length);
-                }
-
-                AppendIdentifierEscapingPotentialKeywords(builder, identifier);
-            }
-            else if (length < 0)
-            {
-                builder.Append(identifier);
+                AppendIdentifierEscapingPotentialKeywords(builder, identifier, out sawInvalidIdentifier);
             }
             else
             {
-                builder.Append(identifier, 0, length);
+                sawInvalidIdentifier = !IsValidIdentifier(identifier);
+                builder.Append(identifier);
             }
         }
 
-        internal string GetIdentifierEscapingPotentialKeywords(string identifier)
+        internal string GetIdentifierEscapingPotentialKeywords(string identifier, out bool sawInvalidIdentifier)
         {
             var pooled = PooledStringBuilder.GetInstance();
             var builder = pooled.Builder;
-            AppendIdentifierEscapingPotentialKeywords(builder, identifier);
+            AppendIdentifierEscapingPotentialKeywords(builder, identifier, out sawInvalidIdentifier);
             return pooled.ToStringAndFree();
         }
 
         #region Language-specific type name formatting behavior
 
-        protected abstract void AppendIdentifierEscapingPotentialKeywords(StringBuilder builder, string identifier);
+        protected abstract void AppendIdentifierEscapingPotentialKeywords(StringBuilder builder, string identifier, out bool sawInvalidIdentifier);
 
         protected abstract void AppendGenericTypeArgumentList(
             StringBuilder builder, 
@@ -281,11 +314,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             DynamicFlagsCustomTypeInfo dynamicFlags,
             ref int index,
             int arity, 
-            bool escapeKeywordIdentifiers);
+            bool escapeKeywordIdentifiers,
+            out bool sawInvalidIdentifier);
 
         protected abstract void AppendRankSpecifier(StringBuilder builder, int rank);
 
-        protected abstract bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic, bool escapeKeywordIdentifiers);
+        protected abstract bool AppendSpecialTypeName(StringBuilder builder, Type type, bool isDynamic);
 
         #endregion
     }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
-using Microsoft.VisualStudio.Debugger.Metadata;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -39,7 +38,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         string IDkmClrFormatter.GetTypeName(DkmInspectionContext inspectionContext, DkmClrType type, DkmClrCustomTypeInfo typeInfo, ReadOnlyCollection<string> formatSpecifiers)
         {
-            return GetTypeName(new TypeAndCustomInfo(type.GetLmrType(), typeInfo));
+            bool unused;
+            return GetTypeName(new TypeAndCustomInfo(type.GetLmrType(), typeInfo), escapeKeywordIdentifiers: false , sawInvalidIdentifier: out unused);
         }
 
         bool IDkmClrFormatter.HasUnderlyingString(DkmClrValue value, DkmInspectionContext inspectionContext)
@@ -58,6 +58,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         // It seems more natural to ask these questions of the ResultProvider, but adding such a component
         // for these few methods seemed a bit overly elaborate given the current internal usage.
         #region Language-specific syntax helpers
+
+        internal abstract bool IsValidIdentifier(string name);
 
         internal abstract bool IsIdentifierPartCharacter(char c);
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
@@ -29,10 +29,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal static string GetExceptionMessage(this DkmClrValue value, string fullNameWithoutFormatSpecifiers, Formatter formatter)
         {
+            bool unused;
             return string.Format(
                 Resources.ExceptionThrown,
                 fullNameWithoutFormatSpecifiers,
-                formatter.GetTypeName(new TypeAndCustomInfo(value.Type)));
+                formatter.GetTypeName(new TypeAndCustomInfo(value.Type), escapeKeywordIdentifiers: false, sawInvalidIdentifier: out unused));
         }
 
         internal static DkmClrValue GetMemberValue(this DkmClrValue value, MemberAndDeclarationInfo member, DkmInspectionContext inspectionContext)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -678,9 +678,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else if (typeDeclaringMemberAndInfo.Type != null)
             {
+                bool unused;
                 if (typeDeclaringMemberAndInfo.Type.IsInterface)
                 {
-                    var interfaceTypeName = this.Formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true);
+                    var interfaceTypeName = this.Formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: true, sawInvalidIdentifier: out unused);
                     name = string.Format("{0}.{1}", interfaceTypeName, name);
                 }
                 else
@@ -689,7 +690,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     var builder = pooled.Builder;
                     builder.Append(name);
                     builder.Append(" (");
-                    builder.Append(this.Formatter.GetTypeName(typeDeclaringMemberAndInfo));
+                    builder.Append(this.Formatter.GetTypeName(typeDeclaringMemberAndInfo, escapeKeywordIdentifiers: false, sawInvalidIdentifier: out unused));
                     builder.Append(')');
                     name = pooled.ToStringAndFree();
                 }
@@ -699,7 +700,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             string display;
             if (value.HasExceptionThrown())
             {
-                display = dataItem.DisplayValue ?? value.GetExceptionMessage(dataItem.FullNameWithoutFormatSpecifiers, this.Formatter);
+                display = dataItem.DisplayValue ?? value.GetExceptionMessage(dataItem.FullNameWithoutFormatSpecifiers ?? dataItem.Name, this.Formatter);
             }
             else if (displayValue != null)
             {

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private Sub AppendEnumTypeAndName(builder As StringBuilder, typeToDisplayOpt As Type, name As String)
             If typeToDisplayOpt IsNot Nothing Then
                 Dim index As Integer = 0
-                AppendQualifiedTypeName(builder, typeToDisplayOpt, Nothing, index, escapeKeywordIdentifiers:=True)
+                AppendQualifiedTypeName(builder, typeToDisplayOpt, Nothing, index, escapeKeywordIdentifiers:=True, sawInvalidIdentifier:=Nothing)
                 builder.Append("."c)
             End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Sub
 
         Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, clrTypeInfo As DkmClrCustomTypeInfo, formatSpecifiers As ReadOnlyCollection(Of String)) As String Implements IDkmClrFormatter.GetTypeName
-            Return GetTypeName(New TypeAndCustomInfo(clrType.GetLmrType(), clrTypeInfo))
+            Return GetTypeName(New TypeAndCustomInfo(clrType.GetLmrType(), clrTypeInfo), escapeKeywordIdentifiers:=False, sawInvalidIdentifier:=Nothing)
         End Function
 
         Private Function IDkmClrFormatter_GetUnderlyingString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext) As String Implements IDkmClrFormatter.GetUnderlyingString
@@ -43,6 +43,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Function IDkmClrFormatter_HasUnderlyingString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext) As Boolean Implements IDkmClrFormatter.HasUnderlyingString
             Return HasUnderlyingString(clrValue, inspectionContext)
+        End Function
+
+        Friend Overrides Function IsValidIdentifier(name As String) As Boolean
+            Return SyntaxFacts.IsValidIdentifier(name)
         End Function
 
         Friend Overrides Function IsIdentifierPartCharacter(c As Char) As Boolean

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
@@ -397,14 +397,14 @@ End Class"
                 EvalResult(rootExpr, "{A}", "A", rootExpr, DkmEvaluationResultFlags.Expandable))
             Dim children = GetChildren(result)
             Verify(children,
-                EvalResult("1<>", "Nothing", "Object", "(New A()).1<>"),
-                EvalResult("@", "Nothing", "Object", "(New A()).@"),
-                EvalResult("CS<>7__8", "Nothing", "Object", "(New A()).CS<>7__8"),
+                EvalResult("1<>", "Nothing", "Object", fullName:=Nothing),
+                EvalResult("@", "Nothing", "Object", fullName:=Nothing),
+                EvalResult("CS<>7__8", "Nothing", "Object", fullName:=Nothing),
                 EvalResult("Shared members", Nothing, "", "A", DkmEvaluationResultFlags.Expandable Or DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class))
             children = GetChildren(children(children.Length - 1))
             Verify(children,
-                EvalResult("[>]", "Nothing", "Object", "A.[>]"),
-                EvalResult("><", "Nothing", "Object", "A.><"))
+                EvalResult("[>]", "Nothing", "Object", fullName:=Nothing),
+                EvalResult("><", "Nothing", "Object", fullName:=Nothing))
 
             type = assembly.GetType("B")
             rootExpr = "New B()"
@@ -414,14 +414,14 @@ End Class"
                 EvalResult(rootExpr, "{B}", "B", rootExpr, DkmEvaluationResultFlags.Expandable))
             children = GetChildren(result)
             Verify(children,
-                EvalResult("1<>", "Nothing", "Object", "(New B()).1<>", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("@", "Nothing", "Object", "(New B()).@", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("VB<>7__8", "Nothing", "Object", "(New B()).VB<>7__8", DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("1<>", "Nothing", "Object", fullName:=Nothing, flags:=DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("@", "Nothing", "Object", fullName:=Nothing, flags:=DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("VB<>7__8", "Nothing", "Object", fullName:=Nothing, flags:=DkmEvaluationResultFlags.ReadOnly),
                 EvalResult("Shared members", Nothing, "", "B", DkmEvaluationResultFlags.Expandable Or DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class))
             children = GetChildren(children(children.Length - 1))
             Verify(children,
-                EvalResult("[>]", "Nothing", "Object", "B.[>]", DkmEvaluationResultFlags.ReadOnly),
-                EvalResult("><", "Nothing", "Object", "B.><", DkmEvaluationResultFlags.ReadOnly))
+                EvalResult("[>]", "Nothing", "Object", fullName:=Nothing, flags:=DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("><", "Nothing", "Object", fullName:=Nothing, flags:=DkmEvaluationResultFlags.ReadOnly))
         End Sub
 
         <Fact, WorkItem(965892)>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
@@ -3,6 +3,7 @@
 Imports System.Runtime.CompilerServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
+Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
@@ -15,7 +16,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         <Extension>
         Public Function GetTypeName(type As System.Type, typeInfo As DkmClrCustomTypeInfo, Optional escapeKeywordIdentifiers As Boolean = False) As String
-            Return VisualBasicFormatter.Instance.GetTypeName(New TypeAndCustomInfo(CType(type, TypeImpl), typeInfo), escapeKeywordIdentifiers)
+            Dim sawInvalidIdentifier As Boolean = Nothing
+            Dim result = VisualBasicFormatter.Instance.GetTypeName(New TypeAndCustomInfo(CType(type, TypeImpl), typeInfo), escapeKeywordIdentifiers, sawInvalidIdentifier)
+            Assert.False(sawInvalidIdentifier)
+            Return result
         End Function
 
     End Module


### PR DESCRIPTION
...because of an invalid identifier.  Since the ResultProvider controls
everything else about the full name, it is only identifiers that can
contain invalid syntax.

Note that this will generally suppress Add Watch on descendents of
affected nodes as well (since the structure is mostly recursive).

Fixes #3272.