### PR TITLE
Fix typo

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public abstract SyntaxNode ReturnStatement(SyntaxNode expression = null);
 
         /// <summary>
-        /// Creates a statement that can be used to throw and exception.
+        /// Creates a statement that can be used to throw an exception.
         /// </summary>
         /// <param name="expression">An optional expression that can be thrown.</param>
         public abstract SyntaxNode ThrowStatement(SyntaxNode expression = null);


### PR DESCRIPTION
Fixes a typo in the summary of SyntaxGenerator.ThrowStatement

@tmeschter don't know if I need to tag anyone else?