### PR TITLE
Port fix for binding redirect range to future

### DIFF
--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -164,17 +164,15 @@ using Microsoft.VisualStudio.Shell;
 
 internal class Constants
 {
+    public const string OldVersionLowerBound = "0.7.0.0";
+    public const string OldVersionUpperBound = "2.0.0.0";
 #if OFFICIAL_BUILD
     // If this is an official build we want to generate binding
     // redirects from our old versions to the release version 
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "0.7.0.0";
     public const string NewVersion = "2.0.0.0";
 #else
     // Non-official builds get redirects to local 42.42.42.42,
     // which will only be built locally
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "2.0.0.0";
     public const string NewVersion = "42.42.42.42";
 #endif
     public const string PublicKeyToken = "31BF3856AD364E35";


### PR DESCRIPTION
Tom's fix in master, #3674, changes the binding redirect range to include
everything in the range up to what we're targeting, instead of just 0.7.0.0.
This fix should also be in future.

@tmeschter @amcasey 