### PR TITLE
Check DkmClrAppDomain.IsUnloaded bfore checking ID

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -23,6 +23,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private static IEnumerable<DkmClrModuleInstance> GetModulesInAppDomain(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
         {
+            if (appDomain.IsUnloaded)
+            {
+                return SpecializedCollections.EmptyEnumerable<DkmClrModuleInstance>();
+            }
+
             var appDomainId = appDomain.Id;
             return runtime.GetModuleInstances().
                 Cast<DkmClrModuleInstance>().


### PR DESCRIPTION
We believe failing to do so is resulting in an ObjectDisposedException:

```
at Microsoft.VisualStudio.Debugger.Clr.DkmClrAppDomain.get_Id()
at Microsoft.CodeAnalysis.ExpressionEvaluator.DkmUtilities.<>c__DisplayClass2_0.<GetModulesInAppDomain>b__0(DkmClrModuleInstance
module)
at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
at Microsoft.CodeAnalysis.ExpressionEvaluator.DkmUtilities.GetMetadataBlocks(DkmClrRuntimeInstance
runtime; DkmClrAppDomain appDomain)
at Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.CSharpInstructionDecoder.GetCompilation(DkmClrModuleInstance
moduleInstance)
at Microsoft.CodeAnalysis.ExpressionEvaluator.FrameDecoder`5.GetNameWithGenericTypeArguments(DkmInspectionContext
inspectionContext; DkmWorkList workList; DkmStackWalkFrame frame; Action`1
onSuccess; Action`1 onFailure)
at Microsoft.CodeAnalysis.ExpressionEvaluator.FrameDecoder`5.Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmLanguageFrameDecoder.GetFrameName(DkmInspectionContext
inspectionContext; DkmWorkList workList; DkmStackWalkFrame frame;
DkmVari...
```