### PR TITLE
Opt projects building against portable into the portable flavor.

### DIFF
--- a/src/Compilers/CSharp/CscCore/CscCore.csproj
+++ b/src/Compilers/CSharp/CscCore/CscCore.csproj
@@ -20,6 +20,7 @@
     <RestorePackages>true</RestorePackages>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
     <TargetCoreClr>true</TargetCoreClr>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\CodeAnalysis.csproj">

--- a/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
+++ b/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
@@ -20,6 +20,7 @@
     <RestorePackages>true</RestorePackages>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
     <TargetCoreClr>true</TargetCoreClr>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\CodeAnalysis.csproj">

--- a/src/Diagnostics/Roslyn/CSharp/CSharpRoslynDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/Roslyn/CSharp/CSharpRoslynDiagnosticAnalyzers.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/Diagnostics/Roslyn/Core/RoslynDiagnosticAnalyzers.csproj
+++ b/src/Diagnostics/Roslyn/Core/RoslynDiagnosticAnalyzers.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />

--- a/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
+++ b/src/Diagnostics/Roslyn/VisualBasic/BasicRoslynDiagnosticAnalyzers.vbproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <ProjectTypeGuids>{14182A97-F7F0-4C62-8B27-98AA8AE2109A};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
   </PropertyGroup>
   <ItemGroup Label="File References">
     <Reference Include="..\..\..\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll" />


### PR DESCRIPTION
This fixes these warnings when Win10 tools are installed due to #4191.

  Unable to add a reference to project 'BasicCodeAnalysis'. The current project does not support references to Portable Library projects.