### PR TITLE
Include usings debug info for expr-bodied members

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1530,6 +1530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     Binder binder = factory.GetBinder(arrowExpression);
                     binder = new ExecutableCodeBinder(arrowExpression, sourceMethod, binder);
+                    importChain = binder.ImportChain;
                     // Add locals
                     return binder.BindExpressionBodyAsBlock(arrowExpression, diagnostics);
                 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -847,9 +847,7 @@ class C
   <methods>
     <method containingType=""C+&lt;F&gt;d__1"" name=""MoveNext"">
       <customDebugInfo>
-        <using>
-          <namespace usingCount=""1"" />
-        </using>
+        <forward declaringType=""C"" methodName=""B"" />
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
           <slot kind=""1"" offset=""11"" />
@@ -866,9 +864,6 @@ class C
         <entry offset=""0x41"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""0"" />
         <entry offset=""0x42"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""0"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x44"">
-        <namespace name=""System.Collections.Generic"" />
-      </scope>
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1119,9 +1119,7 @@ class C
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
-        <using>
-          <namespace usingCount=""1"" />
-        </using>
+        <forward declaringType=""C"" methodName=""G"" parameterNames=""f"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""41"" />
           <slot kind=""30"" offset=""102"" />
@@ -1152,7 +1150,6 @@ class C
         <entry offset=""0x66"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""0"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x67"">
-        <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x66"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x66"" attributes=""0"" />
           <scope startOffset=""0x17"" endOffset=""0x39"">
@@ -1206,9 +1203,7 @@ class C
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
-        <using>
-          <namespace usingCount=""1"" />
-        </using>
+        <forward declaringType=""C"" methodName=""G"" parameterNames=""f"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""0"" />
           <slot kind=""30"" offset=""86"" />
@@ -1239,7 +1234,6 @@ class C
         <entry offset=""0x72"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" document=""0"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x73"">
-        <namespace name=""System"" />
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
         <scope startOffset=""0x21"" endOffset=""0x72"">
           <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x21"" il_end=""0x72"" attributes=""0"" />
@@ -1283,15 +1277,16 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""F"" parameterNames=""a, b"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""G"" parameterNames=""f"" />
+      </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""41"" endLine=""7"" endColumn=""42"" document=""0"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
-        <using>
-          <namespace usingCount=""1"" />
-        </using>
+        <forward declaringType=""C"" methodName=""G"" parameterNames=""f"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""41"" />
           <slot kind=""30"" offset=""89"" />
@@ -1323,7 +1318,6 @@ class C
         <entry offset=""0x90"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""0"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x91"">
-        <namespace name=""System"" />
         <scope startOffset=""0x1"" endOffset=""0x90"">
           <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x1"" il_end=""0x90"" attributes=""0"" />
           <scope startOffset=""0x1d"" endOffset=""0x62"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -4170,15 +4170,18 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""get_P"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+      </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""24"" document=""0"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
-        <using>
-          <namespace usingCount=""0"" />
-        </using>
+        <forward declaringType=""C"" methodName=""get_P"" />
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" document=""0"" />
@@ -4192,9 +4195,11 @@ class C
         public void ExpressionBodiedIndexer()
         {
             var comp = CreateExperimentalCompilationWithMscorlib45(@"
+using System;
+
 class C
 {
-    public int this[int i] => M();
+    public int this[Int32 i] => M();
     public int M()
     {
         return 2;
@@ -4206,18 +4211,24 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""get_Item"" parameterNames=""i"">
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""31"" endLine=""4"" endColumn=""34"" document=""0"" />
-      </sequencePoints>
-    </method>
-    <method containingType=""C"" name=""M"">
       <customDebugInfo>
         <using>
-          <namespace usingCount=""0"" />
+          <namespace usingCount=""1"" />
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" document=""0"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""36"" document=""0"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x7"">
+        <namespace name=""System"" />
+      </scope>
+    </method>
+    <method containingType=""C"" name=""M"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""get_Item"" parameterNames=""i"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""0"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4228,9 +4239,11 @@ class C
         public void ExpressionBodiedMethod()
         {
             var comp = CreateExperimentalCompilationWithMscorlib45(@"
+using System;
+
 class C
 {
-    public int P => 2;
+    public Int32 P => 2;
 }");
             comp.VerifyDiagnostics();
 
@@ -4238,9 +4251,17 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""get_P"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""1"" />
+        </using>
+      </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""22"" document=""0"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""23"" endLine=""6"" endColumn=""24"" document=""0"" />
       </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x2"">
+        <namespace name=""System"" />
+      </scope>
     </method>
   </methods>
 </symbols>");
@@ -4260,6 +4281,11 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""op_Increment"" parameterNames=""c"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+      </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""41"" endLine=""4"" endColumn=""42"" document=""0"" />
       </sequencePoints>
@@ -4272,9 +4298,11 @@ class C
         public void ExpressionBodiedConversion()
         {
             var comp = CreateExperimentalCompilationWithMscorlib45(@"
+using System;
+
 class C
 {
-    public static explicit operator C(int i) => new C();
+    public static explicit operator C(Int32 i) => new C();
 }");
             comp.VerifyDiagnostics();
 
@@ -4282,9 +4310,17 @@ class C
 <symbols>
   <methods>
     <method containingType=""C"" name=""op_Explicit"" parameterNames=""i"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""1"" />
+        </using>
+      </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""49"" endLine=""4"" endColumn=""56"" document=""0"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""51"" endLine=""6"" endColumn=""58"" document=""0"" />
       </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x6"">
+        <namespace name=""System"" />
+      </scope>
     </method>
   </methods>
 </symbols>");


### PR DESCRIPTION
They were getting dropped in ```MethodCompiler.BindMethodBody```.