### PR TITLE
Remove unnecessary calls to Enumerable.Distinct.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -137,13 +137,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             else
             {
                 var symbols = semanticModel.GetSymbols(token, document.Project.Solution.Workspace, bindLiteralsToUnderlyingType: true, cancellationToken: CancellationToken.None);
+                symbol = symbols.FirstOrDefault();
 
-                var bindableParent = document.GetLanguageService<ISyntaxFactsService>().GetBindableParent(token);
-                var overloads = semanticModel.GetMemberGroup(bindableParent);
-
-                symbol = symbols.Concat(overloads)
-                                .Distinct(SymbolEquivalenceComparer.Instance)
-                                 .FirstOrDefault();
+                if (symbol == null)
+                {
+                    var bindableParent = document.GetLanguageService<ISyntaxFactsService>().GetBindableParent(token);
+                    var overloads = semanticModel.GetMemberGroup(bindableParent);
+                    symbol = overloads.FirstOrDefault();
+                }
             }
 
             // Local: return the name if it's the declaration, otherwise the type

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// A predicate for determining if one interface derives from another. Static to avoid unnecessary allocations.
         /// </summary>
         private static readonly Func<INamedTypeSymbol, INamedTypeSymbol, bool> s_findDerivedInterfacesPredicate =
-            (t1, t2) => t1.TypeKind == TypeKind.Interface && t1.OriginalDefinition.AllInterfaces.Distinct(SymbolEquivalenceComparer.Instance).Contains(t2);
+            (t1, t2) => t1.TypeKind == TypeKind.Interface && t1.OriginalDefinition.AllInterfaces.Contains(t2);
 
         /// <summary>
         /// For a given <see cref="Compilation"/>, maps from an interface (from the compilation or one of its dependencies)


### PR DESCRIPTION
Happened to notice these while looking at Rename.