### PR TITLE
Local functions update: Bugfixes and documentation

### DIFF
--- a/docs/features/local-functions.md
+++ b/docs/features/local-functions.md
@@ -37,4 +37,4 @@ TODO:
 	- `LocalScopeBinder.ReportConflictWithLocal()` (twice)
 - `LocalScopeBinder.EnsureSingleDefinition()`, handle case where 'name' exists in both `localsMap` and `localFunctionsMap`. Might be related to `LocalFunctionTests.NameConflictLocalVarLast()`
 - Defining a local function with a dynamic parameter doesn't work at runtime.
-- Return type of `var` is strange - when normally compiling, it works fine, but intellisense/etc doesn't work.
+- Return type of `var` is broken - see LocalFunctionSymbol.cs for an explanation. Fixing it will require a large rewrite of much of return type analysis, as the current system assumes that all return types are known (mostly) without examining the method body.

--- a/docs/features/local-functions.md
+++ b/docs/features/local-functions.md
@@ -3,12 +3,9 @@
 	- Currently thought to be unambiguous past the parameter list (starting at `{` or `=>`), but that requires lots of lookahead.
 	- See LanguageParser.cs for comments on both ambiguity in standard parsing, and ambiguity in error recovery.
 - [x] N-level nested local functions
-- [ ] Capture
-	- [x] Initial implementation
-	- [ ] Tests
-	- [x] IDE integration
-	- Works alongside lambdas and behaves very similarly
-	- Implemented zero-allocation closures on functions never converted to a delegate
+- [x] Capture
+	- Works alongside lambdas and behaves very similarly in fallback cases
+	- Has zero-allocation closures (struct frames by ref) on functions never converted to a delegate and are not an iterator/async
 - [x] Standard parameter features
 	- params
 	- ref/out
@@ -32,6 +29,7 @@
 Intentionally disabled features that might eventually be in the end result:
 - Calling a local function with a dynamic argument (due to name mangling and potential conflicts with closures and possibly overloads/shadows)
 - Referring to a local function in an expression tree (note that defining a local function itself in an expression tree is impossible)
+- Definite assignment rules: Currently, all captured variables must be assigned at point of local function declaration. Might change to requiring assignment at point of local function use, not declaration (would allow mutually recursive local functions without nesting, etc.). Related to "Visibility" point in main list.
 
 TODO:
 
@@ -39,3 +37,4 @@ TODO:
 	- `LocalScopeBinder.ReportConflictWithLocal()` (twice)
 - `LocalScopeBinder.EnsureSingleDefinition()`, handle case where 'name' exists in both `localsMap` and `localFunctionsMap`. Might be related to `LocalFunctionTests.NameConflictLocalVarLast()`
 - Defining a local function with a dynamic parameter doesn't work at runtime.
+- Return type of `var` is strange - when normally compiling, it works fine, but intellisense/etc doesn't work.

--- a/docs/features/local-functions.md
+++ b/docs/features/local-functions.md
@@ -8,7 +8,7 @@
 	- [ ] Tests
 	- [x] IDE integration
 	- Works alongside lambdas and behaves very similarly
-	- Partially implemented zero-allocation closures on functions never converted to a delegate (nested zero-alloc closures are disabled)
+	- Implemented zero-allocation closures on functions never converted to a delegate
 - [x] Standard parameter features
 	- params
 	- ref/out

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -445,13 +445,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     block = null;
                     hasErrors = true;
