### PR TITLE
Local functions update: Use detection, expression trees, inferred multiple returns

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -158,6 +158,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Get local functions declared immediately in scope represented by the node.
+        /// </summary>
+        internal virtual ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            return this.Next.GetDeclaredLocalFunctionsForScope(node);
+        }
+
+        /// <summary>
         /// The member containing the binding context.  Note that for the purposes of the compiler,
         /// a lambda expression is considered a "member" of its enclosing method, field, or lambda.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -152,17 +152,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get locals declared immediately in scope represented by the node.
         /// </summary>
-        internal virtual ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal virtual ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
-            return this.Next.GetDeclaredLocalsForScope(node);
+            return this.Next.GetDeclaredLocalsForScope();
         }
 
         /// <summary>
         /// Get local functions declared immediately in scope represented by the node.
         /// </summary>
-        internal virtual ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal virtual ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
-            return this.Next.GetDeclaredLocalFunctionsForScope(node);
+            return this.Next.GetDeclaredLocalFunctionsForScope();
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2132,7 +2132,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return new BoundBlock(node, blockBinder.GetDeclaredLocalsForScope(node), boundStatements.ToImmutableAndFree());
+            return new BoundBlock(
+                node,
+                blockBinder.GetDeclaredLocalsForScope(node),
+                blockBinder.GetDeclaredLocalFunctionsForScope(node),
+                boundStatements.ToImmutableAndFree());
         }
 
         internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false)
@@ -3271,7 +3275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Need to attach the tree for when we generate sequence points.
-            return new BoundBlock(node, locals, ImmutableArray.Create(statement)) { WasCompilerGenerated = node.Kind() != SyntaxKind.ArrowExpressionClause };
+            return new BoundBlock(node, locals, ImmutableArray<LocalFunctionSymbol>.Empty, ImmutableArray.Create(statement)) { WasCompilerGenerated = node.Kind() != SyntaxKind.ArrowExpressionClause };
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement boundBody = BindPossibleEmbeddedStatement(node.Statement, diagnostics);
 
             return new BoundFixedStatement(node,
-                                           GetDeclaredLocalsForScope(node),
+                                           GetDeclaredLocalsForScope(),
                                            boundMultipleDeclarations,
                                            boundBody);
         }
