### PR TITLE
Move file system completion support from Features layer to EditorFeatures layer

### DIFF
--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -94,13 +94,13 @@
     <Compile Include="ChangeSignature\ChangeSignatureCommandHandler.cs" />
     <Compile Include="Classification\CSharpEditorClassificationService.cs" />
     <Compile Include="CommentSelection\CSharpCommentUncommentService.cs" />
-    <Compile Include="Completion\CompletionProviders\GlobalAssemblyCacheCompletionHelper.cs" />
     <Compile Include="Completion\CompletionProviders\OverrideCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\PartialCompletionProvider.cs" />
-    <Compile Include="Completion\CompletionProviders\ReferenceDirectiveCompletionProvider.ItemRules.cs" />
-    <Compile Include="Completion\CompletionProviders\ReferenceDirectiveCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\XmlDocCommentCompletion\XmlDocCommentCompletionItemRules.cs" />
     <Compile Include="Completion\CompletionProviders\XmlDocCommentCompletion\XmlDocCommentCompletionProvider.cs" />
+    <Compile Include="Completion\FileSystem\GlobalAssemblyCacheCompletionHelper.cs" />
+    <Compile Include="Completion\FileSystem\ReferenceDirectiveCompletionProvider.cs" />
+    <Compile Include="Completion\FileSystem\ReferenceDirectiveCompletionProvider.ItemRules.cs" />
     <Compile Include="ContentType\ContentTypeDefinitions.cs" />
     <Compile Include="CSharpEditorResources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -286,6 +286,7 @@
     <None Include="packages.config" />
     <PublicAPI Include="PublicAPI.txt" />
   </ItemGroup>
