### PR TITLE
Test Fixup for a Line Normalization Issue.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Organizing/AbstractOrganizerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/AbstractOrganizerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Organizing;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Organizing
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Organizing
             {
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
                 var newRoot = OrganizingService.OrganizeAsync(document).Result.GetSyntaxRootAsync().Result;
-                Assert.Equal(final, newRoot.ToFullString());
+                Assert.Equal(final.NormalizeLineEndings(), newRoot.ToFullString());
             }
         }
 


### PR DESCRIPTION
This is a workaround for Issue #4109. It normalizes the line endings of the expected text so that the test will compare to the correct expected value even if the input line endings are '\n' isntead of '\r\n'.