### PR TITLE
Ensure that syntax tree actions are also re-executed by the solution …

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
                 var project = workspace.CurrentSolution.Projects.First(p => p.Name == "P1").WithAssemblyName("newName");
                 var worker = ExecuteOperation(workspace, w => w.ChangeProject(project.Id, project.Solution));
 
-                Assert.Equal(0, worker.SyntaxDocumentIds.Count);
+                Assert.Equal(5, worker.SyntaxDocumentIds.Count);
                 Assert.Equal(5, worker.DocumentIds.Count);
             }
         }
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
                 var project = workspace.CurrentSolution.Projects.First(p => p.Name == "P1").AddAdditionalDocument("a1", SourceText.From("")).Project;
                 var worker = ExecuteOperation(workspace, w => w.ChangeProject(project.Id, project.Solution));
 
-                Assert.Equal(0, worker.SyntaxDocumentIds.Count);
+                Assert.Equal(5, worker.SyntaxDocumentIds.Count);
                 Assert.Equal(5, worker.DocumentIds.Count);
             }
         }

--- a/src/Features/Core/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Features/Core/SolutionCrawler/InvocationReasons_Constants.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public static readonly InvocationReasons ProjectConfigurationChanged =
             new InvocationReasons(
                 ImmutableHashSet.Create<string>(
+                                    PredefinedInvocationReasons.SyntaxChanged,
                                     PredefinedInvocationReasons.SemanticChanged));
 
         public static readonly InvocationReasons SolutionRemoved =


### PR DESCRIPTION
…crawler when compilation options (or analyzer rule severity) are changed.

Fixes #3796