### PR TITLE
Remove namespaces from ScriptOptions.Default

### DIFF
--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp.Test
         [Fact]
         public void TestRunVoidScript()
         {
-            var result = CSharpScript.RunAsync("Console.WriteLine(0);");
+            var result = CSharpScript.RunAsync("System.Console.WriteLine(0);");
             var task = result.ReturnValue;
             Assert.Null(task.Result);
         }

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -33,8 +33,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         static ScriptOptions()
         {
             Default = new ScriptOptions()
-                        .WithReferences(typeof(int).GetTypeInfo().Assembly)
-                        .WithNamespaces("System");
+                        .WithReferences(typeof(int).GetTypeInfo().Assembly);
         }
 
         private ScriptOptions(

--- a/src/Scripting/VisualBasicTest/ScriptTests.vb
+++ b/src/Scripting/VisualBasicTest/ScriptTests.vb
@@ -62,9 +62,16 @@ Namespace Microsoft.CodeAnalysis.Scripting.VisualBasic.UnitTests
 
         <Fact>
         Public Sub TestRunVoidScript()
-            Dim result = VisualBasicScript.RunAsync("Console.WriteLine(0)", DefaultOptions)
+            Dim result = VisualBasicScript.RunAsync("System.Console.WriteLine(0)", DefaultOptions)
             Dim task = result.ReturnValue
             Assert.Null(task.Result)
+        End Sub
+
+        <Fact>
+        Public Sub TestDefaultNamespaces()
+            ' If this ever changes, it is important to ensure that the 
+            ' IDE is also updated with the same default namespaces.
+            Assert.Empty(ScriptOptions.Default.Namespaces)
         End Sub
 
         Public Class Globals


### PR DESCRIPTION
The IDE does not consume ```ScriptOptions.Default``` so the IDE and the host
were out of sync.  For example, ```typeof(Console)``` would be squiggled
in the Interactive window but would evaluate correctly when submitted.

Fixes #4154