### PR TITLE
Local functions update: By-ref struct closures

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -79,7 +80,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var lambdaFrame = local.Type.OriginalDefinition as LambdaFrame;
                 if ((object)lambdaFrame != null)
                 {
-                    return lambdaFrame.ConstructIfGeneric(frame.TypeArgumentsNoUseSiteDiagnostics);
+                    // lambdaFrame may have less generic type parameters than frame, so trim them down (the first N will always match)
+                    var typeArguments = frame.TypeArgumentsNoUseSiteDiagnostics;
+                    if (typeArguments.Length > lambdaFrame.Arity)
+                    {
+                        typeArguments = ImmutableArray.Create(typeArguments, 0, lambdaFrame.Arity);
+                    }
+                    return lambdaFrame.ConstructIfGeneric(typeArguments);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -252,31 +252,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// Finds all generic methods and forces them to be classes. TODO: We should be able to handle this, but for this prototype it's too complicated.
-            /// </summary>
-            private void MarkGenericMethodsAsClass()
-            {
-                foreach (var scope in this.LambdaScopes)
-                {
-                    var isGeneric = false;
-                    var method = scope.Key;
-                    while (method != null && !isGeneric)
-                    {
-                        isGeneric = method.Arity != 0;
-                        method = method.ContainingSymbol as MethodSymbol;
-                    }
-                    if (isGeneric)
-                    {
-                        var node = scope.Value;
-                        do
-                        {
-                            ScopesThatCantBeStructs.Add(node);
-                        } while (this.ScopeParent.TryGetValue(node, out node));
-                    }
-                }
-            }
-
-            /// <summary>
             /// Create the optimized plan for the location of lambda methods and whether scopes need access to parent scopes
             ///  </summary>
             internal void ComputeLambdaScopesAndFrameCaptures()
@@ -357,8 +332,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-
-                MarkGenericMethodsAsClass();
             }
 
             /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -71,9 +71,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // A mapping from every local function to its lowered method
         private struct MappedLocalFunction
         {
-            public readonly MethodSymbol Symbol;
+            public readonly SynthesizedLambdaMethod Symbol;
             public readonly ClosureKind ClosureKind;
-            public MappedLocalFunction(MethodSymbol symbol, ClosureKind closureKind)
+            public MappedLocalFunction(SynthesizedLambdaMethod symbol, ClosureKind closureKind)
             {
                 Symbol = symbol;
                 ClosureKind = closureKind;
@@ -449,6 +449,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundThisReference(syntax, frameClass);
             }
 
+            // If the current method has by-ref struct closure parameters, and one of them is correct, use it.
+            var lambda = _currentMethod as SynthesizedLambdaMethod;
+            if (lambda != null)
+            {
+                var start = lambda.ParameterCount - lambda.ExtraSynthesizedParameterCount;
+                for (var i = start; i < lambda.ParameterCount; i++)
+                {
+                    var potentialParameter = lambda.Parameters[i];
+                    if (potentialParameter.Type.OriginalDefinition == frameClass)
+                    {
+                        return new BoundParameter(syntax, potentialParameter);
+                    }
+                }
+            }
+
             // Otherwise we need to return the value from a frame pointer local variable...
             Symbol framePointer = _framePointers[frameClass];
             CapturedSymbolReplacement proxyField;
@@ -668,7 +683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBaseReference(BoundBaseReference node)
         {
-            return (_currentMethod.ContainingType == _topLevelMethod.ContainingType)
+            return (!_currentMethod.IsStatic && _currentMethod.ContainingType == _topLevelMethod.ContainingType)
                 ? node
                 : FramePointer(node.Syntax, _topLevelMethod.ContainingType); // technically, not the correct static type
         }
@@ -735,6 +750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void RemapLocalFunction(
             CSharpSyntaxNode syntax, MethodSymbol symbol,
             out BoundExpression receiver, out MethodSymbol method,
+            ref ImmutableArray<BoundExpression> parameters,
             ImmutableArray<TypeSymbol> typeArguments = default(ImmutableArray<TypeSymbol>))
         {
             Debug.Assert(symbol.MethodKind == MethodKind.LocalFunction);
@@ -742,13 +758,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             var constructed = symbol as ConstructedMethodSymbol;
             if (constructed != null)
             {
-                RemapLocalFunction(syntax, constructed.ConstructedFrom, out receiver, out method, this.TypeMap.SubstituteTypes(constructed.TypeArguments));
+                RemapLocalFunction(syntax, constructed.ConstructedFrom, out receiver, out method, ref parameters, this.TypeMap.SubstituteTypes(constructed.TypeArguments));
                 return;
             }
 
             var mappedLocalFunction = _localFunctionMap[(LocalFunctionSymbol)symbol];
-            method = mappedLocalFunction.Symbol;
 
+            var lambda = mappedLocalFunction.Symbol;
+            var frameCount = lambda.ExtraSynthesizedParameterCount;
+            if (frameCount != 0)
+            {
+                Debug.Assert(!parameters.IsDefault);
+                var builder = ArrayBuilder<BoundExpression>.GetInstance();
+                builder.AddRange(parameters);
+                var start = lambda.ParameterCount - frameCount;
+                for (int i = start; i < lambda.ParameterCount; i++)
+                {
+                    // will always be a NamedTypeSymbol, it's always a closure class
+                    var frame = FrameOfType(syntax, (NamedTypeSymbol)lambda.Parameters[i].Type);
+                    builder.Add(frame);
+                }
+                parameters = builder.ToImmutableAndFree();
+            }
+
+            method = lambda;
             NamedTypeSymbol constructedFrame;
             RemapLambdaOrLocalFunction(syntax, symbol, typeArguments, mappedLocalFunction.ClosureKind, ref method, out receiver, out constructedFrame);
         }
@@ -759,8 +792,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 BoundExpression receiver;
                 MethodSymbol method;
-                RemapLocalFunction(node.Syntax, node.Method, out receiver, out method);
-                node = node.Update(receiver, method, node.Arguments);
+                var arguments = node.Arguments;
+                RemapLocalFunction(node.Syntax, node.Method, out receiver, out method, ref arguments);
+                node = node.Update(receiver, method, arguments);
             }
             var visited = base.VisitCall(node);
             if (visited.Kind != BoundKind.Call)
