### PR TITLE
Defer building blob heap to metadata serialization phase

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Emit
         private readonly InstanceAndStructuralReferenceIndex<IGenericMethodInstanceReference> _methodSpecIndex;
         private readonly HeapOrReferenceIndex<ITypeReference> _typeRefIndex;
         private readonly InstanceAndStructuralReferenceIndex<ITypeReference> _typeSpecIndex;
-        private readonly HeapOrReferenceIndex<int> _standAloneSignatureIndex;
+        private readonly HeapOrReferenceIndex<BlobIdx> _standAloneSignatureIndex;
         private readonly Dictionary<IMethodDefinition, AddedOrChangedMethodInfo> _addedOrChangedMethods;
 
         public DeltaMetadataWriter(
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Emit
             _methodSpecIndex = new InstanceAndStructuralReferenceIndex<IGenericMethodInstanceReference>(this, new MethodSpecComparer(this), lastRowId: sizes[(int)TableIndex.MethodSpec]);
             _typeRefIndex = new HeapOrReferenceIndex<ITypeReference>(this, lastRowId: sizes[(int)TableIndex.TypeRef]);
             _typeSpecIndex = new InstanceAndStructuralReferenceIndex<ITypeReference>(this, new TypeSpecComparer(this), lastRowId: sizes[(int)TableIndex.TypeSpec]);
-            _standAloneSignatureIndex = new HeapOrReferenceIndex<int>(this, lastRowId: sizes[(int)TableIndex.StandAloneSig]);
+            _standAloneSignatureIndex = new HeapOrReferenceIndex<BlobIdx>(this, lastRowId: sizes[(int)TableIndex.StandAloneSig]);
 
             _addedOrChangedMethods = new Dictionary<IMethodDefinition, AddedOrChangedMethodInfo>();
         }
@@ -402,12 +402,12 @@ namespace Microsoft.CodeAnalysis.Emit
             return _typeSpecIndex.Rows;
         }
 
-        protected override int GetOrAddStandAloneSignatureIndex(int blobIndex)
+        protected override int GetOrAddStandAloneSignatureIndex(BlobIdx blobIndex)
         {
             return _standAloneSignatureIndex.GetOrAdd(blobIndex);
         }
 
-        protected override IReadOnlyList<int> GetStandAloneSignatures()
+        protected override IReadOnlyList<BlobIdx> GetStandAloneSignatures()
         {
             return _standAloneSignatureIndex.Rows;
         }
@@ -630,7 +630,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     encInfos.Add(CreateEncLocalInfo(local, signature));
                 }
 
-                int blobIndex = heaps.GetBlobIndex(writer);
+                BlobIdx blobIndex = heaps.GetBlobIndex(writer);
                 localSignatureRowId = GetOrAddStandAloneSignatureIndex(blobIndex);
                 writer.Free();
             }

--- a/src/Compilers/Core/Portable/PEWriter/BlobWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/BlobWriter.cs
@@ -591,6 +591,10 @@ namespace Microsoft.Cci
             }
         }
 
+        private const int SingleByteCompressedIntegerMaxValue = 0x7f;
+        private const int TwoByteCompressedIntegerMaxValue = 0x3fff;
+        private const int MaxCompressedIntegerValue = 0x1fffffff;
+
         /// <summary>
         /// Implements compressed unsigned integer encoding as defined by ECMA-335-II chapter 23.2: Blobs and signatures.
         /// </summary>
@@ -605,21 +609,21 @@ namespace Microsoft.Cci
         /// </remarks>
         internal void WriteCompressedUInt(uint val)
         {
+            Debug.Assert(val <= MaxCompressedIntegerValue);
+
             unchecked
             {
-                if (val <= 0x7f)
+                if (val <= SingleByteCompressedIntegerMaxValue)
                 {
                     WriteByte((byte)val);
                 }
-                else if (val <= 0x3fff)
+                else if (val <= TwoByteCompressedIntegerMaxValue)
                 {
                     WriteByte((byte)(0x80 | (val >> 8)));
                     WriteByte((byte)val);
                 }
                 else
                 {
-                    Debug.Assert(val <= 0x1fffffff);
-
                     WriteByte((byte)(0xc0 | (val >> 24)));
                     WriteByte((byte)(val >> 16));
                     WriteByte((byte)(val >> 8));
@@ -630,14 +634,14 @@ namespace Microsoft.Cci
 
         internal static int GetCompressedIntegerSize(int value)
         {
-            Debug.Assert(value <= 0x1fffffff);
+            Debug.Assert(value <= MaxCompressedIntegerValue);
 
-            if (value <= 0x7f)
+            if (value <= SingleByteCompressedIntegerMaxValue)
             {
                 return 1;
             }
 
-            if (value <= 0x3fff)
+            if (value <= TwoByteCompressedIntegerMaxValue)
             {
                 return 2;
             }

--- a/src/Compilers/Core/Portable/PEWriter/BlobWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/BlobWriter.cs
@@ -628,6 +628,23 @@ namespace Microsoft.Cci
             }
         }
 
+        internal static int GetCompressedIntegerSize(int value)
+        {
+            Debug.Assert(value <= 0x1fffffff);
+
+            if (value <= 0x7f)
+            {
+                return 1;
+            }
+
+            if (value <= 0x3fff)
+            {
+                return 2;
+            }
+
+            return 4;
+        }
+
         /// <summary>
         /// Writes a constant value (see ECMA-335 Partition II section 22.9) at the current position.
         /// </summary>

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Cci
         private readonly InstanceAndStructuralReferenceIndex<IGenericMethodInstanceReference> _methodSpecIndex;
         private readonly HeapOrReferenceIndex<ITypeReference> _typeRefIndex;
         private readonly InstanceAndStructuralReferenceIndex<ITypeReference> _typeSpecIndex;
-        private readonly HeapOrReferenceIndex<int> _standAloneSignatureIndex;
+        private readonly HeapOrReferenceIndex<BlobIdx> _standAloneSignatureIndex;
 
         public static MetadataWriter Create(
             EmitContext context,
@@ -82,7 +82,7 @@ namespace Microsoft.Cci
             _methodSpecIndex = new InstanceAndStructuralReferenceIndex<IGenericMethodInstanceReference>(this, new MethodSpecComparer(this));
             _typeRefIndex = new HeapOrReferenceIndex<ITypeReference>(this);
             _typeSpecIndex = new InstanceAndStructuralReferenceIndex<ITypeReference>(this, new TypeSpecComparer(this));
-            _standAloneSignatureIndex = new HeapOrReferenceIndex<int>(this);
+            _standAloneSignatureIndex = new HeapOrReferenceIndex<BlobIdx>(this);
         }
 
         protected override ushort Generation
@@ -265,12 +265,12 @@ namespace Microsoft.Cci
             return _typeSpecIndex.Rows;
         }
 
-        protected override int GetOrAddStandAloneSignatureIndex(int blobIndex)
+        protected override int GetOrAddStandAloneSignatureIndex(BlobIdx blobIndex)
         {
             return _standAloneSignatureIndex.GetOrAdd(blobIndex);
         }
 
-        protected override IReadOnlyList<int> GetStandAloneSignatures()
+        protected override IReadOnlyList<BlobIdx> GetStandAloneSignatures()
         {
             return _standAloneSignatureIndex.Rows;
         }

--- a/src/Compilers/Core/Portable/PEWriter/MemberRefComparer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MemberRefComparer.cs
@@ -34,15 +34,15 @@ namespace Microsoft.Cci
                 return false;
             }
 
