### PR TITLE
return project that implements IAnalyzerHost wrapped by Com Wrapper.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
@@ -25,7 +25,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 this.Workspace,
                 this.HostDiagnosticUpdateSource);
 
-            projectRoot.SetProjectSite(project);
+            // give back Com Wrapper com object over managed version so that consumer like project k can QI it to IAnalyzerHost
+            projectRoot.SetProjectSite((ICSharpProjectSite)project.ComAggregate);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -113,6 +113,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             Contract.ThrowIfNull(projectSystemName);
 
+            // hold onto Com wrapper before CCW is created for this object.
+            this.ComAggregate = Implementation.Interop.ComAggregate.CreateAggregatedObject(this);
+
             this.ServiceProvider = serviceProvider;
 
             _language = language;
@@ -157,6 +160,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             SetIsWebsite(hierarchy);
         }
+
+        // hold onto ComAggregate of this managed COM object so that
+        // managed consumer like project k can QI this to IAnalyzerHost to
+        // manage analyzer related information such as additional files, ruleset files and etc.
+        internal object ComAggregate { get; }
 
         private static string GetProjectType(IVsHierarchy hierarchy)
         {

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Public Function CreateProject(wszName As String, punkProject As Object, pProjHier As IVsHierarchy, pVbCompilerHost As IVbCompilerHost) As IVbCompilerProject Implements IVbCompiler.CreateProject
             Dim visualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspaceImpl)()
             Dim hostDiagnosticUpdateSource = ComponentModel.GetService(Of HostDiagnosticUpdateSource)()
-            Return New VisualBasicProjectShimWithServices(
+            Dim project = New VisualBasicProjectShimWithServices(
                 visualStudioWorkspace.ProjectTracker,
                 pVbCompilerHost,
                 wszName,
@@ -29,6 +29,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 Me.ComponentModel.GetService(Of MiscellaneousFilesWorkspace),
                 visualStudioWorkspace,
                 hostDiagnosticUpdateSource)
+
+            ' wrap managed com object to com wrapper so that consumer can QI it to IAnalyzerHost.
+            ' currently, IAnalyzerHost is only way to add analyzer related information such as additional files/analyzer references/ruleset files if consumer
+            ' doesn't come through msbuild
+            Return DirectCast(project.ComAggregate, IVbCompilerProject)
         End Function
 
         Public Function IsValidIdentifier(wszIdentifier As String) As Boolean Implements IVbCompiler.IsValidIdentifier


### PR DESCRIPTION
managed consumer (such as project k) that consumes our project can't QI to IAnalyzerHost. but they need IAnalyzerHost to manipulate analyzer related information.

so made it to follow the ComAggregator pattern we use for other features such as language service, code model.