### PR TITLE
Make TokenOfStringCached  independent of length

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -1468,9 +1468,9 @@ FullWidthRepeat:
             End If
         End Function
 
-        Private Function TokenOfStringCached(spelling As String, Optional kind As SyntaxKind = SyntaxKind.IdentifierToken) As SyntaxKind
+        Private Function TokenOfStringCached(spelling As String) As SyntaxKind
             If spelling.Length = 1 OrElse spelling.Length > 16 Then
-                Return kind
+                Return SyntaxKind.IdentifierToken
             End If
 
             Return _KeywordsObjs.GetOrMakeValue(spelling)

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlTokenFactories.vb
@@ -162,7 +162,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End Select
 
             If contextualKind = SyntaxKind.XmlNameToken Then
-                contextualKind = TokenOfStringCached(text, SyntaxKind.XmlNameToken)
+                contextualKind = TokenOfStringCached(text)
+                If contextualKind = SyntaxKind.IdentifierToken Then
+                    contextualKind = SyntaxKind.XmlNameToken
+                End If
             End If
 
             Dim followingTrivia = ScanXmlWhitespace()


### PR DESCRIPTION
For lengths that are not between 2 and 16 (inclusive) it immediately
returned its second argument.  For all other cases, it inspected the
string.  When the second argument was anything other than
SyntaxKind.Identifier (in particular, SyntaxKind.XmlNameToken), the
two values would not agree and so the output depended on the length
of the first (string) argument.

For example, passing ("a", SyntaxKind.XmlNameToken) used to return
SyntaxKind.XmlNameToken, but passing ("aa", SyntaxKind.XmlNameToken)
used to return SyntaxKind.IdentifierToken.  Now they both return
SyntaxKind.XmlNameToken (Edit: this isn't quite true - they both return
SyntaxKind.IdentifierToken, which is then mapped to XmlNameToken).

The only impact seems to be on parsing error recovery.  If this
turns out to make the behavior less desirable, then then we should
change the behavior so that *both* return SyntaxKind.IdentifierToken
(i.e. stop remapping the output).