### PR TITLE
Report diagnostics when short-circuiting emit

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2250,12 +2250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken)
         {
-            // Do not waste a slot in the submission chain for submissions that contain no executable code
-            // (they may only contain #r directives, usings, etc.)
-            if (IsSubmission && !HasCodeToEmit())
-            {
-                return null;
-            }
+            Debug.Assert(!IsSubmission || HasCodeToEmit());
 
             string runtimeMDVersion = GetRuntimeMetadataVersion(emitOptions, diagnostics);
             if (runtimeMDVersion == null)

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1579,6 +1579,15 @@ namespace Microsoft.CodeAnalysis
                 return ToEmitResultAndFree(diagnostics, success: false, entryPointOpt: null);
             }
 
+            // Do not waste a slot in the submission chain for submissions that contain no executable code
+            // (they may only contain #r directives, usings, etc.)
+            if (IsSubmission && !HasCodeToEmit())
+            {
+                // Still report diagnostics since downstream submissions will assume there are no errors.
+                diagnostics.AddRange(this.GetDiagnostics());
+                return ToEmitResultAndFree(diagnostics, success: false, entryPointOpt: null);
+            }
+
             var moduleBeingBuilt = this.CreateModuleBuilder(
                 options,
                 manifestResources,

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2147,12 +2147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             cancellationToken As CancellationToken) As CommonPEModuleBuilder
 
             Debug.Assert(diagnostics.IsEmptyWithoutResolution) ' True, but not required.
-
-            ' Do not waste a slot in the submission chain for submissions that contain no executable code
-            ' (they may only contain #r directives, usings, etc.)
-            If IsSubmission AndAlso Not HasCodeToEmit() Then
-                Return Nothing
-            End If
+            Debug.Assert(Not IsSubmission OrElse HasCodeToEmit())
 
             ' Get the runtime metadata version from the cor library. If this fails we have no reasonable value to give.
             Dim runtimeMetadataVersion = GetRuntimeMetadataVersion()

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -402,6 +402,27 @@ End Function")
             'Assert.False(symbols.Any(Function(s) s.Name = "Roslyn"))
         End Sub
 
+        <WorkItem(3795, "https:'github.com/dotnet/roslyn/issues/3795")>
+        <Fact>
+        Public Sub ErrorInUsing()
+            Dim submission = VisualBasicCompilation.CreateSubmission("sub1", Parse("Imports Unknown", options:=TestOptions.Script), {MscorlibRef})
+
+            Dim expectedErrors = <errors><![CDATA[
+BC40056: Namespace or type specified in the Imports 'Unknown' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
+Imports Unknown
+        ~~~~~~~
+]]></errors>
+
+            ' Emit produces the same diagnostics as GetDiagnostics (below).
+            Using stream As New MemoryStream()
+                Dim emitResult = submission.Emit(stream)
+                Assert.False(emitResult.Success)
+                emitResult.Diagnostics.AssertTheseDiagnostics(expectedErrors)
+            End Using
+
+            submission.GetDiagnostics().AssertTheseDiagnostics(expectedErrors)
+        End Sub
+
 #End Region
 
 #Region "Anonymous types"


### PR DESCRIPTION
As an optimization, submissions not containing declarations are not
emitted.  However, when we short-circuit emission, we also skip diagnostic
reporting (e.g. in usings) that can trigger an assert in the next
submission (which assumes that all errors have been reported).

Fixes #3795