### PR TITLE
Move DeclTable diagnostics into parser

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2108,8 +2108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Assembly.ForceComplete(location, cancellationToken);
 
-            var result = this.FreezeDeclarationDiagnostics().Concat(
-                ((SourceModuleSymbol)this.SourceModule).Diagnostics);
+            var result = this.FreezeDeclarationDiagnostics();
 
             if (locationFilterOpt != null)
             {

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.Cache.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.Cache.cs
@@ -4,10 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -29,7 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal readonly Lazy<ISet<string>> TypeNames;
             internal readonly Lazy<ISet<string>> NamespaceNames;
             internal readonly Lazy<ImmutableArray<ReferenceDirective>> ReferenceDirectives;
-            internal readonly Lazy<ImmutableArray<Diagnostic>> ReferenceDirectiveDiagnostics;
 
             public Cache(DeclarationTable table)
             {
@@ -44,9 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 this.ReferenceDirectives = new Lazy<ImmutableArray<ReferenceDirective>>(
                     () => MergedRoot.Value.Declarations.OfType<RootSingleNamespaceDeclaration>().SelectMany(r => r.ReferenceDirectives).AsImmutable());
-
-                this.ReferenceDirectiveDiagnostics = new Lazy<ImmutableArray<Diagnostic>>(
-                    () => MergedRoot.Value.Declarations.OfType<RootSingleNamespaceDeclaration>().SelectMany(r => r.ReferenceDirectiveDiagnostics).AsImmutable());
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -39,7 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly Lazy<ICollection<string>> _typeNames;
         private readonly Lazy<ICollection<string>> _namespaceNames;
         private readonly Lazy<ICollection<ReferenceDirective>> _referenceDirectives;
-        private readonly Lazy<ICollection<Diagnostic>> _referenceDirectiveDiagnostics;
 
         private DeclarationTable(
             ImmutableSetWithInsertionOrder<RootSingleNamespaceDeclaration> allOlderRootDeclarations,
@@ -53,7 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             _typeNames = new Lazy<ICollection<string>>(GetMergedTypeNames);
             _namespaceNames = new Lazy<ICollection<string>>(GetMergedNamespaceNames);
             _referenceDirectives = new Lazy<ICollection<ReferenceDirective>>(GetMergedReferenceDirectives);
-            _referenceDirectiveDiagnostics = new Lazy<ICollection<Diagnostic>>(GetMergedDiagnostics);
         }
 
         public DeclarationTable AddRootDeclaration(Lazy<RootSingleNamespaceDeclaration> lazyRootDeclaration)
@@ -178,20 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private ICollection<Diagnostic> GetMergedDiagnostics()
-        {
-            var cachedDiagnostics = _cache.ReferenceDirectiveDiagnostics.Value;
-
-            if (_latestLazyRootDeclaration == null)
-            {
-                return cachedDiagnostics;
-            }
-            else
-            {
-                return UnionCollection<Diagnostic>.Create(cachedDiagnostics, _latestLazyRootDeclaration.Value.ReferenceDirectiveDiagnostics);
-            }
-        }
-
         private static readonly Predicate<Declaration> s_isNamespacePredicate = d => d.Kind == DeclarationKind.Namespace;
         private static readonly Predicate<Declaration> s_isTypePredicate = d => d.Kind != DeclarationKind.Namespace;
 
@@ -262,15 +244,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return _referenceDirectives.Value;
-            }
-        }
-
-
-        public IEnumerable<Diagnostic> Diagnostics
-        {
-            get
-            {
-                return _referenceDirectiveDiagnostics.Value;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Declarations/RootSingleNamespaceDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/RootSingleNamespaceDeclaration.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed class RootSingleNamespaceDeclaration : SingleNamespaceDeclaration
     {
-        private readonly ImmutableArray<Diagnostic> _referenceDirectiveDiagnostics;
         private readonly ImmutableArray<ReferenceDirective> _referenceDirectives;
         private readonly bool _hasAssemblyAttributes;
         private readonly bool _hasUsings;
@@ -24,7 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxReference treeNode,
             ImmutableArray<SingleNamespaceOrTypeDeclaration> children,
             ImmutableArray<ReferenceDirective> referenceDirectives,
-            ImmutableArray<Diagnostic> referenceDirectiveDiagnostics,
             bool hasAssemblyAttributes)
             : base(string.Empty,
                    treeNode,
@@ -32,21 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                    children: children)
         {
             Debug.Assert(!referenceDirectives.IsDefault);
-            Debug.Assert(!referenceDirectiveDiagnostics.IsDefault);
 
             _referenceDirectives = referenceDirectives;
-            _referenceDirectiveDiagnostics = referenceDirectiveDiagnostics;
             _hasAssemblyAttributes = hasAssemblyAttributes;
             _hasUsings = hasUsings;
             _hasExternAliases = hasExternAliases;
-        }
-
-        public ImmutableArray<Diagnostic> ReferenceDirectiveDiagnostics
-        {
-            get
-            {
-                return _referenceDirectiveDiagnostics;
-            }
         }
 
         public ImmutableArray<ReferenceDirective> ReferenceDirectives

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -347,10 +347,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private DirectiveTriviaSyntax ParseReferenceDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive, bool isFollowingToken)
         {
-            if (isActive && isFollowingToken)
+            if (isActive)
             {
-                keyword = this.AddError(keyword, ErrorCode.ERR_PPReferenceFollowsToken);
+                if (Options.Kind == SourceCodeKind.Regular)
+                {
+                    keyword = this.AddError(keyword, ErrorCode.ERR_ReferenceDirectiveOnlyAllowedInScripts);
+                }
+                else if (isFollowingToken)
+                {
+                    keyword = this.AddError(keyword, ErrorCode.ERR_PPReferenceFollowsToken);
+                }
             }
+
 
             SyntaxToken file = this.EatToken(SyntaxKind.StringLiteralToken, ErrorCode.ERR_ExpectedPPFile, reportError: isActive);
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -445,6 +445,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.NamespaceKeyword);
             var namespaceToken = this.EatToken(SyntaxKind.NamespaceKeyword);
 
+            if (IsScript || IsInteractive)
+            {
+                namespaceToken = this.AddError(namespaceToken, ErrorCode.ERR_NamespaceNotAllowedInScript);
+            }
+
             var name = this.ParseQualifiedName();
             if (ContainsGeneric(name))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -342,11 +342,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal IEnumerable<Diagnostic> Diagnostics
-        {
-            get { return _sources.Diagnostics; }
-        }
-
         public override ImmutableArray<Location> Locations
         {
             get

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -2723,7 +2723,7 @@ System.Diagnostics.Process.GetCurrentProcess();
                 // (2,4): error CS7010: Quoted file name expected
                 Diagnostic(ErrorCode.ERR_ExpectedPPFile, "System"),
                 // (2,1): error CS7011: #r is only allowed in scripts
-                Diagnostic(ErrorCode.ERR_ReferenceDirectiveOnlyAllowedInScripts, @"#r ""System.Core"""));
+                Diagnostic(ErrorCode.ERR_ReferenceDirectiveOnlyAllowedInScripts, "r"));
         }
 
         private static readonly string s_resolvedPath = Path.GetPathRoot(Directory.GetCurrentDirectory()) + "RESOLVED";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -15617,7 +15617,15 @@ namespace N1
    class A { public int Foo() { return 2; }}
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics();
+            var expectedDiagnostics = new[] 
+            {
+                // (2,1): error CS7021: You cannot declare namespace in script code
+                // namespace N1
+                Diagnostic(ErrorCode.ERR_NamespaceNotAllowedInScript, "namespace").WithLocation(2, 1)
+            };
+
+            CreateCompilationWithMscorlib(Parse(text, options: TestOptions.Script)).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilationWithMscorlib(Parse(text, options: TestOptions.Interactive)).VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/DisabledRegionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/DisabledRegionTests.cs
@@ -112,7 +112,7 @@ class C { }
 class C { }
 ";
 
