### PR TITLE
Filter IInteractiveWindowCommands on import...

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Interactive;
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Interactive;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
@@ -24,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
             HostServices hostServices,
             IViewClassifierAggregatorService classifierAggregator,
             IInteractiveWindowCommandsFactory commandsFactory,
-            IInteractiveWindowCommand[] commands,
+            ImmutableArray<IInteractiveWindowCommand> commands,
             IContentTypeRegistryService contentTypeRegistry,
             string responseFileDirectory,
             string initialWorkingDirectory)

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             HostServices hostServices,
             IViewClassifierAggregatorService classifierAggregator,
             IInteractiveWindowCommandsFactory commandsFactory,
-            IInteractiveWindowCommand[] commands,
+            ImmutableArray<IInteractiveWindowCommand> commands,
             string responseFilePath,
             string initialWorkingDirectory,
             string interactiveHostPath,
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             _classifierAggregator = classifierAggregator;
             _initialWorkingDirectory = initialWorkingDirectory;
             _commandsFactory = commandsFactory;
-            _commands = commands.ToImmutableArray();
+            _commands = commands;
 
             var hostPath = interactiveHostPath;
             _interactiveHost = new InteractiveHost(replType, hostPath, initialWorkingDirectory);

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/Commands/LoadCommand.cs
@@ -9,10 +9,12 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 {
     [Export(typeof(IInteractiveWindowCommand))]
+    [ContentType("code")]
     internal sealed class LoadCommand : IInteractiveWindowCommand
     {
         private const string CommandName = "load";
@@ -36,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 
         public string Description
         {
+            // TODO: Needs localization...
             get { return "Executes the specified file within the current interactive session."; }
         }
 

--- a/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
+++ b/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
@@ -1,12 +1,12 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.IO
 Imports Microsoft.CodeAnalysis.Editor.Interactive
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Interactive
 Imports Microsoft.VisualStudio.Text.Classification
 Imports Microsoft.VisualStudio.Utilities
-Imports Microsoft.VisualStudio.InteractiveWindow
 Imports Microsoft.VisualStudio.InteractiveWindow.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
         Public Sub New(hostServices As HostServices,
                        classifierAggregator As IViewClassifierAggregatorService,
                        commandsFactory As IInteractiveWindowCommandsFactory,
-                       commands As IInteractiveWindowCommand(),
+                       commands As ImmutableArray(Of IInteractiveWindowCommand),
                        contentTypeRegistry As IContentTypeRegistryService,
                        responseFileDirectory As String,
                        initialWorkingDirectory As String)

--- a/src/InteractiveWindow/Editor/Commands/ClearScreenCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/ClearScreenCommand.cs
@@ -2,10 +2,7 @@
 
 using System.ComponentModel.Composition;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
 
 namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 {
@@ -20,12 +17,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         public override string Description
         {
-            get { return "Clears the contents of the REPL editor window, leaving history and execution context intact."; }
+            // TODO: Needs localization...
+            get { return "Clears the contents of the editor window, leaving history and execution context intact."; }
         }
 
         public override IEnumerable<string> Names
         {
-            get { yield return "cls"; }
+            get { yield return "cls"; yield return "clear"; }
         }
     }
 }

--- a/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/HelpCommand.cs
@@ -14,12 +14,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         private static readonly string[] s_details = new[]
         {
-            "  command-name    Name of the REPL command to display help on.",
+            // TODO: Needs localization...
+            "  command-name    Name of the command to display help on.",
         };
 
         public override string Description
         {
-            get { return "Display help on specified REPL command, or all available REPL commands and key bindings if none specified."; }
+            // TODO: Needs localization...
+            get { return "Display help on specified command, or all available commands and key bindings if none specified."; }
         }
 
         public override IEnumerable<string> Names
@@ -29,12 +31,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         public override string CommandLine
         {
+            // TODO: Needs localization...
             get { return "[command-name]"; }
-        }
-
-        public override IEnumerable<string> DetailedDescription
-        {
-            get { return base.DetailedDescription; }
         }
 
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
@@ -43,7 +41,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             IInteractiveWindowCommand command;
             if (!ParseArguments(window, arguments, out commandName, out command))
             {
-                window.ErrorOutputWriter.WriteLine(string.Format("Unknown REPL command '{0}'", commandName));
+                // TODO: Needs localization...
+                window.ErrorOutputWriter.WriteLine(string.Format("Unknown command '{0}'", commandName));
                 ReportInvalidArguments(window);
                 return ExecutionResult.Failed;
             }
@@ -80,7 +79,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             // display help on a particular command:
             command = commands[name];
 
-            if (command == null && name.StartsWith(prefix, StringComparison.Ordinal))
+            if (command == null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 name = name.Substring(prefix.Length);
                 command = commands[name];

--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
@@ -3,9 +3,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 {
@@ -14,17 +14,21 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
     /// 
     /// This interface is a MEF contract and can be implemented and exported to add commands to the REPL window.
     /// </summary>
+    [ContentType("code")]
     internal abstract class InteractiveWindowCommand : IInteractiveWindowCommand
     {
+        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
+
+        public abstract string Description { get; }
+
+        public abstract IEnumerable<string> Names { get; }
+
         public virtual IEnumerable<ClassificationSpan> ClassifyArguments(ITextSnapshot snapshot, Span argumentsSpan, Span spanToClassify)
         {
             return Enumerable.Empty<ClassificationSpan>();
         }
 
-        public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);
-        public abstract string Description { get; }
-
-        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
+        public virtual string CommandLine
         {
             get { return null; }
         }
@@ -34,12 +38,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             get { return null; }
         }
 
-        public virtual string CommandLine
-        {
-            get { return null; }
-        }
-
-        public virtual IEnumerable<string> Names
+        public virtual IEnumerable<KeyValuePair<string, string>> ParametersDescription
         {
             get { return null; }
         }

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -166,7 +166,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             var commands = interactiveCommands.GetCommands();
 
             Assert.NotEmpty(commands);
-            Assert.NotNull(commands.Where(n => n.Names.First() == "cls").SingleOrDefault());
+            Assert.Equal(2, commands.Where(n => n.Names.First() == "cls").Count());
+            Assert.Equal(2, commands.Where(n => n.Names.Last() == "clear").Count());
             Assert.NotNull(commands.Where(n => n.Names.First() == "help").SingleOrDefault());
             Assert.NotNull(commands.Where(n => n.Names.First() == "reset").SingleOrDefault());
         }

--- a/src/InteractiveWindow/Version.props
+++ b/src/InteractiveWindow/Version.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion>1.0.0</RoslynSemanticVersion>
+    <RoslynSemanticVersion>1.1.0</RoslynSemanticVersion>
   </PropertyGroup>
 </Project>

--- a/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
+++ b/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
@@ -92,6 +92,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Interactive;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.VisualStudio.InteractiveWindow.Shell;
 
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         private readonly IViewClassifierAggregatorService _classifierAggregator;
         private readonly IContentTypeRegistryService _contentTypeRegistry;
         private readonly IInteractiveWindowCommandsFactory _commandsFactory;
-        private readonly IInteractiveWindowCommand[] _commands;
+        private readonly ImmutableArray<IInteractiveWindowCommand> _commands;
 
         // TODO: support multi-instance windows
         // single instance of the Interactive Window
@@ -39,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             _classifierAggregator = classifierAggregator;
             _contentTypeRegistry = contentTypeRegistry;
             _vsWorkspace = workspace;
-            _commands = commands;
+            _commands = FilterCommands(commands, contentType: "code");
             _vsInteractiveWindowFactory = interactiveWindowFactory;
             _commandsFactory = commandsFactory;
         }
