### PR TITLE
Express command visibility in vsct...

### DIFF
--- a/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowPackage.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.LanguageServices.Interactive;
 using Microsoft.VisualStudio.Shell;
-using Roslyn.Utilities;
 using Microsoft.VisualStudio.InteractiveWindow.Shell;
 using LanguageServiceGuids = Microsoft.VisualStudio.LanguageServices.Guids;
 
@@ -13,8 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
 {
     [Guid(LanguageServiceGuids.CSharpReplPackageIdString)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [ProvideMenuResource("Menus.ctmenu", 16)]
-    [ProvideAutoLoad(VSConstants.UICONTEXT.CSharpProject_string)]
+    [ProvideMenuResource("Menus.ctmenu", 17)]
     [ProvideLanguageExtension(LanguageServiceGuids.CSharpLanguageServiceIdString, ".csx")]
     [ProvideInteractiveWindow(
         IdString,

--- a/src/VisualStudio/CSharp/Repl/Commands.vsct
+++ b/src/VisualStudio/CSharp/Repl/Commands.vsct
@@ -36,7 +36,11 @@
       <Bitmap guid="guidCSharpInteractiveImages" href="Resources\CSharpInteractive.png" usedList="bmpCSharpInteractiveWindow"/>
     </Bitmaps>
   </Commands>
-
+  
+  <VisibilityConstraints>
+    <VisibilityItem context="guidCSProjectContext" guid="guidCSharpInteractiveCommandSet" id="cmdidResetInteractiveFromProject" />
+  </VisibilityConstraints>
+  
   <KeyBindings>
     <KeyBinding guid="guidCSharpInteractiveCommandSet" id="cmdidCSharpInteractiveToolWindow" editor="guidVSStd97" mod1="Control" key1="W" mod2="Control" key2="I" />
     <KeyBinding guid="guidCSharpInteractiveCommandSet" id="cmdidCSharpInteractiveToolWindow" editor="guidVSStd97" mod1="Control" key1="W" key2="I" />
@@ -55,5 +59,7 @@
     <GuidSymbol name="guidCSharpInteractiveImages" value="{F6A1DE39-7690-4ED5-AF68-9569926B2F3A}" >
       <IDSymbol name="bmpCSharpInteractiveWindow" value="0x01" />
     </GuidSymbol>
+
+    <GuidSymbol name="guidCSProjectContext" value="{FAE04EC1-301F-11D3-BF4B-00C04F79EFBC}" />
   </Symbols>
 </CommandTable>

--- a/src/VisualStudio/VisualBasic/Repl/Commands.vsct
+++ b/src/VisualStudio/VisualBasic/Repl/Commands.vsct
@@ -37,6 +37,10 @@
     </Bitmaps>
   </Commands>
 
+  <VisibilityConstraints>
+    <VisibilityItem context="guidVBProjectContext" guid="guidVisualBasicInteractiveCommandSet" id="cmdidResetInteractiveFromProject" />
+  </VisibilityConstraints>
+  
   <!-- We need to pick a different keyboard shortcut for VB Interactive
   <KeyBindings>
     <KeyBinding guid="guidVisualBasicInteractiveCommandSet" id="cmdidVisualBasicInteractiveToolWindow" editor="guidVSStd97" mod1="Control" key1="W" mod2="Control" key2="I" />
@@ -57,5 +61,7 @@
     <GuidSymbol name="guidVisualBasicInteractiveImages" value="{4B45CA50-2FB8-4BAC-AAB5-3B5BBAF0C093}" >
       <IDSymbol name="bmpVisualBasicInteractiveWindow" value="0x01" />
     </GuidSymbol>
+
+    <GuidSymbol name="guidVBProjectContext" value="{164B10B9-B200-11D0-8C61-00A0C91E29D5}" />
   </Symbols>
 </CommandTable>

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicVsInteractiveWindowPackage.vb
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicVsInteractiveWindowPackage.vb
@@ -4,7 +4,6 @@ Imports System.ComponentModel.Design
 Imports System.Runtime.InteropServices
 Imports Microsoft.VisualStudio.LanguageServices.Interactive
 Imports Microsoft.VisualStudio.Shell
-Imports Roslyn.Utilities
 Imports Microsoft.VisualStudio.InteractiveWindow.Shell
 Imports LanguageServiceGuids = Microsoft.VisualStudio.LanguageServices.Guids
 
@@ -12,8 +11,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Interactive
 
     <Guid(LanguageServiceGuids.VisualBasicReplPackageIdString)>
     <PackageRegistration(UseManagedResourcesOnly:=True)>
-    <ProvideMenuResource("Menus.ctmenu", 16)>
-    <ProvideAutoLoad(VSConstants.UICONTEXT.VBProject_string)>
+    <ProvideMenuResource("Menus.ctmenu", 17)>
     <ProvideInteractiveWindow(
         VisualBasicVsInteractiveWindowPackage.IdString,
         Orientation:=ToolWindowOrientation.Bottom,


### PR DESCRIPTION
This will allow VS to figure out when to display the "Reset Interactive from Project" command without having to load the Interactive assemblies (execute code).