### PR TITLE
Ensures that history always contains what user has typed

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -345,8 +345,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     _window.SetActiveCode(command);
                 }
 
-                FinishCurrentSubmissionInput();
+                // Add command to history before calling FinishCurrentSubmissionInput as it adds newline 
+                // to the end of the command.
                 _window._history.Add(_window._currentLanguageBuffer.CurrentSnapshot.GetExtent());
+                FinishCurrentSubmissionInput();
             }
 
             private void AppendUncommittedInput(string text)
@@ -489,6 +491,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     return Task.FromResult<object>(null);
                 }
 
+                // get command to save to history before calling FinishCurrentSubmissionInput
+                // as it adds newline at the end
+                var historySpan = _window._currentLanguageBuffer.CurrentSnapshot.GetExtent();
                 FinishCurrentSubmissionInput();
 
                 _window._history.UncommittedInput = null;
@@ -504,7 +509,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
                 else
                 {
-                    _window._history.Add(trimmedSpan);
+                    _window._history.Add(historySpan);
                     State = State.ExecutingInput;
 
                     StartCursorTimer();

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -55,6 +55,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             return snapshotMock.Object;
         }
 
+        public string GetTextFromCurrentLanguageBuffer
+        {
+            get
+            {
+                return Window.CurrentLanguageBuffer.CurrentSnapshot.GetText();
+            }
+        }
+
         #endregion
 
         [Fact]
@@ -608,6 +616,25 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Window.TextView.Caret.Position.VirtualBufferPosition.GetLineAndColumn(out actualLine, out actualColumn);
             Assert.Equal(expectedLine, actualLine.LineNumber);
             Assert.Equal(expectedColumn, actualColumn);
+        }
+		
+		[Fact]
+        public void CheckHistoryPrevious()
+        {
+            const string V = "1 ";
+            Window.InsertCode(V);
+            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            Task.Run(() => Window.Operations.ExecuteInput()).PumpingWait();
+            Window.Operations.HistoryPrevious();
+            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/4121")]
+        public void CheckHistoryAfterResetButtonClick()
+        {
+            Task.Run(() => Window.Operations.ResetAsync(initialize: true)).PumpingWait();
+            Task.Run(() => Window.Operations.HistoryPrevious()).PumpingWait();
+            Assert.Equal("#reset", GetTextFromCurrentLanguageBuffer);
         }
     }
 }


### PR DESCRIPTION
We never trim what user has typed and we don't add newline at the end of the command
Fixes #4239 