### PR TITLE
Test for structs in using in async method

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -3288,6 +3288,43 @@ class Test
             sequencePoints: "Test+<F>d__2.MoveNext");
         }
 
+        [Fact]
+        public void MutatingStructWithUsing()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+class Program
+{
+    public static void Main()
+    {
+        (new Program()).Test().Wait();
+    }
+
+    public async Task Test()
+    {
+        var list = new List<int> {1, 2, 3};
+
+        using (var enumerator = list.GetEnumerator()) 
+        {
+            Console.WriteLine(enumerator.MoveNext());
+            Console.WriteLine(enumerator.Current);
+
+            await Task.Delay(1);
+        }
+    }
+}";
+
+            var expectedOutput = @"True
+1";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput);
+        }
+
         [Fact, WorkItem(1942, "https://github.com/dotnet/roslyn/issues/1942")]
         public void HoistStructure()
         {


### PR DESCRIPTION
This issue was reported through the following stackoverflow post:

>
http://stackoverflow.com/questions/29230626/why-is-enumerator-movenext-not-working-as-i-expect-it-when-used-with-using-and-a

The Roslyn compiler fixed a bug present in the native compiler around
the use of structs inside a using inside an async method.  The native
compiler was generating some of the method calls on a copy of the struct
which caused  the mutation to be ignored.   Roslyn correctly generates
them all on the lifted value.

Looking around I couldn't find a specific regression test for this
functionality so adding one.