### PR TITLE
Unify C# and VB suggestion mode completion providers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     {
         internal override ICompletionProvider CreateCompletionProvider()
         {
-            return new SuggestionModeCompletionProvider();
+            return new CSharpSuggestionModeCompletionProvider();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -344,7 +344,7 @@ End Class
         End Sub
 
         Friend Overrides Function CreateCompletionProvider() As ICompletionProvider
-            Return New SuggestionModeCompletionProvider()
+            Return New VisualBasicSuggestionModeCompletionProvider()
         End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/CSharpFeatures.csproj
+++ b/src/Features/CSharp/CSharpFeatures.csproj
@@ -77,13 +77,13 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
-    <InternalsVisibleTo Include="Roslyn.CSharp.InteractiveEditorFeatures" />    
+    <InternalsVisibleTo Include="Roslyn.CSharp.InteractiveEditorFeatures" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.VisualBasic.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.UnitTests" />
-    <InternalsVisibleToTest Include="Roslyn.VisualStudio.CSharp.UnitTests" />    
+    <InternalsVisibleToTest Include="Roslyn.VisualStudio.CSharp.UnitTests" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Compilers\CSharp\Portable\Syntax\LambdaUtilities.cs">
@@ -147,7 +147,7 @@
     <Compile Include="Completion\CompletionProviders\ObjectInitializerCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\SnippetCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\SpeculativeTCompletionProvider.cs" />
-    <Compile Include="Completion\CompletionProviders\SuggestionModeCompletionProvider.cs" />
+    <Compile Include="Completion\SuggestionMode\CSharpSuggestionModeCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\SymbolCompletionProvider.cs" />
     <Compile Include="Completion\CSharpCompletionItem.cs" />
     <Compile Include="Completion\CSharpCompletionOptions.cs" />

--- a/src/Features/CSharp/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Completion/CSharpCompletionService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new ObjectCreationCompletionProvider(),
                 new ObjectInitializerCompletionProvider(),
                 new SpeculativeTCompletionProvider(),
-                new SuggestionModeCompletionProvider(),
+                new CSharpSuggestionModeCompletionProvider(),
                 new EnumAndCompletionListTagCompletionProvider(),
                 new CrefCompletionProvider(),
                 new SnippetCompletionProvider(),

--- a/src/Features/CSharp/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
@@ -1,66 +1,29 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.Completion.SuggestionMode;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
-    internal class SuggestionModeCompletionProvider : ICompletionProvider
+    internal class CSharpSuggestionModeCompletionProvider : SuggestionModeCompletionProvider
     {
-        public bool IsCommitCharacter(CompletionItem completionItem, char ch, string textTypedSoFar)
+        protected override TextSpan GetFilterSpan(SourceText text, int position)
         {
-            return false;
+            return CompletionUtilities.GetTextChangeSpan(text, position);
         }
 
-        public bool SendEnterThroughToEditor(CompletionItem completionItem, string textTypedSoFar)
-        {
-            return false;
-        }
-
-        public bool IsTriggerCharacter(SourceText text, int characterPosition, OptionSet options)
-        {
-            return false;
-        }
-
-        public TextChange GetTextChange(CompletionItem selectedItem, char? ch = null, string textTypedSoFar = null)
-        {
-            return new TextChange(selectedItem.FilterSpan, selectedItem.DisplayText);
-        }
-
-        public async Task<CompletionItemGroup> GetGroupAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken)
-        {
-            if (!triggerInfo.IsAugment)
-            {
-                return null;
-            }
-
-            var builder = await this.GetBuilderAsync(document, position, triggerInfo, cancellationToken).ConfigureAwait(false);
-            if (builder == null)
-            {
-                return null;
-            }
-
-            return new CompletionItemGroup(
-                SpecializedCollections.EmptyEnumerable<CompletionItem>(),
-                builder,
-                isExclusive: false);
-        }
-
-        private async Task<CompletionItem> GetBuilderAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<CompletionItem> GetBuilderAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (triggerInfo.TriggerReason == CompletionTriggerReason.TypeCharCommand)
             {
@@ -69,12 +32,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 if (triggerInfo.IsDebugger)
                 {
                     // Aggressive Intellisense in the debugger: always show the builder 
-                    return new CompletionItem(this, "", CompletionUtilities.GetTextChangeSpan(text, position), isBuilder: true);
+                    return CreateEmptyBuilder(text, position);
                 }
 
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
-                token = token.GetPreviousTokenIfTouchingWord(position);
+                var token = tree
+                    .FindTokenOnLeftOfPosition(position, cancellationToken)
+                    .GetPreviousTokenIfTouchingWord(position);
+
                 if (token.Kind() == SyntaxKind.None)
                 {
                     return null;
@@ -85,37 +50,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 if (IsLambdaExpression(semanticModel, position, token, typeInferrer, cancellationToken))
                 {
-                    return new CompletionItem(this, CSharpFeaturesResources.LambdaExpression,
-                        CompletionUtilities.GetTextChangeSpan(text, position),
-                        CSharpFeaturesResources.AutoselectDisabledDueToPotentialLambdaDeclaration.ToSymbolDisplayParts(),
-                        isBuilder: true);
+                    return CreateBuilder(text, position, CSharpFeaturesResources.LambdaExpression, CSharpFeaturesResources.AutoselectDisabledDueToPotentialLambdaDeclaration);
                 }
                 else if (IsAnonymousObjectCreation(token))
                 {
-                    return new CompletionItem(this, CSharpFeaturesResources.MemberName,
-                        CompletionUtilities.GetTextChangeSpan(text, position),
-                        CSharpFeaturesResources.AutoselectDisabledDueToPossibleExplicitlyNamesAnonTypeMemCreation.ToSymbolDisplayParts(),
-                        isBuilder: true);
+                    return CreateBuilder(text, position, CSharpFeaturesResources.MemberName, CSharpFeaturesResources.AutoselectDisabledDueToPossibleExplicitlyNamesAnonTypeMemCreation);
                 }
                 else if (token.IsPreProcessorExpressionContext())
                 {
-                    return new CompletionItem(this, "", CompletionUtilities.GetTextChangeSpan(text, position), isBuilder: true);
+                    return CreateEmptyBuilder(text, position);
                 }
                 else if (IsImplicitArrayCreation(semanticModel, token, position, typeInferrer, cancellationToken))
                 {
-                    return new CompletionItem(this, CSharpFeaturesResources.ImplicitArrayCreation,
-                        CompletionUtilities.GetTextChangeSpan(text, position),
-                        CSharpFeaturesResources.AutoselectDisabledDueToPotentialImplicitArray.ToSymbolDisplayParts(),
-                        isBuilder: true);
+                    return CreateBuilder(text, position, CSharpFeaturesResources.ImplicitArrayCreation, CSharpFeaturesResources.AutoselectDisabledDueToPotentialImplicitArray);
                 }
-                else
+                else if (token.IsKindOrHasMatchingText(SyntaxKind.FromKeyword) || token.IsKindOrHasMatchingText(SyntaxKind.JoinKeyword))
                 {
-                    return token.IsKindOrHasMatchingText(SyntaxKind.FromKeyword) || token.IsKindOrHasMatchingText(SyntaxKind.JoinKeyword)
-                        ? new CompletionItem(this, CSharpFeaturesResources.RangeVariable,
-                            CompletionUtilities.GetTextChangeSpan(text, position),
-                            CSharpFeaturesResources.AutoselectDisabledDueToPotentialRangeVariableDecl.ToSymbolDisplayParts(),
-                        isBuilder: true)
-                        : null;
+                    return CreateBuilder(text, position, CSharpFeaturesResources.RangeVariable, CSharpFeaturesResources.AutoselectDisabledDueToPotentialRangeVariableDecl);
                 }
             }
 
@@ -185,11 +136,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var inferredTypes = typeInferrer.InferTypes(semanticModel, position, cancellationToken: cancellationToken);
 
             return inferredTypes.Any(type => type.GetDelegateType(semanticModel.Compilation).IsDelegateType());
-        }
-
-        public bool IsFilterCharacter(CompletionItem completionItem, char ch, string textTypedSoFar)
-        {
-            return false;
         }
     }
 }

