### PR TITLE
Hide InternalsVisibleToTypeScript items from UI tree

### DIFF
--- a/build/Targets/GenerateInternalsVisibleTo.targets
+++ b/build/Targets/GenerateInternalsVisibleTo.targets
@@ -14,6 +14,9 @@
     <InternalsVisibleToTest>
       <Visible>false</Visible>
     </InternalsVisibleToTest>
+    <InternalsVisibleToTypeScript>
+      <Visible>false</Visible>
+    </InternalsVisibleToTypeScript>
   </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(PublicKey)' != '' and '$(SignAssembly)' == 'True'">

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -120,9 +120,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ProjectLanguage)' == 'CSharp' AND '$(TargetNetFX20)' == 'true'">
-    <Reference Include="$(FrameworkPathOverride)\mscorlib.dll">
-      <Private>False</Private>
-    </Reference>
+    <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
InternalsVisibleToTypeScript items are showing up the Solution Explorer visual tree
as missing items (because the C# project system treats them as files). Hide them
like the other InternalsVisibleToXX items.