-            IFieldReference/*?*/ xf = x as IFieldReference;
-            IFieldReference/*?*/ yf = y as IFieldReference;
+            var xf = x as IFieldReference;
+            var yf = y as IFieldReference;
             if (xf != null && yf != null)
             {
                 return _metadataWriter.GetFieldSignatureIndex(xf) == _metadataWriter.GetFieldSignatureIndex(yf);
             }
 
-            IMethodReference/*?*/ xm = x as IMethodReference;
-            IMethodReference/*?*/ ym = y as IMethodReference;
+            var xm = x as IMethodReference;
+            var ym = y as IMethodReference;
             if (xm != null && ym != null)
             {
                 return _metadataWriter.GetMethodSignatureIndex(xm) == _metadataWriter.GetMethodSignatureIndex(ym);
@@ -55,17 +55,17 @@ namespace Microsoft.Cci
         {
             int hash = Hash.Combine(memberRef.Name, (int)_metadataWriter.GetMemberRefParentCodedIndex(memberRef) << 4);
 
-            IFieldReference/*?*/ fieldRef = memberRef as IFieldReference;
+            var fieldRef = memberRef as IFieldReference;
             if (fieldRef != null)
             {
-                hash = Hash.Combine(hash, (int)_metadataWriter.GetFieldSignatureIndex(fieldRef));
+                hash = Hash.Combine(hash, _metadataWriter.GetFieldSignatureIndex(fieldRef).GetHashCode());
             }
             else
             {
-                IMethodReference/*?*/ methodRef = memberRef as IMethodReference;
+                var methodRef = memberRef as IMethodReference;
                 if (methodRef != null)
                 {
-                    hash = Hash.Combine(hash, (int)_metadataWriter.GetMethodSignatureIndex(methodRef));
+                    hash = Hash.Combine(hash, _metadataWriter.GetMethodSignatureIndex(methodRef).GetHashCode());
                 }
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
@@ -14,16 +14,81 @@ using Roslyn.Utilities;
 namespace Microsoft.Cci
 {
     /// <summary>
-    /// Wraps a virtual string table index.
-    /// An override to SerializeIndex does the resolving at the right time.
+    /// Represents a value on #String heap that has not been serialized yet.
     /// </summary>
-    internal struct StringIdx
+    internal struct StringIdx : IEquatable<StringIdx>
     {
-        public readonly int VirtIdx;
+        // index in _stringIndexToHeapPositionMap
+        public readonly int MapIndex;
 
         internal StringIdx(int virtIdx)
         {
-            this.VirtIdx = virtIdx;
+            MapIndex = virtIdx;
+        }
+
+        public bool Equals(StringIdx other)
+        {
+            return MapIndex == other.MapIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is StringIdx && Equals((StringIdx)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return MapIndex.GetHashCode();
+        }
+
+        public static bool operator ==(StringIdx left, StringIdx right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(StringIdx left, StringIdx right)
+        {
+            return !left.Equals(right);
+        }
+    }
+
+    /// <summary>
+    /// Represents a value on #Blob heap that has not been serialized yet.
+    /// </summary>
+    internal struct BlobIdx : IEquatable<BlobIdx>
+    {
+        // The position of the blob on heap relative to the start of the heap.
+        // In EnC deltas this value is not the same as the value stored in blob token.
+        public readonly int HeapPosition;
+
+        internal BlobIdx(int heapPosition)
+        {
+            HeapPosition = heapPosition;
+        }
+
+        public bool Equals(BlobIdx other)
+        {
+            return HeapPosition == other.HeapPosition;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BlobIdx && Equals((BlobIdx)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HeapPosition.GetHashCode();
+        }
+
+        public static bool operator ==(BlobIdx left, BlobIdx right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(BlobIdx left, BlobIdx right)
+        {
+            return !left.Equals(right);
         }
     }
 
@@ -32,75 +97,76 @@ namespace Microsoft.Cci
         private static readonly Encoding s_utf8Encoding = Encoding.UTF8;
 
         // #US heap
-        private readonly Dictionary<string, int> _userStringIndex = new Dictionary<string, int>();
+        private readonly Dictionary<string, int> _userStrings = new Dictionary<string, int>();
         private readonly BlobWriter _userStringWriter = new BlobWriter(1024);
-        private readonly int _userStringIndexStartOffset;
+        private readonly int _userStringHeapStartOffset;
 
         // #String heap
-        private Dictionary<string, StringIdx> _stringIndex = new Dictionary<string, StringIdx>(128);
-        private int[] _stringIndexMap;
-        private readonly BlobWriter _stringWriter = new BlobWriter(1024);
-        private readonly int _stringIndexStartOffset;
+        private Dictionary<string, StringIdx> _strings = new Dictionary<string, StringIdx>(128);
+        private int[] _stringIndexToHeapPositionMap;
+        private BlobWriter _stringWriter;
+        private readonly int _stringHeapStartOffset;
 
         // #Blob heap
-        private readonly Dictionary<ImmutableArray<byte>, int> _blobIndex = new Dictionary<ImmutableArray<byte>, int>(ByteSequenceComparer.Instance);
-        private readonly BlobWriter _blobWriter = new BlobWriter(1024);
-        private readonly int _blobIndexStartOffset;
+        private readonly Dictionary<ImmutableArray<byte>, BlobIdx> _blobs = new Dictionary<ImmutableArray<byte>, BlobIdx>(ByteSequenceComparer.Instance);
+        private readonly int _blobHeapStartOffset;
+        private int _blobHeapSize;
 
         // #GUID heap
-        private readonly Dictionary<Guid, int> _guidIndex = new Dictionary<Guid, int>();
+        private readonly Dictionary<Guid, int> _guids = new Dictionary<Guid, int>();
         private readonly BlobWriter _guidWriter = new BlobWriter(16); // full metadata has just a single guid
 
         private bool _streamsAreComplete;
 
         public MetadataHeapsBuilder(
-            int userStringIndexStartOffset = 0,
-            int stringIndexStartOffset = 0,
-            int blobIndexStartOffset = 0,
-            int guidIndexStartOffset = 0)
+            int userStringHeapStartOffset = 0,
+            int stringHeapStartOffset = 0,
+            int blobHeapStartOffset = 0,
+            int guidHeapStartOffset = 0)
         {
             // Add zero-th entry to heaps. 
             // Full metadata represent empty blob/string at heap index 0.
             // Delta metadata requires these to avoid nil generation-relative handles, 
             // which are technically viable but confusing.
-            _blobWriter.WriteByte(0);
-            _stringWriter.WriteByte(0);
             _userStringWriter.WriteByte(0);
+
+            _blobs.Add(ImmutableArray<byte>.Empty, new BlobIdx(0));
+            _blobHeapSize = 1;
 
             // When EnC delta is applied #US, #String and #Blob heaps are appended.
             // Thus indices of strings and blobs added to this generation are offset
             // by the sum of respective heap sizes of all previous generations.
-            _userStringIndexStartOffset = userStringIndexStartOffset;
-            _stringIndexStartOffset = stringIndexStartOffset;
-            _blobIndexStartOffset = blobIndexStartOffset;
+            _userStringHeapStartOffset = userStringHeapStartOffset;
+            _stringHeapStartOffset = stringHeapStartOffset;
+            _blobHeapStartOffset = blobHeapStartOffset;
 
             // Unlike other heaps, #Guid heap in EnC delta is zero-padded.
-            _guidWriter.Pad(guidIndexStartOffset);
+            _guidWriter.Pad(guidHeapStartOffset);
         }
 
-        internal int GetBlobIndex(BlobWriter stream)
+        internal BlobIdx GetBlobIndex(BlobWriter stream)
         {
             // TODO: avoid making a copy if the blob exists in the index
             return GetBlobIndex(stream.ToImmutableArray());
         }
 
-        internal int GetBlobIndex(ImmutableArray<byte> blob)
+        internal BlobIdx GetBlobIndex(ImmutableArray<byte> blob)
         {
-            int result = 0;
-            if (blob.Length == 0 || _blobIndex.TryGetValue(blob, out result))
+            BlobIdx index;
+            if (!_blobs.TryGetValue(blob, out index))
             {
-                return result;
+                Debug.Assert(!_streamsAreComplete);
+
+                index = new BlobIdx(_blobHeapSize);
+                _blobs.Add(blob, index);
+
+                _blobHeapSize += BlobWriter.GetCompressedIntegerSize(blob.Length) + blob.Length;
             }
 
-            Debug.Assert(!_streamsAreComplete);
-            result = _blobWriter.Position + _blobIndexStartOffset;
-            _blobIndex.Add(blob, result);
-            _blobWriter.WriteCompressedUInt((uint)blob.Length);
-            _blobWriter.WriteBytes(blob);
-            return result;
+            return index;
         }
 
-        public int GetConstantBlobIndex(object value)
+        public BlobIdx GetConstantBlobIndex(object value)
         {
             string str = value as string;
             if (str != null)
@@ -113,7 +179,7 @@ namespace Microsoft.Cci
             return this.GetBlobIndex(writer);
         }
 
-        public int GetBlobIndex(string str)
+        public BlobIdx GetBlobIndex(string str)
         {
             byte[] byteArray = new byte[str.Length * 2];
             int i = 0;
@@ -134,7 +200,7 @@ namespace Microsoft.Cci
             }
 
             int result;
-            if (_guidIndex.TryGetValue(guid, out result))
+            if (_guids.TryGetValue(guid, out result))
             {
                 return result;
             }
@@ -158,22 +224,10 @@ namespace Microsoft.Cci
             // Its first element is numbered 1, its second 2, and so on.
             int result = (_guidWriter.Length >> 4) + 1;
 
-            _guidIndex.Add(guid, result);
+            _guids.Add(guid, result);
             _guidWriter.WriteBytes(guid.ToByteArray());
 
             return result;
-        }
-
-        public unsafe byte[] GetExistingBlob(int signatureOffset)
-        {
-            fixed (byte* ptr = _blobWriter.Buffer)
-            {
-                var reader = new BlobReader(ptr + signatureOffset, (int)_blobWriter.Length + _blobIndexStartOffset - signatureOffset);
-                int size;
-                bool isValid = reader.TryReadCompressedInteger(out size);
-                Debug.Assert(isValid);
-                return reader.ReadBytes(size);
-            }
         }
 
         public StringIdx GetStringIndex(string str)
@@ -183,11 +237,11 @@ namespace Microsoft.Cci
             {
                 index = new StringIdx(0);
             }
-            else if (!_stringIndex.TryGetValue(str, out index))
+            else if (!_strings.TryGetValue(str, out index))
             {
                 Debug.Assert(!_streamsAreComplete);
-                index = new StringIdx(_stringIndex.Count + 1); // idx 0 is reserved for empty string
-                _stringIndex.Add(str, index);
+                index = new StringIdx(_strings.Count + 1); // idx 0 is reserved for empty string
+                _strings.Add(str, index);
             }
 
             return index;
@@ -195,17 +249,22 @@ namespace Microsoft.Cci
 
         public int ResolveStringIndex(StringIdx index)
         {
-            return _stringIndexMap[index.VirtIdx];
+            return _stringHeapStartOffset + _stringIndexToHeapPositionMap[index.MapIndex];
+        }
+
+        public int ResolveBlobIndex(BlobIdx index)
+        {
+            return _blobHeapStartOffset + index.HeapPosition;
         }
 
         public int GetUserStringToken(string str)
         {
             int index;
-            if (!_userStringIndex.TryGetValue(str, out index))
+            if (!_userStrings.TryGetValue(str, out index))
             {
                 Debug.Assert(!_streamsAreComplete);
-                index = _userStringWriter.Position + _userStringIndexStartOffset;
-                _userStringIndex.Add(str, index);
+                index = _userStringWriter.Position + _userStringHeapStartOffset;
+                _userStrings.Add(str, index);
                 _userStringWriter.WriteCompressedUInt((uint)str.Length * 2 + 1);
                 _userStringWriter.WriteUTF16(str);
 
@@ -276,10 +335,10 @@ namespace Microsoft.Cci
         {
             var heapSizes = new int[MetadataTokens.HeapCount];
 
-            heapSizes[(int)HeapIndex.UserString] = (int)_userStringWriter.Length;
-            heapSizes[(int)HeapIndex.String] = (int)_stringWriter.Length;
-            heapSizes[(int)HeapIndex.Blob] = (int)_blobWriter.Length;
-            heapSizes[(int)HeapIndex.Guid] = (int)_guidWriter.Length;
+            heapSizes[(int)HeapIndex.UserString] = _userStringWriter.Length;
+            heapSizes[(int)HeapIndex.String] = _stringWriter.Length;
+            heapSizes[(int)HeapIndex.Blob] = _blobHeapSize;
+            heapSizes[(int)HeapIndex.Guid] = _guidWriter.Length;
 
             return ImmutableArray.CreateRange(heapSizes);
         }
@@ -291,34 +350,38 @@ namespace Microsoft.Cci
         private void SerializeStringHeap()
         {
             // Sort by suffix and remove stringIndex
-            var sorted = new List<KeyValuePair<string, StringIdx>>(_stringIndex);
+            var sorted = new List<KeyValuePair<string, StringIdx>>(_strings);
             sorted.Sort(new SuffixSort());
-            _stringIndex = null;
+            _strings = null;
+
+            _stringWriter = new BlobWriter(1024);
 
             // Create VirtIdx to Idx map and add entry for empty string
-            _stringIndexMap = new int[sorted.Count + 1];
-            _stringIndexMap[0] = 0;
+            _stringIndexToHeapPositionMap = new int[sorted.Count + 1];
+
+            _stringIndexToHeapPositionMap[0] = 0;
+            _stringWriter.WriteByte(0);
 
             // Find strings that can be folded
             string prev = string.Empty;
-            foreach (KeyValuePair<string, StringIdx> cur in sorted)
+            foreach (KeyValuePair<string, StringIdx> entry in sorted)
             {
-                int position = _stringWriter.Position + _stringIndexStartOffset;
+                int position = _stringWriter.Position;
 
                 // It is important to use ordinal comparison otherwise we'll use the current culture!
-                if (prev.EndsWith(cur.Key, StringComparison.Ordinal))
+                if (prev.EndsWith(entry.Key, StringComparison.Ordinal))
                 {
                     // Map over the tail of prev string. Watch for null-terminator of prev string.
-                    _stringIndexMap[cur.Value.VirtIdx] = position - (s_utf8Encoding.GetByteCount(cur.Key) + 1);
+                    _stringIndexToHeapPositionMap[entry.Value.MapIndex] = position - (s_utf8Encoding.GetByteCount(entry.Key) + 1);
                 }
                 else
                 {
-                    _stringIndexMap[cur.Value.VirtIdx] = position;
-                    _stringWriter.WriteString(cur.Key, s_utf8Encoding);
+                    _stringIndexToHeapPositionMap[entry.Value.MapIndex] = position;
+                    _stringWriter.WriteString(entry.Key, s_utf8Encoding);
                     _stringWriter.WriteByte(0);
                 }
 
-                prev = cur.Key;
+                prev = entry.Key;
             }
         }
 
@@ -350,15 +413,43 @@ namespace Microsoft.Cci
             }
         }
 
-        public void WriteTo(BlobWriter stream, out int guidHeapStartOffset)
+        public void WriteTo(BlobWriter writer, out int guidHeapStartOffset)
         {
-            WriteAligned(_stringWriter, stream);
-            WriteAligned(_userStringWriter, stream);
+            WriteAligned(_stringWriter, writer);
+            WriteAligned(_userStringWriter, writer);
 
-            guidHeapStartOffset = stream.Position;
+            guidHeapStartOffset = writer.Position;
 
-            WriteAligned(_guidWriter, stream);
-            WriteAligned(_blobWriter, stream);
+            WriteAligned(_guidWriter, writer);
+            WriteAlignedBlobHeap(writer);
+        }
+
+        private void WriteAlignedBlobHeap(BlobWriter writer)
+        {
+            int heapStart = writer.Position;
+            
+            // ensure enough space in the buffer:
+            writer.Position += _blobHeapSize;
+
+            // Perf consideration: With large heap the following loop may cause a lot of cache misses 
+            // since the order of entries in _blobs dictionary depends on the hash of the array values, 
+            // which is not correlated to the heap index. If we observe such issue we should order 
+            // the entries by heap position before running this loop.
+            foreach (var entry in _blobs)
+            {
+                int heapOffset = entry.Value.HeapPosition;
+                var blob = entry.Key;
+
+                writer.Position = heapStart + heapOffset;
+                writer.WriteCompressedUInt((uint)blob.Length);
+                writer.WriteBytes(blob);
+            }
+
+            Debug.Assert(writer.Length - heapStart == _blobHeapSize);
+
+            // add padding:
+            writer.Position = writer.Length;
+            writer.Write(0, BitArithmeticUtilities.Align(_blobHeapSize, 4) - _blobHeapSize);
         }
 
         private static void WriteAligned(BlobWriter source, BlobWriter target)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Cci
 
             // EDMAURER provide some reasonable size estimates for these that will avoid
             // much of the reallocation that would occur when growing these from empty.
-            _signatureIndex = new Dictionary<ISignature, int>(module.HintNumberOfMethodDefinitions); //ignores field signatures
+            _signatureIndex = new Dictionary<ISignature, KeyValuePair<BlobIdx, ImmutableArray<byte>>>(module.HintNumberOfMethodDefinitions); //ignores field signatures
 
             _numTypeDefsEstimate = module.HintNumberOfMethodDefinitions / 6;
             _exportedTypeIndex = new Dictionary<ITypeReference, int>(_numTypeDefsEstimate);
@@ -363,13 +363,13 @@ namespace Microsoft.Cci
         /// The index is into the full metadata. However, deltas
         /// are not required to return rows from previous generations.
         /// </summary>
-        protected abstract int GetOrAddStandAloneSignatureIndex(int blobIndex);
+        protected abstract int GetOrAddStandAloneSignatureIndex(BlobIdx blobIndex);
 
         /// <summary>
         /// The signature indices to be emitted, in row order. These
         /// are just the signature indices from the current generation.
         /// </summary>
-        protected abstract IReadOnlyList<int> GetStandAloneSignatures();
+        protected abstract IReadOnlyList<BlobIdx> GetStandAloneSignatures();
 
         protected abstract IEnumerable<INamespaceTypeDefinition> GetTopLevelTypes(IModule module);
 
@@ -419,17 +419,20 @@ namespace Microsoft.Cci
         private ReferenceIndexer _referenceVisitor;
 
         protected readonly MetadataHeapsBuilder heaps;
-        private readonly Dictionary<ICustomAttribute, int> _customAttributeSignatureIndex = new Dictionary<ICustomAttribute, int>();
-        private readonly Dictionary<ITypeReference, int> _typeSpecSignatureIndex = new Dictionary<ITypeReference, int>();
+        private readonly Dictionary<ICustomAttribute, BlobIdx> _customAttributeSignatureIndex = new Dictionary<ICustomAttribute, BlobIdx>();
+        private readonly Dictionary<ITypeReference, BlobIdx> _typeSpecSignatureIndex = new Dictionary<ITypeReference, BlobIdx>();
         private readonly Dictionary<ITypeReference, int> _exportedTypeIndex;
         private readonly List<ITypeReference> _exportedTypeList;
         private readonly Dictionary<string, int> _fileRefIndex = new Dictionary<string, int>(32);  //more than enough in most cases
         private readonly List<IFileReference> _fileRefList = new List<IFileReference>(32);
-        private readonly Dictionary<IFieldReference, int> _fieldSignatureIndex = new Dictionary<IFieldReference, int>();
-        private readonly Dictionary<ISignature, int> _signatureIndex;
-        private readonly Dictionary<IMarshallingInformation, int> _marshallingDescriptorIndex = new Dictionary<IMarshallingInformation, int>();
+        private readonly Dictionary<IFieldReference, BlobIdx> _fieldSignatureIndex = new Dictionary<IFieldReference, BlobIdx>();
+
+        // We need to keep track of both the index of the signature and the actual blob to support VB static local naming scheme.
+        private readonly Dictionary<ISignature, KeyValuePair<BlobIdx, ImmutableArray<byte>>> _signatureIndex;
+
+        private readonly Dictionary<IMarshallingInformation, BlobIdx> _marshallingDescriptorIndex = new Dictionary<IMarshallingInformation, BlobIdx>();
         protected readonly List<MethodImplementation> methodImplList = new List<MethodImplementation>();
-        private readonly Dictionary<IGenericMethodInstanceReference, int> _methodInstanceSignatureIndex = new Dictionary<IGenericMethodInstanceReference, int>();
+        private readonly Dictionary<IGenericMethodInstanceReference, BlobIdx> _methodInstanceSignatureIndex = new Dictionary<IGenericMethodInstanceReference, BlobIdx>();
 
         // Well known dummy cor library types whose refs are used for attaching assembly attributes off within net modules
         // There is no guarantee the types actually exist in a cor library
@@ -740,9 +743,9 @@ namespace Microsoft.Cci
             return this.GetOrAddModuleRefIndex(moduleName);
         }
 
-        private int GetCustomAttributeSignatureIndex(ICustomAttribute customAttribute)
+        private BlobIdx GetCustomAttributeSignatureIndex(ICustomAttribute customAttribute)
         {
-            int result;
+            BlobIdx result;
             if (_customAttributeSignatureIndex.TryGetValue(customAttribute, out result))
             {
                 return result;
@@ -850,9 +853,9 @@ namespace Microsoft.Cci
             return result;
         }
 
-        internal int GetFieldSignatureIndex(IFieldReference fieldReference)
+        internal BlobIdx GetFieldSignatureIndex(IFieldReference fieldReference)
         {
-            int result;
+            BlobIdx result;
             ISpecializedFieldReference specializedFieldReference = fieldReference.AsSpecializedFieldReference;
             if (specializedFieldReference != null)
             {
@@ -1116,9 +1119,9 @@ namespace Microsoft.Cci
             return result;
         }
 
-        internal int GetMethodInstanceSignatureIndex(IGenericMethodInstanceReference methodInstanceReference)
+        internal BlobIdx GetMethodInstanceSignatureIndex(IGenericMethodInstanceReference methodInstanceReference)
         {
-            int result;
+            BlobIdx result;
             if (_methodInstanceSignatureIndex.TryGetValue(methodInstanceReference, out result))
             {
                 return result;
@@ -1138,9 +1141,9 @@ namespace Microsoft.Cci
             return result;
         }
 
-        private int GetMarshallingDescriptorIndex(IMarshallingInformation marshallingInformation)
+        private BlobIdx GetMarshallingDescriptorIndex(IMarshallingInformation marshallingInformation)
         {
-            int result;
+            BlobIdx result;
             if (_marshallingDescriptorIndex.TryGetValue(marshallingInformation, out result))
             {
                 return result;
@@ -1154,12 +1157,12 @@ namespace Microsoft.Cci
             return result;
         }
 
-        private int GetMarshallingDescriptorIndex(ImmutableArray<byte> descriptor)
+        private BlobIdx GetMarshallingDescriptorIndex(ImmutableArray<byte> descriptor)
         {
             return heaps.GetBlobIndex(descriptor);
         }
 
-        private int GetMemberRefSignatureIndex(ITypeMemberReference memberRef)
+        private BlobIdx GetMemberRefSignatureIndex(ITypeMemberReference memberRef)
         {
             IFieldReference fieldReference = memberRef as IFieldReference;
             if (fieldReference != null)
@@ -1171,43 +1174,56 @@ namespace Microsoft.Cci
             if (methodReference != null)
             {
                 return this.GetMethodSignatureIndex(methodReference);
-            }            // TODO: error
+            }
 
-            return 0;
+            // TODO: error
+            return default(BlobIdx);
         }
 
-        internal int GetMethodSignatureIndex(IMethodReference methodReference)
+        internal BlobIdx GetMethodSignatureIndex(IMethodReference methodReference)
         {
-            int result;
+            ImmutableArray<byte> signatureBlob;
+            return GetMethodSignatureIndexAndBlob(methodReference, out signatureBlob);
+        }
+
+        internal byte[] GetMethodSignature(IMethodReference methodReference)
+        {
+            ImmutableArray<byte> signatureBlob;
+            GetMethodSignatureIndexAndBlob(methodReference, out signatureBlob);
+            return signatureBlob.ToArray();
+        }
+
+        private BlobIdx GetMethodSignatureIndexAndBlob(IMethodReference methodReference, out ImmutableArray<byte> signatureBlob)
+        {
+            BlobIdx result;
             ISpecializedMethodReference specializedMethodReference = methodReference.AsSpecializedMethodReference;
             if (specializedMethodReference != null)
             {
                 methodReference = specializedMethodReference.UnspecializedVersion;
             }
 
-            if (_signatureIndex.TryGetValue(methodReference, out result))
+            KeyValuePair<BlobIdx, ImmutableArray<byte>> existing;
+            if (_signatureIndex.TryGetValue(methodReference, out existing))
             {
-                return result;
+                signatureBlob = existing.Value;
+                return existing.Key;
             }
 
             var writer = BlobWriter.GetInstance();
             this.SerializeSignature(methodReference, methodReference.GenericParameterCount, methodReference.ExtraParameters, writer);
-            result = heaps.GetBlobIndex(writer);
-            _signatureIndex.Add(methodReference, result);
+
+            signatureBlob = writer.ToImmutableArray();
+            result = heaps.GetBlobIndex(signatureBlob);
+            _signatureIndex.Add(methodReference, KeyValuePair.Create(result, signatureBlob));
             writer.Free();
             return result;
         }
 
-        internal byte[] GetMethodSignature(IMethodReference methodReference)
-        {
-            return heaps.GetExistingBlob((int)GetMethodSignatureIndex(methodReference));
-        }
-
-        private int GetGenericMethodInstanceIndex(IGenericMethodInstanceReference genericMethodInstanceReference)
+        private BlobIdx GetGenericMethodInstanceIndex(IGenericMethodInstanceReference genericMethodInstanceReference)
         {
             var writer = BlobWriter.GetInstance();
             this.SerializeGenericMethodInstanceSignature(writer, genericMethodInstanceReference);
-            int result = heaps.GetBlobIndex(writer);
+            BlobIdx result = heaps.GetBlobIndex(writer);
             writer.Free();
             return result;
         }
@@ -1274,10 +1290,10 @@ namespace Microsoft.Cci
             return constant.CompileTimeValue.Type.TypeCode(Context);
         }
 
-        private int GetPermissionSetIndex(ImmutableArray<ICustomAttribute> permissionSet)
+        private BlobIdx GetPermissionSetIndex(ImmutableArray<ICustomAttribute> permissionSet)
         {
             var writer = BlobWriter.GetInstance();
-            int result;
+            BlobIdx result;
             try
             {
                 writer.WriteByte((byte)'.');
@@ -1314,18 +1330,19 @@ namespace Microsoft.Cci
             return result;
         }
 
-        private int GetPropertySignatureIndex(IPropertyDefinition propertyDef)
+        private BlobIdx GetPropertySignatureIndex(IPropertyDefinition propertyDef)
         {
-            int result;
-            if (_signatureIndex.TryGetValue(propertyDef, out result))
+            KeyValuePair<BlobIdx, ImmutableArray<byte>> existing;
+            if (_signatureIndex.TryGetValue(propertyDef, out existing))
             {
-                return result;
+                return existing.Key;
             }
 
             var writer = BlobWriter.GetInstance();
             this.SerializeSignature(propertyDef, 0, ImmutableArray<IParameterTypeInformation>.Empty, writer);
-            result = heaps.GetBlobIndex(writer);
-            _signatureIndex.Add(propertyDef, result);
+            var blob = writer.ToImmutableArray();
+            var result = heaps.GetBlobIndex(blob);
+            _signatureIndex.Add(propertyDef, KeyValuePair.Create(result, blob));
             writer.Free();
             return result;
         }
@@ -1809,9 +1826,9 @@ namespace Microsoft.Cci
             return t.AsNestedTypeReference;
         }
 
-        internal int GetTypeSpecSignatureIndex(ITypeReference typeReference)
+        internal BlobIdx GetTypeSpecSignatureIndex(ITypeReference typeReference)
         {
-            int result;
+            BlobIdx result;
             if (_typeSpecSignatureIndex.TryGetValue(typeReference, out result))
             {
                 return result;
@@ -2411,7 +2428,7 @@ namespace Microsoft.Cci
         private struct AssemblyRefTableRow
         {
             public Version Version;
-            public uint PublicKeyToken;
+            public BlobIdx PublicKeyToken;
             public StringIdx Name;
             public StringIdx Culture;
             public AssemblyContentType ContentType;
@@ -2427,7 +2444,7 @@ namespace Microsoft.Cci
             {
                 AssemblyRefTableRow r = new AssemblyRefTableRow();
                 r.Version = assemblyRef.Version;
-                r.PublicKeyToken = (uint)heaps.GetBlobIndex(assemblyRef.PublicKeyToken);
+                r.PublicKeyToken = heaps.GetBlobIndex(assemblyRef.PublicKeyToken);
 
                 Debug.Assert(!string.IsNullOrEmpty(assemblyRef.Name));
                 r.Name = this.GetStringIndexForPathAndCheckLength(assemblyRef.Name, assemblyRef);
@@ -2483,12 +2500,12 @@ namespace Microsoft.Cci
                 return;
             }
 
-            _assemblyKey = (uint)heaps.GetBlobIndex(assembly.PublicKey);
+            _assemblyKey = heaps.GetBlobIndex(assembly.PublicKey);
             _assemblyName = this.GetStringIndexForPathAndCheckLength(assembly.Name, assembly);
             _assemblyCulture = heaps.GetStringIndex(assembly.Culture);
         }
 
-        private uint _assemblyKey;
+        private BlobIdx _assemblyKey;
         private StringIdx _assemblyName;
         private StringIdx _assemblyCulture;
 
@@ -2566,7 +2583,7 @@ namespace Microsoft.Cci
             }
         }
 
-        private struct ConstantRow { public byte Type; public uint Parent; public uint Value; }
+        private struct ConstantRow { public byte Type; public uint Parent; public BlobIdx Value; }
 
         private ConstantRow CreateConstantRow(object value, uint parent)
         {
@@ -2574,7 +2591,7 @@ namespace Microsoft.Cci
             {
                 Type = (byte)GetConstantTypeCode(value),
                 Parent = parent,
-                Value = (uint)heaps.GetConstantBlobIndex(value)
+                Value = heaps.GetConstantBlobIndex(value)
             };
         }
 
@@ -2737,7 +2754,7 @@ namespace Microsoft.Cci
             r.Parent = parentToken;
             var ctor = customAttribute.Constructor(Context);
             r.Type = this.GetCustomAttributeTypeCodedIndex(ctor);
-            r.Value = (uint)this.GetCustomAttributeSignatureIndex(customAttribute);
+            r.Value = this.GetCustomAttributeSignatureIndex(customAttribute);
             r.OriginalPosition = _customAttributeTable.Count;
             _customAttributeTable.Add(r);
         }
@@ -2756,7 +2773,7 @@ namespace Microsoft.Cci
             }
         }
 
-        private struct CustomAttributeRow { public uint Parent; public uint Type; public uint Value; public int OriginalPosition; }
+        private struct CustomAttributeRow { public uint Parent; public uint Type; public BlobIdx Value; public int OriginalPosition; }
 
         private readonly List<CustomAttributeRow> _customAttributeTable = new List<CustomAttributeRow>();
 
@@ -2814,7 +2831,7 @@ namespace Microsoft.Cci
             foreach (DeclarativeSecurityAction securityAction in groupedSecurityAttributes.Keys)
             {
                 r.Action = (ushort)securityAction;
-                r.PermissionSet = (uint)this.GetPermissionSetIndex(groupedSecurityAttributes[securityAction]);
+                r.PermissionSet = this.GetPermissionSetIndex(groupedSecurityAttributes[securityAction]);
                 r.OriginalIndex = _declSecurityTable.Count;
                 _declSecurityTable.Add(r);
             }
@@ -2836,7 +2853,7 @@ namespace Microsoft.Cci
             }
         }
 
-        private struct DeclSecurityRow { public ushort Action; public uint Parent; public uint PermissionSet; public int OriginalIndex; }
+        private struct DeclSecurityRow { public ushort Action; public uint Parent; public BlobIdx PermissionSet; public int OriginalIndex; }
 
         private readonly List<DeclSecurityRow> _declSecurityTable = new List<DeclSecurityRow>();
 
@@ -2979,9 +2996,9 @@ namespace Microsoft.Cci
 
                 var marshallingInformation = fieldDef.MarshallingInformation;
 
-                r.NativeType = (uint)(marshallingInformation != null
+                r.NativeType = (marshallingInformation != null)
                     ? this.GetMarshallingDescriptorIndex(marshallingInformation)
-                    : this.GetMarshallingDescriptorIndex(fieldDef.MarshallingDescriptor));
+                    : this.GetMarshallingDescriptorIndex(fieldDef.MarshallingDescriptor);
 
                 uint fieldDefIndex = (uint)this.GetFieldDefIndex(fieldDef);
                 r.Parent = fieldDefIndex << 1;
@@ -3000,9 +3017,9 @@ namespace Microsoft.Cci
 
                 var marshallingInformation = parDef.MarshallingInformation;
 
-                r.NativeType = (uint)(marshallingInformation != null
+                r.NativeType = (marshallingInformation != null)
                     ? this.GetMarshallingDescriptorIndex(marshallingInformation)
-                    : this.GetMarshallingDescriptorIndex(parDef.MarshallingDescriptor));
+                    : this.GetMarshallingDescriptorIndex(parDef.MarshallingDescriptor);
 
                 uint parameterDefIndex = (uint)this.GetParameterDefIndex(parDef);
                 r.Parent = (parameterDefIndex << 1) | 1;
@@ -3023,7 +3040,7 @@ namespace Microsoft.Cci
             }
         }
 
