### PR TITLE
Fix xml doc gen

### DIFF
--- a/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
             {
                 foreach (var typeParam in typeParameterList.Parameters)
                 {
-                    list.Add("/// <typeparam name=\"" + typeParam.Identifier.ToString() + "\"></typeparam>");
+                    list.Add("/// <typeparam name=\"" + typeParam.Identifier.ValueText + "\"></typeparam>");
                 }
             }
 
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
             {
                 foreach (var param in parameterList.Parameters)
                 {
-                    list.Add("/// <param name=\"" + param.Identifier.ToString() + "\"></param>");
+                    list.Add("/// <param name=\"" + param.Identifier.ValueText + "\"></param>");
                 }
             }
 

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -64,7 +64,7 @@ class C
 @"class C
 {
     //$$
-    int M<@T>(int @foo) { return 0; }
+    int M<@int>(int @foo) { return 0; }
 }";
 
             var expected =
@@ -73,10 +73,10 @@ class C
     /// <summary>
     /// $$
     /// </summary>
-    /// <typeparam name=""T""></typeparam>
+    /// <typeparam name=""int""></typeparam>
     /// <param name=""foo""></param>
     /// <returns></returns>
-    int M<@T>(int @foo) { return 0; }
+    int M<@int>(int @foo) { return 0; }
 }";
 
             VerifyTypingCharacter(code, expected);
@@ -197,7 +197,7 @@ class C
 @"class C
 {
     //$$
-    void M<@T>(int @foo) {  }
+    void M<@T>(int @int) {  }
 }";
 
             var expected =
@@ -207,8 +207,8 @@ class C
     /// $$
     /// </summary>
     /// <typeparam name=""T""></typeparam>
-    /// <param name=""foo""></param>
-    void M<@T>(int @foo) {  }
+    /// <param name=""int""></param>
+    void M<@T>(int @int) {  }
 }";
 
             VerifyTypingCharacter(code, expected);

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -58,6 +58,31 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_Method_WithVerbatimParams()
+        {
+            var code =
+@"class C
+{
+    //$$
+    int M<@T>(int @foo) { return 0; }
+}";
+
+            var expected =
+@"class C
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    /// <typeparam name=""T""></typeparam>
+    /// <param name=""foo""></param>
+    /// <returns></returns>
+    int M<@T>(int @foo) { return 0; }
+}";
+
+            VerifyTypingCharacter(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TypingCharacter_AutoProperty()
         {
             var code =
@@ -160,6 +185,30 @@ class C
     /// <typeparam name=""T""></typeparam>
     /// <param name=""foo""></param>
     void M<T>(int foo) {  }
+}";
+
+            VerifyTypingCharacter(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_VoidMethod_WithVerbatimParams()
+        {
+            var code =
+@"class C
+{
+    //$$
+    void M<@T>(int @foo) {  }
+}";
+
+            var expected =
+@"class C
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    /// <typeparam name=""T""></typeparam>
+    /// <param name=""foo""></param>
+    void M<@T>(int @foo) {  }
 }";
 
             VerifyTypingCharacter(code, expected);


### PR DESCRIPTION
Fix #2936

IMHO the name value for xml doc should not include language specific escape token "@", so I prefer fixing the generating part.