### PR TITLE
Properly specify the round-trip format specifiers for floats and doubles in IMethodXML (used by WinForms)

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -464,8 +463,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
         {
             using (NumberTag(GetTypeName(type)))
             {
-                // TODO(DustinCa): Add more unit tests to ensure that floats are correct.
-                EncodedText(Convert.ToString(value, CultureInfo.InvariantCulture));
+                if (value is double)
+                {
+                    // Note: use G17 for doubles to ensure that we roundtrip properly on 64-bit
+                    EncodedText(((double)value).ToString("G17", CultureInfo.InvariantCulture));
+                }
+                else if (value is float)
+                {
+                    EncodedText(((float)value).ToString("R", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    EncodedText(Convert.ToString(value, CultureInfo.InvariantCulture));
+                }
             }
         }
 

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_CSAssignments.vb
@@ -1142,5 +1142,73 @@ class C
             Test(definition, expected)
         End Sub
 
+        <WorkItem(4149, "https://github.com/dotnet/roslyn/issues/4149")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub CSAssignments_RoundTrippedDoubles()
+            Dim definition =
+    <Workspace>
+        <Project Language="C#" CommonReferences="true">
+            <Document>
+class C
+{
+    void $$M()
+    {
+        double d = 9.2233720368547758E+18D;
+    }
+}
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <Local line="5">
+        <Type>System.Double</Type>
+        <Name>d</Name>
+        <Expression>
+            <Literal>
+                <Number type="System.Double">9.2233720368547758E+18</Number>
+            </Literal>
+        </Expression>
+    </Local>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <WorkItem(4149, "https://github.com/dotnet/roslyn/issues/4149")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub CSAssignments_RoundTrippedSingles()
+            Dim definition =
+    <Workspace>
+        <Project Language="C#" CommonReferences="true">
+            <Document>
+class C
+{
+    void $$M()
+    {
+        float s = 0.333333343F;
+    }
+}
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <Local line="5">
+        <Type>System.Single</Type>
+        <Name>s</Name>
+        <Expression>
+            <Literal>
+                <Number type="System.Single">0.333333343</Number>
+            </Literal>
+        </Expression>
+    </Local>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
@@ -990,5 +990,69 @@ End Class
             Test(definition, expected)
         End Sub
 
+        <WorkItem(4149, "https://github.com/dotnet/roslyn/issues/4149")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBAssignments_RoundTrippedDoubles()
+            Dim definition =
+    <Workspace>
+        <Project Language="Visual Basic" CommonReferences="true">
+            <Document>
+Class C
+    Sub $$M()
+        Dim d As Double = 9.2233720368547758E+18R
+    End Sub
+End Class
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <Local line="3">
+        <Type>System.Double</Type>
+        <Name>d</Name>
+        <Expression>
+            <Literal>
+                <Number type="System.Double">9.2233720368547758E+18</Number>
+            </Literal>
+        </Expression>
+    </Local>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <WorkItem(4149, "https://github.com/dotnet/roslyn/issues/4149")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBAssignments_RoundTrippedSingles()
+            Dim definition =
+    <Workspace>
+        <Project Language="Visual Basic" CommonReferences="true">
+            <Document>
+Class C
+    Sub $$M()
+        Dim s As Single = 0.333333343F
+    End Sub
+End Class
+            </Document>
+        </Project>
+    </Workspace>
+
+            Dim expected =
+<Block>
+    <Local line="3">
+        <Type>System.Single</Type>
+        <Name>s</Name>
+        <Expression>
+            <Literal>
+                <Number type="System.Single">0.333333343</Number>
+            </Literal>
+        </Expression>
+    </Local>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes issue #4149.

Reviewers: @Pilchie, @jasonmalinowski