### PR TITLE
Unflip condition in InteractiveWindow.InsertCode

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             public void InsertCode(string text)
             {
-                if (_window._stdInputStart == null)
+                if (_window._stdInputStart != null)
                 {
                     return;
                 }

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         [Fact]
         public void CallBackspaceOnNonUIThread()
         {
-            Window.Operations.BreakLine(); // Something to backspace.
+            Window.InsertCode("1"); // Something to backspace.
             Task.Run(() => Window.Operations.Backspace()).PumpingWait();
         }
 
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         [Fact]
         public void CallClearViewOnNonUIThread()
         {
-            Window.Operations.BreakLine(); // Something to clear.
+            Window.InsertCode("1"); // Something to clear.
             Task.Run(() => Window.Operations.ClearView()).PumpingWait();
         }
 
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         [Fact]
         public void CallSelectAllOnNonUIThread()
         {
-            Window.Operations.BreakLine(); // Something to select.
+            Window.InsertCode("1"); // Something to select.
             Task.Run(() => Window.Operations.SelectAll()).PumpingWait();
         }
 


### PR DESCRIPTION
It should work when there is no standard input.  This was causing problems
for a lot of (still skipped) integration tests.