### PR TITLE
 Made XmlDocumentationProvider and FileBased derivative public. Fixes #1465.

### DIFF
--- a/src/Workspaces/Core/Desktop/PublicAPI.txt
+++ b/src/Workspaces/Core/Desktop/PublicAPI.txt
@@ -1,4 +1,6 @@
 Microsoft.CodeAnalysis.CommandLineProject
+Microsoft.CodeAnalysis.FileBasedXmlDocumentationProvider
+Microsoft.CodeAnalysis.FileBasedXmlDocumentationProvider.FileBasedXmlDocumentationProvider(string filePath) -> void
 Microsoft.CodeAnalysis.FileTextLoader
 Microsoft.CodeAnalysis.FileTextLoader.DefaultEncoding.get -> System.Text.Encoding
 Microsoft.CodeAnalysis.FileTextLoader.FileTextLoader(string path, System.Text.Encoding defaultEncoding) -> void
@@ -17,6 +19,8 @@ Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.OpenSolutionAsync(string solutio
 Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.Properties.get -> System.Collections.Immutable.ImmutableDictionary<string, string>
 Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.SkipUnrecognizedProjects.get -> bool
 Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.SkipUnrecognizedProjects.set -> void
+override Microsoft.CodeAnalysis.FileBasedXmlDocumentationProvider.Equals(object obj) -> bool
+override Microsoft.CodeAnalysis.FileBasedXmlDocumentationProvider.GetHashCode() -> int
 override Microsoft.CodeAnalysis.FileTextLoader.LoadTextAndVersionAsync(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DocumentId documentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.TextAndVersion>
 override Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.CanApplyChange(Microsoft.CodeAnalysis.ApplyChangesKind feature) -> bool
 override Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.TryApplyChanges(Microsoft.CodeAnalysis.Solution newSolution) -> bool

--- a/src/Workspaces/Core/Desktop/Utilities/Documentation/FileBasedXmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/Documentation/FileBasedXmlDocumentationProvider.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class FileBasedXmlDocumentationProvider : XmlDocumentationProvider
+    public sealed class FileBasedXmlDocumentationProvider : XmlDocumentationProvider
     {
         private readonly string _filePath;
 

--- a/src/Workspaces/Core/Portable/PublicAPI.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.txt
@@ -829,6 +829,7 @@ Microsoft.CodeAnalysis.WorkspaceKind
 Microsoft.CodeAnalysis.WorkspaceRegistration
 Microsoft.CodeAnalysis.WorkspaceRegistration.Workspace.get -> Microsoft.CodeAnalysis.Workspace
 Microsoft.CodeAnalysis.WorkspaceRegistration.WorkspaceChanged -> System.EventHandler
+Microsoft.CodeAnalysis.XmlDocumentationProvider
 abstract Microsoft.CodeAnalysis.CodeActions.CodeAction.Title.get -> string
 abstract Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.ComputeOperationsAsync(object options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeActionOperation>>
 abstract Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.GetOptions(System.Threading.CancellationToken cancellationToken) -> object
@@ -984,6 +985,7 @@ abstract Microsoft.CodeAnalysis.Host.HostWorkspaceServices.GetService<TWorkspace
 abstract Microsoft.CodeAnalysis.Host.HostWorkspaceServices.HostServices.get -> Microsoft.CodeAnalysis.Host.HostServices
 abstract Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Workspace.get -> Microsoft.CodeAnalysis.Workspace
 abstract Microsoft.CodeAnalysis.TextLoader.LoadTextAndVersionAsync(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DocumentId documentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.TextAndVersion>
+abstract Microsoft.CodeAnalysis.XmlDocumentationProvider.GetSourceStream(System.Threading.CancellationToken cancellationToken) -> System.IO.Stream
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.ClassName = "class name" -> string
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.Comment = "comment" -> string
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.DelegateName = "delegate name" -> string
@@ -1075,6 +1077,7 @@ override Microsoft.CodeAnalysis.VersionStamp.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.VersionStamp.GetHashCode() -> int
 override Microsoft.CodeAnalysis.VersionStamp.ToString() -> string
 override Microsoft.CodeAnalysis.WorkspaceDiagnostic.ToString() -> string
+override Microsoft.CodeAnalysis.XmlDocumentationProvider.GetDocumentationForSymbol(string documentationMemberID, System.Globalization.CultureInfo preferredCulture, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
 static Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpans(Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.Text.TextSpan textSpan, Microsoft.CodeAnalysis.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Classification.ClassifiedSpan>
 static Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpansAsync(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Text.TextSpan textSpan, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Classification.ClassifiedSpan>>
 static Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(string title, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>> createChangedDocument, string equivalenceKey = null) -> Microsoft.CodeAnalysis.CodeActions.CodeAction
@@ -1245,6 +1248,7 @@ static Microsoft.CodeAnalysis.VersionStamp.operator !=(Microsoft.CodeAnalysis.Ve
 static Microsoft.CodeAnalysis.VersionStamp.operator ==(Microsoft.CodeAnalysis.VersionStamp left, Microsoft.CodeAnalysis.VersionStamp right) -> bool
 static Microsoft.CodeAnalysis.Workspace.GetWorkspaceRegistration(Microsoft.CodeAnalysis.Text.SourceTextContainer textContainer) -> Microsoft.CodeAnalysis.WorkspaceRegistration
 static Microsoft.CodeAnalysis.Workspace.TryGetWorkspace(Microsoft.CodeAnalysis.Text.SourceTextContainer textContainer, out Microsoft.CodeAnalysis.Workspace workspace) -> bool
+static Microsoft.CodeAnalysis.XmlDocumentationProvider.Create(byte[] xmlDocCommentBytes) -> Microsoft.CodeAnalysis.XmlDocumentationProvider
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeActionOperation>>
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputePreviewOperationsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeActionOperation>>
 virtual Microsoft.CodeAnalysis.CodeActions.CodeAction.EquivalenceKey.get -> string

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -11,7 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal abstract class XmlDocumentationProvider : DocumentationProvider
+    public abstract class XmlDocumentationProvider : DocumentationProvider
     {
         private readonly NonReentrantLock _gate = new NonReentrantLock();
         private Dictionary<string, string> _docComments;


### PR DESCRIPTION
Made the [XmlDocumentationProvider](https://github.com/dotnet/roslyn/blob/f165907871d6ca3bbee50f90dfaded7ff6307aa5/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs) and the derivative [FileBasedXmlDocumentationProvider](https://github.com/dotnet/roslyn/blob/f165907871d6ca3bbee50f90dfaded7ff6307aa5/src/Workspaces/Core/Desktop/Utilities/Documentation/FileBasedXmlDocumentationProvider.cs) public.
This should fix issue #1465.