@@ -2134,8 +2134,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new BoundBlock(
                 node,
-                blockBinder.GetDeclaredLocalsForScope(node),
-                blockBinder.GetDeclaredLocalFunctionsForScope(node),
+                blockBinder.GetDeclaredLocalsForScope(),
+                blockBinder.GetDeclaredLocalFunctionsForScope(),
                 boundStatements.ToImmutableAndFree());
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
@@ -56,5 +56,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            if (node.Kind() == SyntaxKind.Block)
+            {
+                if (((BlockSyntax)node).Statements == _statements)
+                {
+                    return this.LocalFunctions;
+                }
+            }
+            else if (_statements.Count == 1 && _statements.First() == node)
+            {
+                return this.LocalFunctions;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
@@ -40,38 +40,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (labels != null) ? labels.ToImmutableAndFree() : ImmutableArray<LabelSymbol>.Empty;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
-            if (node.Kind() == SyntaxKind.Block)
-            {
-                if (((BlockSyntax)node).Statements == _statements)
-                {
-                    return this.Locals;
-                }
-            }
-            else if (_statements.Count == 1 && _statements.First() == node)
-            {
-                return this.Locals;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return this.Locals;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
-            if (node.Kind() == SyntaxKind.Block)
-            {
-                if (((BlockSyntax)node).Statements == _statements)
-                {
-                    return this.LocalFunctions;
-                }
-            }
-            else if (_statements.Count == 1 && _statements.First() == node)
-            {
-                return this.LocalFunctions;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return this.LocalFunctions;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -149,12 +149,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
             throw ExceptionUtilities.Unreachable;
         }

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -154,6 +154,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable;
         }
 
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
         internal override BoundSwitchStatement BindSwitchExpressionAndSections(SwitchStatementSyntax node, Binder originalBinder, DiagnosticBag diagnostics)
         {
             // There's supposed to be a SwitchBinder (or other overrider of this method) in the chain.

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -46,5 +46,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            if (node == _syntax)
+            {
+                return ImmutableArray<LocalFunctionSymbol>.Empty;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -37,24 +37,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ImmutableArray<LocalSymbol>.Empty;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
-            if (node == _syntax)
-            {
-                return this.Locals;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return this.Locals;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
-            if (node == _syntax)
-            {
-                return ImmutableArray<LocalFunctionSymbol>.Empty;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return ImmutableArray<LocalFunctionSymbol>.Empty;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -46,5 +46,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            if (node == _syntax)
+            {
+                return ImmutableArray<LocalFunctionSymbol>.Empty;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -37,24 +37,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ImmutableArray<LocalSymbol>.Empty;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
-            if (_syntax == node)
-            {
-                return this.Locals;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return this.Locals;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
-            if (node == _syntax)
-            {
-                return ImmutableArray<LocalFunctionSymbol>.Empty;
-            }
-
-            throw ExceptionUtilities.Unreachable;
+            return ImmutableArray<LocalFunctionSymbol>.Empty;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -444,5 +444,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -440,12 +440,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope()
         {
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope()
         {
             throw ExceptionUtilities.Unreachable;
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -549,6 +549,7 @@
   -->
   <Node Name="BoundBlock" Base="BoundStatementList">
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
+    <Field Name="LocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -525,21 +525,19 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static BoundBlock SynthesizedNoLocals(CSharpSyntaxNode syntax, BoundStatement statement)
         {
-            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty,
+            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty,
                 ImmutableArray.Create(statement))
             { WasCompilerGenerated = true };
         }
 
         public static BoundBlock SynthesizedNoLocals(CSharpSyntaxNode syntax, ImmutableArray<BoundStatement> statements)
         {
-            Debug.Assert(statements.Length > 0);
-            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, statements) { WasCompilerGenerated = true };
+            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, statements) { WasCompilerGenerated = true };
         }
 
         public static BoundBlock SynthesizedNoLocals(CSharpSyntaxNode syntax, params BoundStatement[] statements)
         {
-            Debug.Assert(statements.Length > 0);
-            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, statements.AsImmutableOrNull()) { WasCompilerGenerated = true };
+            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, statements.AsImmutableOrNull()) { WasCompilerGenerated = true };
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _inferredReturnType;
         }
 
-        internal static TypeSymbol InferReturnType(BoundBlock block, Binder binder, bool isAsync, ref HashSet<DiagnosticInfo> useSiteDiagnostics, out bool inferredFromSingleType)
+        private static TypeSymbol InferReturnType(BoundBlock block, Binder binder, bool isAsync, ref HashSet<DiagnosticInfo> useSiteDiagnostics, out bool inferredFromSingleType)
         {
             int numberOfDistinctReturns;
             var resultTypes = BlockReturns.GetReturnTypes(block, out numberOfDistinctReturns);
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T).Construct(bestResultType);
         }
 
-        private sealed class BlockReturns : BoundTreeWalker
+        internal sealed class BlockReturns : BoundTreeWalker
         {
             private readonly ArrayBuilder<TypeSymbol> _types;
             private bool _hasReturnWithoutArgument;

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3878,6 +3878,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An expression tree may not contain a local function or a reference to a local function.
+        /// </summary>
+        internal static string ERR_ExpressionTreeContainsLocalFunction {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionTreeContainsLocalFunction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree may not contain a multidimensional array initializer.
         /// </summary>
         internal static string ERR_ExpressionTreeContainsMultiDimensionalArrayInitializer {
@@ -7546,6 +7555,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_ReturnTypeIsStaticClass {
             get {
                 return ResourceManager.GetString("ERR_ReturnTypeIsStaticClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot infer the return type of {0} due to differing return types..
+        /// </summary>
+        internal static string ERR_ReturnTypesDontMatch {
+            get {
+                return ResourceManager.GetString("ERR_ReturnTypesDontMatch", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4641,4 +4641,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ConstantStringTooLong" xml:space="preserve">
     <value>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</value>
   </data>
+  <data name="ERR_ExpressionTreeContainsLocalFunction" xml:space="preserve">
+    <value>An expression tree may not contain a local function or a reference to a local function</value>
+  </data>
+  <data name="ERR_ReturnTypesDontMatch" xml:space="preserve">
+    <value>Cannot infer the return type of {0} due to differing return types.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 BoundStatement retStatement = F.Return(retExpression);
 
                 // Create a bound block 
-                F.CloseMethod(F.Block(ImmutableArray.Create<LocalSymbol>(boundLocal.LocalSymbol), assignment, retStatement));
+                F.CloseMethod(F.Block(ImmutableArray.Create<LocalSymbol>(boundLocal.LocalSymbol), ImmutableArray<LocalFunctionSymbol>.Empty, assignment, retStatement));
             }
 
             internal override bool HasSpecialName

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
@@ -81,6 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var body = F.Block(
                         ImmutableArray.Create<LocalSymbol>(hashCode, i),
+                        ImmutableArray<LocalFunctionSymbol>.Empty,
                         F.If(
                             F.Binary(BinaryOperatorKind.ObjectNotEqual, F.SpecialType(SpecialType.System_Boolean),
                                 F.Parameter(text),

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             statement = new BoundSequencePoint(accessor.SyntaxNode, statement) { WasCompilerGenerated = true };
 
-            return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create<BoundStatement>(statement)) { WasCompilerGenerated = true };
+            return BoundBlock.SynthesizedNoLocals(syntax, statement);
         }
 
         /// <summary>
@@ -358,10 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                                       memberDescriptor.Name),
                                                                       syntax.Location));
 
-                return new BoundBlock(syntax,
-                    locals: ImmutableArray<LocalSymbol>.Empty,
-                    statements: ImmutableArray.Create<BoundStatement>(@return))
-                { WasCompilerGenerated = true };
+                return BoundBlock.SynthesizedNoLocals(syntax, @return);
             }
 
             Binder.ReportUseSiteDiagnostics(updateMethod, diagnostics, syntax);
@@ -404,12 +401,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     { WasCompilerGenerated = true })
                 { WasCompilerGenerated = true };
 
-                return new BoundBlock(syntax,
-                    locals: ImmutableArray<LocalSymbol>.Empty,
+                return BoundBlock.SynthesizedNoLocals(syntax,
                     statements: ImmutableArray.Create<BoundStatement>(
                         eventUpdate,
-                        @return))
-                { WasCompilerGenerated = true };
+                        @return));
             }
 
             compareExchangeMethod = compareExchangeMethod.Construct(ImmutableArray.Create<TypeSymbol>(delegateType));
@@ -505,6 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new BoundBlock(syntax,
                 locals: tmps.AsImmutable(),
+                localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                 statements: ImmutableArray.Create<BoundStatement>(
                     tmp0Init,
                     loopStart,
@@ -548,6 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBlock(
                     syntax,
                     ImmutableArray<LocalSymbol>.Empty,
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create<BoundStatement>(
                         new BoundTryStatement(
                             syntax,
@@ -556,6 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             new BoundBlock(
                                 syntax,
                                 ImmutableArray<LocalSymbol>.Empty,
+                                ImmutableArray<LocalFunctionSymbol>.Empty,
                                 ImmutableArray.Create<BoundStatement>(
                                     baseFinalizeCall)
                             )

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -847,7 +847,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (methodSymbol.IsScriptConstructor)
                 {
-                    body = new BoundBlock(methodSymbol.GetNonNullSyntaxNode(), ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty) { WasCompilerGenerated = true };
+                    body = BoundBlock.SynthesizedNoLocals(methodSymbol.GetNonNullSyntaxNode(), ImmutableArray<BoundStatement>.Empty);
                     includeInitializersInBody = false;
                     importChain = null;
                 }
@@ -858,7 +858,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundTypeOrInstanceInitializers initializerStatements = InitializerRewriter.Rewrite(processedInitializers.BoundInitializers, methodSymbol, submissionResultType);
 
                     // the lowered script initializers should not be treated as initializers anymore but as a method body:
-                    body = new BoundBlock(initializerStatements.Syntax, ImmutableArray<LocalSymbol>.Empty, initializerStatements.Statements) { WasCompilerGenerated = true };
+                    body = BoundBlock.SynthesizedNoLocals(initializerStatements.Syntax, initializerStatements.Statements);
                     includeInitializersInBody = false;
 
                     importChain = null;
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (body != null && methodSymbol.ContainingType.IsStructType() && !methodSymbol.IsImplicitConstructor)
                         {
                             // In order to get correct diagnostics, we need to analyze initializers and the body together.
-                            body = body.Update(body.Locals, body.Statements.Insert(0, analyzedInitializers));
+                            body = body.Update(body.Locals, body.LocalFunctions, body.Statements.Insert(0, analyzedInitializers));
                             includeInitializersInBody = false;
                             analyzedInitializers = null;
                         }
@@ -1592,7 +1592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 statements = ImmutableArray.Create(constructorInitializer, body);
             }
 
-            return new BoundBlock(method.GetNonNullSyntaxNode(), ImmutableArray<LocalSymbol>.Empty, statements) { WasCompilerGenerated = true };
+            return BoundBlock.SynthesizedNoLocals(method.GetNonNullSyntaxNode(), statements);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1311,5 +1311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NameofExtensionMethod = 8093,
         WRN_AlignmentMagnitude = 8094,
         ERR_ConstantStringTooLong = 8095,
+        ERR_ExpressionTreeContainsLocalFunction = 8096,
+        ERR_ReturnTypesDontMatch = 8097,
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1472,17 +1472,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var symbol in locals)
             {
-                ReportIfUnused(symbol, assigned: true);
+                ReportIfUnused(symbol);
             }
         }
 
-        private void ReportIfUnused(LocalFunctionSymbol symbol, bool assigned)
+        private void ReportIfUnused(LocalFunctionSymbol symbol)
         {
             if (!_usedLocalFunctions.Contains(symbol))
             {
                 if (!string.IsNullOrEmpty(symbol.Name)) // avoid diagnostics for parser-inserted names
                 {
-                    Diagnostics.Add(assigned && _writtenVariables.Contains(symbol) ? ErrorCode.WRN_UnreferencedVarAssg : ErrorCode.WRN_UnreferencedVar, symbol.Locations[0], symbol.Name);
+                    Diagnostics.Add(ErrorCode.WRN_UnreferencedVar, symbol.Locations[0], symbol.Name);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -88,10 +88,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case BoundKind.Block:
                     var block = (BoundBlock)node;
-                    return block.Update(block.Locals, block.Statements.Add(ret));
+                    return block.Update(block.Locals, block.LocalFunctions, block.Statements.Add(ret));
 
                 default:
-                    return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create(ret, node));
+                    return new BoundBlock(syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, ImmutableArray.Create(ret, node));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -226,6 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var completeTry = _F.Block(
                 locals.ToImmutableAndFree(),
+                ImmutableArray<LocalFunctionSymbol>.Empty,
                 statements.ToImmutableAndFree());
 
             return completeTry;
@@ -402,6 +403,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return _F.Block(
                     ImmutableArray.Create<LocalSymbol>(obj),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     objInit,
                     _F.If(
                         _F.ObjectNotEqual(
@@ -430,6 +432,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // better rethrow 
                 rethrow = _F.Block(
                     ImmutableArray.Create(ex),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     assignment,
                     _F.If(_F.ObjectEqual(_F.Local(ex), _F.Null(ex.Type)), rethrow),
                     // ExceptionDispatchInfo.Capture(pendingExceptionLocal).Throw();
@@ -484,6 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         currentAwaitCatchFrame.pendingCaughtException,
                         currentAwaitCatchFrame.pendingCatch).
                         AddRange(currentAwaitCatchFrame.GetHoistedLocals()),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     _F.HiddenSequencePoint(),
                     _F.Assignment(
                         _F.Local(currentAwaitCatchFrame.pendingCatch),
@@ -616,6 +620,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var handler = _F.Block(
                     handlerLocals,
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     handlerStatements.ToImmutableAndFree()
                 );
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bodyBuilder.Add(
                 F.Try(
                     F.Block(ImmutableArray<LocalSymbol>.Empty,
+                        ImmutableArray<LocalFunctionSymbol>.Empty,
                         // switch (state) ...
                         F.HiddenSequencePoint(),
                         Dispatch(),
@@ -201,6 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     body.Syntax, 
                     F.Block(
                         locals.ToImmutableAndFree(), 
+                        ImmutableArray<LocalFunctionSymbol>.Empty,
                         newStatements));
 
             if (rootScopeHoistedLocals.Length > 0)
@@ -301,6 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 LocalSymbol resultTemp = F.SynthesizedLocal(type);
                 return F.Block(
                     ImmutableArray.Create(awaiterTemp, resultTemp),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                         awaitIfIncomplete,
                         F.Assignment(F.Local(resultTemp), getResultCall),
                         F.ExpressionStatement(nullAwaiter),
@@ -312,6 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // $awaiterTemp = null;
                 return F.Block(
                     ImmutableArray.Create(awaiterTemp),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                         awaitIfIncomplete,
                         F.ExpressionStatement(getResultCall),
                         F.ExpressionStatement(nullAwaiter));
@@ -474,6 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     thenClause: F.Block(
                         ImmutableArray.Create(notifyCompletionTemp),
+                        ImmutableArray<LocalFunctionSymbol>.Empty,
                         F.Assignment(
                             F.Local(notifyCompletionTemp),
                                 // Use reference conversion rather than dynamic conversion:
@@ -505,6 +510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return F.Block(
                 SingletonOrPair(criticalNotifyCompletedTemp, thisTemp),
+                ImmutableArray<LocalFunctionSymbol>.Empty,
                 blockBuilder.ToImmutableAndFree());
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -193,6 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return F.Block(
                     ImmutableArray.Create(builderVariable),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     bodyBuilder.ToImmutableAndFree());
             }
             catch (SyntheticBoundNodeFactory.MissingPredefinedMember ex)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var substituterOpt = (substituteTemps && _tempSubstitution.Count > 0) ? new LocalSubstituter(_tempSubstitution) : null;
-            var result = _F.Block(builder.GetLocals(), builder.GetStatements(substituterOpt));
+            var result = _F.Block(builder.GetLocals(), ImmutableArray<LocalFunctionSymbol>.Empty, builder.GetStatements(substituterOpt));
 
             builder.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -213,6 +213,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Error(ErrorCode.ERR_ComRefCallInExpressionTree, node);
                 }
+                else if (method.MethodKind == MethodKind.LocalFunction)
+                {
+                    Error(ErrorCode.ERR_ExpressionTreeContainsLocalFunction, node);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // state_0:
             // state = -1;
             // [[rewritten body]]
-            newBody = F.Block(ImmutableArray.Create(cachedState),
+            newBody = F.Block(ImmutableArray.Create(cachedState), ImmutableArray<LocalFunctionSymbol>.Empty,
                     F.Block(
                         F.HiddenSequencePoint(),
                         F.Assignment(F.Local(cachedState), F.Field(F.This(), stateField))
@@ -153,6 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var disposeBody = F.Block(
                                     ImmutableArray.Create<LocalSymbol>(stateLocal),
+                                    ImmutableArray<LocalFunctionSymbol>.Empty,
                                     F.Assignment(F.Local(stateLocal), F.Field(F.This(), stateField)),
                                     EmitFinallyFrame(rootFrame, state),
                                     F.Return());
@@ -179,6 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //   return methodValue;
                 newBody = F.Block(
                         ImmutableArray.Create<LocalSymbol>(_methodValue),
+                        ImmutableArray<LocalFunctionSymbol>.Empty,
                         newBody,
                         F.Assignment(this.F.Local(_methodValue), this.F.Literal(true)),
                         F.Label(_exitLabel),

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             bodyBuilder.Add(F.Return(F.Local(resultVariable)));
-            F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), bodyBuilder.ToImmutableAndFree()));
+            F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), ImmutableArray<LocalFunctionSymbol>.Empty, bodyBuilder.ToImmutableAndFree()));
 
             // Generate IEnumerable.GetEnumerator
             var getEnumerator = OpenMethodImplementation(IEnumerable_GetEnumerator);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_addedLocals != null)
             {
                 _addedStatements.Add(body);
-                body = new BoundBlock(body.Syntax, _addedLocals.ToImmutableAndFree(), _addedStatements.ToImmutableAndFree()) { WasCompilerGenerated = true };
+                body = new BoundBlock(body.Syntax, _addedLocals.ToImmutableAndFree(), ImmutableArray<LocalFunctionSymbol>.Empty, _addedStatements.ToImmutableAndFree()) { WasCompilerGenerated = true };
                 _addedLocals = null;
                 _addedStatements = null;
             }
@@ -839,7 +839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // TODO: we may not need to update if there was nothing to rewrite.
-            return node.Update(newLocals.ToImmutableAndFree(), newStatements.ToImmutableAndFree());
+            return node.Update(newLocals.ToImmutableAndFree(), node.LocalFunctions, newStatements.ToImmutableAndFree());
         }
 
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)
@@ -965,7 +965,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         newStatements.Add((BoundStatement)this.Visit(s));
                     }
 
-                    return new BoundBlock(node.Syntax, newLocals.ToImmutableAndFree(), newStatements.ToImmutableAndFree(), node.HasErrors);
+                    return new BoundBlock(node.Syntax, newLocals.ToImmutableAndFree(), ImmutableArray<LocalFunctionSymbol>.Empty, newStatements.ToImmutableAndFree(), node.HasErrors);
                 });
             }
             else
@@ -986,7 +986,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     InsertAndFreePrologue(newStatements, prologue);
                     newStatements.Add((BoundStatement)base.VisitSwitchStatement(node));
 
-                    return new BoundBlock(node.Syntax, newLocals.ToImmutableAndFree(), newStatements.ToImmutableAndFree(), node.HasErrors);
+                    return new BoundBlock(node.Syntax, newLocals.ToImmutableAndFree(), ImmutableArray<LocalFunctionSymbol>.Empty, newStatements.ToImmutableAndFree(), node.HasErrors);
                 });
             }
             else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Block.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Block.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node.WasCompilerGenerated || !this.GenerateDebugInfo || node.Syntax.Kind() == SyntaxKind.ArrowExpressionClause)
             {
-                return node.Update(node.Locals, VisitList(node.Statements));
+                return node.Update(node.Locals, node.LocalFunctions, VisitList(node.Statements));
             }
 
             BlockSyntax syntax = node.Syntax as BlockSyntax;
@@ -39,13 +39,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.Add(new BoundSequencePointWithSpan(syntax, null, cBspan));
             }
 
-            return new BoundBlock(syntax, node.Locals, builder.ToImmutableAndFree(), node.HasErrors);
+            return new BoundBlock(syntax, node.Locals, node.LocalFunctions, builder.ToImmutableAndFree(), node.HasErrors);
         }
 
         public override BoundNode VisitNoOpStatement(BoundNoOpStatement node)
         {
             return (node.WasCompilerGenerated || !this.GenerateDebugInfo)
-                ? new BoundBlock(node.Syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty)
+                ? new BoundBlock(node.Syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, ImmutableArray<BoundStatement>.Empty)
                 : AddSequencePoint(node);
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return _factory.Block(
                     localBuilder.ToImmutableAndFree(),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     new BoundTryStatement(
                         _factory.Syntax,
                         _factory.Block(statementBuilder.ToImmutableAndFree()),
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 statementBuilder.AddRange(cleanup);
-                return _factory.Block(localBuilder.ToImmutableAndFree(), statementBuilder.ToImmutableAndFree());
+                return _factory.Block(localBuilder.ToImmutableAndFree(), ImmutableArray<LocalFunctionSymbol>.Empty, statementBuilder.ToImmutableAndFree());
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -208,6 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     finallyBlockOpt = new BoundBlock(forEachSyntax,
                         locals: ImmutableArray<LocalSymbol>.Empty,
+                        localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                         statements: ImmutableArray.Create<BoundStatement>(disposeStmt));
                 }
                 else
@@ -259,6 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // if (d != null) d.Dispose();
                     finallyBlockOpt = new BoundBlock(forEachSyntax,
                         locals: ImmutableArray.Create<LocalSymbol>(disposableVar),
+                        localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                         statements: ImmutableArray.Create<BoundStatement>(disposableVarDecl, ifStmt));
                 }
 
@@ -274,6 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundStatement tryFinally = new BoundTryStatement(forEachSyntax,
                     tryBlock: new BoundBlock(forEachSyntax,
                         locals: ImmutableArray<LocalSymbol>.Empty,
+                        localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                         statements: ImmutableArray.Create<BoundStatement>(whileLoop)),
                     catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
                     finallyBlockOpt: finallyBlockOpt);
@@ -284,6 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = new BoundBlock(
                     syntax: forEachSyntax,
                     locals: ImmutableArray.Create(enumeratorVar),
+                    localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                     statements: ImmutableArray.Create<BoundStatement>(enumeratorVarDecl, tryFinally));
             }
             else
@@ -296,6 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = new BoundBlock(
                     syntax: forEachSyntax,
                     locals: ImmutableArray.Create(enumeratorVar),
+                    localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                     statements: ImmutableArray.Create<BoundStatement>(enumeratorVarDecl, whileLoop));
             }
 
@@ -485,7 +490,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static BoundBlock CreateBlockDeclaringIterationVariable(
-            LocalSymbol iterationVariable, 
+            LocalSymbol iterationVariable,
             BoundStatement iteratorVariableInitialization,
             BoundStatement rewrittenBody,
             ForEachStatementSyntax forEachSyntax)
@@ -502,6 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBlock(
                 forEachSyntax,
                 locals: ImmutableArray.Create(iterationVariable),
+                localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                 statements: ImmutableArray.Create(iteratorVariableInitialization, rewrittenBody));
         }
 
