### PR TITLE
Don't trigger "completionlist tag" completion in trivia

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -342,6 +342,32 @@ End Class
             VerifyItemIsAbsent(markup, "e As E")
         End Sub
 
+        <WorkItem(3518, "https://github.com/dotnet/roslyn/issues/3518")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NotInTrivia()
+            Dim markup = <Text><![CDATA[
+Class C
+    Sub Test()
+        M(Type2.A)
+        ' $$
+    End Sub
+
+    Private Sub M(a As Type1)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+''' <completionlist cref="Type2"/>
+Public Class Type1
+End Class
+
+Public Class Type2
+    Public Shared A As Type1
+    Public Shared B As Type1
+End Class
+]]></Text>.Value
+            VerifyNoItemsExist(markup)
+        End Sub
+
         Friend Overrides Function CreateCompletionProvider() As CompletionListProvider
             Return New CompletionListTagCompletionProvider()
         End Function

--- a/src/Features/VisualBasic/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
+++ b/src/Features/VisualBasic/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
@@ -14,7 +14,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         Inherits EnumCompletionProvider
 
         Protected Overrides Function GetPreselectedSymbolsWorker(context As AbstractSyntaxContext, position As Integer, options As OptionSet, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of ISymbol))
-            If context.SyntaxTree.IsObjectCreationTypeContext(position, cancellationToken) Then
+            If context.SyntaxTree.IsObjectCreationTypeContext(position, cancellationToken) OrElse
+                context.SyntaxTree.IsInNonUserCode(position, cancellationToken) Then
                 Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
             End If
 


### PR DESCRIPTION
Fixes #3518.

This was originally https://github.com/dotnet/roslyn/pull/3519 against stabilization, but this is a PR to get into master. Note that @dpoeschl has an additional change to fix up the type inferrer.

cc @Pilchie @dpoeschl @jasonmalinowski 