@@ -1014,7 +1048,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundExpression receiver;
                     MethodSymbol method;
-                    RemapLocalFunction(node.Syntax, node.MethodOpt, out receiver, out method);
+                    var arguments = default(ImmutableArray<BoundExpression>);
+                    RemapLocalFunction(node.Syntax, node.MethodOpt, out receiver, out method, ref arguments);
                     var result = new BoundDelegateCreationExpression(node.Syntax, receiver, method, isExtensionMethod: false, type: node.Type);
                     return result;
                 }
@@ -1049,7 +1084,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundExpression receiver;
                     MethodSymbol method;
-                    RemapLocalFunction(conversion.Syntax, conversion.SymbolOpt, out receiver, out method);
+                    var arguments = default(ImmutableArray<BoundExpression>);
+                    RemapLocalFunction(conversion.Syntax, conversion.SymbolOpt, out receiver, out method, ref arguments);
                     var result = new BoundDelegateCreationExpression(conversion.Syntax, receiver, method, isExtensionMethod: false, type: conversion.Type);
                     return result;
                 }
@@ -1165,12 +1201,41 @@ namespace Microsoft.CodeAnalysis.CSharp
             out DebugId topLevelMethodId,
             out DebugId lambdaId)
         {
+            ImmutableArray<TypeSymbol> structClosures;
             int closureOrdinal;
             if (_analysis.LambdaScopes.TryGetValue(node.Symbol, out lambdaScope))
             {
-                translatedLambdaContainer = containerAsFrame = _frames[lambdaScope];
-                closureKind = ClosureKind.General;
-                closureOrdinal = containerAsFrame.ClosureOrdinal;
+                containerAsFrame = _frames[lambdaScope];
+                var structClosureParamBuilder = ArrayBuilder<TypeSymbol>.GetInstance();
+                while (containerAsFrame != null && containerAsFrame.IsValueType)
+                {
+                    structClosureParamBuilder.Add(containerAsFrame);
+                    if (this._analysis.NeedsParentFrame.Contains(lambdaScope) && this._analysis.ScopeParent.TryGetValue(lambdaScope, out lambdaScope))
+                    {
+                        containerAsFrame = _frames[lambdaScope];
+                    }
+                    else
+                    {
+                        // can happen when scope no longer needs parent frame, or we're at the outermost level and the "parent frame" is top level "this".
+                        lambdaScope = null;
+                        containerAsFrame = null;
+                    }
+                }
+                // Reverse it because we're going from inner to outer, and parameters are in order of outer to inner
+                structClosureParamBuilder.ReverseContents();
+                structClosures = structClosureParamBuilder.ToImmutableAndFree();
+                if (containerAsFrame == null)
+                {
+                    closureKind = ClosureKind.Static; // not exactly... but we've rewritten the receiver to be a by-ref parameter
+                    translatedLambdaContainer = _topLevelMethod.ContainingType;
+                    closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
+                }
+                else
+                {
+                    closureKind = ClosureKind.General;
+                    translatedLambdaContainer = containerAsFrame;
+                    closureOrdinal = containerAsFrame.ClosureOrdinal;
+                }
             }
             else if (_analysis.CapturedVariablesByLambda[node.Symbol].Count == 0)
             {
@@ -1187,6 +1252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureKind = ClosureKind.Static;
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
+                structClosures = default(ImmutableArray<TypeSymbol>);
             }
             else
             {
@@ -1194,13 +1260,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 translatedLambdaContainer = _topLevelMethod.ContainingType;
                 closureKind = ClosureKind.ThisOnly;
                 closureOrdinal = LambdaDebugInfo.ThisOnlyClosureOrdinal;
+                structClosures = default(ImmutableArray<TypeSymbol>);
             }
 
             // Move the body of the lambda to a freshly generated synthetic method on its frame.
             topLevelMethodId = GetTopLevelMethodId();
             lambdaId = GetLambdaId(node.Syntax, closureKind, closureOrdinal);
 
-            var synthesizedMethod = new SynthesizedLambdaMethod(translatedLambdaContainer, closureKind, _topLevelMethod, topLevelMethodId, node, lambdaId);
+            var synthesizedMethod = new SynthesizedLambdaMethod(translatedLambdaContainer, structClosures, closureKind, _topLevelMethod, topLevelMethodId, node, lambdaId);
             CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(translatedLambdaContainer, synthesizedMethod);
 
             foreach (var parameter in node.Symbol.Parameters)

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -14,9 +14,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class SynthesizedLambdaMethod : SynthesizedMethodBaseSymbol, ISynthesizedMethodBodyImplementationSymbol
     {
         private readonly MethodSymbol _topLevelMethod;
+        private readonly ImmutableArray<TypeSymbol> _structClosures;
 
         internal SynthesizedLambdaMethod(
             NamedTypeSymbol containingType,
+            ImmutableArray<TypeSymbol> structClosures,
             ClosureKind closureKind,
             MethodSymbol topLevelMethod,
             DebugId topLevelMethodId,
@@ -35,6 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                        | (lambdaNode.Symbol.IsAsync ? DeclarationModifiers.Async : 0))
         {
             _topLevelMethod = topLevelMethod;
+            _structClosures = structClosures;
 
             TypeMap typeMap;
             ImmutableArray<TypeParameterSymbol> typeParameters;
@@ -87,8 +90,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 lambdaId.Generation);
         }
 
-        internal override int ParameterCount => this.BaseMethod.ParameterCount;
-
         // The lambda symbol might have declared no parameters in the case
         //
         // D d = delegate {};
@@ -101,6 +102,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // UNDONE: synthetic parameters; in this implementation we use the parameter
         // UNDONE: names from the delegate. Does it really matter?
         protected override ImmutableArray<ParameterSymbol> BaseMethodParameters => this.BaseMethod.Parameters;
+
+        protected override ImmutableArray<TypeSymbol> ExtraSynthesizedRefParameters => _structClosures;
+        internal int ExtraSynthesizedParameterCount => this._structClosures.IsDefault ? 0 : this._structClosures.Length;
 
         internal override bool GenerateDebugInfo => !this.IsAsync;
         internal override bool IsExpressionBodied => false;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -37,31 +37,51 @@ namespace Microsoft.CodeAnalysis.CSharp
                        | (lambdaNode.Symbol.IsAsync ? DeclarationModifiers.Async : 0))
         {
             _topLevelMethod = topLevelMethod;
-            _structClosures = structClosures;
 
             TypeMap typeMap;
             ImmutableArray<TypeParameterSymbol> typeParameters;
+            ImmutableArray<TypeParameterSymbol> constructedFromTypeParameters;
             LambdaFrame lambdaFrame;
 
             lambdaFrame = this.ContainingType as LambdaFrame;
             switch (closureKind)
             {
                 case ClosureKind.Singleton: // all type parameters on method (except the top level method's)
+                case ClosureKind.General: // only lambda's type parameters on method (rest on class)
                     Debug.Assert(lambdaFrame != null);
-                    typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, lambdaFrame.ContainingMethod);
+                    typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, out constructedFromTypeParameters, lambdaFrame.ContainingMethod);
                     break;
                 case ClosureKind.ThisOnly: // all type parameters on method
                 case ClosureKind.Static:
                     Debug.Assert(lambdaFrame == null);