-        private struct FieldMarshalRow { public uint Parent; public uint NativeType; }
+        private struct FieldMarshalRow { public uint Parent; public BlobIdx NativeType; }
 
         private readonly List<FieldMarshalRow> _fieldMarshalTable = new List<FieldMarshalRow>();
 
@@ -3068,12 +3085,12 @@ namespace Microsoft.Cci
                 }
 
                 r.Name = this.GetStringIndexForNameAndCheckLength(fieldDef.Name, fieldDef);
-                r.Signature = (uint)this.GetFieldSignatureIndex(fieldDef);
+                r.Signature = this.GetFieldSignatureIndex(fieldDef);
                 _fieldDefTable.Add(r);
             }
         }
 
-        private struct FieldDefRow { public ushort Flags; public StringIdx Name; public uint Signature; }
+        private struct FieldDefRow { public ushort Flags; public StringIdx Name; public BlobIdx Signature; }
 
         private readonly List<FieldDefRow> _fieldDefTable = new List<FieldDefRow>();
 
@@ -3093,12 +3110,12 @@ namespace Microsoft.Cci
                 FileTableRow r = new FileTableRow();
                 r.Flags = fileReference.HasMetadata ? 0u : 1u;
                 r.FileName = this.GetStringIndexForPathAndCheckLength(fileReference.FileName);
