### PR TITLE
Remove dependency on Microsoft.CodeAnalysis.Workspaces

### DIFF
--- a/src/Diagnostics/CodeAnalysis/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Diagnostics/CodeAnalysis/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
     /// This analyzer catches violations of this requirement in the code actions registered by a <see cref="CodeFixProvider"/> that supports <see cref="FixAllProvider"/>.
     /// </summary>
     public abstract class FixerWithFixAllAnalyzer<TLanguageKindEnum> : DiagnosticAnalyzer
-        where TLanguageKindEnum : struct
-    {
-        private static string s_codeFixProviderMetadataName = typeof(CodeFixProvider).FullName;
-        private static string s_codeActionMetadataName = typeof(CodeAction).FullName;
+        where TLanguageKindEnum: struct
+    { 
+        private static string s_codeFixProviderMetadataName = "Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider";
+        private static string s_codeActionMetadataName = "Microsoft.CodeAnalysis.CodeActions.CodeAction";
         private const string GetFixAllProviderMethodName = "GetFixAllProvider";
         private const string CreateMethodName = "Create";
         private const string EquivalenceKeyPropertyName = "EquivalenceKey";


### PR DESCRIPTION
FixerWithFixAllAnalyzer references types in the Workspaces assembly in a
couple of places:
``` C#
private static string CodeFixProviderMetadataName = typeof(CodeFixProvider).FullName;
```

This creates a runtime dependency on Microsoft.CodeAnalysis.Workspaces.dll
which is part of VS but not part of the compilers (csc/vbc/vbcscompiler).
The analyzers that derive from this type thus work in VS but fail during
build with a `TypeInitializationException`.

The fix is to use hard-coded strings for the names of these types. As
they are part of the public API, their names won't be changing anytime
soon.

This does not remove the project-to-project reference to Workspaces.
Doing so would have required fixing up a bunch of `<see cref="..." />`
elements in the doc comments to use the full name of these types as well,
generally making them much uglier. This isn't necessary to fix the
runtime issue.

Fixes #3706.