### PR TITLE
VS crash during EnC around active statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -7410,7 +7410,7 @@ class C
         }
 
         [Fact]
-        public void MethodToAsyncMethod_WithActiveStatement()
+        public void MethodToAsyncMethod_WithActiveStatement1()
         {
             string src1 = @"
 class C
@@ -7437,11 +7437,68 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.AwaitExpression));
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.AwaitExpression),
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async Task<int> F()"));
         }
 
         [Fact]
-        public void MethodToAsyncMethod_WithActiveStatementInLambda()
+        public void MethodToAsyncMethod_WithActiveStatement2()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    <AS:0>{</AS:0>
+        Console.WriteLine(1);
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static async void F()
+    <AS:0>{</AS:0>
+        Console.WriteLine(1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async void F()"));
+        }
+
+        [Fact]
+        public void MethodToAsyncMethod_WithActiveStatement3()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        <AS:0>Console.WriteLine(1);</AS:0>
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static async void F()
+    {
+        <AS:0>Console.WriteLine(1);</AS:0>
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async void F()"));
+        }
+
+        [Fact]
+        public void MethodToAsyncMethod_WithActiveStatementInLambda1()
         {
             string src1 = @"
 class C
@@ -7471,7 +7528,67 @@ class C
         }
 
         [Fact]
-        public void MethodToAsyncMethod_WithoutActiveStatement()
+        public void MethodToAsyncMethod_WithActiveStatementInLambda_2()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        var f = new Action(() => { <AS:1>Console.WriteLine(1);</AS:1> });
+        <AS:0>f();</AS:0>
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static async void F()
+    {
+        var f = new Action(() => { <AS:1>Console.WriteLine(1);</AS:1> });
+        <AS:0>f();</AS:0>
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async void F()"));
+        }
+
+        [Fact]
+        public void MethodToAsyncMethod_WithLambda()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    <AS:0>{</AS:0>
+        var f = new Action(() => { Console.WriteLine(1); });
+        f();
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static async void F()
+    <AS:0>{</AS:0>
+        var f = new Action(() => { Console.WriteLine(1); });
+        f();
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async void F()"));
+        }
+
+        [Fact]
+        public void MethodToAsyncMethod_WithoutActiveStatement_1()
         {
             string src1 = @"
 class C
@@ -7490,6 +7607,33 @@ class C
     {
         Console.WriteLine(1);
         return await Task.FromResult(1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void MethodToAsyncMethod_WithoutActiveStatement_2()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        Console.WriteLine(1);
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static async void F()
+    {
+        Console.WriteLine(1);
     }
 }
 ";

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -6601,7 +6601,29 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.Delete, "=> F(1)", CSharpFeaturesResources.AwaitExpression));
+                Diagnostic(RudeEditKind.Delete, "=> F(1)", CSharpFeaturesResources.AwaitExpression),
+                Diagnostic(RudeEditKind.ModifiersUpdate, "static Task<int> F()", FeaturesResources.Method));
+        }
+
+        [Fact]
+        public void Await_Delete6()
+        {
+            var src1 = @"
+class C
+{
+    static async void F() => F();
+}
+";
+            var src2 = @"
+class C
+{
+    static void F() => F();
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
+                Diagnostic(RudeEditKind.ModifiersUpdate, "static void F()", "method"));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -2471,7 +2471,8 @@ class Test
 }";
             var edits = GetTopEdits(src1, src2);
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "await", CSharpFeaturesResources.AwaitExpression));
+                Diagnostic(RudeEditKind.Delete, "await", CSharpFeaturesResources.AwaitExpression),
+                Diagnostic(RudeEditKind.ModifiersUpdate, "public Task<int> WaitAsync()", "method"));
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.AwaitStatementUpdate,
                 RudeEditKind.InsertFile,
                 RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas,
+                RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement,
             };
 
             var arg2 = new HashSet<RudeEditKind>()

--- a/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -2346,6 +2346,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     newModifiers = newModifiers.RemoveAt(newAsyncIndex);
                 }
 
+                // 'async' keyword is allowed to add, but not to remove.
+                if (oldAsyncIndex >= 0 && newAsyncIndex < 0)
+                {
+                    return false;
+                }
+
                 return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers);
             }
 
@@ -3005,12 +3011,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         internal override void ReportOtherRudeEditsAroundActiveStatement(
             List<RudeEditDiagnostic> diagnostics,
             Match<SyntaxNode> match,
+            SyntaxNode oldBody,
+            SyntaxNode newBody,
             SyntaxNode oldActiveStatement,
             SyntaxNode newActiveStatement,
             bool isLeaf)
         {
             ReportRudeEditsForAncestorsDeclaringInterStatementTemps(diagnostics, match, oldActiveStatement, newActiveStatement, isLeaf);
             ReportRudeEditsForCheckedStatements(diagnostics, oldActiveStatement, newActiveStatement, isLeaf);
+            ReportRudeEditsForStateMachineMethod(diagnostics, oldBody, newBody, oldActiveStatement, newActiveStatement);
         }
 
         private void ReportRudeEditsForCheckedStatements(
@@ -3121,6 +3130,30 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
 
             return true;
+        }
+
+        private void ReportRudeEditsForStateMachineMethod(
+            List<RudeEditDiagnostic> diagnostics,
+            SyntaxNode oldBody,
+            SyntaxNode newBody,
+            SyntaxNode oldActiveStatement,
+            SyntaxNode newActiveStatement)
+        {
+            var isInLambdaBody = FindEnclosingLambdaBody(oldBody, oldActiveStatement);
+            if (isInLambdaBody != null)
+            {
+                return;
+            }
+
+            // It is allow to update a regular method to an async method or an iterator.
+            // The only restriction is a presence of an active statement in the method body
+            // since the debugger does not support remapping active statements to a different method.
+            if (!SyntaxUtilities.IsAsyncMethodOrLambda(oldBody.Parent) && SyntaxUtilities.IsAsyncMethodOrLambda(newBody.Parent))
+            {
+                diagnostics.Add(new RudeEditDiagnostic(
+                    RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement,
+                    GetDiagnosticSpan(newBody.Parent, EditKind.Update)));
+            }
         }
 
         #endregion