+  <ItemGroup />
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/EditorFeatures/CSharp/Completion/FileSystem/GlobalAssemblyCacheCompletionHelper.cs
+++ b/src/EditorFeatures/CSharp/Completion/FileSystem/GlobalAssemblyCacheCompletionHelper.cs
@@ -5,12 +5,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
+namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem
 {
     internal sealed class GlobalAssemblyCacheCompletionHelper
     {

--- a/src/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.ItemRules.cs
+++ b/src/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.ItemRules.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Options;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
+namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem
 {
     internal partial class ReferenceDirectiveCompletionProvider
     {

--- a/src/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.cs
+++ b/src/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.cs
@@ -9,13 +9,13 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
+namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem
 {
     // TODO(cyrusn): Use a predefined name here.
     [ExportCompletionProvider("ReferenceDirectiveCompletionProvider", LanguageNames.CSharp)]
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
 
         private ICurrentWorkingDirectoryDiscoveryService GetFileSystemDiscoveryService(ITextSnapshot textSnapshot)
         {
-            return PathCompletionUtilities.GetCurrentWorkingDirectoryDiscoveryService(textSnapshot);
+            return CurrentWorkingDirectoryDiscoveryService.GetService(textSnapshot);
         }
 
         private TextSpan GetTextChangeSpan(SyntaxToken stringLiteral, int position)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/GlobalAssemblyCacheCompletionHelperTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/GlobalAssemblyCacheCompletionHelperTests.cs
@@ -4,12 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders;
+using Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Language.Intellisense;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/EditorFeatures/CSharpTest/Completion/ReferenceDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ReferenceDirectiveCompletionProviderTests.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders;
+using Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -413,6 +413,11 @@
     <Compile Include="Implementation\GoToDefinition\IGoToDefinitionService.cs" />
     <Compile Include="Implementation\Intellisense\Completion\CompletionProviders\MemberInsertingCompletionItemRules.cs" />
     <Compile Include="Implementation\Intellisense\Completion\CompletionProviders\XmlDocCommentCompletion\AbstractXmlDocCommentCompletionItemRules.cs" />
+    <Compile Include="Implementation\Intellisense\Completion\FileSystem\CurrentWorkingDirectoryDiscoveryService.cs" />
+    <Compile Include="Implementation\Intellisense\Completion\FileSystem\FileSystemCompletionHelper.cs" />
+    <Compile Include="Implementation\Intellisense\Completion\FileSystem\ICurrentWorkingDirectoryDiscoveryService.cs" />
+    <Compile Include="Implementation\Intellisense\Completion\FileSystem\IOUtilities.cs" />
+    <Compile Include="Implementation\Intellisense\Completion\FileSystem\PathCompletionUtilities.cs" />
     <Compile Include="Implementation\KeywordHighlighting\AbstractKeywordHighlighter.cs" />
     <Compile Include="Implementation\KeywordHighlighting\HighlighterTagProducer.cs" />
     <Compile Include="Implementation\KeywordHighlighting\HighlighterViewTaggerProvider.cs" />
@@ -501,7 +506,6 @@
     <Compile Include="Implementation\Intellisense\Completion\Controller_TypeChar.cs" />
     <Compile Include="Implementation\Intellisense\Completion\DescriptionModifyingCompletionItem.cs" />
     <Compile Include="Implementation\Intellisense\Completion\Model.cs" />
-    <Compile Include="Implementation\Intellisense\Completion\PathCompletionUtilities.cs" />
     <Compile Include="Implementation\Intellisense\Completion\Presentation\CompletionPresenter.cs" />
     <Compile Include="Implementation\Intellisense\Completion\Presentation\CompletionPresenterSession.cs" />
     <Compile Include="Implementation\Intellisense\Completion\Presentation\CompletionSet2.cs" />
@@ -834,6 +838,7 @@
     </None>
     <PublicAPI Include="PublicAPI.txt" />
   </ItemGroup>
+  <ItemGroup />
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/CurrentWorkingDirectoryDiscoveryService.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/CurrentWorkingDirectoryDiscoveryService.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.IO;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 
-namespace Microsoft.CodeAnalysis.Completion.Providers
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem
 {
     internal class CurrentWorkingDirectoryDiscoveryService : ICurrentWorkingDirectoryDiscoveryService
     {
@@ -16,6 +16,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public string CurrentDirectory
         {
             get { return Directory.GetCurrentDirectory(); }
+        }
+
+        public static ICurrentWorkingDirectoryDiscoveryService GetService(ITextSnapshot textSnapshot)
+        {
+            ICurrentWorkingDirectoryDiscoveryService result;
+            return textSnapshot.TextBuffer.Properties.TryGetProperty(typeof(ICurrentWorkingDirectoryDiscoveryService), out result)
+                ? result
+                : Instance;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/FileSystemCompletionHelper.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/FileSystemCompletionHelper.cs
@@ -7,11 +7,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Completion.Providers
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem
 {
     internal sealed class FileSystemCompletionHelper
     {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/ICurrentWorkingDirectoryDiscoveryService.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/ICurrentWorkingDirectoryDiscoveryService.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Microsoft.CodeAnalysis.Completion.Providers
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem
 {
     internal interface ICurrentWorkingDirectoryDiscoveryService
     {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/IOUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/IOUtilities.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Security;
 
-namespace Microsoft.CodeAnalysis.Completion.Providers
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem
 {
     internal static class IOUtilities
     {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/PathCompletionUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/PathCompletionUtilities.cs
@@ -2,13 +2,10 @@
 
 using System;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem
 {
     internal static class PathCompletionUtilities
     {
@@ -106,14 +103,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             return -1;
-        }
-
-        internal static ICurrentWorkingDirectoryDiscoveryService GetCurrentWorkingDirectoryDiscoveryService(ITextSnapshot textSnapshot)
-        {
-            ICurrentWorkingDirectoryDiscoveryService result;
-            return textSnapshot.TextBuffer.Properties.TryGetProperty(typeof(ICurrentWorkingDirectoryDiscoveryService), out result)
-                ? result
-                : CurrentWorkingDirectoryDiscoveryService.Instance;
         }
     }
 }

--- a/src/Features/Core/Completion/CompletionListContext.cs
+++ b/src/Features/Core/Completion/CompletionListContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 
@@ -47,6 +48,19 @@ namespace Microsoft.CodeAnalysis.Completion
             }
 
             _itemsBuilder.Add(item);
+        }
+
+        public void AddItems(IEnumerable<CompletionItem> items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            foreach (var item in items)
+            {
+                AddItem(item);
+            }
         }
 
         public ImmutableArray<CompletionItem> GetItems()

--- a/src/Features/Core/Completion/Providers/TextCompletionListProvider.cs
+++ b/src/Features/Core/Completion/Providers/TextCompletionListProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
-    internal abstract class TextCompletionProvider : AbstractCompletionProvider
+    internal abstract class TextCompletionProvider : CompletionListProvider
     {
         /// <summary>
         /// Returns a CompletionItemGroup for the specified position in the text.

--- a/src/Features/Core/Features.csproj
+++ b/src/Features/Core/Features.csproj
@@ -170,12 +170,8 @@
     <Compile Include="Completion\Providers\AbstractObjectCreationCompletionProvider.cs" />
     <Compile Include="Completion\Providers\AbstractObjectInitializerCompletionProvider.cs" />
     <Compile Include="Completion\Providers\AbstractSymbolCompletionProvider.cs" />
-    <Compile Include="Completion\Providers\CurrentWorkingDirectoryDiscoveryService.cs" />
-    <Compile Include="Completion\Providers\FileSystemCompletionHelper.cs" />
     <Compile Include="Completion\CompletionListProvider.cs" />
-    <Compile Include="Completion\Providers\ICurrentWorkingDirectoryDiscoveryService.cs" />
     <Compile Include="Completion\Providers\IKeywordRecommender.cs" />
-    <Compile Include="Completion\Providers\IOUtilities.cs" />
     <Compile Include="Completion\Providers\ISnippetCompletionProvider.cs" />
     <Compile Include="Completion\Providers\KeywordCompletionItemRules.cs" />
     <Compile Include="Completion\Providers\ObjectInitializerCompletionItemRules.cs" />

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -13,7 +13,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
-using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
@@ -28,6 +27,7 @@ using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Microsoft.CodeAnalysis.Scripting;
 using Roslyn.Utilities;
 using GacFileResolver = WORKSPACES::Microsoft.CodeAnalysis.Scripting.GacFileResolver;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 
 namespace Microsoft.CodeAnalysis.Editor.Interactive
 {

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.ItemRules.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.ItemRules.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Interactive;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -87,9 +87,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
                 return ImmutableArray<CompletionItem>.Empty;
             }
 
-            var fileSystem = PathCompletionUtilities.GetCurrentWorkingDirectoryDiscoveryService(snapshot);
+            var fileSystem = CurrentWorkingDirectoryDiscoveryService.GetService(snapshot);
 
-            var searchPaths = ImmutableArray.Create<string>(fileSystem.CurrentDirectory);
+            var searchPaths = ImmutableArray.Create(fileSystem.CurrentDirectory);
 
             var helper = new FileSystemCompletionHelper(
                 this,

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/LoadCommandCompletionProvider.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -34,6 +33,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             }
 
             return new CompletionList(items);
+        }
+
+        public override async Task ProduceCompletionListAsync(CompletionListContext context)
+        {
+            var document = context.Document;
+            var position = context.Position;
+            var triggerInfo = context.TriggerInfo;
+            var cancellationToken = context.CancellationToken;
+
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var items = GetItems(text, position, triggerInfo, cancellationToken);
+
+            context.AddItems(items);
         }
 
         public override bool IsTriggerCharacter(SourceText text, int characterPosition, OptionSet options)
@@ -104,12 +116,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             var pathThroughLastSlash = this.GetPathThroughLastSlash(text, position, quotedPathGroup);
 
             return helper.GetItems(pathThroughLastSlash, documentPath: null);
-        }
-
-        protected override async Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(Document document, int position, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken)
-        {
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            return GetItems(text, position, triggerInfo, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
In order to make the Features layer portable, file system completion needs to be moved out.