### PR TITLE
ReplaceSyntaxTree should throw on duplicate

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -709,7 +709,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref bool referenceDirectivesChanged)
         {
             var lazyRoot = new Lazy<RootSingleNamespaceDeclaration>(() => DeclarationTreeBuilder.ForTree(tree, options.ScriptClassName ?? "", isSubmission));
-            declMap = declMap.SetItem(tree, lazyRoot);
+            declMap = declMap.Add(tree, lazyRoot); // Callers are responsible for checking for existing entries.
             declTable = declTable.AddRootDeclaration(lazyRoot);
             referenceDirectivesChanged = referenceDirectivesChanged || tree.HasReferenceDirectives();
         }
@@ -829,6 +829,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var declMap = _rootNamespaces;
+
+            if (declMap.ContainsKey(newTree))
+            {
+                throw new ArgumentException(CSharpResources.SyntaxTreeAlreadyPresent, nameof(newTree));
+            }
+
             var declTable = _declarationTable;
             bool referenceDirectivesChanged = false;
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -452,6 +452,9 @@ class D
             // add again and verify that it throws
             Assert.Throws<ArgumentException>(() => comp.AddSyntaxTrees(t1));
 
+            // replace with existing and verify that it throws
+            Assert.Throws<ArgumentException>(() => comp.ReplaceSyntaxTree(t1, comp.SyntaxTrees[0]));
+
             // SyntaxTrees have reference equality. This removal should fail.
             Assert.Throws<ArgumentException>(() => comp = comp.RemoveSyntaxTrees(SyntaxFactory.ParseSyntaxTree(s1)));
             Assert.Equal(4, comp.SyntaxTrees.Length);
@@ -1656,12 +1659,6 @@ class C { }", options: TestOptions.Script);
 
             var ars = arc.ReplaceSyntaxTree(tc, ts);
             Assert.False(arc.ReferenceManagerEquals(ars));
-
-            var ar3 = arc.ReplaceSyntaxTree(tc, ta);
-            Assert.True(arc.ReferenceManagerEquals(ar3));
-
-            var as1 = ars.ReplaceSyntaxTree(tr, ts);
-            Assert.False(ars.ReferenceManagerEquals(as1));
         }
 
         private sealed class EvolvingTestReference : PortableExecutableReference

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -877,7 +877,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             )
 
             Dim entry = New DeclarationTableEntry(New Lazy(Of RootSingleNamespaceDeclaration)(Function() ForTree(tree, compilationOptions, isSubmission)), isEmbedded:=False)
-            declMap = declMap.Add(tree, entry)
+            declMap = declMap.Add(tree, entry) ' Callers are responsible for checking for existing entries.
             declTable = declTable.AddRootDeclaration(entry)
             referenceDirectivesChanged = referenceDirectivesChanged OrElse tree.HasReferenceDirectives
         End Sub
@@ -989,6 +989,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim declMap = _rootNamespaces
+
+            If declMap.ContainsKey(vbNewTree) Then
+                Throw New ArgumentException(VBResources.SyntaxTreeAlreadyPresent, NameOf(newTree))
+            End If
+
             Dim declTable = _declarationTable
             Dim referenceDirectivesChanged = False
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -423,6 +423,9 @@ End Namespace
             comp = comp.AddSyntaxTrees(t1).ReplaceSyntaxTree(t1, t1)
             Assert.Equal(3, comp.SyntaxTrees.Length)
 
+            ' Replace with existing and verify that it throws
+            Assert.Throws(Of ArgumentException)(Sub() comp.ReplaceSyntaxTree(t1, comp.SyntaxTrees(0)))
+
             Assert.Throws(Of ArgumentException)(Sub() comp.AddSyntaxTrees(t1))
 
             ' SyntaxTrees have reference equality. This removal should fail.


### PR DESCRIPTION
...as AddSyntaxTrees does.