### PR TITLE
Fix Interactive window indentation

### DIFF
--- a/src/InteractiveWindow/EditorTest/InteractiveWindowEditorsFactoryService.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowEditorsFactoryService.cs
@@ -10,6 +10,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
     [Export(typeof(IInteractiveWindowEditorFactoryService))]
     internal class InteractiveWindowEditorsFactoryService : IInteractiveWindowEditorFactoryService
     {
+        public const string ContentType = "text";
+
         private readonly ITextBufferFactoryService _textBufferFactoryService;
         private readonly ITextEditorFactoryService _textEditorFactoryService;
         private readonly IContentTypeRegistryService _contentTypeRegistry;
@@ -33,7 +35,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             IContentType contentType;
             if (!window.Properties.TryGetProperty(typeof(IContentType), out contentType))
             {
-                contentType = _contentTypeRegistry.GetContentType("text");
+                contentType = _contentTypeRegistry.GetContentType(ContentType);
             }
 
             return _textBufferFactoryService.CreateTextBuffer(contentType);

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
@@ -88,6 +88,7 @@
     <Compile Include="InteractiveWindowTests.cs" />
     <Compile Include="TestContentTypeDefinition.cs" />
     <Compile Include="TestInteractiveEngine.cs" />
+    <Compile Include="TestSmartIndent.cs" />
     <Compile Include="TestWaitIndicator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -408,5 +408,64 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         {
             Task.Run(() => Window.Operations.Cancel()).PumpingWait();
         }
+
+        [WorkItem(4235, "https://github.com/dotnet/roslyn/issues/4235")]
+        [Fact]
+        public void TestIndentation1()
+        {
+            TestIndentation(indentSize: 1);
+        }
+
+        [WorkItem(4235, "https://github.com/dotnet/roslyn/issues/4235")]
+        [Fact]
+        public void TestIndentation2()
+        {
+            TestIndentation(indentSize: 2);
+        }
+
+        [WorkItem(4235, "https://github.com/dotnet/roslyn/issues/4235")]
+        [Fact]
+        public void TestIndentation3()
+        {
+            TestIndentation(indentSize: 3);
+        }
+
+        [WorkItem(4235, "https://github.com/dotnet/roslyn/issues/4235")]
+        [Fact]
+        public void TestIndentation4()
+        {
+            TestIndentation(indentSize: 4);
+        }
+
+        private void TestIndentation(int indentSize)
+        {
+            const int promptWidth = 2;
+
+            _testHost.ExportProvider.GetExport<TestSmartIndentProvider>().Value.SmartIndent = new TestSmartIndent(
+                promptWidth,
+                promptWidth + indentSize,
+                promptWidth
+            );
+
+            AssertCaretVirtualPosition(0, promptWidth);
+            Window.InsertCode("{");
+            AssertCaretVirtualPosition(0, promptWidth + 1);
+            Window.Operations.BreakLine();
+            AssertCaretVirtualPosition(1, promptWidth + indentSize);
+            Window.InsertCode("Console.WriteLine();");
+            Window.Operations.BreakLine();
+            AssertCaretVirtualPosition(2, promptWidth);
+            Window.InsertCode("}");
+            AssertCaretVirtualPosition(2, promptWidth + 1);
+        }
+
+        private void AssertCaretVirtualPosition(int expectedLine, int expectedColumn)
+        {
+            ITextSnapshotLine actualLine;
+            int actualColumn;
+            Window.TextView.Caret.Position.VirtualBufferPosition.GetLineAndColumn(out actualLine, out actualColumn);
+            Assert.Equal(expectedLine, actualLine.LineNumber);
+            Assert.Equal(expectedColumn, actualColumn);
+        }
     }
 }

--- a/src/InteractiveWindow/EditorTest/TestSmartIndent.cs
+++ b/src/InteractiveWindow/EditorTest/TestSmartIndent.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
+{
+    internal class TestSmartIndent : ISmartIndent
+    {
+        private readonly int[] _lineToIndentMap;
+
+        public TestSmartIndent(params int[] lineToIndentMap)
+        {
+            _lineToIndentMap = lineToIndentMap;
+        }
+
+        int? ISmartIndent.GetDesiredIndentation(ITextSnapshotLine line)
+        {
+            return _lineToIndentMap[line.LineNumber];
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+
+    internal class DummySmartIndent : ISmartIndent
+    {
+        public static readonly ISmartIndent Instance = new DummySmartIndent();
+
+        private DummySmartIndent()
+        {
+        }
+
+        int? ISmartIndent.GetDesiredIndentation(ITextSnapshotLine line)
+        {
+            return null;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+
+    [Export(typeof(TestSmartIndentProvider))]
+    [Export(typeof(ISmartIndentProvider))]
+    [ContentType(InteractiveWindowEditorsFactoryService.ContentType)]
+    internal class TestSmartIndentProvider : ISmartIndentProvider
+    {
+        public ISmartIndent SmartIndent;
+
+        ISmartIndent ISmartIndentProvider.CreateSmartIndent(ITextView textView) => SmartIndent ?? DummySmartIndent.Instance;
+    }
+}


### PR DESCRIPTION
The value returned from
```ISmartIndentationService.GetDesiredIndentation``` is absolute, but we
were assuming it was relevant to the prompt.

Fixes #4235