-                    // TODO: add a message for this? (but parser currently doesn't produce syntax node with both null)
+                    // TODO: add a message for this?
                     diagnostics.Add(ErrorCode.ERR_ConcreteMissingBody, localSymbol.Locations[0], localSymbol);
                 }
 
                 if (block != null)
                 {
-                    localSymbol.ComputeReturnType(block, forceNotNull: true, isIterator: false);
+                    localSymbol.ComputeReturnType(block, returnNullIfUnknown: false, isIterator: false);
 
                     // Have to do ControlFlowPass here because in MethodCompiler, we don't call this for synthed methods
                     // rather we go directly to LowerBodyOrInitializer, which skips over flow analysis (which is in CompileMethod)

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var localFunctionsMap = this.LocalFunctionsMap;
-            if (localFunctionsMap != null && (options & LookupOptions.NamespaceAliasesOnly) == 0)
+            if (localFunctionsMap != null && options.CanConsiderLocals())
             {
                 LocalFunctionSymbol localSymbol;
                 if (localFunctionsMap.TryGetValue(name, out localSymbol))

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Bind switch section
             ImmutableArray<BoundSwitchSection> boundSwitchSections = BindSwitchSections(node.Sections, originalBinder, diagnostics);
 
-            return new BoundSwitchStatement(node, boundSwitchExpression, constantTargetOpt, Locals, boundSwitchSections, this.BreakLabel, null);
+            return new BoundSwitchStatement(node, boundSwitchExpression, constantTargetOpt, Locals, LocalFunctions, boundSwitchSections, this.BreakLabel, null);
         }
 
         // Bind the switch expression and set the switch governing type

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -653,6 +653,7 @@
     
     <!-- Locals declared immediately within the switch block. -->
     <Field Name="InnerLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
+    <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
     <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundSwitchSection&gt;"/>    
     <Field Name="BreakLabel" Type="GeneratedLabelSymbol"/>
     <!-- Well-known member populated during lowering -->

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2339,6 +2339,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot infer the type of &apos;{0}&apos; as it does not return a value..
+        /// </summary>
+        internal static string ERR_CantInferVoid {
+            get {
+                return ResourceManager.GetString("ERR_CantInferVoid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot create temporary file -- {0}.
         /// </summary>
         internal static string ERR_CantMakeTempFile {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4656,4 +4656,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_DynamicLocalFunctionParameter" xml:space="preserve">
     <value>Cannot invoke the local function '{0}' with dynamic parameters.</value>
   </data>
+  <data name="ERR_CantInferVoid" xml:space="preserve">
+    <value>Cannot infer the type of '{0}' as it does not return a value.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -1522,7 +1522,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // expressions do not contain labels or branches
                 BoundExpression boundExpression = node.BoundExpression;
                 ImmutableArray<BoundSwitchSection> switchSections = (ImmutableArray<BoundSwitchSection>)this.VisitList(node.SwitchSections);
-                return node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, switchSections, breakLabelClone, node.StringEquality);
+                return node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, switchSections, breakLabelClone, node.StringEquality);
             }
 
             public override BoundNode VisitSwitchLabel(BoundSwitchLabel node)

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1318,7 +1318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 this.RecordLabel(breakLabel);
             }
 
-            var result = node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, switchSections, breakLabel, node.StringEquality);
+            var result = node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, switchSections, breakLabel, node.StringEquality);
 
             // implicit control flow
             EnsureOnlyEvalStack();

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1314,5 +1314,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpressionTreeContainsLocalFunction = 8096,
         ERR_ReturnTypesDontMatch = 8097,
         ERR_DynamicLocalFunctionParameter = 8098,
+        ERR_CantInferVoid = 8099,
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1302,6 +1302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DeclareVariables(node.InnerLocals);
             var result = base.VisitSwitchStatement(node);
             ReportUnusedVariables(node.InnerLocals);
+            ReportUnusedVariables(node.InnerLocalFunctions);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundSpillSequenceBuilder builder = null;
             var boundExpression = VisitExpression(ref builder, node.BoundExpression);
             var switchSections = this.VisitList(node.SwitchSections);
-            return UpdateStatement(builder, node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, switchSections, node.BreakLabel, node.StringEquality), substituteTemps: true);
+            return UpdateStatement(builder, node.Update(boundExpression, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, switchSections, node.BreakLabel, node.StringEquality), substituteTemps: true);
         }
 
         public override BoundNode VisitThrowStatement(BoundThrowStatement node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // EnC: We need to insert a hidden sequence point to handle function remapping in case 
             // the containing method is edited while methods invoked in the expression are being executed.
-            var rewrittenStatement = MakeSwitchStatement(syntax, AddConditionSequencePoint(rewrittenExpression, node), rewrittenSections, node.ConstantTargetOpt, node.InnerLocals, node.BreakLabel, node);
+            var rewrittenStatement = MakeSwitchStatement(syntax, AddConditionSequencePoint(rewrittenExpression, node), rewrittenSections, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, node.BreakLabel, node);
 
             // Create the sequence point if generating debug info and
             // node is not compiler generated
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> rewrittenSections,
             LabelSymbol constantTargetOpt,
             ImmutableArray<LocalSymbol> locals,
+            ImmutableArray<LocalFunctionSymbol> localFunctions,
             GeneratedLabelSymbol breakLabel,
             BoundSwitchStatement oldNode)
         {
@@ -82,8 +83,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)rewrittenExpression.Type != null);
 
             return rewrittenExpression.Type.IsNullableType() ?
