### PR TITLE
Local functions update: Closure progress

### DIFF
--- a/docs/features/local-functions.md
+++ b/docs/features/local-functions.md
@@ -8,7 +8,7 @@
 	- [ ] Tests
 	- [x] IDE integration
 	- Works alongside lambdas and behaves very similarly
-	- No optimized closures (struct closure class)
+	- Partially implemented zero-allocation closures on functions never converted to a delegate (nested zero-alloc closures are disabled)
 - [x] Standard parameter features
 	- params
 	- ref/out
@@ -34,4 +34,4 @@ TODO:
 - Update error messages.
 	- `LocalScopeBinder.ReportConflictWithLocal()` (twice)
 - `LocalScopeBinder.EnsureSingleDefinition()`, handle case where 'name' exists in both `localsMap` and `localFunctionsMap`. Might be related to `LocalFunctionTests.NameConflictLocalVarLast()`
-- `LambdaRewriter.RewriteLambdaOrLocalFunction()`, check `_analysis.methodsConvertedToDelegates.Contains(node.Symbol)` and don't use a static frame if true (just emit a static method)
+- Defining a local function with a dynamic parameter doesn't work at runtime.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ClosureKind.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ClosureKind.cs
@@ -5,10 +5,16 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal enum ClosureKind
     {
         /// <summary>
-        /// The closure doesn't declare any variables. 
-        /// Display class is a singleton and may be shared with other top-level methods.
+        /// The closure doesn't declare any variables, and is never converted to a delegate.
+        /// Lambdas are emitted directly to the containing class as a static method.
         /// </summary>
         Static,
+
+        /// <summary>
+        /// The closure doesn't declare any variables, and is converted to a delegate at least once.
+        /// Display class is a singleton and may be shared with other top-level methods.
+        /// </summary>
+        Singleton,
 
         /// <summary>
         /// The closure only contains a reference to the containing class instance ("this").

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode VisitLambda(BoundLambda node)
             {
-                MethodsConvertedToDelegates.Add(node.Symbol);
+                MethodsConvertedToDelegates.Add(node.Symbol.OriginalDefinition);
                 return VisitLambdaOrFunction(node);
             }
 
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Use OriginalDefinition to strip generic type parameters
                     ReferenceVariable(node.Syntax, node.MethodOpt.OriginalDefinition);
-                    MethodsConvertedToDelegates.Add(node.MethodOpt);
+                    MethodsConvertedToDelegates.Add(node.MethodOpt.OriginalDefinition);
                 }
                 return base.VisitDelegateCreationExpression(node);
             }
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // Use OriginalDefinition to strip generic type parameters
                         ReferenceVariable(node.Syntax, node.SymbolOpt.OriginalDefinition);