--- a/src/Features/Core/Completion/SuggestionMode/SuggestionModeCompletionProvider.cs
+++ b/src/Features/Core/Completion/SuggestionMode/SuggestionModeCompletionProvider.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Completion.SuggestionMode
+{
+    internal abstract class SuggestionModeCompletionProvider : ICompletionProvider
+    {
+        protected abstract Task<CompletionItem> GetBuilderAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken);
+        protected abstract TextSpan GetFilterSpan(SourceText text, int position);
+
+        public async Task<CompletionItemGroup> GetGroupAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!triggerInfo.IsAugment)
+            {
+                return null;
+            }
+
+            var builder = await this.GetBuilderAsync(document, position, triggerInfo, cancellationToken).ConfigureAwait(false);
+            if (builder == null)
+            {
+                return null;
+            }
+
+            return new CompletionItemGroup(
+                SpecializedCollections.EmptyEnumerable<CompletionItem>(),
+                builder,
+                isExclusive: false);
+        }
+
+        protected CompletionItem CreateEmptyBuilder(SourceText text, int position)
+        {
+            return CreateBuilder(text, position, displayText: null, description: null);
+        }
+
+        protected CompletionItem CreateBuilder(SourceText text, int position, string displayText, string description)
+        {
+            return new CompletionItem(
+                completionProvider: this,
+                displayText: displayText ?? string.Empty,
+                filterSpan: GetFilterSpan(text, position),
+                description: description != null ? description.ToSymbolDisplayParts() : default(ImmutableArray<SymbolDisplayPart>),
+                isBuilder: true);
+        }
+
+        public TextChange GetTextChange(CompletionItem selectedItem, char? ch = default(char?), string textTypedSoFar = null) => new TextChange(selectedItem.FilterSpan, selectedItem.DisplayText);
+        public bool IsCommitCharacter(CompletionItem completionItem, char ch, string textTypedSoFar) => false;
+        public bool IsFilterCharacter(CompletionItem completionItem, char ch, string textTypedSoFar) => false;
+        public bool IsTriggerCharacter(SourceText text, int characterPosition, OptionSet options) => false;
+        public bool SendEnterThroughToEditor(CompletionItem completionItem, string textTypedSoFar) => false;
+    }
+}

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Completion\Providers\ITextCompletionProvider.cs" />
     <Compile Include="Completion\Providers\KeywordCompletionItem.cs" />
     <Compile Include="Completion\Providers\RecommendedKeyword.cs" />
