### PR TITLE
Remove MEF-imported ICompletionRules

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
@@ -6,11 +6,9 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Completion.Rules;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -32,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         private readonly IInlineRenameService _inlineRenameService;
         private readonly IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession> _completionPresenter;
         private readonly IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> _asyncListeners;
-        private readonly IList<Lazy<ICompletionRules, OrderableLanguageMetadata>> _allCompletionRules;
         private readonly IList<Lazy<ICompletionProvider, OrderableLanguageMetadata>> _allCompletionProviders;
         private readonly IEnumerable<Lazy<IBraceCompletionSessionProvider, IBraceCompletionMetadata>> _autoBraceCompletionChars;
         private readonly Dictionary<IContentType, ImmutableHashSet<char>> _autoBraceCompletionCharSet;
@@ -44,12 +41,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             IInlineRenameService inlineRenameService,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners,
             [ImportMany] IEnumerable<Lazy<IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession>, OrderableMetadata>> completionPresenters,
-            [ImportMany] IEnumerable<Lazy<ICompletionRules, OrderableLanguageMetadata>> allCompletionRules,
             [ImportMany] IEnumerable<Lazy<ICompletionProvider, OrderableLanguageMetadata>> allCompletionProviders,
             [ImportMany] IEnumerable<Lazy<IBraceCompletionSessionProvider, IBraceCompletionMetadata>> autoBraceCompletionChars)
             : this(editorOperationsFactoryService, undoHistoryRegistry, inlineRenameService,
                   ExtensionOrderer.Order(completionPresenters).Select(lazy => lazy.Value).FirstOrDefault(),
-                  asyncListeners, allCompletionRules, allCompletionProviders, autoBraceCompletionChars)
+                  asyncListeners, allCompletionProviders, autoBraceCompletionChars)
         {
         }
 
@@ -59,7 +55,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             IInlineRenameService inlineRenameService,
             IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession> completionPresenter,
             IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners,
-            IEnumerable<Lazy<ICompletionRules, OrderableLanguageMetadata>> allCompletionRules,
             IEnumerable<Lazy<ICompletionProvider, OrderableLanguageMetadata>> allCompletionProviders,
             IEnumerable<Lazy<IBraceCompletionSessionProvider, IBraceCompletionMetadata>> autoBraceCompletionChars)
         {
@@ -68,7 +63,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             _inlineRenameService = inlineRenameService;
             _completionPresenter = completionPresenter;
             _asyncListeners = asyncListeners;
-            _allCompletionRules = ExtensionOrderer.Order(allCompletionRules);
             _allCompletionProviders = ExtensionOrderer.Order(allCompletionProviders);
             _autoBraceCompletionChars = autoBraceCompletionChars;
             _autoBraceCompletionCharSet = new Dictionary<IContentType, ImmutableHashSet<char>>();
@@ -111,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 textView, subjectBuffer,
                 _editorOperationsFactoryService, _undoHistoryRegistry, _completionPresenter,
                 new AggregateAsynchronousOperationListener(_asyncListeners, FeatureAttribute.CompletionSet),
-                _allCompletionRules, _allCompletionProviders, autobraceCompletionCharSet);
+                _allCompletionProviders, autobraceCompletionCharSet);
 
             return true;
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion.Rules;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -18,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             #region Fields that can be accessed from either thread
 
-            private readonly IList<ICompletionRules> _completionRules;
+            private readonly ICompletionRules _completionRules;
 
             // When we issue filter tasks, provide them with a (monotonically increasing) id.  That
             // way, when they run we can bail on computation if they've been superceded by another
@@ -27,10 +21,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             #endregion
 
-            public Session(Controller controller, ModelComputation<Model> computation, IEnumerable<ICompletionRules> completionRules, ICompletionPresenterSession presenterSession)
+            public Session(Controller controller, ModelComputation<Model> computation, ICompletionRules completionRules, ICompletionPresenterSession presenterSession)
                 : base(controller, computation, presenterSession)
             {
-                _completionRules = completionRules.ToList();
+                _completionRules = completionRules;
 
                 this.PresenterSession.ItemCommitted += OnPresenterSessionItemCommitted;
                 this.PresenterSession.ItemSelected += OnPresenterSessionItemSelected;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
@@ -213,9 +213,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 private bool ItemsMatch(CompletionItem item1, CompletionItem item2)
                 {
                     Contract.Assert(item1.DisplayText == item2.DisplayText);
-                    return _session._completionRules.Select(r => r.ItemsMatch(item1, item2))
-                                .FirstOrDefault(m => m.HasValue)
-                                .Value;
+
+                    return _session._completionRules.ItemsMatch(item1, item2).Value;
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Completion.Rules;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -45,7 +44,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
-        private readonly IList<Lazy<ICompletionRules, OrderableLanguageMetadata>> _allCompletionRules;
         private readonly IEnumerable<Lazy<ICompletionProvider, OrderableLanguageMetadata>> _allCompletionProviders;
         private readonly ImmutableHashSet<char> _autoBraceCompletionChars;
         private readonly bool _isDebugger;
@@ -58,7 +56,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession> presenter,
             IAsynchronousOperationListener asyncListener,
-            IList<Lazy<ICompletionRules, OrderableLanguageMetadata>> allCompletionRules,
             IEnumerable<Lazy<ICompletionProvider, OrderableLanguageMetadata>> allCompletionProviders,
             ImmutableHashSet<char> autoBraceCompletionChars,
             bool isDebugger,
@@ -67,7 +64,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             _editorOperationsFactoryService = editorOperationsFactoryService;
             _undoHistoryRegistry = undoHistoryRegistry;
-            _allCompletionRules = allCompletionRules;
             _allCompletionProviders = allCompletionProviders;
             _autoBraceCompletionChars = autoBraceCompletionChars;
             _isDebugger = isDebugger;
@@ -81,7 +77,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession> presenter,
             IAsynchronousOperationListener asyncListener,
-            IList<Lazy<ICompletionRules, OrderableLanguageMetadata>> allCompletionRules,
             IEnumerable<Lazy<ICompletionProvider, OrderableLanguageMetadata>> allCompletionProviders,
             ImmutableHashSet<char> autoBraceCompletionChars)
         {
@@ -92,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return textView.GetOrCreatePerSubjectBufferProperty(subjectBuffer, s_controllerPropertyKey,
                 (v, b) => new Controller(textView, subjectBuffer, editorOperationsFactoryService, undoHistoryRegistry,
                     presenter, asyncListener,
-                    allCompletionRules, allCompletionProviders, autoBraceCompletionChars,
+                    allCompletionProviders, autoBraceCompletionChars,
                     isDebugger, isImmediateWindow));
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
@@ -136,11 +135,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 }
             }
 