-            ParserErrorMessageTests.ParseAndValidate(source,
+            ParserErrorMessageTests.ParseAndValidate(source, TestOptions.Script,
                 Diagnostic(ErrorCode.ERR_ExpectedPPFile, ""));
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -164,7 +164,7 @@ using System;
 # r ""foo""
 ";
 
-            ParserErrorMessageTests.ParseAndValidate(test, Diagnostic(ErrorCode.ERR_PPReferenceFollowsToken, "r"));
+            ParserErrorMessageTests.ParseAndValidate(test, TestOptions.Script, Diagnostic(ErrorCode.ERR_PPReferenceFollowsToken, "r"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -67,21 +67,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         #region Helpers
 
-        private CSharpParseOptions GetOptions(string[] defines)
+        private CSharpParseOptions GetOptions(SourceCodeKind kind, string[] defines)
         {
-            return new CSharpParseOptions(languageVersion: LanguageVersion.CSharp4, preprocessorSymbols: defines);
+            return new CSharpParseOptions(languageVersion: LanguageVersion.CSharp4, kind: kind, preprocessorSymbols: defines);
         }
 
         private CompilationUnitSyntax Parse(string text, params string[] defines)
         {
-            var options = this.GetOptions(defines);
+            return Parse(text, SourceCodeKind.Regular, defines);
+        }
+
+        private CompilationUnitSyntax Parse(string text, SourceCodeKind kind, params string[] defines)
+        {
+            var options = this.GetOptions(kind, defines);
             var itext = SourceText.From(text);
             return SyntaxFactory.ParseSyntaxTree(itext, options).GetCompilationUnitRoot();
         }
 
         private SyntaxTree ParseTree(string text, params string[] defines)
         {
-            var options = this.GetOptions(defines);
+            var options = this.GetOptions(SourceCodeKind.Regular, defines);
             var itext = SourceText.From(text);
             return SyntaxFactory.ParseSyntaxTree(itext, options);
         }
@@ -3709,7 +3714,7 @@ static void Main() { }
         public void TestReference()
         {
             var text = @"#r ""bogus""";
-            var node = Parse(text);
+            var node = Parse(text, SourceCodeKind.Script);
             TestRoundTripping(node, text);
             VerifyDirectivesSpecial(node, new DirectiveInfo
             {
@@ -3724,7 +3729,7 @@ static void Main() { }
         public void TestReferenceWithComment()
         {
             var text = @"#r ""bogus"" // FOO";
-            var node = Parse(text);
+            var node = Parse(text, SourceCodeKind.Script);
             TestRoundTripping(node, text);
             VerifyDirectivesSpecial(node, new DirectiveInfo
             {
@@ -3797,7 +3802,7 @@ static void Main() { }
 #r ""C:\Documents and Settings\someuser\Local Settings\Temp\{f0a37341-d692-11d4-a984-009027ec0a9c}\test.cs"" // comment
 #r ""mailto://someuser@microsoft.com""
 ";
-            var node = Parse(text);
+            var node = Parse(text, SourceCodeKind.Script);
             TestRoundTripping(node, text);
             VerifyDirectives(node, SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia,
                 SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia,

--- a/src/Compilers/VisualBasic/Portable/Declarations/Declaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/Declaration.vb
@@ -1,16 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Diagnostics
-Imports System.Linq
-Imports System.Text
-Imports System.Threading
-Imports Microsoft.CodeAnalysis.Collections
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     '''<summary>

--- a/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.Cache.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.Cache.vb
@@ -1,14 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Diagnostics
-Imports System.Linq
-Imports System.Threading
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Partial Class DeclarationTable
@@ -28,9 +20,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Friend ReadOnly NamespaceNames As Lazy(Of ICollection(Of String))
             Friend ReadOnly ReferenceDirectives As Lazy(Of ImmutableArray(Of ReferenceDirective))
 
-            ' Stores diagnostics related to #r directives
-            Friend ReadOnly ReferenceDirectiveDiagnostics As Lazy(Of ImmutableArray(Of Diagnostic))
-
             Public Sub New(table As DeclarationTable)
                 Me.MergedRoot = New Lazy(Of MergedNamespaceDeclaration)(AddressOf table.MergeOlderNamespaces)
 
@@ -40,9 +29,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 Me.ReferenceDirectives = New Lazy(Of ImmutableArray(Of ReferenceDirective))(
                     Function() table.SelectManyFromOlderDeclarationsNoEmbedded(Function(r) r.ReferenceDirectives))
-
-                Me.ReferenceDirectiveDiagnostics = New Lazy(Of ImmutableArray(Of Diagnostic))(
-                    Function() table.SelectManyFromOlderDeclarationsNoEmbedded(Function(r) r.ReferenceDirectiveDiagnostics))
             End Sub
         End Class
     End Class

--- a/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.vb
@@ -50,9 +50,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly _namespaceNames As Lazy(Of ICollection(Of String))
         Private ReadOnly _referenceDirectives As Lazy(Of ICollection(Of ReferenceDirective))
 
-        ' Stores diagnostics related to #r directives
-        Private ReadOnly _referenceDirectiveDiagnostics As Lazy(Of ICollection(Of Diagnostic))
-
         Private _lazyAllRootDeclarations As ImmutableArray(Of RootSingleNamespaceDeclaration)
 
         Private Sub New(allOlderRootDeclarations As ImmutableHashSet(Of DeclarationTableEntry),
@@ -65,7 +62,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._typeNames = New Lazy(Of ICollection(Of String))(AddressOf GetMergedTypeNames)
             Me._namespaceNames = New Lazy(Of ICollection(Of String))(AddressOf GetMergedNamespaceNames)
             Me._referenceDirectives = New Lazy(Of ICollection(Of ReferenceDirective))(AddressOf GetMergedReferenceDirectives)
-            Me._referenceDirectiveDiagnostics = New Lazy(Of ICollection(Of Diagnostic))(AddressOf GetMergedDiagnostics)
         End Sub
 
         Public Function AddRootDeclaration(lazyRootDeclaration As DeclarationTableEntry) As DeclarationTable
@@ -186,16 +182,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Function
 
-        Private Function GetMergedDiagnostics() As ICollection(Of Diagnostic)
-            Dim cachedDiagnostics = _cache.ReferenceDirectiveDiagnostics.Value
-            Dim latestRoot = GetLatestRootDeclarationIfAny(includeEmbedded:=False)
-            If latestRoot Is Nothing Then
-                Return cachedDiagnostics
-            Else
-                Return UnionCollection(Of Diagnostic).Create(cachedDiagnostics, latestRoot.ReferenceDirectiveDiagnostics)
-            End If
-        End Function
-
         Private Function GetLatestRootDeclarationIfAny(includeEmbedded As Boolean) As RootSingleNamespaceDeclaration
             Return If((_latestLazyRootDeclaration IsNot Nothing) AndAlso (includeEmbedded OrElse Not _latestLazyRootDeclaration.IsEmbedded),
                       _latestLazyRootDeclaration.Root.Value,
@@ -257,12 +243,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public ReadOnly Property ReferenceDirectives As ICollection(Of ReferenceDirective)
             Get
                 Return _referenceDirectives.Value
-            End Get
-        End Property
-
-        Public ReadOnly Property ReferenceDirectiveDiagnostics As ICollection(Of Diagnostic)
-            Get
-                Return _referenceDirectiveDiagnostics.Value
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Declarations/RootSingleNamespaceDeclaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/RootSingleNamespaceDeclaration.vb
@@ -1,30 +1,13 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Diagnostics
-Imports System.Linq
-Imports System.Text
-Imports System.Threading
-Imports Microsoft.CodeAnalysis.Collections
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Class RootSingleNamespaceDeclaration
         Inherits GlobalNamespaceDeclaration
 
-        Private _referenceDirectiveDiagnostics As ImmutableArray(Of Diagnostic)
         Private _referenceDirectives As ImmutableArray(Of ReferenceDirective)
         Private ReadOnly _hasAssemblyAttributes As Boolean
-
-        Public ReadOnly Property ReferenceDirectiveDiagnostics As ImmutableArray(Of Diagnostic)
-            Get
-                Return _referenceDirectiveDiagnostics
-            End Get
-        End Property
 
         Public ReadOnly Property ReferenceDirectives As ImmutableArray(Of ReferenceDirective)
             Get
@@ -42,15 +25,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        treeNode As SyntaxReference,
                        children As ImmutableArray(Of SingleNamespaceOrTypeDeclaration),
                        referenceDirectives As ImmutableArray(Of ReferenceDirective),
-                       diagnostics As ImmutableArray(Of Diagnostic),
                        hasAssemblyAttributes As Boolean)
             MyBase.New(hasImports, treeNode, treeNode.GetLocation(), children)
 
             Debug.Assert(Not referenceDirectives.IsDefault)
-            Debug.Assert(Not diagnostics.IsDefault)
 
             Me._referenceDirectives = referenceDirectives
-            Me._referenceDirectiveDiagnostics = diagnostics
             Me._hasAssemblyAttributes = hasAssemblyAttributes
         End Sub
     End Class

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -1633,6 +1633,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim namespaceKeyword As KeywordSyntax = ReportModifiersOnStatementError(ERRID.ERR_SpecifiersInvalidOnInheritsImplOpt, Attributes, Specifiers, DirectCast(CurrentToken, KeywordSyntax))
 
+            If IsScript Then
+                namespaceKeyword = AddError(namespaceKeyword, ERRID.ERR_NamespaceNotAllowedInScript)
+            End If
+
             Dim unexpectedSyntax As SyntaxList(Of SyntaxToken) = Nothing
             Dim result As NamespaceStatementSyntax
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -658,7 +658,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             builder.AddRange(Me._diagnosticBagDeclare)
             builder.AddRange(Me._lazyBoundImports.Diagnostics)
             builder.AddRange(Me._lazyLinkedAssemblyDiagnostics)
-            builder.AddRange(Me._declarationTable.ReferenceDirectiveDiagnostics)
 
             For Each tree In SyntaxTrees
                 builder.AddRange(GetSourceFile(tree).DeclarationErrors)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
@@ -1002,6 +1002,22 @@ p1 as vb$anonymous1
         Assert.Equal("(Of T)", DirectCast(c.Members(3), OperatorBlockSyntax).OperatorStatement.OperatorToken.TrailingTrivia.Node.ToFullString)
     End Sub
 
+    <Fact>
+    Public Sub ERR_NamespaceNotAllowedInScript()
+        Const source = "
+Namespace N
+End Namespace
+"
+
+        Dim expectedDiagnostics = <errors><![CDATA[
+BC36965: You cannot declare Namespace in script code
+Namespace N
+~~~~~~~~~
+]]></errors>
+        Parse(source, TestOptions.Script).AssertTheseDiagnostics(expectedDiagnostics)
+        Parse(source, TestOptions.Interactive).AssertTheseDiagnostics(expectedDiagnostics)
+    End Sub
+
 #End Region
 
 End Class


### PR DESCRIPTION
The errors being reported in the declaration table were inherently
syntactic and moving them into the parser eliminates some complexity.

Note: VB is not currently reporting
ERR_ReferenceDirectiveOnlyAllowedInScripts since it does not (yet)
lex/parse reference directives.