### PR TITLE
Don't look for labels in UsingsBinders

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/UsingsBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingsBinder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override void LookupSymbolsInSingleBinder(
             LookupResult result, string name, int arity, ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            if ((options & LookupOptions.NamespaceAliasesOnly) != 0)
+            if (!ShouldLookInUsings(options))
             {
                 return;
             }
@@ -57,14 +57,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             tmp.Free();
         }
-
         protected override void AddLookupSymbolsInfoInSingleBinder(
             LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
+
+            if (!ShouldLookInUsings(options))
+            {
+                return;
+            }
+
             // Add types within namespaces imported through usings, but don't add nested namespaces.
             LookupOptions usingOptions = (options & ~(LookupOptions.NamespaceAliasesOnly | LookupOptions.NamespacesOrTypesOnly)) | LookupOptions.MustNotBeNamespace;
 
             Imports.AddLookupSymbolsInfoInUsings(ConsolidatedUsings, this, result, usingOptions);
+        }
+
+        private static bool ShouldLookInUsings(LookupOptions options)
+        {
+            return (options & (LookupOptions.NamespaceAliasesOnly | LookupOptions.LabelsOnly)) == 0;
         }
 
         internal override bool SupportsExtensionMethods

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2023,6 +2023,17 @@ class D
             submission.GetDiagnostics().Verify(expectedDiagnostics);
         }
 
+        [WorkItem(3817, "https://github.com/dotnet/roslyn/issues/3817")]
+        [Fact]
+        public void LabelLookup()
+        {
+            const string source = "using System; 1";
+            var tree = Parse(source, options: TestOptions.Script);
+            var submission = CSharpCompilation.CreateSubmission("sub1", tree, new[] { MscorlibRef });
+            var model = submission.GetSemanticModel(tree);
+            Assert.Empty(model.LookupLabels(source.Length - 1)); // Used to assert.
+        }
+
         private CSharpCompilation CreateSubmission(string code, CSharpParseOptions options, int expectedErrorCount = 0)
         {
             var submission = CSharpCompilation.CreateSubmission("sub",

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -423,6 +423,16 @@ Imports Unknown
             submission.GetDiagnostics().AssertTheseDiagnostics(expectedErrors)
         End Sub
 
+        <WorkItem(3817, "https://github.com/dotnet/roslyn/issues/3817")>
+        <Fact>
+        Public Sub LabelLookup()
+            Const source = "Imports System : 1"
+            Dim tree = Parse(source, options:=TestOptions.Script)
+            Dim submission = VisualBasicCompilation.CreateSubmission("sub1", tree, {MscorlibRef})
+            Dim model = submission.GetSemanticModel(tree)
+            Assert.Empty(model.LookupLabels(source.Length - 1))
+        End Sub
+
 #End Region
 
 #Region "Anonymous types"


### PR DESCRIPTION
We were asserting because the lookup was nonsensical.

Fixes #3817