### PR TITLE
Add spacing rules around Dictionary Initializers

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -357,5 +357,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return false;
             }
         }
+
+        public static bool IsOpenBraceOrCommaOfObjectInitializer(this SyntaxToken token)
+        {
+            return (token.IsKind(SyntaxKind.OpenBraceToken) || token.IsKind(SyntaxKind.CommaToken)) &&
+                token.Parent.IsKind(SyntaxKind.ObjectInitializerExpression);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting.Rules;
@@ -141,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // For spacing Before Square Braces
-            if (currentKind == SyntaxKind.OpenBracketToken && HasFormattableBracketParent(currentToken))
+            if (currentKind == SyntaxKind.OpenBracketToken && HasFormattableBracketParent(currentToken) && !previousToken.IsOpenBraceOrCommaOfObjectInitializer())
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceBeforeOpenSquareBracket);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -229,7 +229,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // * )
-            // * [
             // * ]
             // * ,
             // * .
@@ -237,12 +236,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             switch (currentToken.Kind())
             {
                 case SyntaxKind.CloseParenToken:
-                case SyntaxKind.OpenBracketToken:
                 case SyntaxKind.CloseBracketToken:
                 case SyntaxKind.CommaToken:
                 case SyntaxKind.DotToken:
                 case SyntaxKind.MinusGreaterThanToken:
                     return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
+            // * [
+            if (currentToken.IsKind(SyntaxKind.OpenBracketToken) && !previousToken.IsOpenBraceOrCommaOfObjectInitializer())
+            {
+                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
             // case * :

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6258,5 +6258,27 @@ class Program
 }";
             AssertFormat(code, code);
         }
+
+        [WorkItem(1184285)]
+        [WorkItem(4280, "https://github.com/dotnet/roslyn/issues/4280")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatDictionaryInitializers()
+        {
+            var code = @"class Program
+{
+    void Main()
+    {
+        var sample = new Dictionary<string, string> {[""x""] = ""d""    ,[""z""]   =  ""XX"" };
+    }
+}";
+            var expected = @"class Program
+{
+    void Main()
+    {
+        var sample = new Dictionary<string, string> { [""x""] = ""d"", [""z""] = ""XX"" };
+    }
+}";
+            AssertFormat(expected, code);
+        }
     }
 }


### PR DESCRIPTION
Fix #4280 Add spacing rules around the dictionary initializers to have a
behavior similar to Object Initializers