### PR TITLE
Test Fixup for a Line Normalization Issue.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Organizing/OrganizeUsingsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/OrganizeUsingsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Organizing
             {
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
                 var newRoot = OrganizeImportsService.OrganizeImportsAsync(document, specialCaseSystem).Result.GetSyntaxRootAsync().Result;
-                Assert.Equal(final, newRoot.ToFullString());
+                Assert.Equal(final.NormalizeLineEndings(), newRoot.ToFullString());
             }
         }
 


### PR DESCRIPTION
This normalizes the line endings of the expected text in the CSharpEditorFeatures OrganizeImportsTests so that the test will compare to the correct expected value even if the input line endings are '\n' isntead of '\r\n'.

These were missed in PR #4111 due to the issue only repro'ing on a small subset of machines and being difficult to manually repro at that.