### PR TITLE
No longer mark text buffers as user-readonly

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -146,7 +146,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             if (ErrorHandler.Succeeded(textBuffer.GetStateFlags(out textBufferFlags)) &&
                 0 != (textBufferFlags & ((uint)BUFFERSTATEFLAGS.BSF_FILESYS_READONLY | (uint)BUFFERSTATEFLAGS.BSF_USER_READONLY)))
             {
-                ((IVsPersistDocData2)textBuffer).SetDocDataReadOnly(1);
                 readOnlyStatus = READONLYSTATUS.ROSTATUS_ReadOnly;
             }
 


### PR DESCRIPTION
Fixes #4039 - TFS doesn't auto checkout files in VB Winforms Project.

Whenever we create an editor for buffer, we would mark the buffer as
user read-only (ie via SetDocDataReadOnly) if the buffer was read-only
on disk or already user read-only.

This is incorrect for two reasons:

1.  First, this line of code that was removed would only ever run on existing buffers.
     New buffer's had not yet been loaded/populated, so they were never considered
     read-only.

2.  Calling SetDocDataReadOnly is effectively equivalent to calling
     SetStateFlags(BUFFERSTATEFLAGS.BSF_USER_READONLY), so effectively we're
     reading the state flags, only to go and set the same flags that we just read,
     except adding BSF_USER_READONLY if it was marked as as BSF_FILESYS_READONLY.

We shouldn't be setting these flags at all, we don't populating any of these buffers. We
should let those that do populate the buffers worry about whether it's read-only or not.