-                MakeSwitchStatementWithNullableExpression(syntax, rewrittenExpression, rewrittenSections, constantTargetOpt, locals, breakLabel, oldNode) :
-                MakeSwitchStatementWithNonNullableExpression(syntax, rewrittenExpression, rewrittenSections, constantTargetOpt, locals, breakLabel, oldNode);
+                MakeSwitchStatementWithNullableExpression(syntax, rewrittenExpression, rewrittenSections, constantTargetOpt, locals, localFunctions, breakLabel, oldNode) :
+                MakeSwitchStatementWithNonNullableExpression(syntax, rewrittenExpression, rewrittenSections, constantTargetOpt, locals, localFunctions, breakLabel, oldNode);
         }
 
         private BoundStatement MakeSwitchStatementWithNonNullableExpression(
@@ -92,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> rewrittenSections,
             LabelSymbol constantTargetOpt,
             ImmutableArray<LocalSymbol> locals,
+            ImmutableArray<LocalFunctionSymbol> localFunctions,
             GeneratedLabelSymbol breakLabel,
             BoundSwitchStatement oldNode)
         {
@@ -113,6 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundExpression: rewrittenExpression,
                 constantTargetOpt: constantTargetOpt,
                 innerLocals: locals,
+                innerLocalFunctions: localFunctions,
                 switchSections: rewrittenSections,
                 breakLabel: breakLabel,
                 stringEquality: stringEquality);
@@ -124,6 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> rewrittenSections,
             LabelSymbol constantTargetOpt,
             ImmutableArray<LocalSymbol> locals,
+            ImmutableArray<LocalFunctionSymbol> localFunctions,
             GeneratedLabelSymbol breakLabel,
             BoundSwitchStatement oldNode)
         {
@@ -168,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // rewrite switch statement
             BoundStatement rewrittenSwitchStatement = MakeSwitchStatementWithNonNullableExpression(syntax,
-                rewrittenExpression, rewrittenSections, constantTargetOpt, locals, breakLabel, oldNode);
+                rewrittenExpression, rewrittenSections, constantTargetOpt, locals, localFunctions, breakLabel, oldNode);
 
             statementBuilder.Add(rewrittenSwitchStatement);
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var newInnerLocals = RewriteLocals(node.InnerLocals);
             BoundExpression boundExpression = (BoundExpression)this.Visit(node.BoundExpression);
             ImmutableArray<BoundSwitchSection> switchSections = (ImmutableArray<BoundSwitchSection>)this.VisitList(node.SwitchSections);
-            return node.Update(boundExpression, node.ConstantTargetOpt, newInnerLocals, switchSections, node.BreakLabel, node.StringEquality);
+            return node.Update(boundExpression, node.ConstantTargetOpt, newInnerLocals, node.InnerLocalFunctions, switchSections, node.BreakLabel, node.StringEquality);
         }
 
         public override BoundNode VisitForStatement(BoundForStatement node)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -730,6 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ex,
                 null,
                 ImmutableArray<LocalSymbol>.Empty,
+                ImmutableArray<LocalFunctionSymbol>.Empty,
                 s,
                 breakLabel,
                 null)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2810,7 +2810,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private void ParseBlockAndExpressionBodiesWithSemicolon(
             out BlockSyntax blockBody,
             out ArrowExpressionClauseSyntax expressionBody,
-            out SyntaxToken semicolon)
+            out SyntaxToken semicolon,
+            bool parseSemicolonAfterBlock = true)
         {
             // Check for 'forward' declarations with no block of any kind
             if (this.CurrentToken.Kind == SyntaxKind.SemicolonToken)
@@ -2843,7 +2844,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 semicolon = this.EatToken(SyntaxKind.SemicolonToken);
             }
             // Check for bad semicolon after block body
