### PR TITLE
Starting in VS2015 update 1, we no longer consider inherited members within using static.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -83,6 +83,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return InCref && !this.Flags.Includes(BinderFlags.CrefParameterOrReturnType); }
         }
 
+        protected virtual bool InUsing => false;
+
         /// <summary>
         /// Returns true if the node is in a position where an unbound type
         /// such as (C&lt;,&gt;) is allowed.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -673,6 +673,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 }
 
+                // Starting in VS2015 update 1, we no longer consider inherited members within using static.
+                if (InUsing)
+                {
+                    break;
+                }
+
                 if (basesBeingResolved != null && basesBeingResolved.ContainsReference(type.OriginalDefinition))
                 {
                     var other = GetNearestOtherSymbol(basesBeingResolved, type);

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -47,7 +47,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             _container = container;
             _imports = imports ?? Imports.Empty;
+            _inUsing = (imports != null);
         }
+
+        protected override bool InUsing => _inUsing;
 
         internal NamespaceOrTypeSymbol Container
         {


### PR DESCRIPTION
Fixes #369

This change is pending review of its language implications.

This situation doesn't arise in VB because VB's `Imports` does not import types from types, unlike C#'s `using static` that does import types from types.

/cc @jaredpar @AlekseyTs @agocke @MadsTorgersen 
