### PR TITLE
Filter IInteractiveWindowCommands on import...

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Interactive;
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Interactive;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
@@ -24,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
             HostServices hostServices,
             IViewClassifierAggregatorService classifierAggregator,
             IInteractiveWindowCommandsFactory commandsFactory,
-            IInteractiveWindowCommand[] commands,
+            ImmutableArray<IInteractiveWindowCommand> commands,
             IContentTypeRegistryService contentTypeRegistry,
             string responseFileDirectory,
             string initialWorkingDirectory)

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             HostServices hostServices,
             IViewClassifierAggregatorService classifierAggregator,
             IInteractiveWindowCommandsFactory commandsFactory,
-            IInteractiveWindowCommand[] commands,
+            ImmutableArray<IInteractiveWindowCommand> commands,
             string responseFilePath,
             string initialWorkingDirectory,
             string interactiveHostPath,
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             _classifierAggregator = classifierAggregator;
             _initialWorkingDirectory = initialWorkingDirectory;
             _commandsFactory = commandsFactory;
-            _commands = commands.ToImmutableArray();
+            _commands = commands;
 
             var hostPath = interactiveHostPath;
             _interactiveHost = new InteractiveHost(replType, hostPath, initialWorkingDirectory);

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoleAttribute.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoleAttribute.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         {
             if ((name != null) && name.Contains(","))
             {
+                // TODO: Needs localization...
                 throw new ArgumentException($"{nameof(InteractiveWindowRoleAttribute)} name cannot contain commas. Apply multiple attributes if you want to support multiple roles.", nameof(name));
             }
 

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoleAttribute.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoleAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Editor.Interactive
+{
+    // TODO: Make public and unify with Python Tools InteractiveWindowRoleAttribute.
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal class InteractiveWindowRoleAttribute : Attribute
+    {
+        public InteractiveWindowRoleAttribute(string name)
+        {
+            if ((name != null) && name.Contains(","))
+            {
+                throw new ArgumentException($"{nameof(InteractiveWindowRoleAttribute)} name cannot contain commas. Apply multiple attributes if you want to support multiple roles.", nameof(name));
+            }
+
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoles.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveWindowRoles.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Editor.Interactive
+{
+    internal static class InteractiveWindowRoles
+    {
+        public const string Any = null;
+    }
+}

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
         public override string Description
         {
             // TODO: Needs localization...
-            get { return "Clears the contents of the REPL editor window, leaving history and execution context intact."; }
+            get { return "Clears the contents of the editor window, leaving history and execution context intact."; }
         }
 
         public override IEnumerable<string> Names

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public override string Description
         {
+            // TODO: Needs localization...
             get { return "Clears the contents of the REPL editor window, leaving history and execution context intact."; }
         }
 

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
@@ -3,10 +3,14 @@
 using System.ComponentModel.Composition;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
-namespace Microsoft.VisualStudio.InteractiveWindow.Commands
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 {
     [Export(typeof(IInteractiveWindowCommand))]
+    [InteractiveWindowRole(InteractiveWindowRoles.Any)]
     internal sealed class ClearScreenCommand : InteractiveWindowCommand
     {
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ClearScreenCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public override IEnumerable<string> Names
         {
-            get { yield return "cls"; }
+            get { yield return "cls"; yield return "clear"; }
         }
     }
 }

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             // display help on a particular command:
             command = commands[name];
 
-            if (command == null && name.StartsWith(prefix, StringComparison.Ordinal))
+            if (command == null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 name = name.Substring(prefix.Length);
                 command = commands[name];

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
@@ -19,13 +19,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
         private static readonly string[] s_details = new[]
         {
             // TODO: Needs localization...
-            "  command-name    Name of the REPL command to display help on.",
+            "  command-name    Name of the command to display help on.",
         };
 
         public override string Description
         {
             // TODO: Needs localization...
-            get { return "Display help on specified REPL command, or all available REPL commands and key bindings if none specified."; }
+            get { return "Display help on specified command, or all available REPL commands and key bindings if none specified."; }
         }
 
         public override IEnumerable<string> Names
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             if (!ParseArguments(window, arguments, out commandName, out command))
             {
                 // TODO: Needs localization...
-                window.ErrorOutputWriter.WriteLine(string.Format("Unknown REPL command '{0}'", commandName));
+                window.ErrorOutputWriter.WriteLine(string.Format("Unknown command '{0}'", commandName));
                 ReportInvalidArguments(window);
                 return ExecutionResult.Failed;
             }

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
@@ -39,11 +39,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             get { return "[command-name]"; }
         }
 
-        public override IEnumerable<string> DetailedDescription
-        {
-            get { return base.DetailedDescription; }
-        }
-
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
         {
             string commandName;

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
+{
+    [Export(typeof(IInteractiveWindowCommand))]
+    [InteractiveWindowRole(InteractiveWindowRoles.Any)]
+    internal sealed class HelpReplCommand : InteractiveWindowCommand
+    {
+        internal const string CommandName = "help";
+
+        private static readonly string[] s_details = new[]
+        {
+            "  command-name    Name of the REPL command to display help on.",
+        };
+
+        public override string Description
+        {
+            get { return "Display help on specified REPL command, or all available REPL commands and key bindings if none specified."; }
+        }
+
+        public override IEnumerable<string> Names
+        {
+            get { yield return CommandName; }
+        }
+
+        public override string CommandLine
+        {
+            get { return "[command-name]"; }
+        }
+
+        public override IEnumerable<string> DetailedDescription
+        {
+            get { return base.DetailedDescription; }
+        }
+
+        public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
+        {
+            string commandName;
+            IInteractiveWindowCommand command;
+            if (!ParseArguments(window, arguments, out commandName, out command))
+            {
+                window.ErrorOutputWriter.WriteLine(string.Format("Unknown REPL command '{0}'", commandName));
+                ReportInvalidArguments(window);
+                return ExecutionResult.Failed;
+            }
+
+            var commands = (IInteractiveWindowCommands)window.Properties[typeof(IInteractiveWindowCommands)];
+            if (command != null)
+            {
+                commands.DisplayCommandHelp(command);
+            }
+            else
+            {
+                commands.DisplayHelp();
+            }
+
+            return ExecutionResult.Succeeded;
+        }
+
+        private static readonly char[] s_whitespaceChars = new[] { '\r', '\n', ' ', '\t' };
+
+        private bool ParseArguments(IInteractiveWindow window, string arguments, out string commandName, out IInteractiveWindowCommand command)
+        {
+            string name = arguments.Split(s_whitespaceChars)[0];
+
+            if (name.Length == 0)
+            {
+                command = null;
+                commandName = null;
+                return true;
+            }
+
+            var commands = window.GetInteractiveCommands();
+            string prefix = commands.CommandPrefix;
+
+            // display help on a particular command:
+            command = commands[name];
+
+            if (command == null && name.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                name = name.Substring(prefix.Length);
+                command = commands[name];
+            }
+
+            commandName = name;
+            return command != null;
+        }
+    }
+}

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/HelpCommand.cs
@@ -18,11 +18,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         private static readonly string[] s_details = new[]
         {
+            // TODO: Needs localization...
             "  command-name    Name of the REPL command to display help on.",
         };
 
         public override string Description
         {
+            // TODO: Needs localization...
             get { return "Display help on specified REPL command, or all available REPL commands and key bindings if none specified."; }
         }
 
@@ -33,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public override string CommandLine
         {
+            // TODO: Needs localization...
             get { return "[command-name]"; }
         }
 
@@ -47,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             IInteractiveWindowCommand command;
             if (!ParseArguments(window, arguments, out commandName, out command))
             {
+                // TODO: Needs localization...
                 window.ErrorOutputWriter.WriteLine(string.Format("Unknown REPL command '{0}'", commandName));
                 ReportInvalidArguments(window);
                 return ExecutionResult.Failed;

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/InteractiveWindowCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/InteractiveWindowCommand.cs
@@ -17,15 +17,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
     /// </summary>
     internal abstract class InteractiveWindowCommand : IInteractiveWindowCommand
     {
+        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
+
+        public abstract string Description { get; }
+
+        public abstract IEnumerable<string> Names { get; }
+
         public virtual IEnumerable<ClassificationSpan> ClassifyArguments(ITextSnapshot snapshot, Span argumentsSpan, Span spanToClassify)
         {
             return Enumerable.Empty<ClassificationSpan>();
         }
 
-        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
-        public abstract string Description { get; }
-
-        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
+        public virtual string CommandLine
         {
             get { return null; }
         }
@@ -35,12 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             get { return null; }
         }
 
-        public virtual string CommandLine
-        {
-            get { return null; }
-        }
-
-        public virtual IEnumerable<string> Names
+        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
         {
             get { return null; }
         }

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/InteractiveWindowCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/InteractiveWindowCommand.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
+{
+    /// <summary>
+    /// Represents a command which can be run from a REPL window.
+    /// 
+    /// This interface is a MEF contract and can be implemented and exported to add commands to the REPL window.
+    /// </summary>
+    internal abstract class InteractiveWindowCommand : IInteractiveWindowCommand
+    {
+        public virtual IEnumerable<ClassificationSpan> ClassifyArguments(ITextSnapshot snapshot, Span argumentsSpan, Span spanToClassify)
+        {
+            return Enumerable.Empty<ClassificationSpan>();
+        }
+
+        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
+        public abstract string Description { get; }
+
+        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
+        {
+            get { return null; }
+        }
+
+        public virtual IEnumerable<string> DetailedDescription
+        {
+            get { return null; }
+        }
+
+        public virtual string CommandLine
+        {
+            get { return null; }
+        }
+
+        public virtual IEnumerable<string> Names
+        {
+            get { return null; }
+        }
+
+        protected void ReportInvalidArguments(IInteractiveWindow window)
+        {
+            var commands = (IInteractiveWindowCommands)window.Properties[typeof(IInteractiveWindowCommands)];
+            commands.DisplayCommandUsage(this, window.ErrorOutputWriter, displayDetails: false);
+        }
+    }
+}

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.InteractiveWindow.Commands;
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 {
     [Export(typeof(IInteractiveWindowCommand))]
+    [InteractiveWindowRole(InteractiveWindowRoles.Any)]
     internal sealed class LoadCommand : IInteractiveWindowCommand
     {
         private const string CommandName = "load";

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public string Description
         {
+            // TODO: Needs localization...
             get { return "Executes the specified file within the current interactive session."; }
         }
 

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
@@ -5,13 +5,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Interactive;
 using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
-namespace Microsoft.VisualStudio.InteractiveWindow.Commands
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 {
     [Export(typeof(IInteractiveWindowCommand))]
+    [InteractiveWindowRole(InteractiveWindowRoles.Any)]
     internal sealed class ResetCommand : InteractiveWindowCommand
     {
         private const string CommandName = "reset";
@@ -60,7 +64,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
                 return ExecutionResult.Failed;
             }
 
-            return ((InteractiveWindow)window).ResetAsync(init.Value);
+            return window.Operations.ResetAsync(init.Value);
         }
 
         internal static string BuildCommandLine(bool initialize)

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public override string Description
         {
+            // TODO: Needs localization...
             get { return "Reset the execution environment to the initial state, keep REPL history."; }
         }
 
@@ -49,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             {
                 return new ReadOnlyCollection<KeyValuePair<string, string>>(new[]
                 {
+                    // TODO: Needs localization...
                     new KeyValuePair<string, string>(NoConfigParameterName, "Reset to a clean environment (only mscorlib referenced), do not run initialization script.")
                 });
             }

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
         public override string Description
         {
             // TODO: Needs localization...
-            get { return "Reset the execution environment to the initial state, keep REPL history."; }
+            get { return "Reset the execution environment to the initial state, keep history."; }
         }
 
         public override IEnumerable<string> Names

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/ResetCommand.cs
@@ -48,11 +48,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
         {
             get
             {
-                return new ReadOnlyCollection<KeyValuePair<string, string>>(new[]
-                {
-                    // TODO: Needs localization...
-                    new KeyValuePair<string, string>(NoConfigParameterName, "Reset to a clean environment (only mscorlib referenced), do not run initialization script.")
-                });
+                // TODO: Needs localization...
+                yield return new KeyValuePair<string, string>(NoConfigParameterName, "Reset to a clean environment (only mscorlib referenced), do not run initialization script.");
             }
         }
 

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
@@ -63,15 +63,29 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -117,6 +131,7 @@
     <InternalsVisibleTo Include="Roslyn.CSharp.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Roslyn.VisualBasic.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.CSharp.Repl" />
+    <InternalsVisibleTo Include="Roslyn.VisualStudio.InteractiveServices" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.VisualBasic.Repl" />
     <!-- The rest are for test purposes only. -->
     <InternalsVisibleToTest Include="Roslyn.Hosting.Diagnostics" />
@@ -139,8 +154,14 @@
     <Compile Include="Extensibility\Interactive\InteractiveEvaluator.cs" />
     <Compile Include="Extensibility\Interactive\InteractiveMetadataReferenceResolver.cs" />
     <Compile Include="Implementation\Completion\Presentation\CompletionPresenter.cs" />
+    <Compile Include="Implementation\Interactive\Commands\ClearScreenCommand.cs" />
     <Compile Include="Implementation\Interactive\Commands\CommandArgumentsParser.cs" />
+    <Compile Include="Implementation\Interactive\Commands\HelpCommand.cs" />
+    <Compile Include="Implementation\Interactive\Commands\InteractiveWindowCommand.cs" />
+    <Compile Include="Extensibility\Interactive\InteractiveWindowRoleAttribute.cs" />
+    <Compile Include="Extensibility\Interactive\InteractiveWindowRoles.cs" />
     <Compile Include="Implementation\Interactive\Commands\LoadCommand.cs" />
+    <Compile Include="Implementation\Interactive\Commands\ResetCommand.cs" />
     <Compile Include="Implementation\Interactive\InertClassifierProvider.cs" />
     <Compile Include="Implementation\Interactive\InertClassifierProvider.InertClassifier.cs" />
     <Compile Include="Implementation\Interactive\InteractiveCommandContentTypeLanguageService.cs" />

--- a/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
+++ b/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
@@ -1,12 +1,12 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.IO
 Imports Microsoft.CodeAnalysis.Editor.Interactive
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Interactive
 Imports Microsoft.VisualStudio.Text.Classification
 Imports Microsoft.VisualStudio.Utilities
-Imports Microsoft.VisualStudio.InteractiveWindow
 Imports Microsoft.VisualStudio.InteractiveWindow.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
         Public Sub New(hostServices As HostServices,
                        classifierAggregator As IViewClassifierAggregatorService,
                        commandsFactory As IInteractiveWindowCommandsFactory,
-                       commands As IInteractiveWindowCommand(),
+                       commands As ImmutableArray(Of IInteractiveWindowCommand),
                        contentTypeRegistry As IContentTypeRegistryService,
                        responseFileDirectory As String,
                        initialWorkingDirectory As String)

--- a/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
@@ -32,11 +32,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             get { return "[command-name]"; }
         }
 
-        public override IEnumerable<string> DetailedDescription
-        {
-            get { return base.DetailedDescription; }
-        }
-
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
         {
             string commandName;

--- a/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             // display help on a particular command:
             command = commands[name];
 
-            if (command == null && name.StartsWith(prefix, StringComparison.Ordinal))
+            if (command == null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 name = name.Substring(prefix.Length);
                 command = commands[name];

--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 
@@ -16,15 +15,18 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
     /// </summary>
     internal abstract class InteractiveWindowCommand : IInteractiveWindowCommand
     {
+        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
+
+        public abstract string Description { get; }
+
+        public abstract IEnumerable<string> Names { get; }
+
         public virtual IEnumerable<ClassificationSpan> ClassifyArguments(ITextSnapshot snapshot, Span argumentsSpan, Span spanToClassify)
         {
             return Enumerable.Empty<ClassificationSpan>();
         }
 
-        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
-        public abstract string Description { get; }
-
-        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
+        public virtual string CommandLine
         {
             get { return null; }
         }
@@ -34,12 +36,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             get { return null; }
         }
 
-        public virtual string CommandLine
-        {
-            get { return null; }
-        }
-
-        public virtual IEnumerable<string> Names
+        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
         {
             get { return null; }
         }

--- a/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         public override string Description
         {
-            get { return "Reset the execution environment to the initial state, keep REPL history."; }
+            get { return "Reset the execution environment to the initial state, keep history."; }
         }
 
         public override IEnumerable<string> Names
@@ -43,10 +43,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
         {
             get
             {
-                return new ReadOnlyCollection<KeyValuePair<string, string>>(new[]
-                {
-                    new KeyValuePair<string, string>(NoConfigParameterName, "Reset to a clean environment (only mscorlib referenced), do not run initialization script.")
-                });
+                yield return new KeyValuePair<string, string>(NoConfigParameterName, "Reset to a clean environment (only mscorlib referenced), do not run initialization script.");
             }
         }
 

--- a/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
@@ -50,14 +50,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
         {
             int noConfigStart, noConfigEnd;
-            bool? init = ParseArguments(arguments, out noConfigStart, out noConfigEnd);
-            if (init == null)
+            if (!TryParseArguments(arguments, out noConfigStart, out noConfigEnd))
             {
                 ReportInvalidArguments(window);
                 return ExecutionResult.Failed;
             }
 
-            return ((InteractiveWindow)window).ResetAsync(init.Value);
+            return ((InteractiveWindow)window).ResetAsync(initialize: noConfigStart > -1);
         }
 
         internal static string BuildCommandLine(bool initialize)
@@ -71,15 +70,16 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             string arguments = snapshot.GetText(argumentsSpan);
 
             int noConfigStart, noConfigEnd;
-            bool? init = ParseArguments(arguments, out noConfigStart, out noConfigEnd);
-
-            if (noConfigStart >= 0)
+            if (TryParseArguments(arguments, out noConfigStart, out noConfigEnd))
             {
-                yield return new ClassificationSpan(new SnapshotSpan(snapshot, Span.FromBounds(argumentsSpan.Start + noConfigStart, argumentsSpan.Start + noConfigEnd)), _registry.Keyword);
+                if (noConfigStart > -1)
+                {
+                    yield return new ClassificationSpan(new SnapshotSpan(snapshot, Span.FromBounds(argumentsSpan.Start + noConfigStart, argumentsSpan.Start + noConfigEnd)), _registry.Keyword);
+                }
             }
         }
 
-        private static bool? ParseArguments(string arguments, out int noConfigStart, out int noConfigEnd)
+        private static bool TryParseArguments(string arguments, out int noConfigStart, out int noConfigEnd)
         {
             noConfigStart = noConfigEnd = -1;
 
@@ -93,10 +93,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             {
                 noConfigStart = arguments.IndexOf(noconfig, StringComparison.OrdinalIgnoreCase);
                 noConfigEnd = noConfigStart + noconfig.Length;
-                return false;
+                return true;
             }
 
-            return null;
+            return false;
         }
     }
 }

--- a/src/InteractiveWindow/Editor/InteractiveWindow.csproj
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.csproj
@@ -25,30 +25,14 @@
     <InternalsVisibleToTest Include="Roslyn.InteractiveWindow.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Editor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/src/InteractiveWindow/Editor/InteractiveWindow.csproj
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.csproj
@@ -25,14 +25,30 @@
     <InternalsVisibleToTest Include="Roslyn.InteractiveWindow.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Editor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
+++ b/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
@@ -92,6 +92,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
@@ -108,8 +108,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         private static ImmutableArray<IInteractiveWindowCommand> FilterCommands(IInteractiveWindowCommand[] commands, string supportedRole)
         {
             return commands.Where(
-                c => c.GetType().GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), inherit: true).Where(
-                    a => ((InteractiveWindowRoleAttribute)a).Name == supportedRole).Any()).ToImmutableArray();
+                c => c.GetType().GetCustomAttributes(typeof(InteractiveWindowRoleAttribute), inherit: true).Any(
+                    a => ((InteractiveWindowRoleAttribute)a).Name == supportedRole)).ToImmutableArray();
         }
     }
 }


### PR DESCRIPTION
We need to distinguish commands exported by the C#/VB Repl and other Repls
using the same InteractiveWindow component (i.e. Python Tools).
Otherwise, commands with duplicate names may be imported (causing an
Exception when we attempt to initialize the InteractiveWindow).

Unfortunately, there is no *good* way to distinguish the "core" commands
exported by the InteractiveWindow (clear, help, reset) and many of the
commands exported by Python Tools (some have an attribute, but others do
not).  In order to continue working on top of VS2015 RTM, we'll duplicate
all the commands that we care about and mark them with an attribute.

The implementation of the InteractiveWindowRoleAttribute may be a bit
over-engineered for what we *need* right now, but it has the benefits of:

- Allowing for different commands to apply to a design-time vs a
  debug-time Repl, etc...
- Being very close to what Python Tools already does, so it should be easy
  to make this attribute public and unify our code...

Until our scenarios are a bit more concrete, however, we'll just define
the "Any" role.