### PR TITLE
Fix 4090

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6495,5 +6495,24 @@ End Class
             VerifyItemIsAbsent(text, "X")
         End Sub
 
+        <WorkItem(4900, "https://github.com/dotnet/roslyn/issues/4090")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub ColorColorInstanceSharedRegression()
+            Dim text =
+<code><![CDATA[
+Class Instance
+    Public Shared x as Integer
+    Public y as Integer
+End Class
+
+Class Program
+    Sub Foo()
+        Instance.$$
+    End Sub
+End Class
+]]></code>.Value
+            VerifyItemIsAbsent(text, "y")
+            VerifyItemExists(text, "x")
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6497,7 +6497,7 @@ End Class
 
         <WorkItem(4900, "https://github.com/dotnet/roslyn/issues/4090")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Sub ColorColorInstanceSharedRegression()
+        Public Sub NoInstanceMembersWhenDottingIntoType()
             Dim text =
 <code><![CDATA[
 Class Instance
@@ -6514,5 +6514,27 @@ End Class
             VerifyItemIsAbsent(text, "y")
             VerifyItemExists(text, "x")
         End Sub
+
+        <WorkItem(4900, "https://github.com/dotnet/roslyn/issues/4090")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NoSharedMemberWhenDottingIntoInstance()
+            Dim text =
+<code><![CDATA[
+Class Instance
+    Public Shared x as Integer
+    Public y as Integer
+End Class
+
+Class Program
+    Sub Foo()
+        Dim x = new Instance()
+        x.$$
+    End Sub
+End Class
+]]></code>.Value
+            VerifyItemIsAbsent(text, "x")
+            VerifyItemExists(text, "y")
+        End Sub
+
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
@@ -183,7 +183,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             End If
 
             Dim leftHandTypeInfo = context.SemanticModel.GetTypeInfo(leftExpression, cancellationToken)
-            Dim lifeHandSymbolInfo = context.SemanticModel.GetSymbolInfo(leftExpression, cancellationToken)
+            Dim leftHandSymbolInfo = context.SemanticModel.GetSymbolInfo(leftExpression, cancellationToken)
 
             Dim excludeInstance = False
             Dim excludeShared = True ' do not show shared members by default
@@ -191,16 +191,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             Dim inNameOfExpression = node.IsParentKind(SyntaxKind.NameOfExpression)
 
             Dim container = DirectCast(leftHandTypeInfo.Type, INamespaceOrTypeSymbol)
-            If leftHandTypeInfo.Type.IsErrorType AndAlso lifeHandSymbolInfo.Symbol IsNot Nothing Then
+            If leftHandTypeInfo.Type.IsErrorType AndAlso leftHandSymbolInfo.Symbol IsNot Nothing Then
                 ' TODO remove this when 531549 which causes leftHandTypeInfo to be an error type is fixed
-                container = lifeHandSymbolInfo.Symbol.GetSymbolType()
+                container = leftHandSymbolInfo.Symbol.GetSymbolType()
             End If
 
             Dim couldBeMergedNamespace = False
 
-            If lifeHandSymbolInfo.Symbol IsNot Nothing Then
+            If leftHandSymbolInfo.Symbol IsNot Nothing Then
 
-                Dim firstSymbol = lifeHandSymbolInfo.Symbol
+                Dim firstSymbol = leftHandSymbolInfo.Symbol
 
                 Select Case firstSymbol.Kind
                     Case SymbolKind.TypeParameter
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 ' Check for color color
                 Dim speculativeTypeBinding = context.SemanticModel.GetSpeculativeTypeInfo(context.Position, leftExpression, SpeculativeBindingOption.BindAsTypeOrNamespace)
                 Dim speculativeAliasBinding = context.SemanticModel.GetSpeculativeAliasInfo(context.Position, leftExpression, SpeculativeBindingOption.BindAsTypeOrNamespace)
-                If speculativeAliasBinding Is Nothing AndAlso firstSymbol.GetSymbolType() Is speculativeTypeBinding.Type Then
+                If TypeOf leftHandSymbolInfo.Symbol IsNot INamespaceOrTypeSymbol AndAlso speculativeAliasBinding Is Nothing AndAlso firstSymbol.GetSymbolType() Is speculativeTypeBinding.Type Then
                     excludeShared = False
                     excludeInstance = False
                 End If
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 End If
 
             Else
-                couldBeMergedNamespace = ContainsNamespaceCandidateSymbols(lifeHandSymbolInfo)
+                couldBeMergedNamespace = ContainsNamespaceCandidateSymbols(leftHandSymbolInfo)
             End If
 
             If container Is Nothing AndAlso Not couldBeMergedNamespace Then
@@ -266,14 +266,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
 
             ' No completion on types/namespace after conditional access
             If leftExpression.Parent.IsKind(SyntaxKind.ConditionalAccessExpression) AndAlso
-                (couldBeMergedNamespace OrElse lifeHandSymbolInfo.GetBestOrAllSymbols().FirstOrDefault().MatchesKind(SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Alias)) Then
+                (couldBeMergedNamespace OrElse leftHandSymbolInfo.GetBestOrAllSymbols().FirstOrDefault().MatchesKind(SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Alias)) Then
                 Return SpecializedCollections.EmptyCollection(Of ISymbol)()
             End If
 
             Dim position = node.SpanStart
             Dim symbols As IEnumerable(Of ISymbol)
             If couldBeMergedNamespace Then
-                symbols = lifeHandSymbolInfo.CandidateSymbols _
+                symbols = leftHandSymbolInfo.CandidateSymbols _
                     .OfType(Of INamespaceSymbol) _
                     .SelectMany(Function(n) LookupSymbolsInContainer(n, context.SemanticModel, position, excludeInstance))
             Else
@@ -299,8 +299,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             End If
 
             ' If the left expression is My.MyForms, we should filter out all non-property symbols
-            If lifeHandSymbolInfo.Symbol IsNot Nothing AndAlso
-               lifeHandSymbolInfo.Symbol.IsMyFormsProperty(context.SemanticModel.Compilation) Then
+            If leftHandSymbolInfo.Symbol IsNot Nothing AndAlso
+               leftHandSymbolInfo.Symbol.IsMyFormsProperty(context.SemanticModel.Compilation) Then
 
                 symbols = symbols.Where(Function(s) s.Kind = SymbolKind.Property)
             End If


### PR DESCRIPTION
We should only do the color color binding check of the expression originally bound as something other than a type or namespace.