### PR TITLE
RudeEdit error message has a placeholder not filled in

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -4875,7 +4875,7 @@ partial class C
                 "Update [a = 1]@22 -> [a = 2]@22");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2"));
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.Field));
         }
 
         [Fact]
@@ -4887,7 +4887,7 @@ partial class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;"));
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;", FeaturesResources.AutoProperty));
         }
 
         [Fact]
@@ -4902,7 +4902,7 @@ partial class C
                 "Update [a = 1]@22 -> [a = 2]@22");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2"));
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.Field));
         }
 
         [Fact]
@@ -4914,7 +4914,7 @@ partial class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;"));
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;", FeaturesResources.AutoProperty));
         }
 
         [Fact]

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -4865,7 +4865,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.Field))
         End Sub
 
         <Fact>
@@ -4875,7 +4875,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.AutoProperty))
         End Sub
 
         <Fact>
@@ -4885,7 +4885,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.Field))
         End Sub
 
         <Fact>
@@ -4895,7 +4895,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.AutoProperty))
         End Sub
 
         <Fact>
@@ -4905,7 +4905,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.Field))
         End Sub
 
         <Fact>
@@ -4915,7 +4915,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2"))
+                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.AutoProperty))
         End Sub
 
         <Fact>

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2638,7 +2638,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 if (!isConstructor)
                 {
                     // rude edit: Editing a field/property initializer of a partial type.
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.PartialTypeInitializerUpdate, newDeclaration.Span));
+                    diagnostics.Add(new RudeEditDiagnostic(
+                                        RudeEditKind.PartialTypeInitializerUpdate, 
+                                        newDeclaration.Span,
+                                        newDeclaration,
+                                        new[] { GetTopLevelDisplayName(newDeclaration, EditKind.Update)}));
                     return false;
                 }
 


### PR DESCRIPTION
This fixes #3604 by passing the display name for rude edit diagnostics.