### PR TITLE
Remove unneeded references to remove build warning. 

### DIFF
--- a/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
@@ -62,7 +62,6 @@
     </RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="System.Composition.AttributedModel">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.$(MicrosoftCompositionVersion)\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -83,8 +82,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Microsoft.Composition.$(MicrosoftCompositionVersion)\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Import Include="Microsoft.VisualBasic" />


### PR DESCRIPTION
Remove unneeded references to remove build warning. 

Building BasicRoslyncDiagnosticAnalyzers.project resulted in a build
warning about not being able to find System.Data.

Portable projects themselves don't need to specify any references as
they are implicitly added by the portable targets. Removed all framework
references, which also cleaned up the warning.