-            else if (this.CurrentToken.Kind == SyntaxKind.SemicolonToken)
+            else if (parseSemicolonAfterBlock && this.CurrentToken.Kind == SyntaxKind.SemicolonToken)
             {
                 semicolon = this.EatTokenWithPrejudice(ErrorCode.ERR_UnexpectedSemicolon);
             }
@@ -8196,7 +8197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             BlockSyntax blockBody;
             ArrowExpressionClauseSyntax expressionBody;
             SyntaxToken semicolon;
-            this.ParseBlockAndExpressionBodiesWithSemicolon(out blockBody, out expressionBody, out semicolon);
+            this.ParseBlockAndExpressionBodiesWithSemicolon(out blockBody, out expressionBody, out semicolon, parseSemicolonAfterBlock: false);
 
             IsInAsync = parentScopeIsInAsync;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -158,6 +158,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /*
+        Note: `var` return types are currently very broken in subtle ways, in particular in the IDE scenario when random things are being bound.
+        The basic problem is that a LocalFunctionSymbol needs to compute its return type, and to do that it needs access to its BoundBlock.
+        However, the BoundBlock needs access to the local function's return type. Recursion detection is tricky, because this property (.ReturnType)
+        doesn't have access to the binder where it is being accessed from (i.e. either from inside the local function, where it should report an error,
+        or from outside, where it should attempt to infer the return type from the block).
+
+        The current (broken) system assumes that Binder_Statements.cs BindLocalFunctionStatement will always be called (and so a block will be provided)
+        before any (valid) uses of the local function are bound that require knowing the return type. This assumption breaks in the IDE, where
+        a use of a local function may be bound before BindLocalFunctionStatement is called on the corresponding local function.
+        */
         internal TypeSymbol ComputeReturnType(BoundBlock body, bool returnNullIfUnknown, bool isIterator)
         {
             if (_returnType != null)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // force lazy init
             ComputeParameters();
-            ComputeReturnType(body: null, forceNotNull: true, isIterator: false);
+            ComputeReturnType(body: null, returnNullIfUnknown: false, isIterator: false);
 
             var diags = ImmutableInterlocked.InterlockedExchange(ref _diagnostics, default(ImmutableArray<Diagnostic>));
             if (!diags.IsDefault)
@@ -135,8 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                ComputeReturnType(body: null, forceNotNull: true, isIterator: false);
-                return _returnType;
+                return ComputeReturnType(body: null, returnNullIfUnknown: false, isIterator: false);
             }
         }
 
@@ -147,8 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                ComputeReturnType(body: null, forceNotNull: false, isIterator: false);
-                return _returnType;
+                return ComputeReturnType(body: null, returnNullIfUnknown: true, isIterator: false);
             }
         }
 
@@ -156,16 +154,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                ComputeReturnType(body: null, forceNotNull: true, isIterator: true);
-                return _returnType;
+                return ComputeReturnType(body: null, returnNullIfUnknown: false, isIterator: true);
             }
         }
 
-        internal void ComputeReturnType(BoundBlock body, bool forceNotNull, bool isIterator)
+        internal TypeSymbol ComputeReturnType(BoundBlock body, bool returnNullIfUnknown, bool isIterator)
         {
             if (_returnType != null)
             {
-                return;
+                return _returnType;
             }
             var diagnostics = DiagnosticBag.GetInstance();
             // we might call this multiple times if it's var. Only bind the first time, and cache if it's var.
@@ -188,24 +185,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else if (body == null)
                 {
-                    if (forceNotNull)
+                    if (returnNullIfUnknown)
                     {
-                        returnType = _binder.CreateErrorType("var");
-                        diagnostics.Add(ErrorCode.ERR_RecursivelyTypedVariable, _syntax.ReturnType.Location, this);
+                        diagnostics.Free();
+                        return null;
                     }
-                    else
-                    {
-                        return; // leave _returnType null
-                    }
+                    returnType = _binder.CreateErrorType("var");
+                    diagnostics.Add(ErrorCode.ERR_RecursivelyTypedVariable, _syntax.ReturnType.Location, this);
                 }
                 else
                 {
                     returnType = InferReturnType(body, diagnostics);
                 }
             }