-                    typeMap = TypeMap.Empty.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, null);
-                    break;
-                case ClosureKind.General: // only lambda's type parameters on method (rest on class)
-                    Debug.Assert(lambdaFrame != null);
-                    typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, lambdaFrame.ContainingMethod);
+                    typeMap = TypeMap.Empty.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, out constructedFromTypeParameters, null);
                     break;
                 default:
                     throw ExceptionUtilities.Unreachable;
             }
+
+            if (!structClosures.IsDefaultOrEmpty && typeParameters.Length != 0)
+            {
+                var constructedStructClosures = ArrayBuilder<TypeSymbol>.GetInstance();
+                foreach (var closure in structClosures)
+                {
+                    var frame = (LambdaFrame)closure;
+                    NamedTypeSymbol constructed;
+                    if (frame.Arity == 0)
+                    {
+                        constructed = frame;
+                    }
+                    else
+                    {
+                        var originals = frame.ConstructedFromTypeParameters;
+                        var newArgs = typeMap.SubstituteTypeParameters(originals);
+                        constructed = frame.Construct(newArgs);
+                    }
+                    constructedStructClosures.Add(constructed);
+                }
+                structClosures = constructedStructClosures.ToImmutableAndFree();
+            }
+            _structClosures = structClosures;
 
             AssignTypeMapAndTypeParameters(typeMap, typeParameters);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override int ParameterCount
         {
-            get { return this.BaseMethod.ParameterCount; }
+            get { return this.Parameters.Length; }
         }
 
         public sealed override ImmutableArray<ParameterSymbol> Parameters