-                r.HashValue = (uint)heaps.GetBlobIndex(fileReference.GetHashValue(hashAlgorithm));
+                r.HashValue = heaps.GetBlobIndex(fileReference.GetHashValue(hashAlgorithm));
                 _fileTable.Add(r);
             }
         }
 
-        private struct FileTableRow { public uint Flags; public StringIdx FileName; public uint HashValue; }
+        private struct FileTableRow { public uint Flags; public StringIdx FileName; public BlobIdx HashValue; }
 
         private readonly List<FileTableRow> _fileTable = new List<FileTableRow>();
 
@@ -3254,12 +3271,12 @@ namespace Microsoft.Cci
                 MemberRefRow r = new MemberRefRow();
                 r.Class = this.GetMemberRefParentCodedIndex(memberRef);
                 r.Name = this.GetStringIndexForNameAndCheckLength(memberRef.Name, memberRef);
-                r.Signature = (uint)this.GetMemberRefSignatureIndex(memberRef);
+                r.Signature = this.GetMemberRefSignatureIndex(memberRef);
                 _memberRefTable.Add(r);
             }
         }
 
-        private struct MemberRefRow { public uint Class; public StringIdx Name; public uint Signature; }
+        private struct MemberRefRow { public uint Class; public StringIdx Name; public BlobIdx Signature; }
 
         private readonly List<MemberRefRow> _memberRefTable = new List<MemberRefRow>();
 
