### PR TITLE
Use different ContentType for InteractiveWindowCommands...

### DIFF
--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
     /// 
     /// This interface is a MEF contract and can be implemented and exported to add commands to the REPL window.
     /// </summary>
-    [ContentType("code")]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
     internal abstract class InteractiveWindowCommand : IInteractiveWindowCommand
     {
         public abstract Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments);

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             _classifierAggregator = classifierAggregator;
             _contentTypeRegistry = contentTypeRegistry;
             _vsWorkspace = workspace;
-            _commands = FilterCommands(commands, contentType: "code");
+            _commands = FilterCommands(commands, contentType: PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName);
             _vsInteractiveWindowFactory = interactiveWindowFactory;
             _commandsFactory = commandsFactory;
         }


### PR DESCRIPTION
I didn't know about ```PredefinedInteractiveCommandsContentTypes```
when I initially added the ContentType attribute to the interactive
commands.  Switching to use the constant defined there (instead of
just "code")...