### PR TITLE
Fixing Build/AssemblyVersion during OfficialBuild

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -258,8 +258,8 @@
       </PropertyGroup>
     </When>
 
-    <When Condition="'$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">
-      <!-- We're real-signing the build, but don't have a build number. Just use the RoslynSemanticVersion.
+    <When Condition="'$(OfficialBuild)' == 'true' OR '$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">
+      <!-- We're creating an official or real-signed build, but don't have a build number. Just use the RoslynSemanticVersion.
            This happens if the build template does not pass BuildNumber down to MSBuild. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>


### PR DESCRIPTION
This fixes the Build/AssemblyVersion to be the same as RoslynSemanticVersion when OfficialBuild is true, but no BuildVersion was passed in.