### PR TITLE
Open source build improvements

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -47,34 +47,8 @@
   </Target>
 
   <Target Name="Test">
-
-    <ItemGroup Condition="'$(PublicBuild)' == '' AND '$(CIBuild)' == ''">
-      <TestAssemblies
-        Include="Binaries\$(Configuration)\**\$(IncludePattern)"
-        Exclude="Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(PublicBuild)' == '' AND '$(CIBuild)' == 'true'">
-      <TestAssemblies
-        Include="Binaries\$(Configuration)\**\$(IncludePattern)"
-        Exclude="
-        Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;
-        Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll;" />
-    </ItemGroup>
-
-    <!-- The Microsoft.CodeAnalysis.Scripting.UnitTests.dll is disabled due to https://github.com/dotnet/roslyn/issues/860 -->
-    <ItemGroup Condition="'$(PublicBuild)' == 'true' AND '$(CIBuild)' == ''">
-      <TestAssemblies
-        Include="Binaries\$(Configuration)\**\$(IncludePattern)"
-        Exclude="
-        Binaries\$(Configuration)\Roslyn.Compilers.NativeClient.UnitTests.dll;
-        Binaries\$(Configuration)\Microsoft.CodeAnalysis.Scripting.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.Services.Editor.UnitTests2.dll;
-        Binaries\$(Configuration)\Roslyn.Services.Editor.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.Services.Editor.VisualBasic.UnitTests.dll;
-        Binaries\$(Configuration)\Roslyn.Services.Editor.CSharp.UnitTests.dll;" />
+    <ItemGroup>
+      <TestAssemblies Include="Binaries\$(Configuration)\**\$(IncludePattern)" />
     </ItemGroup>
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe packages\xunit.runners.2.0.0-alpha-build2576\tools $(RunTestArgs) @(TestAssemblies, ' ')" />

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -12,12 +12,9 @@
   <PropertyGroup>
     <RoslynSolution>$(MSBuildThisFileDirectory)Roslyn.sln</RoslynSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <RunTestArgs></RunTestArgs>
-    <RunTestArgs Condition="'$(Test64)' == 'true'">-test64</RunTestArgs>
+    <RunTestArgs>$(RunTestArgs) -xml</RunTestArgs>
+    <RunTestArgs Condition="'$(Test64)' == 'true'">$(RunTestArgs) -test64</RunTestArgs>
     <IncludePattern Condition="'$(IncludePattern)' == ''">*.UnitTests*.dll</IncludePattern>
-
-    <!-- Emit XML in a CIBuild in order to get structured test results -->
-    <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) -xml</RunTestArgs>
   </PropertyGroup>
 
   <Target Name="RestorePackages">

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -209,7 +209,7 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND '$(ImportVSSDKTargets)' == 'true' AND '$(CIBuild)' == ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND '$(ImportVSSDKTargets)' == 'true'" />
 
   <!-- ====================================================================================
 

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -3,6 +3,13 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
           Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') AND '$(MSBuildProjectExtension)' != '.vcxproj'" />
 
+  <PropertyGroup Condition="'$(DevEnvDir)' == ''">
+    <DevEnvDir>$(VSINSTALLDIR)\Common7\IDE</DevEnvDir>
+    <DevEnvDir Condition="'$(VisualStudioVersion)' == '12.0'">$(VS120COMNTOOLS)\..\IDE</DevEnvDir>
+    <DevEnvDir Condition="'$(VisualStudioVersion)' == '14.0'">$(VS140COMNTOOLS)\..\IDE</DevEnvDir>
+    <DevEnvDir>$([System.IO.Path]::GetFullPath('$(DevEnvDir)'))</DevEnvDir>
+  </PropertyGroup>
+
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VisualStudioReferenceMajorVersion Condition="'$(VisualStudioReferenceMajorVersion)' == ''">$(VisualStudioVersion.Substring(0, $(VisualStudioVersion.IndexOf('.'))))</VisualStudioReferenceMajorVersion>
@@ -33,6 +40,10 @@
     <MicrosoftDiaSymReaderNativeVersion>1.1.0-alpha1</MicrosoftDiaSymReaderNativeVersion>
     <NuGetCommandLineVersion>$(NuGetCommandLineAssemblyVersion)</NuGetCommandLineVersion>
     <MicrosoftCompositionVersion>$(MicrosoftCompositionAssemblyVersion)</MicrosoftCompositionVersion>
