### PR TITLE
Formatting leaves comment before case statement undisturbed

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2736,6 +2736,98 @@ End Module
                 expectedIndentation:=0)
         End Sub
 
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentAtCaseBlockEnd()
+            Dim code = <code>Class Program
+    Public Sub M()
+        Dim s = 1
+        Select Case s
+            Case 1
+                System.Console.WriteLine(s)
+
+            Case 2
+        End Select
+    End Sub
+End Class
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=6,
+                expectedIndentation:=16)
+        End Sub
+
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentAtCaseBlockEndComment()
+            Dim code = <code>Class Program
+    Public Sub M()
+        Dim s = 1
+        Select Case s
+            Case 1
+                System.Console.WriteLine(s)
+                ' This comment belongs to case 1
+
+            Case 2
+        End Select
+    End Sub
+End Class
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=7,
+                expectedIndentation:=16)
+        End Sub
+
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentAtCaseBlockInbetweenComments()
+            Dim code = <code>Class Program
+    Public Sub M()
+        Dim s = 1
+        Select Case s
+            Case 1
+                System.Console.WriteLine(s)
+                ' This comment belongs to case 1
+
+            ' This comment belongs to case 2
+            Case 2
+        End Select
+    End Sub
+End Class
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=7,
+                expectedIndentation:=16)
+        End Sub
+
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub SmartIndentAtCaseBlockEndUntabbedComment()
+            Dim code = <code>Class Program
+    Public Sub M()
+        Dim s = 1
+        Select Case s
+            Case 1
+                System.Console.WriteLine(s)
+            ' This comment belongs to case 1
+
+            Case 2
+        End Select
+    End Sub
+End Class
+</code>.Value
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=7,
+                expectedIndentation:=12)
+        End Sub
+
         Private Shared Sub AssertSmartIndentIndentationInProjection(markup As String,
                                                                     expectedIndentation As Integer)
             Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromLines({markup})

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -122,6 +122,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 Return LineColumnRule.PreserveLinesWithAbsoluteIndentation(lines, indentation:=0)
             End If
 
+            ' comment before a Case Statement case
+            If trivia2.Kind = SyntaxKind.CommentTrivia AndAlso
+               Token2.Kind = SyntaxKind.CaseKeyword AndAlso Token2.Parent.IsKind(SyntaxKind.CaseStatement) Then
+                Return LineColumnRule.Preserve()
+            End If
+
             ' comment case
             If trivia2.Kind = SyntaxKind.CommentTrivia OrElse
                trivia2.Kind = SyntaxKind.DocumentationCommentTrivia Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
@@ -10,12 +10,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Protected Sub AddIndentBlockOperation(operations As List(Of IndentBlockOperation), startToken As SyntaxToken, endToken As SyntaxToken, Optional [option] As IndentBlockOption = IndentBlockOption.RelativePosition, Optional dontIncludeNextTokenTrailingTrivia As Boolean = False)
+        Protected Sub AddIndentBlockOperation(operations As List(Of IndentBlockOperation), startToken As SyntaxToken, endToken As SyntaxToken, Optional [option] As IndentBlockOption = IndentBlockOption.RelativePosition)
             If startToken.Kind = SyntaxKind.None OrElse endToken.Kind = SyntaxKind.None Then
                 Return
             End If
 
-            Dim span = GetIndentBlockSpan(startToken, endToken, dontIncludeNextTokenTrailingTrivia)
+            Dim span = GetIndentBlockSpan(startToken, endToken)
             operations.Add(FormattingOperations.CreateIndentBlockOperation(startToken, endToken, span, indentationDelta:=1, [option]:=[option]))
         End Sub
 
@@ -50,14 +50,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Return TextSpan.FromBounds(previousToken.Span.End, endToken.FullSpan.End)
         End Function
 
-        Private Function GetIndentBlockSpan(startToken As SyntaxToken, endToken As SyntaxToken, Optional dontIncludeNextTokenTrailingTrivia As Boolean = False) As TextSpan
+        Private Function GetIndentBlockSpan(startToken As SyntaxToken, endToken As SyntaxToken) As TextSpan
             ' special case for colon trivia
             Dim spanStart = startToken.GetPreviousToken(includeZeroWidth:=True).Span.End
             Dim nextToken = endToken.GetNextToken(includeZeroWidth:=True)
-
-            If dontIncludeNextTokenTrailingTrivia Then
-                Return TextSpan.FromBounds(spanStart, endToken.Span.End)
-            End If
 
             For Each trivia In nextToken.LeadingTrivia.Reverse()
                 If trivia.Kind = SyntaxKind.EndOfLineTrivia Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                         Return
                     End If
 
-                    AddIndentBlockOperation(operations, pair.Item1, pair.Item2, dontIncludeNextTokenTrailingTrivia:=True)
+                    AddIndentBlockOperation(operations, pair.Item1, pair.Item2)
                     Return
                 End If
             End If

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4209,8 +4209,9 @@ End Class
             AssertFormatLf2CrLf(text.Value, expected.Value)
         End Sub
 
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
-        Public Sub EmptyCaseBlockCommentGetsIndented()
+        Public Sub CaseCommentsRemainsUndisturbed()
             Dim text = <Code>
 Class Program
     Sub Main(args As String())
@@ -4233,7 +4234,7 @@ Class Program
         Dim s = 0
         Select Case s
             Case 0
-                ' Comment should be indented
+            ' Comment should be indented
             Case 2
                 ' comment
                 Console.WriteLine(s)

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -3968,6 +3968,7 @@ End Module
         End Sub
 
         <WorkItem(796562)>
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
         Public Sub TriviaAtEndOfCaseBelongsToNextCase()
             Dim text = <Code>
@@ -3976,7 +3977,8 @@ Class X
         Select Case x
             Case 1
                 Return 2
-                ' This comment describes case 2.
+                ' This comment describes case 1
+            ' This comment describes case 2
             Case 2,
                 Return 3
         End Select
@@ -3992,7 +3994,8 @@ Class X
         Select Case x
             Case 1
                 Return 2
-            ' This comment describes case 2.
+                ' This comment describes case 1
+            ' This comment describes case 2
             Case 2,
                 Return 3
         End Select

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4218,7 +4218,7 @@ Class Program
         Dim s = 0
         Select Case s
             Case 0
-            ' Comment should be indented
+            ' Comment should not be indented
             Case 2
                 ' comment
                 Console.WriteLine(s)
@@ -4234,7 +4234,7 @@ Class Program
         Dim s = 0
         Select Case s
             Case 0
-            ' Comment should be indented
+            ' Comment should not be indented
             Case 2
                 ' comment
                 Console.WriteLine(s)


### PR DESCRIPTION
Fix #3293 Formatting leaves comment before case statement undisturbed so
that user can choose to align the comment with the subsequent case
statement to represent the case statement or leave the comment as part
of the previous case content