### PR TITLE
Fix NRE when binding bad labels

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Skipping the first label symbol ensures that the errors (if any),
                         // are reported on all but the first duplicate case label.
                         diagnostics.Add(ErrorCode.ERR_DuplicateCaseLabel, node.Location,
-                            label.SwitchCaseLabelConstant == null ? label.Name : label.SwitchCaseLabelConstant.Value);
+                            label.SwitchCaseLabelConstant?.Value ?? label.Name);
                         hasDuplicateErrors = true;
                     }
                     break;


### PR DESCRIPTION
This change fixes a NRE getting symbol information when the following
conditions were met in a method body:

1. The enum value has multiple constant expressions which are unbindable
2. The method body has a switch with at least two labels that have the
bad constant

When a method body of this nature is bound via the API (will never bind
in command line due to the constant value errors) the compiler will
detect duplicate label expression and attempt to emit a diagnostic.  The
preference for the diagnostic is to use the constant value, and failing
that, the label name.

In this case the label does have a constant value element but it is bad
so it has a null value.  This leads to an NRE in the diagnostic layer.
The fix is to simply use more robust detection of the constant value.