### PR TITLE
Don't crash when invoking signature help on an inaccessible item.

### DIFF
--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
                 }
 
                 var includeInstance = !throughExpression.IsKind(SyntaxKind.IdentifierName) ||
-                    semanticModel.LookupSymbols(throughExpression.SpanStart, name: throughSymbol.Name).Any(s => !(s is INamedTypeSymbol));
+                    semanticModel.LookupSymbols(throughExpression.SpanStart, name: throughSymbol.Name).Any(s => !(s is INamedTypeSymbol)) ||
+                    (!(throughSymbol is INamespaceOrTypeSymbol) && semanticModel.LookupSymbols(throughExpression.SpanStart, container: throughSymbol.ContainingType).Any(s => !(s is INamedTypeSymbol)));
 
                 var includeStatic = throughSymbol is INamedTypeSymbol ||
                     (throughExpression.IsKind(SyntaxKind.IdentifierName) &&

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -1947,5 +1947,29 @@ class C
 
             Test(markup, expectedOrderedItems);
         }
+
+        [WorkItem(4144, "https://github.com/dotnet/roslyn/issues/4144")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public void TestSigHelpIsVisibleOnInaccessibleItem()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+class A
+{
+    List<int> args;
+}
+
+class B : A
+{
+    void M()
+    {
+        args.Add($$
+    }
+}
+";
+
+            Test(markup, new[] { new SignatureHelpTestItem("void List<int>.Add(int item)") });
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -1849,5 +1849,27 @@ End Class
 "
             Test(markup, SpecializedCollections.SingletonEnumerable(New SignatureHelpTestItem("C.Next()", String.Empty)))
         End Sub
+
+        <WorkItem(4144, "https://github.com/dotnet/roslyn/issues/4144")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Sub TestSigHelpIsVisibleOnInaccessibleItem()
+            Dim markup = "
+Imports System.Collections.Generic
+
+Class A
+    Dim args As List(Of Integer)
+End Class
+
+Class B
+    Inherits A
+
+    Sub M()
+        args.Add($$
+    End Sub
+End Class
+"
+
+            Test(markup, {New SignatureHelpTestItem("List(Of Integer).Add(item As Integer)")})
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4144.

As reported by a customer, when attempting to show signature help on an inaccessible item can cause a crash.  The fix is: when checking if we're looking for instance members, also consider the containing type of the invocation expression, not just if it's name is visible.

**Question for reviewers:**
Consider the following code (taken from the unit test):

``` C#
class A
{
    List<int> args;
}

class B : A
{
    void M()
    {
        args.Add$$
    }
}
```

There is no crash in VB, but the `args` symbol also doesn't bind to begin with, like it does in C#.  Given this scenario it can either be argued that when the user typed `args` they knew exactly what they were doing and they intend to update the definition of `args` to be `public` or `protected`, *or*, they were unaware of the private field and they might be surprised by the completion/sig-help sessions that follow the dot.  Thoughts?

As it stands now, `Add(int item)` appears in the completion list after typing the dot in C#, but nothing appears in VB.

**Edit**
After digging in a bit, VB _does_ show the appropriate completion items, but I wasn't originally seeing that due to some unnoticed changes on my box.