@@ -3377,12 +3394,12 @@ namespace Microsoft.Cci
             {
                 MethodSpecRow r = new MethodSpecRow();
                 r.Method = this.GetMethodDefOrRefCodedIndex(genericMethodInstanceReference.GetGenericMethod(Context));
-                r.Instantiation = (uint)this.GetGenericMethodInstanceIndex(genericMethodInstanceReference);
+                r.Instantiation = this.GetGenericMethodInstanceIndex(genericMethodInstanceReference);
                 _methodSpecTable.Add(r);
             }
         }
 
-        private struct MethodSpecRow { public uint Method; public uint Instantiation; }
+        private struct MethodSpecRow { public uint Method; public BlobIdx Instantiation; }
 
         private readonly List<MethodSpecRow> _methodSpecTable = new List<MethodSpecRow>();
 
@@ -3400,7 +3417,7 @@ namespace Microsoft.Cci
                     ImplFlags = (ushort)methodDef.GetImplementationAttributes(Context),
                     Flags = GetMethodFlags(methodDef),
                     Name = this.GetStringIndexForNameAndCheckLength(methodDef.Name, methodDef),
-                    Signature = (uint)this.GetMethodSignatureIndex(methodDef),
+                    Signature = this.GetMethodSignatureIndex(methodDef),
                     ParamList = (uint)this.GetParameterDefIndex(methodDef),
                 };
 
