### PR TITLE
Add instructions for building csc with CscCore

### DIFF
--- a/docs/compilers/Building for Core CLR.md
+++ b/docs/compilers/Building for Core CLR.md
@@ -1,0 +1,26 @@
+Building CoreCLR Csc & Vbc
+=================================================
+
+The compiler projects included in all the solution files currently target only
+the desktop framework. If you want to build a version of each exe compatible
+with CoreCLR, there are two separate projects:
+* [CscCore](../../src/Compilers/CSharp/CscCore/CscCore.csproj)
+* [VbcCore](../../src/Compilers/VisualBasic/VbcCore/VbcCore.csproj)
+
+To build these projects, first execute `powershell .nuget\NuGetRestore.ps1`
+from the root of your clone to restore NuGet packages, and then execute `msbuild`
+on the command line with the path to each of the projects. Note: do not open
+these projects in Visual Studio, as a bug in the DNX build tools will cause
+Visual Studio to hang (https://github.com/dotnet/buildtools/issues/191).
+
+When you build CscCore or VbcCore the binaries will be output to the core-clr
+subdirectory in the output directory. However, by default the executables will
+still run on the desktop runtime. To run on the CoreCLR console host, run the
+powershell script 
+[src/Tools/CopyCoreClrRuntime/CopyCoreClrRuntime.ps1](../../src/Tools/CopyCoreClrRuntime/CopyCoreClrRuntime.ps1) 
+with the path to the output directory as the parameter.
+
+If you then wish to build the csc project with the CoreCLR compiler, simply set
+the CscToolPath environment variable to the core-clr path on your machine and
+the CscToolExe variable to `csc.exe`. Finally, rebuild the csc -- this should
+build csc.exe with the CoreCLR-compatible csc.exe.

--- a/src/Compilers/CSharp/CscCore/CscCore.csproj
+++ b/src/Compilers/CSharp/CscCore/CscCore.csproj
@@ -50,6 +50,9 @@
     <Compile Include="..\..\Helpers\ConsoleUtil.cs">
       <Link>ConsoleUtil.cs</Link>
     </Compile>
+    <Compile Include="..\..\Helpers\NoOpAnalyzerAssemblyLoader.cs">
+      <Link>ConsoleUtil.cs</Link>
+    </Compile>
     <Compile Include="Csc.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/src/Compilers/CSharp/CscCore/Program.cs
+++ b/src/Compilers/CSharp/CscCore/Program.cs
@@ -12,6 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             => Csc.Run(args: args,
                        clientDirectory: AppContext.BaseDirectory,
                        sdkDirectory: @"C:\Windows\Microsoft.NET\Framework\v4.0.30319",
-                       analyzerLoader: null);
+                       analyzerLoader: new NoOpAnalyzerAssemblyLoader());
     }
 }

--- a/src/Compilers/Helpers/NoOpAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Helpers/NoOpAnalyzerAssemblyLoader.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Workaround for assembly loading in core clr -- this loader does nothing.
+    /// </summary>
+    internal sealed class NoOpAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+    {
+        public Assembly LoadFromPath(string fullPath) => null;
+
+        public void AddDependencyLocation(string fullPath) { }
+    }
+}

--- a/src/Compilers/VisualBasic/VbcCore/Program.cs
+++ b/src/Compilers/VisualBasic/VbcCore/Program.cs
@@ -12,6 +12,6 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             => Vbc.Run(args: args,
                        clientDirectory: AppContext.BaseDirectory,
                        sdkDirectory: @"C:\Windows\Microsoft.NET\Framework\v4.0.30319",
-                       analyzerLoader: null);
+                       analyzerLoader: new NoOpAnalyzerAssemblyLoader());
     }
 }

--- a/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
+++ b/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
@@ -50,6 +50,9 @@
     <Compile Include="..\..\Helpers\ConsoleUtil.cs">
       <Link>ConsoleUtil.cs</Link>
     </Compile>
+    <Compile Include="..\..\Helpers\NoOpAnalyzerAssemblyLoader.cs">
+      <Link>ConsoleUtil.cs</Link>
+    </Compile>
     <Compile Include="Vbc.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/src/Tools/CopyCoreClrRuntime/CopyCoreClrRuntime.ps1
+++ b/src/Tools/CopyCoreClrRuntime/CopyCoreClrRuntime.ps1
@@ -1,0 +1,31 @@
+param(
+    [Parameter(Mandatory=$true)]
+    $BinariesPath
+)
+
+$repoRoot = Resolve-Path "$PSScriptRoot\..\..\..\"
+$nugetDir = Resolve-Path "$repoRoot\.nuget"
+$packagesDir = Resolve-Path "$repoRoot\packages"
+
+& "$nugetDir\nuget.exe" restore "$PSScriptRoot\packages.config" `
+                        -PackagesDirectory $packagesDir `
+                        -ConfigFile "$nugetDir\NuGet.Config"
+
+$consoleHostPath = "$packagesDir\Microsoft.NETCore.Runtime.CoreCLR.ConsoleHost-x86.1.0.0-beta-22713\native\win\x86\CoreConsole.exe"
+
+function ReplaceExeWithConsoleHost([string]$exeName)
+{
+    $exePath = "$BinariesPath/$exeName"
+    $dllPath = [System.IO.Path]::ChangeExtension($exePath, "dll")
+    if (Test-Path "$exePath")
+    {
+        Move-Item -Force -Path $exePath -Destination "$dllPath"
+        Copy-Item -Path "$consoleHostPath" -Destination "$exePath"
+    }
+}
+
+ReplaceExeWithConsoleHost "csc.exe"
+ReplaceExeWithConsoleHost "vbc.exe"
+
+Copy-Item -Path "$packagesDir\Microsoft.NETCore.Runtime.CoreCLR-x86.1.0.0-beta-22713\lib\netcore50~windows\x86\*" `
+                -Destination "$BinariesPath"

--- a/src/Tools/CopyCoreClrRuntime/packages.config
+++ b/src/Tools/CopyCoreClrRuntime/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<packages>
+    <package id="Microsoft.NETCore.Runtime.CoreCLR-x86" version="1.0.0-beta-22713" />
+    <package id="Microsoft.NETCore.Runtime.CoreCLR.ConsoleHost-x86" version="1.0.0-beta-22713" />
+</packages>


### PR DESCRIPTION
CscCore is the CoreCLR-compatible version of csc.exe. This change
adds support for building csc with CscCore by adding a no-op step
for analyzer loading, adding a script to copy over the CoreCLR runtime,
and adding instructions for using both of these together.

@jaredpar 