-                        MethodsConvertedToDelegates.Add(node.SymbolOpt);
+                        MethodsConvertedToDelegates.Add(node.SymbolOpt.OriginalDefinition);
                     }
                     if (node.IsExtensionMethod || ((object)node.SymbolOpt != null && !node.SymbolOpt.IsStatic))
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -174,58 +174,81 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// Optimizes local functions that reference other local functions (even themselves) to not need closures if they aren't required.
+            /// Optimizes local functions such that if a local function only references other local functions without closures, it itself doesn't need a closure.
             /// </summary>
             private void RemoveUnneededReferences()
             {
-                var capturedVariablesByLambdaNew = new MultiDictionary<MethodSymbol, Symbol>();
-                var capturedVariablesKeepSet = new HashSet<Symbol>();
+                // Note: methodGraph is the inverse of the dependency graph
+                var methodGraph = new MultiDictionary<MethodSymbol, MethodSymbol>();
+                var capturesThis = new HashSet<MethodSymbol>();
+                var capturesVariable = new HashSet<MethodSymbol>();
+                var visitStack = new Stack<MethodSymbol>();
                 foreach (var methodKvp in CapturedVariablesByLambda)
                 {
-                    var isOnlyThis = false;
-                    var isGeneral = false;
-                    foreach (var reference in CapturedVariablesByLambda.TransitiveClosure(methodKvp.Key))
+                    foreach (var value in methodKvp.Value)
                     {
-                        if (reference.Kind != SymbolKind.Method)
+                        var method = value as MethodSymbol;
+                        if (method != null)
                         {
-                            if (reference == _topLevelMethod.ThisParameter)
+                            methodGraph.Add(method, methodKvp.Key);
+                        }
+                        else if (value == _topLevelMethod.ThisParameter)
+                        {
+                            if (capturesThis.Add(methodKvp.Key))
                             {
-                                isOnlyThis = true;
-                            }
-                            else
-                            {
-                                isGeneral = true;
-                                break;
+                                visitStack.Push(methodKvp.Key);
                             }
                         }
-                    }
-                    if (isGeneral)
-                    {
-                        foreach (var value in methodKvp.Value)
+                        else if (capturesVariable.Add(methodKvp.Key) && !capturesThis.Contains(methodKvp.Key)) // if capturesThis contains methodKvp, it's already in the stack.
                         {
-                            capturedVariablesByLambdaNew.Add(methodKvp.Key, value);
-                            capturedVariablesKeepSet.Add(value);
+                            visitStack.Push(methodKvp.Key);
                         }
-                    }
-                    else if (isOnlyThis)
-                    {
-                        capturedVariablesByLambdaNew.Add(methodKvp.Key, _topLevelMethod.ThisParameter);
-                        capturedVariablesKeepSet.Add(_topLevelMethod.ThisParameter);
                     }
                 }
-                CapturedVariablesByLambda = capturedVariablesByLambdaNew;
-                var capturedVariablesNew = new MultiDictionary<Symbol, CSharpSyntaxNode>();
-                foreach (var oldCaptured in CapturedVariables)
+
+                while (visitStack.Count > 0)
                 {
-                    if (capturedVariablesKeepSet.Contains(oldCaptured.Key))
+                    var current = visitStack.Pop();
+                    var setToAddTo = capturesVariable.Contains(current) ? capturesVariable : capturesThis;
+                    foreach (var capturesCurrent in methodGraph[current])
                     {
-                        foreach (var value in oldCaptured.Value)
+                        if (setToAddTo.Add(capturesCurrent))
                         {
-                            capturedVariablesNew.Add(oldCaptured.Key, value);
+                            visitStack.Push(capturesCurrent);
+                        }
+                    }
+                }
+
+                var capturedVariablesNew = new MultiDictionary<Symbol, CSharpSyntaxNode>();
+                foreach (var old in CapturedVariables)
+                {
+                    var method = old.Key as MethodSymbol;
+                    // don't add if it's a method that only captures 'this'
+                    if (method == null || capturesVariable.Contains(method))
+                    {
+                        foreach (var oldValue in old.Value)
+                        {
+                            capturedVariablesNew.Add(old.Key, oldValue);
                         }
                     }
                 }
                 CapturedVariables = capturedVariablesNew;
+                var capturedVariablesByLambdaNew = new MultiDictionary<MethodSymbol, Symbol>();
+                foreach (var old in CapturedVariablesByLambda)
+                {
+                    if (capturesVariable.Contains(old.Key))
+                    {
+                        foreach (var oldValue in old.Value)
+                        {
+                            capturedVariablesByLambdaNew.Add(old.Key, oldValue);
+                        }
+                    }
+                    else if (capturesThis.Contains(old.Key))
+                    {
+                        capturedVariablesByLambdaNew.Add(old.Key, _topLevelMethod.ThisParameter);
+                    }
+                }
+                CapturedVariablesByLambda = capturedVariablesByLambdaNew;
             }
 
             /// <summary>
@@ -439,10 +462,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode VisitCall(BoundCall node)
             {
-                var localFunction = node.Method as LocalFunctionSymbol;
-                if (localFunction != null)
+                if (node.Method.MethodKind == MethodKind.LocalFunction)
                 {
-                    ReferenceVariable(node.Syntax, localFunction.OriginalDefinition);
+                    // Use OriginalDefinition to strip generic type parameters
+                    ReferenceVariable(node.Syntax, node.Method.OriginalDefinition);
                 }
                 return base.VisitCall(node);
             }
@@ -457,7 +480,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
                 {
-                    ReferenceVariable(node.Syntax, node.MethodOpt);
+                    // Use OriginalDefinition to strip generic type parameters
+                    ReferenceVariable(node.Syntax, node.MethodOpt.OriginalDefinition);
                     MethodsConvertedToDelegates.Add(node.MethodOpt);
                 }
                 return base.VisitDelegateCreationExpression(node);
@@ -514,12 +538,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // using generic MethodSymbol here and not LambdaSymbol because of local functions
                 MethodSymbol lambda = _currentParent as MethodSymbol;