+    <Compile Include="Completion\SuggestionMode\SuggestionModeCompletionProvider.cs" />
     <Compile Include="Diagnostics\AnalyzerDriverResources.cs" />
     <Compile Include="Diagnostics\AnalyzerHelper.cs" />
     <Compile Include="Diagnostics\AbstractHostDiagnosticUpdateSource.cs" />
@@ -551,6 +552,7 @@
   <ItemGroup>
     <PublicAPI Include="PublicAPI.txt" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="..\..\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />
   <ImportGroup Label="Targets">
     <Import Project="..\..\Tools\Microsoft.CodeAnalysis.Toolset.Open\Targets\VSL.Imports.targets" />

--- a/src/Features/VisualBasic/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/BasicFeatures.vbproj
@@ -188,7 +188,7 @@
     <Compile Include="Completion\CompletionProviders\ObjectCreationCompletionProvider.vb" />
     <Compile Include="Completion\CompletionProviders\ObjectInitializerCompletionProvider.vb" />
     <Compile Include="Completion\CompletionProviders\PartialTypeCompletionProvider.vb" />
-    <Compile Include="Completion\CompletionProviders\SuggestionModeCompletionProvider.vb" />
+    <Compile Include="Completion\SuggestionMode\VisualBasicSuggestionModeCompletionProvider.vb" />
     <Compile Include="Completion\CompletionProviders\SymbolCompletionProvider.vb" />
     <Compile Include="Completion\KeywordRecommenders\AbstractKeywordRecommender.vb" />
     <Compile Include="Completion\KeywordRecommenders\ArrayStatements\EraseKeywordRecommender.vb" />

--- a/src/Features/VisualBasic/Completion/VisualBasicCompletionService.vb
+++ b/src/Features/VisualBasic/Completion/VisualBasicCompletionService.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
             New ObjectCreationCompletionProvider(),
             New EnumCompletionProvider(),
             New NamedParameterCompletionProvider(),
-            New SuggestionModeCompletionProvider(),
+            New VisualBasicSuggestionModeCompletionProvider(),
             New ImplementsClauseCompletionProvider(),
             New HandlesClauseCompletionProvider(),
             New PartialTypeCompletionProvider(),


### PR DESCRIPTION
Currently, the C# and VB suggestion mode completion providers both implement ICompletionProvider
in nearly the same way. This change introduces a new base class containing the shared
implementations.

Note: prior to this change, C# and VB returned different values for IsCommitCharacter: false and
true respectively. Now they'll both return false. However, this is OK because the completion
controller handles builder completion items specially and IsCommitCharacter so that is never
actually called in this case.