### PR TITLE
disable loaded dlls checking

### DIFF
--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
@@ -33,8 +33,8 @@
       <PerfVerifyDiagnostics Text="i" ScenarioGroup="CSharp Diagnostics MethodBody" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
@@ -34,8 +34,8 @@
       <PerfVerifyDiagnostics Text="i" ScenarioGroup="CSharp Diagnostics Top Level" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
@@ -30,8 +30,8 @@
       <PerfVerifyLightBulb Text="IClrRuntimeInfo" ScenarioGroup="CSharp LightBulb" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="CSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoBasic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
@@ -32,8 +32,8 @@
       <PerfVerifyDiagnostics Text="c" ScenarioGroup="VisualBasic Diagnostics MethodBody" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
@@ -35,8 +35,8 @@
       <CollectPerfViewTrace Action="Stop" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
@@ -28,8 +28,8 @@
       <PerfVerifyLightBulb Text="IClrRuntimeInfo" ScenarioGroup="Basic LightBulb" TimeGoal="0.1" MemoryGoal="0.9" />
       <PerfStopEtwListener/>
 
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" />
-      <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" />
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="NoCSharp" /> -->
+      <!-- <VerifyRoslynModulesLoadedStatus ExpectedStatus="Basic" /> -->
     </Scenario>
 
   </ScenarioList>


### PR DESCRIPTION
it looks like loaded dlls checking action is broken. when it says wrong dlls are loaded, windbg doesn't agree.