-            // Let the rules factories know that this item was committed.
-            foreach (var rules in GetCompletionRules())
-            {
-                rules.CompletionItemCommitted(item);
-            }
+            // Let the completion rules know that this item was committed.
+            GetCompletionRules().CompletionItemCommitted(item);
         }
 
         private SnapshotSpan GetFinalSpan(SnapshotSpan currentSpan, char commitChar, bool textChanged)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Extensibility.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
@@ -243,23 +242,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 || args.TypedChar == '_';
         }
 
-        private IEnumerable<ICompletionRules> GetCompletionRules()
-        {
-            var defaultRules = GetDefaultCompletionRules();
-
-            Workspace workspace;
-            if (Workspace.TryGetWorkspace(this.SubjectBuffer.AsTextContainer(), out workspace))
-            {
-                var extensionProviders = workspace.Services.SelectMatchingExtensionValues(
-                    _allCompletionRules, this.SubjectBuffer);
-
-                return defaultRules.Concat(extensionProviders);
-            }
-
-            return defaultRules;
-        }
-
-        private IEnumerable<ICompletionRules> GetDefaultCompletionRules()
+        private ICompletionRules GetCompletionRules()
         {
             var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document != null)
@@ -267,11 +250,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 var service = document.Project.LanguageServices.GetService<ICompletionService>();
                 if (service != null)
                 {
-                    return SpecializedCollections.SingletonEnumerable(service.GetDefaultCompletionRules());
+                    return service.GetDefaultCompletionRules();
                 }
             }
 
-            return SpecializedCollections.EmptyEnumerable<ICompletionRules>();
+            return null;
         }
 
         private IEnumerable<ICompletionProvider> GetCompletionProviders()

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -1,12 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
-Imports System.ComponentModel.Composition.Primitives
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
-Imports Microsoft.CodeAnalysis.Completion.Rules
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
 Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
@@ -63,7 +60,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 GetService(Of IInlineRenameService)(),
                 GetExports(Of IAsynchronousOperationListener, FeatureMetadata)(),
                 {New Lazy(Of IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession), OrderableMetadata)(Function() New TestCompletionPresenter(Me), New OrderableMetadata("Presenter"))},
-                GetExports(Of ICompletionRules, OrderableLanguageMetadata)(),
                 completionProviders,
                 GetExports(Of IBraceCompletionSessionProvider, IBraceCompletionMetadata)())
 

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -1,11 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
-Imports Microsoft.CodeAnalysis.Completion.Rules
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
 Imports Microsoft.CodeAnalysis.Editor.Commands
@@ -69,7 +67,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 GetService(Of IInlineRenameService)(),
                 New TestCompletionPresenter(Me),
                 GetExports(Of IAsynchronousOperationListener, FeatureMetadata)(),
-                GetExports(Of ICompletionRules, OrderableLanguageMetadata)(),
                 completionProviders,
                 GetExports(Of IBraceCompletionSessionProvider, IBraceCompletionMetadata)())
 

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -1,11 +1,8 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
-Imports System.ComponentModel.Composition.Primitives
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion.Providers
-Imports Microsoft.CodeAnalysis.Completion.Rules
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
 Imports Microsoft.CodeAnalysis.Editor.Commands
@@ -54,7 +51,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                     GetService(Of IInlineRenameService)(),
                     New TestCompletionPresenter(Me),
                     GetExports(Of IAsynchronousOperationListener, FeatureMetadata)(),
-                    GetExports(Of ICompletionRules, OrderableLanguageMetadata)(),
                     {snippetLazy},
                     GetExports(Of IBraceCompletionSessionProvider, IBraceCompletionMetadata)())
 


### PR DESCRIPTION
The current internal completion API allows for multiple ICompletionRules that can be MEF-exported by third parties. This has never been used to date and the scenario seems a bit suspicious. If the scenario opens up at some point, we can look at adding the mechanism back.

Reviewers: @rchande, @CyrusNajmabadi 