### PR TITLE
Never show the enum backing field in the completion list

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6536,6 +6536,44 @@ End Class
             VerifyItemExists(text, "y")
         End Sub
 
+        <WorkItem(4136, "https://github.com/dotnet/roslyn/issues/4136")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NoValue__WhenDottingIntoEnum()
+            Dim text =
+<code><![CDATA[
+Enum E
+    A
+End Enum
+
+Class Program
+    Sub Foo()
+        E.$$
+    End Sub
+End Class
+]]></code>.Value
+            VerifyItemExists(text, "A")
+            VerifyItemIsAbsent(text, "value__")
+        End Sub
+
+        <WorkItem(4136, "https://github.com/dotnet/roslyn/issues/4136")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub NoValue__WhenDottingIntoLocalOfEnumType()
+            Dim text =
+<code><![CDATA[
+Enum E
+    A
+End Enum
+
+Class Program
+    Sub Foo()
+        Dim x = E.A
+        x.$$
+    End Sub
+End Class
+]]></code>.Value
+            VerifyItemIsAbsent(text, "value__")
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Sub SharedProjectFieldAndPropertiesTreatedAsIdentical()
             Dim markup = <Workspace>

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
@@ -311,6 +311,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             ' Filter events and generated members
             symbols = symbols.Where(Function(s) FilterEventsAndGeneratedSymbols(node, s))
 
+            ' Never show the enum backing field
+            symbols = symbols.Where(Function(s) s.Kind <> SymbolKind.Field OrElse Not s.ContainingType.IsEnumType() OrElse s.Name <> WellKnownMemberNames.EnumBackingFieldName)
+
             Return symbols
         End Function
 


### PR DESCRIPTION
Also, add a test for #4136.

Reviewers: @balajikris @basoundr @brettfo @dpoeschl @DustinCampbell @jasonmalinowski @Pilchie 