### PR TITLE
Dont fail format on MAS with Tabs on

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var commonToken1 = this.Token1;
                 var commonToken2 = this.Token2;
 
-                var span = TextSpan.FromBounds(commonToken1.Span.End, commonToken2.Span.Start);
+                var span = TextSpan.FromBounds(commonToken1.Span.End, commonToken2.Kind() == SyntaxKind.None ? commonToken1.Span.End : commonToken2.Span.Start);
                 if (context.IsSpacingSuppressed(span))
                 {
                     return false;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -74,7 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var commonToken1 = this.Token1;
                 var commonToken2 = this.Token2;
 
-                var span = TextSpan.FromBounds(commonToken1.Span.End, commonToken2.Kind() == SyntaxKind.None ? commonToken1.Span.End : commonToken2.Span.Start);
+                var formatSpanEnd = commonToken2.Kind() == SyntaxKind.None ? commonToken1.Span.End : commonToken2.Span.Start;
+                var span = TextSpan.FromBounds(commonToken1.Span.End, formatSpanEnd);
                 if (context.IsSpacingSuppressed(span))
                 {
                     return false;

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1721,6 +1718,47 @@ class Program
             var actual = formatted.ToFullString();
             var expected = "class C\n{\n}";
 
+            Assert.Equal(expected, actual);
+        }
+
+        [WorkItem(4019, "https://github.com/dotnet/roslyn/issues/4019")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatWithTabs()
+        {
+
+            var code = @"#region Assembly mscorlib
+// C:\
+#endregion
+
+using System.Collections;
+
+class F
+{
+    string s;
+}";
+            var expected = @"#region Assembly mscorlib
+// C:\
+#endregion
+
+using System.Collections;
+
+class F
+{
+	string s;
+}";
+            var tree = SyntaxFactory.ParseCompilationUnit(code);
+
+            var text = DefaultWorkspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
+            var newLine = SyntaxFactory.ElasticEndOfLine(text);
+
+            tree = tree.ReplaceTokens(tree.DescendantTokens(descendIntoTrivia: true)
+                .Where(tr => tr.IsKind(SyntaxKind.EndOfDirectiveToken)), (o, r) => o.WithTrailingTrivia(o.LeadingTrivia.Add(newLine))
+                                                                                    .WithLeadingTrivia(SyntaxFactory.TriviaList())
+                                                                                    .WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation));
+
+            var formatted = Formatter.Format(tree, DefaultWorkspace, DefaultWorkspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, true));
+
+            var actual = formatted.ToFullString();
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
@@ -1748,13 +1748,12 @@ class F
 }";
             var tree = SyntaxFactory.ParseCompilationUnit(code);
 
-            var text = DefaultWorkspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
-            var newLine = SyntaxFactory.ElasticEndOfLine(text);
+            var newLineText = SyntaxFactory.ElasticEndOfLine(DefaultWorkspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp));
 
             tree = tree.ReplaceTokens(tree.DescendantTokens(descendIntoTrivia: true)
-                .Where(tr => tr.IsKind(SyntaxKind.EndOfDirectiveToken)), (o, r) => o.WithTrailingTrivia(o.LeadingTrivia.Add(newLine))
-                                                                                    .WithLeadingTrivia(SyntaxFactory.TriviaList())
-                                                                                    .WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation));
+                                          .Where(tr => tr.IsKind(SyntaxKind.EndOfDirectiveToken)), (o, r) => o.WithTrailingTrivia(o.LeadingTrivia.Add(newLineText))
+                                                                                                              .WithLeadingTrivia(SyntaxFactory.TriviaList())
+                                                                                                              .WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation));
 
             var formatted = Formatter.Format(tree, DefaultWorkspace, DefaultWorkspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, true));
 


### PR DESCRIPTION
Fixes #4019 While formatting a complextrivia that falls as a end_of_tree
trivia of a tree that is being formatted, adjust the span of the
ComplexTrivia for formatting purposes