@@ -605,8 +611,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // { V v = (V)a[p]; /* node.Body */ }
 
-            BoundStatement loopBody = CreateBlockDeclaringIterationVariable(iterationVar, iterationVariableDecl, rewrittenBody, forEachSyntax); 
-           
+            BoundStatement loopBody = CreateBlockDeclaringIterationVariable(iterationVar, iterationVariableDecl, rewrittenBody, forEachSyntax);
+
             // for (A[] a = /*node.Expression*/, int p = 0; p < a.Length; p = p + 1) {
             //     V v = (V)a[p];
             //     /*node.Body*/
@@ -808,6 +814,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement result = new BoundBlock(
                 forEachSyntax,
                 ImmutableArray.Create(arrayVar).Concat(upperVar.AsImmutableOrNull()),
+                ImmutableArray<LocalFunctionSymbol>.Empty,
                 ImmutableArray.Create(arrayVarDecl).Concat(upperVarDecl.AsImmutableOrNull()).Add(forLoop));
 
             AddForEachKeywordSequencePoint(forEachSyntax, ref result);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             statementBuilder.Add(new BoundLabelStatement(syntax, breakLabel));
 
             var statements = statementBuilder.ToImmutableAndFree();
-            return new BoundBlock(syntax, outerLocals, statements, hasErrors);
+            return new BoundBlock(syntax, outerLocals, ImmutableArray<LocalFunctionSymbol>.Empty, statements, hasErrors);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
@@ -120,6 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBlock(
                     lockSyntax,
                     ImmutableArray.Create(boundLockTemp.LocalSymbol, boundLockTakenTemp.LocalSymbol),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create(
                         MakeInitialLockSequencePoint(boundLockTempInit, lockSyntax),
                         boundLockTakenTempInit,
@@ -170,6 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBlock(
                     lockSyntax,
                     ImmutableArray.Create(boundLockTemp.LocalSymbol),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create(
                         MakeInitialLockSequencePoint(boundLockTempInit, lockSyntax),
                         enterCall,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
@@ -172,7 +172,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             statementBuilder.Add(rewrittenSwitchStatement);
 
-            return new BoundBlock(syntax, locals: (object)tempLocal == null ? ImmutableArray<LocalSymbol>.Empty : ImmutableArray.Create<LocalSymbol>(tempLocal), statements: statementBuilder.ToImmutableAndFree());
+            return new BoundBlock(
+                syntax,
+                locals: (object)tempLocal == null ? ImmutableArray<LocalSymbol>.Empty : ImmutableArray.Create<LocalSymbol>(tempLocal),
+                localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
+                statements: statementBuilder.ToImmutableAndFree());
         }
 
         private static LabelSymbol GetNullValueTargetSwitchLabel(ImmutableArray<BoundSwitchSection> sections, GeneratedLabelSymbol breakLabel)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBlock(
                     usingSyntax,
                     node.Locals,
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create<BoundStatement>(result));
             }
         }
@@ -141,6 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBlock(
                 syntax: usingSyntax,
                 locals: node.Locals.Add(boundTemp.LocalSymbol),
+                localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                 statements: ImmutableArray.Create<BoundStatement>(expressionStatement, tryFinally));
         }
 
