### PR TITLE
These resourse strings reference an old namespace and type.  

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4204,13 +4204,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>items: must be non-empty</value>
   </data>
   <data name="UseVerbatimIdentifier" xml:space="preserve">
-    <value>Use Roslyn.Compilers.CSharp.Syntax.Identifier or Roslyn.Compilers.CSharp.Syntax.VerbatimIdentifier to create identifier tokens.</value>
+    <value>Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Identifier or Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VerbatimIdentifier to create identifier tokens.</value>
   </data>
   <data name="UseLiteralForTokens" xml:space="preserve">
-    <value>Use Roslyn.Compilers.CSharp.Syntax.Literal to create character literal tokens.</value>
+    <value>Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create character literal tokens.</value>
   </data>
   <data name="UseLiteralForNumeric" xml:space="preserve">
-    <value>Use Roslyn.Compilers.CSharp.Syntax.Literal to create numeric literal tokens.</value>
+    <value>Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create numeric literal tokens.</value>
   </data>
   <data name="ThisMethodCanOnlyBeUsedToCreateTokens" xml:space="preserve">
     <value>This method can only be used to create tokens - {0} is not a token kind.</value>

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -117,31 +116,51 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.IdentifierToken, "text", "valueText", default(SyntaxTriviaList)));
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.CharacterLiteralToken, "text", "valueText", default(SyntaxTriviaList)));
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.NumericLiteralToken, "text", "valueText", default(SyntaxTriviaList)));
-        }
 
-        [Fact]
-        public void TestFreeFormTokenFactoryExceptionMessage_SpecialTokenKinds()
-        {
-            // Make sure the exception message displays the correct namespace/class to use
-            List<SyntaxKind> syntaxKinds = new List<SyntaxKind>()
-            {
-                SyntaxKind.IdentifierToken,
-                SyntaxKind.CharacterLiteralToken,
-                SyntaxKind.NumericLiteralToken
-            };
-            foreach (var kind in syntaxKinds)
+            // Ensure that when they throw, the appropriate message is used
+            using (new EnsureEnglishUICulture())
             {
                 try
                 {
-                    SyntaxFactory.Token(default(SyntaxTriviaList), kind, "text", "valueText", default(SyntaxTriviaList));
+                    SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.IdentifierToken, "text", "valueText", default(SyntaxTriviaList));
                     AssertEx.Fail("Should have thrown");
                     return;
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Contains("Microsoft.CodeAnalysis.CSharp.SyntaxFactory", e.Message);
+                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Identifier or Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VerbatimIdentifier to create identifier tokens.", e.Message);
+                    Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
+                }
+
+                try
+                {
+                    SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.CharacterLiteralToken, "text", "valueText", default(SyntaxTriviaList));
+                    AssertEx.Fail("Should have thrown");
+                    return;
+                }
+                catch (ArgumentException e)
+                {
+                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create character literal tokens.", e.Message);
+                    Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
+                }
+
+                try
+                {
+                    SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.NumericLiteralToken, "text", "valueText", default(SyntaxTriviaList));
+                    AssertEx.Fail("Should have thrown");
+                    return;
+                }
+                catch (ArgumentException e)
+                {
+                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create numeric literal tokens.", e.Message);
+                    Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
             }
+
+            // Make sure that the appropriate methods work as suggested in the exception messages, and don't throw
+            SyntaxFactory.Identifier("text");
+            SyntaxFactory.Literal('c'); //character literal
+            SyntaxFactory.Literal(123); //numeric literal
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -116,6 +117,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.IdentifierToken, "text", "valueText", default(SyntaxTriviaList)));
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.CharacterLiteralToken, "text", "valueText", default(SyntaxTriviaList)));
             Assert.Throws<ArgumentException>(() => SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.NumericLiteralToken, "text", "valueText", default(SyntaxTriviaList)));
+        }
+
+        [Fact]
+        public void TestFreeFormTokenFactoryExceptionMessage_SpecialTokenKinds()
+        {
+            // Make sure the exception message displays the correct namespace/class to use
+            List<SyntaxKind> syntaxKinds = new List<SyntaxKind>()
+            {
+                SyntaxKind.IdentifierToken,
+                SyntaxKind.CharacterLiteralToken,
+                SyntaxKind.NumericLiteralToken
+            };
+            foreach (var kind in syntaxKinds)
+            {
+                try
+                {
+                    SyntaxFactory.Token(default(SyntaxTriviaList), kind, "text", "valueText", default(SyntaxTriviaList));
+                    AssertEx.Fail("Should have thrown");
+                    return;
+                }
+                catch (ArgumentException e)
+                {
+                    Assert.Contains("Microsoft.CodeAnalysis.CSharp.SyntaxFactory", e.Message);
+                }
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Identifier or Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VerbatimIdentifier to create identifier tokens.", e.Message);
+                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Identifier or Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VerbatimIdentifier to create identifier tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
 
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create character literal tokens.", e.Message);
+                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create character literal tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
 
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal("Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create numeric literal tokens.", e.Message);
+                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create numeric literal tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
             }


### PR DESCRIPTION
This caused me a bit of trouble when trying to find the Syntax class, as it also had changed to SyntaxFactory.