-            if (Interlocked.CompareExchange(ref _returnType, returnType, null) != null)
+            var raceReturnType = Interlocked.CompareExchange(ref _returnType, returnType, null);
+            if (raceReturnType != null)
             {
-                return;
+                diagnostics.Free();
+                return raceReturnType;
             }
             if (this.IsAsync && !this.IsGenericTaskReturningAsync(_binder.Compilation) && !this.IsTaskReturningAsync(_binder.Compilation) && !this.IsVoidReturningAsync())
             {
@@ -213,12 +210,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
             }
             AddDiagnostics(diagnostics.ToReadOnlyAndFree());
+            return returnType;
         }
 
         private TypeSymbol InferReturnType(BoundBlock body, DiagnosticBag diagnostics)
         {
             int numberOfDistinctReturns;
             var resultTypes = BoundLambda.BlockReturns.GetReturnTypes(body, out numberOfDistinctReturns);
+            if (numberOfDistinctReturns != resultTypes.Length) // included a "return;", no expression
+            {
+                resultTypes = resultTypes.Concat(ImmutableArray.Create((TypeSymbol)_binder.Compilation.GetSpecialType(SpecialType.System_Void)));
+            }
 
             TypeSymbol returnType;
             if (resultTypes.IsDefaultOrEmpty)
@@ -251,6 +253,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_ReturnTypesDontMatch, Locations[0], this);
                     return returnType;
                 }
+            }
+
+            // do this before async lifting, as inferring Task is also not allowed.
+            if (returnType.SpecialType == SpecialType.System_Void)
+            {
+                diagnostics.Add(ErrorCode.ERR_CantInferVoid, Locations[0], this);
             }
 
             if (IsAsync)
@@ -410,11 +418,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                var tpEnclosing = ContainingType.FindEnclosingTypeParameter(name);
+                var tpEnclosing = ContainingSymbol.FindEnclosingTypeParameter(name);
                 if ((object)tpEnclosing != null)
                 {
                     // Type parameter '{0}' has the same name as the type parameter from outer type '{1}'
-                    diagnostics.Add(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, location, name, tpEnclosing.ContainingType);
+                    diagnostics.Add(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, location, name, tpEnclosing.ContainingSymbol);
                 }
 
                 var typeParameter = new LocalFunctionTypeParameterSymbol(

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1085,6 +1085,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Return the nearest type parameter with the given name in
+        /// this symbol or any enclosing symbol.
+        /// </summary>
+        internal static TypeParameterSymbol FindEnclosingTypeParameter(this Symbol methodOrType, string name)
+        {
+            while (methodOrType != null)
+            {
+                switch (methodOrType.Kind)
+                {
+                    case SymbolKind.Method:
+                    case SymbolKind.NamedType:
+                    case SymbolKind.ErrorType:
+                    case SymbolKind.Field:
+                    case SymbolKind.Property:
+                    case SymbolKind.Event:
+                        break;
+                    default:
+                        return null;
+                }
+                foreach (var typeParameter in methodOrType.GetMemberTypeParameters())
+                {
+                    if (typeParameter.Name == name)
+                    {
+                        return typeParameter;
+                    }
+                }
+                methodOrType = methodOrType.ContainingSymbol;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Return true if the fully qualified name of the type's containing symbol
         /// matches the given name. This method avoids string concatenations
         /// in the common case where the type is a top-level type.


### PR DESCRIPTION
In this PR:

- Documentation (update local-functions.md, comments explaining why `var` is broken)
- Fiddle with return type inference to attempt to fix it. Still broken.
- LocalScopeBinder.cs: nasty bug with subtle fix, caused crash on `void Break<T>(Break x)` (local function name same as parameter type name, local function has to be generic) - what's worse is that this only happens in the editor, so it's not easily testable (as far as I know - so I haven't added a unit test for it)
- BoundSwitchStatement: Added InnerLocalFunctions field, to report unused local functions in switch statements.
- Disable inference of `void` and `Task` (on async locfuncs) with `var`.
- Allow a semicolon after a local function statement (parsed as an empty no-op statement separate from the local function). Previously this was getting greedily eaten by the block parser with a syntax error.
- Fix type parameter conflict detection, so nested local functions with the same type parameter name reports an error instead of usages silently choosing the innermost in-scope one.

FYI @gafter @jaredpar @AlekseyTs @agocke These are just final bugfixes that I found when pounding on it the last week. It's been a fun summer!