@@ -190,6 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBlock(
                     syntax: usingSyntax,
                     locals: ImmutableArray.Create<LocalSymbol>(boundTemp.LocalSymbol), //localSymbol will be declared by an enclosing block
+                    localFunctions: ImmutableArray<LocalFunctionSymbol>.Empty,
                     statements: ImmutableArray.Create<BoundStatement>(
                         rewrittenDeclaration,
                         new BoundExpressionStatement(declarationSyntax, tempAssignment),

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -131,8 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override BoundNode VisitBlock(BoundBlock node)
         {
             var newLocals = RewriteLocals(node.Locals);
+            var newLocalFunctions = node.LocalFunctions;
             var newStatements = VisitList(node.Statements);
-            return node.Update(newLocals, newStatements);
+            return node.Update(newLocals, newLocalFunctions, newStatements);
         }
 
         public override BoundNode VisitSequence(BoundSequence node)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -269,6 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bodyBuilder.Add(GenerateStateMachineCreation(stateMachineVariable, frameType));
             return F.Block(
                 ImmutableArray.Create(stateMachineVariable),
+                ImmutableArray<LocalFunctionSymbol>.Empty,
                 bodyBuilder.ToImmutableAndFree());
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundBlock Block(ImmutableArray<BoundStatement> statements)
         {
-            return Block(ImmutableArray<LocalSymbol>.Empty, statements);
+            return Block(ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, statements);
         }
 
         public BoundBlock Block(params BoundStatement[] statements)
@@ -406,14 +406,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Block(ImmutableArray.Create(statements));
         }
 
-        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, params BoundStatement[] statements)
+        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, params BoundStatement[] statements)
         {
-            return Block(locals, ImmutableArray.Create(statements));
+            return Block(locals, localFunctions, ImmutableArray.Create(statements));
         }
 