-                if ((object)lambda != null && symbol.ContainingSymbol != lambda)
+                // "symbol == lambda" could happen if we're recursive
+                if ((object)lambda != null && symbol != lambda && symbol.ContainingSymbol != lambda)
                 {
                     CapturedVariables.Add(symbol, syntax);
 
                     // mark the variable as captured in each enclosing lambda up to the variable's point of declaration.
-                    for (; (object)lambda != null && symbol.ContainingSymbol != lambda; lambda = lambda.ContainingSymbol as MethodSymbol)
+                    for (; (object)lambda != null && symbol != lambda && symbol.ContainingSymbol != lambda; lambda = lambda.ContainingSymbol as MethodSymbol)
                     {
                         CapturedVariablesByLambda.Add(lambda, symbol);
                     }
@@ -554,7 +579,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (node.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
                     {
-                        ReferenceVariable(node.Syntax, node.SymbolOpt);
+                        // Use OriginalDefinition to strip generic type parameters
+                        ReferenceVariable(node.Syntax, node.SymbolOpt.OriginalDefinition);
                         MethodsConvertedToDelegates.Add(node.SymbolOpt);
                     }
                     if (node.IsExtensionMethod || ((object)node.SymbolOpt != null && !node.SymbolOpt.IsStatic))

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -308,6 +308,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
+
+                // Note the following is temporary, if we do end up changing the signature of closures to take all
+                // parent frames as a parameter list (where structs are by ref) instead of a linked list of frames,
+                // then we no longer need to worry about double-nested struct closures not being passed by reference.
+
+                // It is illegal to have any parent of a scope be a struct (due to by-value parent fields).
+                // So, find the parent of every closure and check if it's a struct. If so, make it a class.
+                foreach (var kvp in LambdaScopes)
+                {
+                    var scope = kvp.Value;
+                    while (NeedsParentFrame.Contains(scope) && ScopeParent.TryGetValue(scope, out scope) && !ScopesThatCantBeStructs.Contains(scope))
+                    {
+                        // The parent is a struct. Mark it a class. Keep going along the tree.
+                        ScopesThatCantBeStructs.Add(scope);
+                    }
+                }
             }
 
             /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     MakeName(topLevelMethod.Name, lambdaNode.Symbol.Name, topLevelMethodId, closureKind, lambdaId) :
                     MakeName(topLevelMethod.Name, topLevelMethodId, closureKind, lambdaId),
                    (closureKind == ClosureKind.ThisOnly ? DeclarationModifiers.Private : DeclarationModifiers.Internal)
+                       | (closureKind == ClosureKind.Static ? DeclarationModifiers.Static : 0)
                        | (lambdaNode.Symbol.IsAsync ? DeclarationModifiers.Async : 0))
         {
             _topLevelMethod = topLevelMethod;
@@ -42,11 +43,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             lambdaFrame = this.ContainingType as LambdaFrame;
             switch (closureKind)
             {
-                case ClosureKind.Static: // all type parameters on method (except the top level method's)
+                case ClosureKind.Singleton: // all type parameters on method (except the top level method's)
                     Debug.Assert(lambdaFrame != null);
                     typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, lambdaFrame.ContainingMethod);
                     break;
                 case ClosureKind.ThisOnly: // all type parameters on method
+                case ClosureKind.Static:
                     Debug.Assert(lambdaFrame == null);
                     typeMap = TypeMap.Empty.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, null);
                     break;

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -194,28 +194,4 @@ namespace Roslyn.Utilities
             _dictionary.Clear();
         }
     }
-
-    internal static class MultiDictionaryExtensions
-    {
-        // Adapted from FunctionExtensions.TransitiveClosure
-        public static HashSet<V> TransitiveClosure<K, V>(this MultiDictionary<K, V> relation, K item) where K : V
-        {
-            var closure = new HashSet<V>();
-            var stack = new Stack<K>();
-            stack.Push(item);
-            while (stack.Count > 0)
-            {
-                var current = stack.Pop();
-                foreach (var newItem in relation[current])
-                {
-                    if (closure.Add(newItem) && newItem is K)
-                    {
-                        stack.Push((K)newItem);
-                    }
-                }
-            }
-
-            return closure;
-        }
-    }
 }


### PR DESCRIPTION
In this PR:

* Fix the problematic example @jaredpar gave to me, where a doubly-nested struct closure would not capture by reference. The fix is to disable struct closures for the outer closure(s), and may be optimized to multiple by-ref struct parameters in a future PR.
* Fix the third bug I've found related to generics and not calling `OriginalDefinition`, as well as other minor bugs (such as a local function marks itself as captured for analysis, when doing so is pointless because it always has access to its closure).
* Re-wrote `RemoveUnneededReferences` to go from `O(frightening)` to something more sane. (previously it was solving a more general case than it needed to - so it simplifies the code a bit, too)
* Added a new `ClosureKind` - `Singleton`. This was previously named `Static`. `Static` now refers to an *actually* static method, `Singleton` refers to the case where a receiver is a dummy singleton on a display class. `Static` is now used for a local function that doesn't capture and is never converted to a delegate.

FYI @jaredpar @VSadov @agocke