### PR TITLE
disable loaded dlls checking

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -379,8 +379,8 @@ Global
 		src\ExpressionEvaluator\CSharp\Source\ResultProvider\CSharpResultProvider.projitems*{bf9dac1e-3a5e-4dc3-bb44-9a64e0d4e9d3}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
 		src\ExpressionEvaluator\Core\Source\ResultProvider\ResultProvider.projitems*{fa0e905d-ec46-466d-b7b2-3b5557f9428c}*SharedItemsImports = 4
-		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{3973b09a-4fbf-44a5-8359-3d22ceb71f71}*SharedItemsImports = 4
 		src\ExpressionEvaluator\Core\Source\ResultProvider\ResultProvider.projitems*{bedc5a4a-809e-4017-9cfd-6c8d4e1847f0}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
@@ -2994,6 +2994,8 @@ Global
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Debug|x86.Build.0 = Debug|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|ARM.ActiveCfg = Release|Any CPU
@@ -3002,6 +3004,8 @@ Global
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|x64.ActiveCfg = Release|Any CPU
 		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|x64.Build.0 = Release|Any CPU
+		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1B42764-D442-4E4C-B2E7-9BA36FFBDDF1}.Release|x86.Build.0 = Release|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -3010,6 +3014,8 @@ Global
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Debug|x86.Build.0 = Debug|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|ARM.ActiveCfg = Release|Any CPU
@@ -3018,6 +3024,8 @@ Global
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|x64.ActiveCfg = Release|Any CPU
 		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|x64.Build.0 = Release|Any CPU
+		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|x86.ActiveCfg = Release|Any CPU
+		{9A61D22F-A414-47C5-A72A-6546ACECDB23}.Release|x86.Build.0 = Release|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -3026,6 +3034,8 @@ Global
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Debug|x86.Build.0 = Debug|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|ARM.ActiveCfg = Release|Any CPU
@@ -3034,6 +3044,8 @@ Global
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|x64.ActiveCfg = Release|Any CPU
 		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|x64.Build.0 = Release|Any CPU
+		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{219EC670-D9C3-4493-AC28-AD42697CCFAD}.Release|x86.Build.0 = Release|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -3042,6 +3054,8 @@ Global
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|x64.Build.0 = Debug|Any CPU
+		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Debug|x86.Build.0 = Debug|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|ARM.ActiveCfg = Release|Any CPU
@@ -3050,6 +3064,8 @@ Global
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|x64.ActiveCfg = Release|Any CPU
 		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|x64.Build.0 = Release|Any CPU
+		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|x86.ActiveCfg = Release|Any CPU
+		{9468F53A-8B08-4DAC-9612-3BBB3BCF0783}.Release|x86.Build.0 = Release|Any CPU
 		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F83343BA-B4EA-451C-B6DB-5D645E6171BC}.Debug|ARM.ActiveCfg = Debug|Any CPU

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
@@ -33,8 +33,8 @@
       <PerfVerifyDiagnostics Text="i" ScenarioGroup="CSharp Diagnostics MethodBody" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
@@ -34,8 +34,8 @@
       <PerfVerifyDiagnostics Text="i" ScenarioGroup="CSharp Diagnostics Top Level" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
@@ -30,8 +30,8 @@
       <PerfVerifyLightBulb Text="IClrRuntimeInfo" ScenarioGroup="CSharp LightBulb" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
@@ -32,8 +32,8 @@
       <PerfVerifyDiagnostics Text="c" ScenarioGroup="VisualBasic Diagnostics MethodBody" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
@@ -35,8 +35,8 @@
       <CollectPerfViewTrace Action="Stop" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
@@ -28,8 +28,8 @@
       <PerfVerifyLightBulb Text="IClrRuntimeInfo" ScenarioGroup="Basic LightBulb" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>


### PR DESCRIPTION
it looks like loaded dlls checking action is broken. when it says wrong dlls are loaded, windbg doesn't agree.