-        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundStatement> statements)
+        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, ImmutableArray<BoundStatement> statements)
         {
-            return new BoundBlock(Syntax, locals, statements) { WasCompilerGenerated = true };
+            return new BoundBlock(Syntax, locals, localFunctions, statements) { WasCompilerGenerated = true };
         }
 
         public BoundReturnStatement Return(BoundExpression expression = null)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -306,6 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return new BoundBlock(syntax,
                     ImmutableArray.Create<LocalSymbol>(submissionLocal.LocalSymbol),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create<BoundStatement>(
                         // var script = new Script();
                         new BoundExpressionStatement(
@@ -440,6 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return new BoundBlock(syntax,
                     ImmutableArray.Create<LocalSymbol>(submissionLocal.LocalSymbol),
+                    ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create<BoundStatement>(submissionAssignment, returnStatement))
                 { WasCompilerGenerated = true };
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2766,7 +2766,10 @@ class Program
     Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 24),
     // (6,26): error CS1023: Embedded statement cannot be a declaration or labeled statement
     //         void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(6, 26)
+    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(6, 26),
+    // (6,14): warning CS0168: The variable 'f' is declared but never used
+    //         void f() { if () const int i = 0; }
+    Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(6, 14)
                 );
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -42,8 +42,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         public override BoundNode VisitBlock(BoundBlock node)
         {
             var rewrittenLocals = node.Locals.WhereAsArray(local => local.IsCompilerGenerated || local.Name == null || this.GetVariable(local.Name) == null);
+            var rewrittenLocalFunctions = node.LocalFunctions;
             var rewrittenStatements = VisitList(node.Statements);
-            return node.Update(rewrittenLocals, rewrittenStatements);
+            return node.Update(rewrittenLocals, rewrittenLocalFunctions, rewrittenStatements);
         }
 
         public override BoundNode VisitLocal(BoundLocal node)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             if (hasChanged)
             {
-                node = new BoundBlock(node.Syntax, ImmutableArray<LocalSymbol>.Empty, builder.ToImmutable()) { WasCompilerGenerated = true };
+                node = BoundBlock.SynthesizedNoLocals(node.Syntax, builder.ToImmutable());
             }
 
             builder.Free();

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             var noLocals = ImmutableArray<LocalSymbol>.Empty;
+            var noLocalFunctions = ImmutableArray<LocalFunctionSymbol>.Empty;
             var initializerInvocation = MethodCompiler.BindConstructorInitializer(this, diagnostics, compilationState.Compilation);
             var syntax = initializerInvocation.Syntax;
 
@@ -25,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 new BoundBlock(
                     syntax,
                     noLocals,
+                    noLocalFunctions,
                     ImmutableArray.Create<BoundStatement>(
                         new BoundExpressionStatement(syntax, initializerInvocation),
                         new BoundReturnStatement(syntax, null))));

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             localsSet.Free();
 
