### PR TITLE
Remove SCC bindings

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -114,10 +114,6 @@
   <PropertyGroup>
     <DeployToSamplesSubfolder Condition="'$(DeployToSamplesSubfolder)' == ''">false</DeployToSamplesSubfolder>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
     <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb.NativeTests/Microsoft.DiaSymReader.PortablePdb.Native.UnitTests.vcxproj
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb.NativeTests/Microsoft.DiaSymReader.PortablePdb.Native.UnitTests.vcxproj
@@ -19,10 +19,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{690CACA9-9F32-47DA-B61D-55231257CBA3}</ProjectGuid>
-    <SccProjectName>SAK</SccProjectName>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccProvider>SAK</SccProvider>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>NativeClientTests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
We no longer use SCC bindings in our project yet the definitions remained around and caused a dialog prompt on solution open.  Removing these as they are no longer needed