@@ -94,6 +94,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 return _parameters;
             }
+        }
+
+        protected virtual ImmutableArray<TypeSymbol> ExtraSynthesizedRefParameters
+        {
+            get { return default(ImmutableArray<TypeSymbol>); }
         }
 
         protected virtual ImmutableArray<ParameterSymbol> BaseMethodParameters
@@ -109,6 +114,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var p in parameters)
             {
                 builder.Add(new SynthesizedParameterSymbol(this, this.TypeMap.SubstituteType(p.OriginalDefinition.Type), ordinal++, p.RefKind, p.Name));
+            }
+            var extraSynthed = ExtraSynthesizedRefParameters;
+            if (!extraSynthed.IsDefaultOrEmpty)
+            {
+                foreach (var extra in extraSynthed)
+                {
+                    builder.Add(new SynthesizedParameterSymbol(this, this.TypeMap.SubstituteType(extra), ordinal++, RefKind.Ref));
+                }
             }
             return builder.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly string _name;
         private readonly TypeMap _typeMap;
         private readonly ImmutableArray<TypeParameterSymbol> _typeParameters;
+        private readonly ImmutableArray<TypeParameterSymbol> _constructedFromTypeParameters;
 
         protected SynthesizedContainer(string name, int parameterCount, bool returnsVoid)
         {
@@ -25,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _name = name;
             _typeMap = TypeMap.Empty;
             _typeParameters = CreateTypeParameters(parameterCount, returnsVoid);
+            _constructedFromTypeParameters = default(ImmutableArray<TypeParameterSymbol>);
         }
 
         protected SynthesizedContainer(string name, MethodSymbol containingMethod)