-            body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
+            body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), ImmutableArray<LocalFunctionSymbol>.Empty, statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
 
             Debug.Assert(!diagnostics.HasAnyErrors());
             Debug.Assert(!body.HasErrors);
@@ -600,7 +600,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 localBuilder.Add(local);
             }
 
-            body = block.Update(localBuilder.ToImmutableAndFree(), block.Statements);
+            body = block.Update(localBuilder.ToImmutableAndFree(), block.LocalFunctions, block.Statements);
             TypeParameterChecker.Check(body, _allTypeParameters);
             compilationState.AddSynthesizedMethod(this, body);
         }


### PR DESCRIPTION
Things in this PR:

* The type `BoundBlock` now contains an `ImmutableArray<LocalFunctionSymbol>` alongside its `ImmutableArray<LocalSymbol>`. This generates lots of noise in this PR, as a lot of construction sites had to be updated. Note that this was planned from the start, in the original local functions discussion BoundBlock having a list was mentioned, but I just never got around to adding it (as it was never needed).
* Data flow analysis now reports unused local functions. This is the reason why `BoundBlock` suddenly needs a symbol list only now, this far in.
* References to local functions are now disallowed in expression trees, which may or may not change in the future (Previously they were generated as a reference to a mangled method name, which seemed wrong). Added a new error for this.
* Multiple return statements in an inferred return type local function must all have exactly the same type. This may change later, but for this prototype it's an acceptable restriction. Added a new error for this.

FYI @jaredpar @VSadov @agocke Theoretically these PRs will get smaller and more frequent compared to the first three, but this one is rather noisy due to the BoundBlock change.