### PR TITLE
Workaround for a crash in EditSession when project loads after debugging session has started

### DIFF
--- a/src/Features/Core/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/EditAndContinue/EditSession.cs
@@ -254,6 +254,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 var baseProject = _baseSolution.GetProject(project.Id);
 
+                // TODO (https://github.com/dotnet/roslyn/issues/1204):
+                if (baseProject == null)
+                {
+                    return ProjectAnalysisSummary.NoChanges;
+                }
+
                 var documentAnalyses = GetChangedDocumentsAnalyses(baseProject, project);
                 if (documentAnalyses.Count == 0)
                 {


### PR DESCRIPTION
The ideal solution is a bit more involved and is tracked by issue https://github.com/dotnet/roslyn/issues/1204