### PR TITLE
don't escape method names in signature help tool tips

### DIFF
--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
@@ -82,6 +82,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
             Dim format = MinimallyQualifiedWithoutParametersFormat
             format = format.RemoveMemberOptions(SymbolDisplayMemberOptions.IncludeType Or SymbolDisplayMemberOptions.IncludeContainingType)
             format = format.RemoveKindOptions(SymbolDisplayKindOptions.IncludeMemberKeyword)
+            format = format.WithMiscellaneousOptions(format.MiscellaneousOptions And (Not SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers))
 
             result.AddRange(symbol.ToMinimalDisplayParts(semanticModel, position, format))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -1835,5 +1835,19 @@ End Class
 
             Test(markup, expectedOrderedItems)
         End Sub
+
+        <WorkItem(3537, "https://github.com/dotnet/roslyn/issues/3537")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Sub TestEscapedIdentifiers()
+            Dim markup = "
+Class C
+    Sub [Next]()
+        Dim x As New C
+        x.Next($$)
+    End Sub
+End Class
+"
+            Test(markup, SpecializedCollections.SingletonEnumerable(New SignatureHelpTestItem("C.Next()", String.Empty)))
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
This change brings the argument-completion tool tip in line with quick info in not escaping special identifier names.  E.g., for the following code, the tooltip for the invocation on the indicated line should display as `C.Next()` instead of `C.[Next]()`.

``` VB
Class C
    Sub [Next]()
        Dim x As New C
        x.Next() ' bug is on this line
    End Sub
End Class
```

Fixes #3537.

Tagging @Pilchie @dpoeschl @jasonmalinowski @rchande  @DustinCampbell @balajikris @basoundr @jmarolf @davkean for review.