### PR TITLE
Fix issue where asking the solution crawler to reanalyze projects was a no-op.

### DIFF
--- a/src/Features/Core/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 var solution = workspace.CurrentSolution;
                 var set = new HashSet<DocumentId>(documentIds ?? SpecializedCollections.EmptyEnumerable<DocumentId>());
-                set.Union(projectIds.Select(id => solution.GetProject(id)).SelectMany(p => p.DocumentIds));
+                set.UnionWith(projectIds.Select(id => solution.GetProject(id)).SelectMany(p => p.DocumentIds));
 
                 coordinator.Reanalyze(analyzer, set);
             }


### PR DESCRIPTION
"Union" is a 'pure' linq extension.  We want to use 'UnionWith' so we actually appropriately mutate the set we're going to process.

Note: this might be a good thing to flag through an analyzer.   As the linq methods are pure, and deferred, not using the result is likely always a bug.