@@ -38,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                _typeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, out _typeParameters);
+                _typeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, out _typeParameters, out _constructedFromTypeParameters);
             }
         }
 
@@ -101,6 +103,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(
                 WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
+        }
+
+        /// <summary>
+        /// Note: Can be default if this SynthesizedContainer was constructed with <see cref="SynthesizedContainer(string, int, bool)"/>
+        /// </summary>
+        internal ImmutableArray<TypeParameterSymbol> ConstructedFromTypeParameters
+        {
+            get { return _constructedFromTypeParameters; }
         }
 
         public sealed override ImmutableArray<TypeParameterSymbol> TypeParameters

--- a/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
@@ -126,7 +126,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return WithAlphaRename(oldOwner.OriginalDefinition.TypeParameters, newOwner, out newTypeParameters);
         }
 
-        internal TypeMap WithConcatAlphaRename(MethodSymbol oldOwner, Symbol newOwner, out ImmutableArray<TypeParameterSymbol> newTypeParameters, MethodSymbol stopAt = null)
+        internal TypeMap WithConcatAlphaRename(
+            MethodSymbol oldOwner,
+            Symbol newOwner,
+            out ImmutableArray<TypeParameterSymbol> newTypeParameters,
+            out ImmutableArray<TypeParameterSymbol> oldTypeParameters,
+            MethodSymbol stopAt = null)
         {
             Debug.Assert(oldOwner.ConstructedFrom == oldOwner);
             Debug.Assert(stopAt == null || stopAt.ConstructedFrom == stopAt);
@@ -161,7 +166,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // If not provided, both should be null (if stopAt != null && oldOwner == null, then it wasn't in the chain)
             Debug.Assert(stopAt == oldOwner);
 
-            return WithAlphaRename(parameters.ToImmutableAndFree(), newOwner, out newTypeParameters);
+            oldTypeParameters = parameters.ToImmutableAndFree();
+            return WithAlphaRename(oldTypeParameters, newOwner, out newTypeParameters);
         }
 
         private static SmallDictionary<TypeParameterSymbol, TypeSymbol> ConstructMapping(ImmutableArray<TypeParameterSymbol> from, ImmutableArray<TypeSymbol> to)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -973,6 +973,21 @@ void Foo<T1>()
 Foo<int>();
 ";
             var verify = VerifyOutputInMain(source, "4", "System");
+            var foo = verify.FindLocalFunction("Foo");
+            var bar = verify.FindLocalFunction("Bar");
+            Assert.Equal(1, foo.Parameters.Length);
+            Assert.Equal(2, bar.Parameters.Length);
+            Assert.Equal(RefKind.Ref, foo.Parameters[0].RefKind);
+            Assert.Equal(RefKind.Ref, bar.Parameters[0].RefKind);
+            Assert.Equal(RefKind.Ref, bar.Parameters[1].RefKind);
+            Assert.True(foo.Parameters[0].Type.IsValueType);
+            Assert.True(bar.Parameters[0].Type.IsValueType);
+            Assert.True(bar.Parameters[1].Type.IsValueType);
+            Assert.Equal(foo.Parameters[0].Type.OriginalDefinition, bar.Parameters[0].Type.OriginalDefinition);
+            var fooFrame = (INamedTypeSymbol)foo.Parameters[0].Type;
+            var barFrame = (INamedTypeSymbol)bar.Parameters[1].Type;
+            Assert.Equal(0, fooFrame.Arity);
+            Assert.Equal(1, barFrame.Arity);
         }
 
         [Fact]


### PR DESCRIPTION
I already have half-implemented struct closures, but they were being passed as the this parameter and any nested struct closures were disallowed.

The basic algorithm is:

If a lambda frame is never used in a delegate construction, and is not used in an async/iterator function, then we are free to turn it into a struct.

While any local function's primary frame is a struct, make the frame be a by-ref parameter on the end of the argument list and make the primary frame be the parent frame of the previous primary frame (then continue the while).

When calling a local function, rewrite the BoundCall with the appropriate frames retrieved from FrameOfType. Generics makes things difficult.

FYI @jaredpar @VSadov @agocke @gafter