### PR TITLE
Tweak rename to improve perf

### DIFF
--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 {
@@ -18,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                                             .OfType<IMethodSymbol>()
                                             .Where(m => !m.Equals(renamedMethod) && m.Arity == renamedMethod.Arity);
 
-            var signatureToConflictingMember = new Dictionary<List<ITypeSymbol>, IMethodSymbol>(new ConflictingSignatureComparer());
+            var signatureToConflictingMember = new Dictionary<ImmutableArray<ITypeSymbol>, IMethodSymbol>(ConflictingSignatureComparer.Instance);
 
             foreach (var method in potentiallyConfictingMethods)
             {
@@ -27,6 +25,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     signatureToConflictingMember[signature] = method;
                 }
             }
+
+            var builder = ArrayBuilder<Location>.GetInstance();
 
             foreach (var signature in GetAllSignatures(renamedMethod, trimOptionalParameters))
             {
@@ -37,72 +37,60 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     if (!(conflictingSymbol.PartialDefinitionPart != null && conflictingSymbol.PartialDefinitionPart == renamedMethod) &&
                         !(conflictingSymbol.PartialImplementationPart != null && conflictingSymbol.PartialImplementationPart == renamedMethod))
                     {
-                        foreach (var location in conflictingSymbol.Locations)
-                        {
-                            yield return location;
-                        }
+                        builder.AddRange(conflictingSymbol.Locations);
                     }
                 }
             }
+
+            return builder.ToImmutableAndFree();
         }
 
-        private sealed class ConflictingSignatureComparer : IEqualityComparer<List<ITypeSymbol>>
+        private sealed class ConflictingSignatureComparer : IEqualityComparer<ImmutableArray<ITypeSymbol>>
         {
-            public bool Equals(List<ITypeSymbol> x, List<ITypeSymbol> y)
-            {
-                if (x.Count != y.Count)
-                {
-                    return false;
-                }
+            public static readonly ConflictingSignatureComparer Instance = new ConflictingSignatureComparer();
 
+            private ConflictingSignatureComparer() { }
+
+            public bool Equals(ImmutableArray<ITypeSymbol> x, ImmutableArray<ITypeSymbol> y)
+            {
                 return x.SequenceEqual(y);
             }
 
-            public int GetHashCode(List<ITypeSymbol> obj)
+            public int GetHashCode(ImmutableArray<ITypeSymbol> obj)
             {
-                // This is a very simple GetHashCode implementation. Doing something "fancier" here
-                // isn't really worth it, since to compute a proper hash we'd end up walking all the
-                // ITypeSymbols anyways.
-                return obj.Count;
+                // This is a very simple GetHashCode implementation. Doing something "fancier" here  
+                // isn't really worth it, since to compute a proper hash we'd end up walking all the  
+                // ITypeSymbols anyways.  
+                return obj.Length;
             }
         }
 
-        private static IEnumerable<List<ITypeSymbol>> GetAllSignatures(IMethodSymbol method, bool trimOptionalParameters)
+        private static ImmutableArray<ImmutableArray<ITypeSymbol>> GetAllSignatures(IMethodSymbol method, bool trimOptionalParameters)
         {
-            // First we'll construct the full signature. This consists of the types of the
-            // parameters, as well as the return type if it's a conversion operator
-            var signature = new List<ITypeSymbol>();
+            var resultBuilder = ArrayBuilder<ImmutableArray<ITypeSymbol>>.GetInstance();
+
+            var signatureBuilder = ArrayBuilder<ITypeSymbol>.GetInstance();
 
             if (method.MethodKind == MethodKind.Conversion)
             {
-                signature.Add(method.ReturnType);
+                signatureBuilder.Add(method.ReturnType);
             }
 
             foreach (var parameter in method.Parameters)
             {
-                signature.Add(parameter.Type);
-            }
-
-            yield return signature;
-
-            // In VB, a method effectively creates multiple signatures which are produced by
-            // chopping off each of the optional parameters on the end, last to first, per 4.1.1 of
-            // the spec.
-            if (trimOptionalParameters)
-            {
-                for (int i = method.Parameters.Length - 1; i >= 0; i--)
+                // In VB, a method effectively creates multiple signatures which are produced by
+                // chopping off each of the optional parameters on the end, last to first, per 4.1.1 of
+                // the spec.
+                if (trimOptionalParameters && parameter.IsOptional)
                 {
-                    if (method.Parameters[i].IsOptional)
-                    {
-                        signature = signature.GetRange(0, signature.Count - 1);
-                        yield return signature;
-                    }
-                    else
-                    {
-                        break;
-                    }
+                    resultBuilder.Add(signatureBuilder.ToImmutable());
                 }
+
+                signatureBuilder.Add(parameter.Type);
             }
+
+            resultBuilder.Add(signatureBuilder.ToImmutableAndFree());
+            return resultBuilder.ToImmutableAndFree();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -33,17 +33,17 @@ namespace Microsoft.CodeAnalysis.Rename
         internal static IEnumerable<ISymbol> GetSymbolsTouchingPosition(int position, SemanticModel semanticModel, Workspace workspace, CancellationToken cancellationToken)
         {
             var bindableToken = semanticModel.SyntaxTree.GetRoot(cancellationToken).FindToken(position, findInsideTrivia: true);
-            var symbols = semanticModel.GetSymbols(bindableToken, workspace, bindLiteralsToUnderlyingType: false, cancellationToken: cancellationToken);
+            var symbols = semanticModel.GetSymbols(bindableToken, workspace, bindLiteralsToUnderlyingType: false, cancellationToken: cancellationToken).ToArray();
 
             // if there are more than one symbol, then remove the alias symbols.
             // When using (not declaring) an alias, the alias symbol and the target symbol are returned
             // by GetSymbols
-            if (symbols.Count() > 1)
+            if (symbols.Length > 1)
             {
-                symbols = symbols.Where(s => s.Kind != SymbolKind.Alias);
+                symbols = symbols.Where(s => s.Kind != SymbolKind.Alias).ToArray();
             }
 
-            if (!symbols.Any())
+            if (symbols.Length == 0)
             {
                 var info = semanticModel.GetSymbolInfo(bindableToken, cancellationToken);
                 if (info.CandidateReason == CandidateReason.MemberGroup)


### PR DESCRIPTION
PerfView showed a couple of hot spots during a particularly slow rename
(```DeclarationTable.ReferenceDirectiveDiagnostics``` to ```Diagnostics```).