### PR TITLE
Don't skip executing analyzer compilation actions in the IDE when Clo…

### DIFF
--- a/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -316,7 +316,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         {
             try
             {
-                if (!CheckOption(project.Solution.Workspace, project.Language, documentOpened: false))
+                // Compilation actions can report diagnostics on open files, so "documentOpened = true"
+                if (!CheckOption(project.Solution.Workspace, project.Language, documentOpened: true))
                 {
                     return;
                 }
@@ -329,7 +330,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 var versions = new VersionArgument(projectTextVersion, semanticVersion, projectVersion);
                 foreach (var stateSet in _stateManager.GetOrUpdateStateSets(project))
                 {
-                    if (SkipRunningAnalyzer(project.CompilationOptions, analyzerDriver, openedDocument: false, skipClosedFileChecks: false, stateSet: stateSet))
+                    // Compilation actions can report diagnostics on open files, so we skipClosedFileChecks.
+                    if (SkipRunningAnalyzer(project.CompilationOptions, analyzerDriver, openedDocument: true, skipClosedFileChecks: true, stateSet: stateSet))
                     {
                         await ClearExistingDiagnostics(project, stateSet, cancellationToken).ConfigureAwait(false);
                         continue;

--- a/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/CommonDiagnosticAnalyzers.cs
@@ -336,5 +336,34 @@ namespace Microsoft.CodeAnalysis
                 }
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class HiddenDiagnosticsCompilationAnalyzer : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+                "ID 1000",
+                "Description1",
+                string.Empty,
+                "Analysis",
+                DiagnosticSeverity.Hidden,
+                true,
+                customTags: WellKnownDiagnosticTags.NotConfigurable);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(this.OnCompilation);
+            }
+
+            private void OnCompilation(CompilationAnalysisContext context)
+            {
+                // Report the hidden diagnostic on all trees in compilation.
+                foreach (var tree in context.Compilation.SyntaxTrees)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, tree.GetRoot().GetLocation()));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
…sedFileDiagnostics flag is turned off OR the analyzer reports only hidden diagnostics. Compilation actions and compilation end actions can report diagnostics on open files, so they must always be executed.

Fixes #4068