### PR TITLE
Fix VB member body span used to determine whether speculative binding should be used

### DIFF
--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -131,15 +131,27 @@
     <DocumentationFile>Roslyn.Services.Editor.UnitTests2.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.CallHierarchy, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Internal, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -182,6 +194,7 @@
   <ItemGroup>
     <Compile Include="CallHierarchy\CallHierarchyTests.vb" />
     <Compile Include="Diagnostics\InMemoryAssemblyLoader.vb" />
+    <Compile Include="LanguageServices\SyntaxFactsServiceTests.vb" />
     <Compile Include="Utilities\MockDocumentNavigationServiceProvider.vb" />
     <Compile Include="Utilities\MockSymbolNavigationServiceProvider.vb" />
     <Compile Include="CodeFixes\CodeFixServiceTests.vb" />

--- a/src/EditorFeatures/Test2/LanguageServices/SyntaxFactsServiceTests.vb
+++ b/src/EditorFeatures/Test2/LanguageServices/SyntaxFactsServiceTests.vb
@@ -1,0 +1,220 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Text
+Imports Roslyn.Utilities
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.LanguageServices
+    Public Class SyntaxFactsServiceTests
+
+        <Fact>
+        Public Sub CSharp_TestGetMemberBodySpanForSpeculativeBinding1()
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    $$void M()
+    {{|MemberBodySpan:
+        var x = 42;
+    |}}
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub CSharp_TestGetMemberBodySpanForSpeculativeBinding2()
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    void $$M()
+    {{|MemberBodySpan:
+        var x = 42;
+    |}}
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub CSharp_TestGetMemberBodySpanForSpeculativeBinding3()
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    void M()$$
+    {{|MemberBodySpan:
+        var x = 42;
+    |}}
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub CSharp_TestGetMemberBodySpanForSpeculativeBinding4()
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    void M()
+    {{|MemberBodySpan:
+        var $$x = 42;
+    |}}
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub CSharp_TestGetMemberBodySpanForSpeculativeBinding5()
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    void M()
+    {
+        var x = 42;
+    }
+$$}
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub VB_TestGetMemberBodySpanForSpeculativeBinding1()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    $$Sub M()
+{|MemberBodySpan:        Dim x = 42
+    |}End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub VB_TestGetMemberBodySpanForSpeculativeBinding2()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub $$M()
+{|MemberBodySpan:        Dim x = 42
+    |}End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub VB_TestGetMemberBodySpanForSpeculativeBinding3()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub M()$$
+{|MemberBodySpan:        Dim x = 42
+    |}End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub VB_TestGetMemberBodySpanForSpeculativeBinding4()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub M()
+{|MemberBodySpan:        Dim $$x = 42
+    |}End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        <Fact>
+        Public Sub VB_TestGetMemberBodySpanForSpeculativeBinding5()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub M()
+        Dim x = 42
+    End Sub
+$$End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            VerifyGetMemberBodySpanForSpeculativeBinding(definition)
+        End Sub
+
+        Private Sub VerifyGetMemberBodySpanForSpeculativeBinding(workspaceDefinition As XElement)
+            Using workspace = TestWorkspaceFactory.CreateWorkspace(workspaceDefinition)
+                Dim cursorDocument = workspace.DocumentWithCursor
+                Dim cursorPosition = cursorDocument.CursorPosition.Value
+
+                Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
+                Dim root = document.GetSyntaxRootAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None)
+                Dim node = root.FindNode(New TextSpan(cursorPosition, 0))
+                Dim syntaxFactsService = document.GetLanguageService(Of ISyntaxFactsService)()
+
+                Dim expected = If(cursorDocument.AnnotatedSpans.ContainsKey("MemberBodySpan"), cursorDocument.AnnotatedSpans!MemberBodySpan.Single(), Nothing)
+                Dim actual = syntaxFactsService.GetMemberBodySpanForSpeculativeBinding(node)
+
+                Assert.Equal(expected, actual)
+            End Using
+        End Sub
+
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
@@ -173,5 +173,23 @@ End Class
 
             VerifyNoItemsExist(code)
         End Sub
+
+        <WorkItem(4167, "https://github.com/dotnet/roslyn/issues/4167")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub ImplementsAfterSub()
+            Dim code = "
+Interface I
+End Interface
+
+Class C
+    Implements I
+
+    Sub M() $$
+    End Sub
+End Class
+"
+
+            VerifyItemExists(code, "Implements")
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -136,6 +136,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         int GetMethodLevelMemberId(SyntaxNode root, SyntaxNode node);
         SyntaxNode GetMethodLevelMember(SyntaxNode root, int memberId);
 
+        /// <summary>
+        /// Given a <see cref="SyntaxNode"/>, return the <see cref="TextSpan"/> representing the span of the member body
+        /// it is contained within. This <see cref="TextSpan"/> is used to determine whether speculative binding should be
+        /// used in performance-critical typing scenarios. Note: if this method fails to find a relevant span, it returns
+        /// an empty <see cref="TextSpan"/> at position 0.
+        /// </summary>
         TextSpan GetMemberBodySpanForSpeculativeBinding(SyntaxNode node);
 
         /// <summary>

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -662,7 +662,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing
                 End If
 
-                Return TextSpan.FromBounds(method.BlockStatement.Span.End, method.EndBlockStatement.SpanStart)
+                ' We don't want to include the BlockStatement or any trailing trivia up to and including its statement
+                ' terminator in the span. Instead, we use the start of the first statement's leading trivia (if any) up
+                ' to the start of the EndBlockStatement. If there aren't any statements in the block, we use the start
+                ' of the EndBlockStatements leading trivia.
+
+                Dim firstStatement = method.Statements.FirstOrDefault()
+                Dim spanStart = If(firstStatement IsNot Nothing,
+                                   firstStatement.FullSpan.Start,
+                                   method.EndBlockStatement.FullSpan.Start)
+
+                Return TextSpan.FromBounds(spanStart, method.EndBlockStatement.SpanStart)
             End If
 
             Return Nothing


### PR DESCRIPTION
To determine whether or not speculative binding should be used, GetSemanticModelForSpanAsync calls into ISyntaxFactsService.GetMemberBodySpanForSpeculativeBinding(). In VB, the span returned by this method started from the end of the block statement to the start of the end block statement. However, for VB, the span should start after the block statement's terminator. Otherwise, a member body speculative semantic model will likey be returned when the requested span is within the trivia after the block statement but before the statement terminator. E.g.

```VB
Class C
    Sub M() |

    End Sub
End Class
```

Fixes Issue #4167 where the Implements keyword was not showing up correctly in VB IntelliSense. Essentially, the problem here is that the Implements keyword recommender does a bit of semantic work to determine whether the enclosing type has an Implements statement in any of its partial types. Before this change, it failed to get the declared symbol for the enclosing type because it was incorrectly querying a speculative semantic model for the method body.