@@ -62,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             }
         }
 
-        protected IInteractiveWindowCommand[] Commands
+        protected ImmutableArray<IInteractiveWindowCommand> Commands
         {
             get
             {
@@ -102,6 +103,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             _vsInteractiveWindow.Show(focus);
 
             return _vsInteractiveWindow;
+        }
+
+        private static ImmutableArray<IInteractiveWindowCommand> FilterCommands(IInteractiveWindowCommand[] commands, string contentType)
+        {
+            return commands.Where(
+                c => c.GetType().GetCustomAttributes(typeof(ContentTypeAttribute), inherit: true).Any(
+                    a => ((ContentTypeAttribute)a).ContentTypes == contentType)).ToImmutableArray();
         }
     }
 }

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -170,8 +170,6 @@ using Microsoft.VisualStudio.Shell;
     PublicKeyToken = "b03f5f7f11d50a3a",
     GenerateCodeBase = false)]
 
-#if !OFFICIAL_BUILD
-
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.InteractiveWindow",
     OldVersionLowerBound = Constants.OldVersionLowerBound,
@@ -187,8 +185,6 @@ using Microsoft.VisualStudio.Shell;
     NewVersion = Constants.NewVersion,
     PublicKeyToken = Constants.PublicKeyToken,
     GenerateCodeBase = false)]
-
-#endif
 
 internal class Constants
 {


### PR DESCRIPTION
We need to distinguish commands we want to import in the C#/VB Repl from
those exported by other Repls using the same InteractiveWindow component
(i.e. Python Tools).  Otherwise, commands with duplicate names may be
imported (causing an Exception when initializing the InteractiveWindow).

Unfortunately, there was previously no *good* way to distinguish the
"core" commands exported by the InteractiveWindow (clear, help, reset) and
many of the commands exported by Python Tools (some have an attribute, but
others do not).

This change adds [ContentType("code")] to all the commands that the C#/VB
Repl wants to import.

In as subsequent change, we will cease to export #load as a Repl command
and instead implement it as a language directive (so it will not conflict
with $load in Python).

Notes:
- Changes rev Microsoft.VisualStudio.InteractiveWindow to 1.1.0.0 and add
  a binding redirect for VS
- Changes include minor cleanup of the "core" command implementations