@@ -3408,7 +3425,7 @@ namespace Microsoft.Cci
             }
         }
 
-        private struct MethodRow { public int Rva; public ushort ImplFlags; public ushort Flags; public StringIdx Name; public uint Signature; public uint ParamList; }
+        private struct MethodRow { public int Rva; public ushort ImplFlags; public ushort Flags; public StringIdx Name; public BlobIdx Signature; public uint ParamList; }
 
         private MethodRow[] _methodTable;
 
@@ -3521,13 +3538,13 @@ namespace Microsoft.Cci
                 var r = new PropertyRow();
                 r.PropFlags = GetPropertyFlags(propertyDef);
                 r.Name = this.GetStringIndexForNameAndCheckLength(propertyDef.Name, propertyDef);
-                r.Type = (uint)this.GetPropertySignatureIndex(propertyDef);
+                r.Type = this.GetPropertySignatureIndex(propertyDef);
                 _propertyTable.Add(r);
             }
         }
 
         [StructLayout(LayoutKind.Auto)]
-        private struct PropertyRow { public ushort PropFlags; public StringIdx Name; public uint Type; }
+        private struct PropertyRow { public ushort PropFlags; public StringIdx Name; public BlobIdx Type; }
 
         private readonly List<PropertyRow> _propertyTable = new List<PropertyRow>();
 
