### PR TITLE
Update DiaSymReader.Native to v1.1.0 that has GetSymReader export

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.Net.RoslynDiagnostics" version="1.0.0-rc3-20150616-02" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.1.0-alpha-00008" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader.Native" version="1.1.0-alpha1" />
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00063" />
   <package id="FakeSign" version="0.9.2" targetFramework="net45" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -30,6 +30,7 @@
     <MicrosoftCompositionAssemblyVersion Condition="'$(MicrosoftCompositionAssemblyVersion)' == ''">1.0.27</MicrosoftCompositionAssemblyVersion>
     <SystemReflectionMetadataVersion>$(SystemReflectionMetadataAssemblyVersion)-alpha-00008</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>$(SystemCollectionsImmutableAssemblyVersion)</SystemCollectionsImmutableVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.1.0-alpha1</MicrosoftDiaSymReaderNativeVersion>
     <NuGetCommandLineVersion>$(NuGetCommandLineAssemblyVersion)</NuGetCommandLineVersion>
     <MicrosoftCompositionVersion>$(MicrosoftCompositionAssemblyVersion)</MicrosoftCompositionVersion>
   </PropertyGroup>

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -719,11 +719,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\..\..\packages\Microsoft.DiaSymReader.Native.1.0.0-rc2\lib\any~windows\x86\Microsoft.DiaSymReader.Native.x86.dll">
+    <Content Include="..\..\..\..\packages\Microsoft.DiaSymReader.Native.$(MicrosoftDiaSymReaderNativeVersion)\lib\any~windows\x86\Microsoft.DiaSymReader.Native.x86.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
-    <Content Include="..\..\..\..\packages\Microsoft.DiaSymReader.Native.1.0.0-rc2\lib\any~windows\amd64\Microsoft.DiaSymReader.Native.amd64.dll">
+    <Content Include="..\..\..\..\packages\Microsoft.DiaSymReader.Native.$(MicrosoftDiaSymReaderNativeVersion)\lib\any~windows\amd64\Microsoft.DiaSymReader.Native.amd64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>

--- a/src/Compilers/Core/Portable/packages.config
+++ b/src/Compilers/Core/Portable/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.DiaSymReader.Native" version="1.0.0-rc2" />
+<packages> 
 </packages>

--- a/src/Test/PdbUtilities/Pdb/PdbToXml.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbToXml.cs
@@ -139,11 +139,16 @@ namespace Roslyn.Test.PdbUtilities
 
             using (var writer = XmlWriter.Create(xmlWriter, s_xmlWriterSettings))
             {
-                using (SymReader symReader = new SymReader(pdbStream, metadataReaderOpt))
+                var symReader = SymReaderFactory.CreateReader(pdbStream, metadataReaderOpt);
+
+                try
                 {
                     var converter = new PdbToXmlConverter(writer, symReader, metadataReaderOpt, options);
-
                     converter.WriteRoot(methodHandles ?? metadataReaderOpt.MethodDefinitions);
+                }
+                finally
+                {
+                    ((ISymUnmanagedDispose)symReader).Destroy();
                 }
             }
         }

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
+using PortablePdb = Microsoft.DiaSymReader.PortablePdb;
+
+namespace Roslyn.Test.PdbUtilities
+{
+    public static class SymReaderFactory
+    {
+        [DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymReader")]
+        private extern static void CreateSymReader32(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
+
+        [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymReader")]
+        private extern static void CreateSymReader64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
+
+        private static ISymUnmanagedReader3 CreateNativeSymReader(Stream pdbStream, object metadataImporter)
+        {
+            object symReader = null;
+
+            var guid = default(Guid);
+            if (IntPtr.Size == 4)
+            {
+                CreateSymReader32(ref guid, out symReader);
+            }
+            else
+            {
+                CreateSymReader64(ref guid, out symReader);
+            }
+
+            var reader = (ISymUnmanagedReader3)symReader;
+            int hr = reader.Initialize(metadataImporter, null, null, new ComStreamWrapper(pdbStream));
+            SymUnmanagedReaderExtensions.ThrowExceptionForHR(hr);
+            return reader;
+        }
+
+        public static ISymUnmanagedReader CreateReader(Stream pdbStream, MetadataReader metadataReaderOpt)
+        {
+            return CreateReader(pdbStream, new DummyMetadataImport(metadataReaderOpt));
+        }
+
+        public static ISymUnmanagedReader CreateReader(Stream pdbStream, object metadataImporter)
+        {
+            pdbStream.Position = 0;
+            bool isPortable = pdbStream.ReadByte() == 'B' && pdbStream.ReadByte() == 'S' && pdbStream.ReadByte() == 'J' && pdbStream.ReadByte() == 'B';
+            pdbStream.Position = 0;
+
+            if (isPortable)
+            {
+                return new PortablePdb.SymReader(new PortablePdb.PortablePdbReader(pdbStream, metadataImporter));
+            }
+            else
+            {
+                return CreateNativeSymReader(pdbStream, metadataImporter);
+            }
+        }
+    }
+}

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -68,6 +68,16 @@
       <HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.5\lib\net45\Microsoft.DiaSymReader.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\packages\Microsoft.DiaSymReader.Native.$(MicrosoftDiaSymReaderNativeVersion)\lib\any~windows\x86\Microsoft.DiaSymReader.Native.x86.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="..\..\..\packages\Microsoft.DiaSymReader.Native.$(MicrosoftDiaSymReaderNativeVersion)\lib\any~windows\amd64\Microsoft.DiaSymReader.Native.amd64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Include="..\..\Compilers\Core\Portable\Collections\PooledStringBuilder.cs">
       <Link>Collections\PooledStringBuilder.cs</Link>
@@ -91,6 +101,7 @@
     <Compile Include="Pdb\PdbToXml.cs" />
     <Compile Include="Pdb\PdbToXmlOptions.cs" />
     <Compile Include="Pdb\SymReader.cs" />
+    <Compile Include="Pdb\SymReaderFactory.cs" />
     <Compile Include="Pdb\Token2SourceLineExporter.cs" />
     <Compile Include="Shared\CustomDebugInfoReader.cs" />
     <Compile Include="Shared\DateTimeUtilities.cs" />

--- a/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/CommonTestBase.CompilationVerifier.cs
@@ -248,7 +248,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             public ISymUnmanagedReader CreateSymReader()
             {
-                return new SymReader(new MemoryStream(EmittedAssemblyPdb.ToArray()));
+                var pdbStream = new MemoryStream(EmittedAssemblyPdb.ToArray());
+                return SymReaderFactory.CreateReader(pdbStream, metadataReaderOpt: null);
             }
 
             public string VisualizeIL(string qualifiedMethodName, bool realIL = false, string sequencePoints = null, bool useRefEmitter = false)


### PR DESCRIPTION
Update compiler tests to use a SymReader from Microsoft.DiaSymReader.Native.nuget.

TODO: Update EE tests.