### PR TITLE
Format during Return in a Brace Completion Session

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
 
         public override void AfterStart(IBraceCompletionSession session, CancellationToken cancellationToken)
         {
-            FormatTrackingSpan(session);
+            FormatTrackingSpan(session, true);
 
             session.TextView.TryMoveCaretToAndEnsureVisible(session.ClosingPoint.GetPoint(session.SubjectBuffer.CurrentSnapshot).Subtract(1));
         }
@@ -65,12 +65,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                 var document = session.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document != null)
                 {
-                    // first add one line in between, and format braces 
-                    if (session.SubjectBuffer.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace))
-                    {
-                        document.InsertText(session.ClosingPoint.GetPosition(session.SubjectBuffer.CurrentSnapshot) - 1, Environment.NewLine, cancellationToken);
-                        FormatTrackingSpan(session, GetFormattingRules(document));
-                    }
+                    document.InsertText(session.ClosingPoint.GetPosition(session.SubjectBuffer.CurrentSnapshot) - 1, Environment.NewLine, cancellationToken);
+                    FormatTrackingSpan(session, false, GetFormattingRules(document));
 
                     // put caret at right indentation
                     PutCaretOnLine(session, session.OpeningPoint.GetPoint(session.SubjectBuffer.CurrentSnapshot).GetContainingLineNumber() + 1);
@@ -114,9 +110,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
             return SpecializedCollections.SingletonEnumerable(BraceCompletionFormattingRule.Instance).Concat(Formatter.GetDefaultFormattingRules(document));
         }
 
-        private void FormatTrackingSpan(IBraceCompletionSession session, IEnumerable<IFormattingRule> rules = null)
+        private void FormatTrackingSpan(IBraceCompletionSession session, bool isAfterSessionStart, IEnumerable<IFormattingRule> rules = null)
         {
-            if (!session.SubjectBuffer.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace))
+            if (!session.SubjectBuffer.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace) && isAfterSessionStart)
             {
                 return;
             }

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
 
         public override void AfterStart(IBraceCompletionSession session, CancellationToken cancellationToken)
         {
-            FormatTrackingSpan(session, true);
+            FormatTrackingSpan(session, shouldHonorAutoFormattingOnCloseBraceOption: true);
 
             session.TextView.TryMoveCaretToAndEnsureVisible(session.ClosingPoint.GetPoint(session.SubjectBuffer.CurrentSnapshot).Subtract(1));
         }
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                 if (document != null)
                 {
                     document.InsertText(session.ClosingPoint.GetPosition(session.SubjectBuffer.CurrentSnapshot) - 1, Environment.NewLine, cancellationToken);
-                    FormatTrackingSpan(session, false, GetFormattingRules(document));
+                    FormatTrackingSpan(session, shouldHonorAutoFormattingOnCloseBraceOption: false, rules: GetFormattingRules(document));
 
                     // put caret at right indentation
                     PutCaretOnLine(session, session.OpeningPoint.GetPoint(session.SubjectBuffer.CurrentSnapshot).GetContainingLineNumber() + 1);
@@ -110,9 +110,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
             return SpecializedCollections.SingletonEnumerable(BraceCompletionFormattingRule.Instance).Concat(Formatter.GetDefaultFormattingRules(document));
         }
 
-        private void FormatTrackingSpan(IBraceCompletionSession session, bool isAfterSessionStart, IEnumerable<IFormattingRule> rules = null)
+        private void FormatTrackingSpan(IBraceCompletionSession session, bool shouldHonorAutoFormattingOnCloseBraceOption, IEnumerable<IFormattingRule> rules = null)
         {
-            if (!session.SubjectBuffer.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace) && isAfterSessionStart)
+            if (!session.SubjectBuffer.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace) && shouldHonorAutoFormattingOnCloseBraceOption)
             {
                 return;
             }

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -757,6 +757,7 @@ class Foo
             }
         }
 
+        [WorkItem(3447, "https://github.com/dotnet/roslyn/issues/3447")]
         [WorkItem(850540)]
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void BlockIndentationWithAutomaticBraceFormattingDisabled()
@@ -773,6 +774,14 @@ class Foo
     {}
 }";
 
+            var expectedAfterReturn = @"class C
+{
+    public void X()
+    {
+
+    }
+}";
+
             var optionSet = new Dictionary<OptionKey, object>
                             {
                                 { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp), false },
@@ -785,7 +794,7 @@ class Foo
                 CheckStart(session.Session);
                 Assert.Equal(expected, session.Session.SubjectBuffer.CurrentSnapshot.GetText());
 
-                CheckReturnOnNonEmptyLine(session.Session, 3);
+                CheckReturn(session.Session, 4, expectedAfterReturn);
             }
         }
 


### PR DESCRIPTION
Fix #3447 Format should happen when Return is issued after starting a
Brace Completion session. We should not listen to
FeatureOnOffOptions.AutoFormattingOnCloseBrace when 'Return' is pressed
during the Brace Completion session