@@ -3614,12 +3631,12 @@ namespace Microsoft.Cci
             foreach (ITypeReference typeSpec in typeSpecs)
             {
                 TypeSpecRow r = new TypeSpecRow();
-                r.Signature = (uint)this.GetTypeSpecSignatureIndex(typeSpec);
+                r.Signature = this.GetTypeSpecSignatureIndex(typeSpec);
                 _typeSpecTable.Add(r);
             }
         }
 
-        private struct TypeSpecRow { public uint Signature; }
+        private struct TypeSpecRow { public BlobIdx Signature; }
 
         private readonly List<TypeSpecRow> _typeSpecTable = new List<TypeSpecRow>();
 
@@ -3733,7 +3750,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteUshort(fieldDef.Flags);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(fieldDef.Name), metadataSizes.StringIndexSize);
-                writer.WriteReference(fieldDef.Signature, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(fieldDef.Signature), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3753,7 +3770,7 @@ namespace Microsoft.Cci
                 writer.WriteUshort(method.ImplFlags);
                 writer.WriteUshort(method.Flags);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(method.Name), metadataSizes.StringIndexSize);
-                writer.WriteReference(method.Signature, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(method.Signature), metadataSizes.BlobIndexSize);
                 writer.WriteReference(method.ParamList, metadataSizes.ParameterIndexSize);
             }
         }
