### PR TITLE
Use a custom ConcurrentQueue in debug mode for synthetic members

### DIFF
--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// we have a custom version of ConcurrentQueue that detects attempted concurrent adds.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        public class ConcurrentQueue<T> : System.Collections.Concurrent.ConcurrentQueue<T>
+        private class ConcurrentQueue<T> : System.Collections.Concurrent.ConcurrentQueue<T>
         {
             // A count of the number of concurrent queue operations in progress. Should always be zero or one,
             // as synthetic members should be added by the compiler to a given type in a well-defined sequential
@@ -323,14 +323,7 @@ namespace Microsoft.CodeAnalysis.Emit
             int queueing;
 
             // A short delay to increase the chance that concurrent Enqueue operation will be diagnosed.
-            static TimeSpan shortDelay = new TimeSpan(ticks: ShouldDelay() ? 2 : 0);
-
-            // The delay is set to change to zero after October 2015, when this whole class should be removed.
-            static bool ShouldDelay()
-            {
-                DateTime today = new DateTime();
-                return today.Year <= 2015 && today.Month <= 10;
-            }
+            static TimeSpan shortDelay = new TimeSpan(2);
 
             /// <summary>
             ///     Adds an object to the end of the ConcurrentQueue.

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -308,6 +308,52 @@ namespace Microsoft.CodeAnalysis.Emit
 
         #region Synthesized Members
 
+#if DEBUG
+        /// <summary>
+        /// The queue of synthesized members of a type should be deterministic, as the members are
+        /// emitted in the order in which they are added to the queue. Therefore for debug purposes
+        /// we have a custom version of ConcurrentQueue that detects attempted concurrent adds.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public class ConcurrentQueue<T> : System.Collections.Concurrent.ConcurrentQueue<T>
+        {
+            // A count of the number of concurrent queue operations in progress. Should always be zero or one,
+            // as synthetic members should be added by the compiler to a given type in a well-defined sequential
+            // order.
+            int queueing;
+
+            // A short delay to increase the chance that concurrent Enqueue operation will be diagnosed.
+            static TimeSpan shortDelay = new TimeSpan(ticks: ShouldDelay() ? 2 : 0);
+
+            // The delay is set to change to zero after October 2015, when this whole class should be removed.
+            static bool ShouldDelay()
+            {
+                DateTime today = new DateTime();
+                return today.Year <= 2015 && today.Month <= 10;
+            }
+
+            /// <summary>
+            ///     Adds an object to the end of the ConcurrentQueue.
+            /// </summary>
+            /// <param name="item">
+            ///     The object to add to the end of the ConcurrentQueue.
+            ///     The value can be a null reference for reference types.
+            /// </param>
+            public new void Enqueue(T item)
+            {
+                if (Interlocked.Increment(ref queueing) != 1)
+                {
+                    throw new System.InvalidOperationException("Concurrent use of " + nameof(SynthesizedDefinitions));
+                }
+                base.Enqueue(item);
+                // To increase the chance of catching concurrency issues, we add a delay to each queued item
+                // so that another thread has a chance to add at the same time.
+                System.Threading.Tasks.Task.Delay(shortDelay).Wait();
+                Interlocked.Decrement(ref queueing);
+            }
+        }
+#endif
+
         /// <summary>
         /// Captures the set of synthesized definitions that should be added to a type
         /// during emit process.

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Emit
             int queueing;
 
             // A short delay to increase the chance that concurrent Enqueue operation will be diagnosed.
-            static TimeSpan shortDelay = new TimeSpan(2);
+            static readonly TimeSpan shortDelay = new TimeSpan(2);
 
             /// <summary>
             ///     Adds an object to the end of the ConcurrentQueue.


### PR DESCRIPTION
to help detect possible concurrent addition of synthetic members to a type. Since we emit
synthesized members for each type in the order in which they appear in the queue, this might
detect some cases of nondeterminism.

I will add an issue to remove this code around October/November. Filed #4337 to track that.

@jaredpar @AlekseyTs @agocke @VSadov 