### PR TITLE
Fix IMethodXML output for VB array creation expressions with empty initializers

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
@@ -1082,5 +1082,65 @@ class C
             Test(definition, expected)
         End Sub
 
+        <WorkItem(4312, "https://github.com/dotnet/roslyn/issues/4312")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub CSAssignments_PropertyAssignedWithEmptyArray()
+            Dim definition =
+    <Workspace>
+        <Project Language="C#" CommonReferences="true">
+            <Document>
+class C
+{
+    private object[] Series { get; set }
+
+    $$void M()
+    {
+        this.Series = new object[0] {};
+    }
+}
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="7">
+        <Expression>
+            <Assignment>
+                <Expression>
+                    <NameRef variablekind="property">
+                        <Expression>
+                            <ThisReference/>
+                        </Expression>
+                        <Name>Series</Name>
+                    </NameRef>
+                </Expression>
+                <Expression>
+                    <NewArray>
+                        <ArrayType rank="1">
+                            <Type>System.Object</Type>
+                        </ArrayType>
+                        <Bound>
+                            <Expression>
+                                <Literal>
+                                    <Number>0</Number>
+                                </Literal>
+                            </Expression>
+                        </Bound>
+                        <Expression>
+                            <Literal>
+                                <Array></Array>
+                            </Literal>
+                        </Expression>
+                    </NewArray>
+                </Expression>
+            </Assignment>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
@@ -938,5 +938,57 @@ End Class
             End Try
         End Sub
 
+        <WorkItem(4312, "https://github.com/dotnet/roslyn/issues/4312")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBAssignments_PropertyAssignedWithEmptyArray()
+            Dim definition =
+    <Workspace>
+        <Project Language="Visual Basic" CommonReferences="true">
+            <Document>
+Class C
+    Private Property Series As Object()
+
+    $$Sub M()
+        Me.Series = New Object(-1) {}
+    End Sub
+End Class
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="5"><Expression>
+        <Assignment>
+            <Expression>
+                <NameRef variablekind="property">
+                    <Expression>
+                        <ThisReference/>
+                    </Expression>
+                    <Name>Series</Name>
+                </NameRef>
+            </Expression>
+            <Expression>
+                <NewArray>
+                    <ArrayType rank="1">
+                        <Type>System.Object</Type>
+                    </ArrayType>
+                    <Bound>
+                        <Expression>
+                            <Literal>
+                                <Number type="System.Int32">0</Number>
+                            </Literal>
+                        </Expression>
+                    </Bound>
+                </NewArray>
+            </Expression>
+        </Assignment>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
@@ -479,28 +479,39 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel.MethodXm
                 GenerateType(type)
 
                 If arrayBounds IsNot Nothing Then
+
                     If Not TryGenerateArrayBounds(arrayBounds, type) Then
                         Return False
                     End If
-                End If
 
-                If initializer IsNot Nothing Then
-                    If type.TypeKind = TypeKind.Array AndAlso arrayBounds Is Nothing Then
-                        Select Case initializer.Kind
-                            Case SyntaxKind.ArrayCreationExpression
-                                If Not TryGenerateArrayCreation(DirectCast(initializer, ArrayCreationExpressionSyntax)) Then
-                                    Return False
-                                End If
-                            Case SyntaxKind.CollectionInitializer
-                                If Not TryGenerateArrayInitializer(DirectCast(initializer, CollectionInitializerSyntax), type) Then
-                                    Return False
-                                End If
-                            Case Else
-                                Return False
-                        End Select
-                    ElseIf Not TryGenerateExpression(initializer) Then
-                        Return False
+                    If initializer IsNot Nothing AndAlso initializer.Kind = SyntaxKind.CollectionInitializer Then
+                        If Not TryGenerateCollectionInitializer(DirectCast(initializer, CollectionInitializerSyntax)) Then
+                            Return False
+                        End If
                     End If
+
+                Else
+                    ' No array bounds...
+
+                    If initializer IsNot Nothing Then
+                        If type.TypeKind = TypeKind.Array Then
+                            Select Case initializer.Kind
+                                Case SyntaxKind.ArrayCreationExpression
+                                    If Not TryGenerateArrayCreation(DirectCast(initializer, ArrayCreationExpressionSyntax)) Then
+                                        Return False
+                                    End If
+                                Case SyntaxKind.CollectionInitializer
+                                    If Not TryGenerateArrayInitializer(DirectCast(initializer, CollectionInitializerSyntax), type) Then
+                                        Return False
+                                    End If
+                                Case Else
+                                    Return False
+                            End Select
+                        ElseIf Not TryGenerateExpression(initializer) Then
+                            Return False
+                        End If
+                    End If
+
                 End If
 
                 Return True


### PR DESCRIPTION
Fixes issue #4312.