@@ -3783,7 +3800,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteReference(memberRef.Class, metadataSizes.MemberRefParentCodedIndexSize);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(memberRef.Name), metadataSizes.StringIndexSize);
-                writer.WriteReference(memberRef.Signature, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(memberRef.Signature), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3794,7 +3811,7 @@ namespace Microsoft.Cci
                 writer.WriteByte(constant.Type);
                 writer.WriteByte(0);
                 writer.WriteReference(constant.Parent, metadataSizes.HasConstantCodedIndexSize);
-                writer.WriteReference(constant.Value, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(constant.Value), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3804,7 +3821,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteReference(customAttribute.Parent, metadataSizes.HasCustomAttributeCodedIndexSize);
                 writer.WriteReference(customAttribute.Type, metadataSizes.CustomAttributeTypeCodedIndexSize);
-                writer.WriteReference(customAttribute.Value, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(customAttribute.Value), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3813,7 +3830,7 @@ namespace Microsoft.Cci
             foreach (FieldMarshalRow fieldMarshal in _fieldMarshalTable)
             {
                 writer.WriteReference(fieldMarshal.Parent, metadataSizes.HasFieldMarshalCodedIndexSize);
-                writer.WriteReference(fieldMarshal.NativeType, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(fieldMarshal.NativeType), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3823,7 +3840,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteUshort(declSecurity.Action);
                 writer.WriteReference(declSecurity.Parent, metadataSizes.DeclSecurityCodedIndexSize);
-                writer.WriteReference(declSecurity.PermissionSet, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(declSecurity.PermissionSet), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3848,9 +3865,9 @@ namespace Microsoft.Cci
 
         private void SerializeStandAloneSigTable(BlobWriter writer, MetadataSizes metadataSizes)
         {
-            foreach (uint blobIndex in this.GetStandAloneSignatures())
+            foreach (BlobIdx blobIndex in this.GetStandAloneSignatures())
             {
-                writer.WriteReference(blobIndex, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(blobIndex), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3888,7 +3905,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteUshort(property.PropFlags);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(property.Name), metadataSizes.StringIndexSize);
-                writer.WriteReference(property.Type, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(property.Type), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3924,7 +3941,7 @@ namespace Microsoft.Cci
         {
             foreach (TypeSpecRow typeSpec in _typeSpecTable)
             {
-                writer.WriteReference(typeSpec.Signature, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(typeSpec.Signature), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -3962,7 +3979,7 @@ namespace Microsoft.Cci
             writer.WriteUshort((ushort)assembly.Version.Build);
             writer.WriteUshort((ushort)assembly.Version.Revision);
             writer.WriteUint(assembly.Flags);
-            writer.WriteReference(_assemblyKey, metadataSizes.BlobIndexSize);
+            writer.WriteReference((uint)heaps.ResolveBlobIndex(_assemblyKey), metadataSizes.BlobIndexSize);
             writer.WriteReference((uint)heaps.ResolveStringIndex(_assemblyName), metadataSizes.StringIndexSize);
             writer.WriteReference((uint)heaps.ResolveStringIndex(_assemblyCulture), metadataSizes.StringIndexSize);
         }
@@ -3987,7 +4004,7 @@ namespace Microsoft.Cci
 
                 writer.WriteUint(flags);
 
-                writer.WriteReference(assemblyRef.PublicKeyToken, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(assemblyRef.PublicKeyToken), metadataSizes.BlobIndexSize);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(assemblyRef.Name), metadataSizes.StringIndexSize);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(assemblyRef.Culture), metadataSizes.StringIndexSize);
                 writer.WriteReference(0, metadataSizes.BlobIndexSize); // hash of referenced assembly. Omitted.
@@ -4000,7 +4017,7 @@ namespace Microsoft.Cci
             {
                 writer.WriteUint(fileReference.Flags);
                 writer.WriteReference((uint)heaps.ResolveStringIndex(fileReference.FileName), metadataSizes.StringIndexSize);
-                writer.WriteReference(fileReference.HashValue, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(fileReference.HashValue), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -4052,7 +4069,7 @@ namespace Microsoft.Cci
             foreach (MethodSpecRow methodSpec in _methodSpecTable)
             {
                 writer.WriteReference(methodSpec.Method, metadataSizes.MethodDefOrRefCodedIndexSize);
-                writer.WriteReference(methodSpec.Instantiation, metadataSizes.BlobIndexSize);
+                writer.WriteReference((uint)heaps.ResolveBlobIndex(methodSpec.Instantiation), metadataSizes.BlobIndexSize);
             }
         }
 
@@ -4194,7 +4211,7 @@ namespace Microsoft.Cci
                 this.SerializeLocalVariableSignature(writer, local);
             }
 
-            int blobIndex = heaps.GetBlobIndex(writer);
+            BlobIdx blobIndex = heaps.GetBlobIndex(writer);
             int signatureIndex = this.GetOrAddStandAloneSignatureIndex(blobIndex);
             writer.Free();
 
@@ -4239,7 +4256,7 @@ namespace Microsoft.Cci
             }
 
             this.SerializeTypeReference(localConstant.Type, writer, false, true);
-            int blobIndex = heaps.GetBlobIndex(writer);
+            BlobIdx blobIndex = heaps.GetBlobIndex(writer);
             int signatureIndex = GetOrAddStandAloneSignatureIndex(blobIndex);
             writer.Free();
 

--- a/src/Compilers/Core/Portable/PEWriter/MethodSpecComparer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MethodSpecComparer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Roslyn.Utilities;
 
 namespace Microsoft.Cci
 {
@@ -27,8 +28,9 @@ namespace Microsoft.Cci
 
         public int GetHashCode(IGenericMethodInstanceReference methodInstanceReference)
         {
-            return (int)((_metadataWriter.GetMethodDefOrRefCodedIndex(methodInstanceReference.GetGenericMethod(_metadataWriter.Context)) << 2) ^
-              _metadataWriter.GetMethodInstanceSignatureIndex(methodInstanceReference));
+            return Hash.Combine(
+                (int)_metadataWriter.GetMethodDefOrRefCodedIndex(methodInstanceReference.GetGenericMethod(_metadataWriter.Context)),
+                _metadataWriter.GetMethodInstanceSignatureIndex(methodInstanceReference).GetHashCode());
         }
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/TypeSpecComparer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/TypeSpecComparer.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Cci
 
         public bool Equals(ITypeReference x, ITypeReference y)
         {
-            return x == y || _metadataWriter.GetTypeSpecSignatureIndex(x) == _metadataWriter.GetTypeSpecSignatureIndex(y);
+            return x == y || _metadataWriter.GetTypeSpecSignatureIndex(x).Equals(_metadataWriter.GetTypeSpecSignatureIndex(y));
         }
 
         public int GetHashCode(ITypeReference typeReference)
         {
-            return (int)_metadataWriter.GetTypeSpecSignatureIndex(typeReference);
+            return _metadataWriter.GetTypeSpecSignatureIndex(typeReference).GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Rather than building #Blob heap incrementally as blobs are encountered while metadata tables are being built just calculate their heap offsets and serialize the blobs later when the heaps are written into the metadata stream. 

This approach has a couple of benefits:
- The size of the heap can be precalculated as blobs are generated and the corresponding space can be reserved in the resulting stream (instead of expanding a writer buffer multiple times).
- We need to hold on the byte arrays during table serialization so that we can avoid emitting duplicates to the stream. We don't need to hold on essentially another copy of the same data during table serialization.