+
+    <!-- If we still have Roslyn installed, our VSIX-producing packages are not going to install, so let's not even try.
+         OpenSourceDebug overrides this by simple virtue that it's property setting is after the include of this file -->
+    <DeployExtension Condition="Exists('$(DevEnvDir)\CommonExtensions\Microsoft\Roslyn\Language Services\extension.vsixmanifest')">false</DeployExtension>
   </PropertyGroup>
 
   <Choose>
@@ -231,13 +242,6 @@
     <CopyVSReferencesToOutput>True</CopyVSReferencesToOutput>
     <AuthenticodeCertificateName>MicrosoftSHA1</AuthenticodeCertificateName>
     <FakeSignToolPath>$(MSBuildThisFileDirectory)..\..\packages\FakeSign.0.9.2\tools\FakeSign.exe</FakeSignToolPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(DevEnvDir)' == ''">
-    <DevEnvDir>$(VSINSTALLDIR)\Common7\IDE</DevEnvDir>
-    <DevEnvDir Condition="'$(VisualStudioVersion)' == '12.0'">$(VS120COMNTOOLS)\..\IDE</DevEnvDir>
-    <DevEnvDir Condition="'$(VisualStudioVersion)' == '14.0'">$(VS140COMNTOOLS)\..\IDE</DevEnvDir>
-    <DevEnvDir>$([System.IO.Path]::GetFullPath('$(DevEnvDir)'))</DevEnvDir>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -3,6 +3,10 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
           Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') AND '$(MSBuildProjectExtension)' != '.vcxproj'" />
 
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DevEnvDir)' == ''">
     <DevEnvDir>$(VSINSTALLDIR)\Common7\IDE</DevEnvDir>
     <DevEnvDir Condition="'$(VisualStudioVersion)' == '12.0'">$(VS120COMNTOOLS)\..\IDE</DevEnvDir>
@@ -11,7 +15,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VisualStudioReferenceMajorVersion Condition="'$(VisualStudioReferenceMajorVersion)' == ''">$(VisualStudioVersion.Substring(0, $(VisualStudioVersion.IndexOf('.'))))</VisualStudioReferenceMajorVersion>
     <VisualStudioReferenceAssemblyVersion Condition="'$(VisualStudioReferenceAssemblyVersion)' == ''">$(VisualStudioReferenceMajorVersion).0.0.0</VisualStudioReferenceAssemblyVersion>
     <VisualStudioCodename>Dev$(VisualStudioReferenceMajorVersion)</VisualStudioCodename>

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -24,14 +24,14 @@ move Binaries\%BuildConfiguration%\* %RoslynRoot%\Binaries\Bootstrap
 msbuild /v:m /t:Clean build/Toolset.sln /p:Configuration=%BuildConfiguration%
 taskkill /F /IM vbcscompiler.exe
 
-msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap BuildAndTest.proj /p:CIBuild=true /p:Configuration=%BuildConfiguration%
+msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap BuildAndTest.proj /p:Configuration=%BuildConfiguration%
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe
     echo Build failed
     exit /b 1
 )
 
-msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap src/Samples/Samples.sln /p:CIBuild=true /p:Configuration=%BuildConfiguration%
+msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap src/Samples/Samples.sln /p:Configuration=%BuildConfiguration%
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe
     echo Build failed

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -12,25 +12,25 @@ namespace RunTests
     public sealed class ProcessOutput
     {
         private readonly int _exitCode;
-        private readonly IEnumerable<string> _outputLines;
-        private readonly IEnumerable<string> _errorLines;
+        private readonly IList<string> _outputLines;
+        private readonly IList<string> _errorLines;
 
         public int ExitCode
         {
             get { return _exitCode; }
         }
 
-        public IEnumerable<string> OutputLines
+        public IList<string> OutputLines
         {
             get { return _outputLines; }
         }
 
-        public IEnumerable<string> ErrorLines
+        public IList<string> ErrorLines
         {
             get { return _errorLines; }
         }
 
-        public ProcessOutput(int exitCode, IEnumerable<string> outputLines, IEnumerable<string> errorLines)
+        public ProcessOutput(int exitCode, IList<string> outputLines, IList<string> errorLines)
         {
             _exitCode = exitCode;
             _outputLines = outputLines;


### PR DESCRIPTION
Make several improvements to Jenkins and community building:

1) If we're running on a non-internal-developer machine, just don't try to deploy extensions since that'll always fail
2) Remove the CIBuild flag entirely -- community and Jenkins builds should just do the same thing
3) Run the same tests everywhere

Reviewers: @jaredpar, @amcasey, @davkean, @tannergooding, @agocke