### PR TITLE
Fix NRE in command line parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
@@ -140,7 +140,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!TryParseOption(arg, out name, out value))
                 {
                     sourceFiles.AddRange(ParseFileArgument(arg, baseDirectory, diagnostics));
-                    sourceFilesSpecified = true;
+                    if (sourceFiles.Count > 0)
+                    {
+                        sourceFilesSpecified = true;
+                    }
                     continue;
                 }
 
@@ -1130,7 +1133,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ReportAnalyzer = reportAnalyzer
             };
         }
-
 
         private static void ParseAndResolveReferencePaths(string switchName, string switchValue, string baseDirectory, List<string> builder, MessageID origin, List<Diagnostic> diagnostics)
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -324,6 +324,16 @@ d.cs
             Assert.Equal(4, resolvedSourceFiles.Length);
         }
 
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void SourceFile_BadPath()
+        {
+            var args = DefaultParse(new[] { @"e:c:\test\test.cs", "/t:library" }, _baseDirectory);
+            Assert.Equal(3, args.Errors.Length);
+            Assert.Equal((int)ErrorCode.FTL_InputFileNameTooLong, args.Errors[0].Code);
+            Assert.Equal((int)ErrorCode.WRN_NoSources, args.Errors[1].Code);
+            Assert.Equal((int)ErrorCode.ERR_OutputNeedsName, args.Errors[2].Code);
+        }
+
         private void CreateFile(TempDirectory folder, string file)
         {
             var f = folder.CreateFile(file);

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7241,6 +7241,13 @@ End Class
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
+
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub SourceFile_BadPath()
+            Dim args = DefaultParse({"e:c:\test\test.cs", "/t:library"}, _baseDirectory)
+            args.Errors.Verify(Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("e:c:\test\test.cs").WithLocation(1, 1))
+        End Sub
     End Class
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>


### PR DESCRIPTION
The command line parser was inconsistent in how it set the
sourceFilesSpecified boolean flag.  In one place it tracked whether the
source files collection was non empty and in another it tracked whether
or not we had attempted to parse an argument as a source file.  This
disconnect lead to a NRE when there was an invalid source file and the
command line tried to calculate the output name for a library project.
Changed the compiler to consistently treat it as tracking whether or not
a valid source file was specified.