### PR TITLE
Remove unnecessary if statement

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2259,16 +2259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var isolated = AsIsolatedDeclaration(declaration);
 
-            var result = PreserveTrivia(isolated, editor);
-
-            if (result == isolated)
-            {
-                return isolated;
-            }
-            else
-            {
-                return result;
-            }
+            return PreserveTrivia(isolated, editor);
         }
 
         private SyntaxNode AsIsolatedDeclaration(SyntaxNode declaration)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1674,11 +1674,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 result = editor(isolated)
             End If
 
-            If result Is isolated Then
-                Return isolated
-            Else
-                Return result
-            End If
+            Return result
         End Function
 
         Private Function GetFullDeclaration(declaration As SyntaxNode) As SyntaxNode


### PR DESCRIPTION
As far as I can tell the == operator on SyntaxNodes does check for reference equality, so these if statements are unnecessary.