--- a/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal abstract void ReportSyntacticRudeEdits(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, Edit<SyntaxNode> edit, Dictionary<SyntaxNode, EditKind> editMap);
         internal abstract void ReportEnclosingExceptionHandlingRudeEdits(List<RudeEditDiagnostic> diagnostics, IEnumerable<Edit<SyntaxNode>> exceptionHandlingEdits, SyntaxNode oldStatement, SyntaxNode newStatement);
-        internal abstract void ReportOtherRudeEditsAroundActiveStatement(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode oldStatement, SyntaxNode newStatement, bool isLeaf);
+        internal abstract void ReportOtherRudeEditsAroundActiveStatement(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode oldBody, SyntaxNode newBody, SyntaxNode oldStatement, SyntaxNode newStatement, bool isLeaf);
         internal abstract void ReportMemberUpdateRudeEdits(List<RudeEditDiagnostic> diagnostics, SyntaxNode newMember, TextSpan? span);
         internal abstract void ReportInsertedMemberSymbolRudeEdits(List<RudeEditDiagnostic> diagnostics, ISymbol newSymbol);
         internal abstract void ReportStateMachineSuspensionPointRudeEdits(List<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode);
@@ -1062,7 +1062,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     }
 
                     // other statements around active statement:
-                    ReportOtherRudeEditsAroundActiveStatement(diagnostics, match, oldStatementSyntax, newStatementSyntax, isLeaf);
+                    ReportOtherRudeEditsAroundActiveStatement(diagnostics, match, oldBody, newBody, oldStatementSyntax, newStatementSyntax, isLeaf);
                 }
                 else if (match == null)
                 {

--- a/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.PartiallyExecutedActiveStatementUpdate,    FeaturesResources.UpdatingAnActiveStatement) },
             { GetDescriptorPair(RudeEditKind.PartiallyExecutedActiveStatementDelete,    FeaturesResources.AnActiveStatementHasBeenRemoved) },
             { GetDescriptorPair(RudeEditKind.InsertFile,                                FeaturesResources.AddingANewFile) },
+            { GetDescriptorPair(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, FeaturesResources.UpdatingStateMachineMethodAroundActive) },
 
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.ModifyingAWhichContainsComplexQuery) },
 

--- a/src/Features/Core/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/EditAndContinue/RudeEditKind.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertFile = 71,
         PartiallyExecutedActiveStatementUpdate = 72,
         PartiallyExecutedActiveStatementDelete = 73,
+        UpdatingStateMachineMethodAroundActiveStatement = 74,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,

--- a/src/Features/Core/FeaturesResources.Designer.cs
+++ b/src/Features/Core/FeaturesResources.Designer.cs
@@ -1980,6 +1980,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Updating async or iterator modifier around an active statement will prevent the debug session from continuing..
+        /// </summary>
+        internal static string UpdatingStateMachineMethodAroundActive {
+            get {
+                return ResourceManager.GetString("UpdatingStateMachineMethodAroundActive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Updating the alias of Declare Statement will prevent the debug session from continuing..
         /// </summary>
         internal static string UpdatingTheAliasOfDeclareStatement {

--- a/src/Features/Core/FeaturesResources.resx
+++ b/src/Features/Core/FeaturesResources.resx
@@ -519,6 +519,10 @@
   <data name="UpdatingAStatementAroundActive" xml:space="preserve">
     <value>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</value>
   </data>
+  <data name="UpdatingStateMachineMethodAroundActive" xml:space="preserve">
+    <value>Updating async or iterator modifier around an active statement will prevent the debug session from continuing.</value>
+    <comment>{Locked="async"}{Locked="iterator"} "async" and "iterator" are C#/VB keywords and should not be localized.</comment>
+  </data>    
   <data name="ModifyingAGenericMethodWillPrevent" xml:space="preserve">
     <value>Modifying a generic method will prevent the debug session from continuing.</value>
   </data>

--- a/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -3091,6 +3091,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Friend Overrides Sub ReportOtherRudeEditsAroundActiveStatement(diagnostics As List(Of RudeEditDiagnostic),
                                                                        match As Match(Of SyntaxNode),
+                                                                       oldBody As SyntaxNode,
+                                                                       newBody As SyntaxNode,
                                                                        oldActiveStatement As SyntaxNode,
                                                                        newActiveStatement As SyntaxNode,
                                                                        isLeaf As Boolean)


### PR DESCRIPTION
Fix #3894. Note that VB porting will be followed.