### PR TITLE
Check DkmClrAppDomain.IsUnloaded...

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -31,7 +31,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var appDomainId = appDomain.Id;
             return runtime.GetModuleInstances().
                 Cast<DkmClrModuleInstance>().
-                Where(module => module.AppDomain.Id == appDomainId);
+                Where(module =>
+                {
+                    var moduleAppDomain = module.AppDomain;
+                    return !moduleAppDomain.IsUnloaded && (moduleAppDomain.Id == appDomainId);
+                });
         }
 
         internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)


### PR DESCRIPTION
Telemetry indicates that we're getting an ObjectDisposedException when calling module.AppDomain.Id.  When we enumerate all the modules in the DkmClrRuntimeInstance, we shouldn't be considering modules that were loaded in AppDomains that have been unloaded.
```
System.ObjectDisposedException
   at Microsoft.VisualStudio.Debugger.Clr.DkmClrAppDomain.get_Id()
   at Microsoft.CodeAnalysis.ExpressionEvaluator.DkmUtilities.<>c__DisplayClass2_0.<GetModulesInAppDomain>b__0(DkmClrModuleInstance module)
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at Microsoft.CodeAnalysis.ExpressionEvaluator.DkmUtilities.GetMetadataBlocks(DkmClrRuntimeInstance runtime; DkmClrAppDomain appDomain)
   at Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.CSharpInstructionDecoder.GetCompilation(DkmClrModuleInstance moduleInstance)
   at Microsoft.CodeAnalysis.ExpressionEvaluator.FrameDecoder`5.GetNameWithGenericTypeArguments(DkmInspectionContext inspectionContext; DkmWorkList workList; DkmStackWalkFrame frame; Action`1 onSuccess; Action`1 onFailure)
   at Microsoft.CodeAnalysis.ExpressionEvaluator.FrameDecoder`5.Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmLanguageFrameDecoder.GetFrameName(DkmInspectionContext inspectionContext; DkmWorkList workList; DkmStackWalkFrame frame; DkmVari...

```