### PR TITLE
Improve ResetCommand

### DIFF
--- a/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
+++ b/src/InteractiveWindow/Editor/Commands/ResetCommand.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
     {
         private const string CommandName = "reset";
         private const string NoConfigParameterName = "noconfig";
+        private static readonly int NoConfigParameterNameLength = NoConfigParameterName.Length;
         private readonly IStandardClassificationService _registry;
 
         [ImportingConstructor]
@@ -51,53 +52,66 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         public override Task<ExecutionResult> Execute(IInteractiveWindow window, string arguments)
         {
-            int noConfigStart, noConfigEnd;
-            if (!TryParseArguments(arguments, out noConfigStart, out noConfigEnd))
+            bool initialize;
+            if (!TryParseArguments(arguments, out initialize))
             {
                 ReportInvalidArguments(window);
                 return ExecutionResult.Failed;
             }
 
-            return window.Operations.ResetAsync(initialize: noConfigStart > -1);
-        }
-
-        internal static string BuildCommandLine(bool initialize)
-        {
-            string result = CommandName;
-            return initialize ? result : result + " " + NoConfigParameterName;
+            return window.Operations.ResetAsync(initialize);
         }
 
         public override IEnumerable<ClassificationSpan> ClassifyArguments(ITextSnapshot snapshot, Span argumentsSpan, Span spanToClassify)
         {
             string arguments = snapshot.GetText(argumentsSpan);
-
-            int noConfigStart, noConfigEnd;
-            if (TryParseArguments(arguments, out noConfigStart, out noConfigEnd))
+            int argumentsStart = argumentsSpan.Start;
+            foreach (var pos in GetNoConfigPositions(arguments))
             {
-                if (noConfigStart > -1)
-                {
-                    yield return new ClassificationSpan(new SnapshotSpan(snapshot, Span.FromBounds(argumentsSpan.Start + noConfigStart, argumentsSpan.Start + noConfigEnd)), _registry.Keyword);
-                }
+                var snapshotSpan = new SnapshotSpan(snapshot, new Span(argumentsStart + pos, NoConfigParameterNameLength));
+                yield return new ClassificationSpan(snapshotSpan, _registry.Keyword);
             }
         }
 
-        private static bool TryParseArguments(string arguments, out int noConfigStart, out int noConfigEnd)
+        /// <remarks>
+        /// Internal for testing.
+        /// </remarks>
+        internal static IEnumerable<int> GetNoConfigPositions(string arguments)
         {
-            noConfigStart = noConfigEnd = -1;
-
-            string noconfig = arguments.Trim();
-            if (noconfig.Length == 0)
+            int startIndex = 0;
+            while (true)
             {
+                int index = arguments.IndexOf(NoConfigParameterName, startIndex, StringComparison.OrdinalIgnoreCase);
+                if (index < 0) yield break;
+
+                if ((index == 0 || char.IsWhiteSpace(arguments[index - 1])) &&
+                    (index + NoConfigParameterNameLength == arguments.Length || char.IsWhiteSpace(arguments[index + NoConfigParameterNameLength])))
+                {
+                    yield return index;
+                }
+
+                startIndex = index + NoConfigParameterNameLength;
+            }
+        }
+
+        /// <remarks>
+        /// Internal for testing.
+        /// </remarks>
+        internal static bool TryParseArguments(string arguments, out bool initialize)
+        {
+            var trimmed = arguments.Trim();
+            if (trimmed.Length == 0)
+            {
+                initialize = true;
+                return true;
+            }
+            else if (string.Equals(trimmed, NoConfigParameterName, StringComparison.OrdinalIgnoreCase))
+            {
+                initialize = false;
                 return true;
             }
 
-            if (string.Compare(noconfig, NoConfigParameterName, StringComparison.OrdinalIgnoreCase) == 0)
-            {
-                noConfigStart = arguments.IndexOf(noconfig, StringComparison.OrdinalIgnoreCase);
-                noConfigEnd = noConfigStart + noconfig.Length;
-                return true;
-            }
-
+            initialize = false;
             return false;
         }
     }

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -636,5 +636,66 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Task.Run(() => Window.Operations.HistoryPrevious()).PumpingWait();
             Assert.Equal("#reset", GetTextFromCurrentLanguageBuffer);
         }
+
+        [Fact]
+        public void ResetCommandArgumentParsing_Success()
+        {
+            bool initialize;
+            Assert.True(ResetCommand.TryParseArguments("", out initialize));
+            Assert.True(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments(" ", out initialize));
+            Assert.True(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments("\r\n", out initialize));
+            Assert.True(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments("noconfig", out initialize));
+            Assert.False(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments(" noconfig ", out initialize));
+            Assert.False(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments("\r\nnoconfig\r\n", out initialize));
+            Assert.False(initialize);
+
+            Assert.True(ResetCommand.TryParseArguments("nOcOnfIg", out initialize));
+            Assert.False(initialize);
+        }
+
+        [Fact]
+        public void ResetCommandArgumentParsing_Failure()
+        {
+            bool initialize;
+            Assert.False(ResetCommand.TryParseArguments("a", out initialize));
+            Assert.False(ResetCommand.TryParseArguments("noconfi", out initialize));
+            Assert.False(ResetCommand.TryParseArguments("noconfig1", out initialize));
+            Assert.False(ResetCommand.TryParseArguments("noconfig 1", out initialize));
+            Assert.False(ResetCommand.TryParseArguments("1 noconfig", out initialize));
+            Assert.False(ResetCommand.TryParseArguments("noconfig\r\na", out initialize));
+        }
+
+        [Fact]
+        public void ResetCommandNoConfigClassification()
+        {
+            Assert.Empty(ResetCommand.GetNoConfigPositions(""));
+            Assert.Empty(ResetCommand.GetNoConfigPositions("a"));
+            Assert.Empty(ResetCommand.GetNoConfigPositions("noconfi"));
+            Assert.Empty(ResetCommand.GetNoConfigPositions("noconfig1"));
+            Assert.Empty(ResetCommand.GetNoConfigPositions("1noconfig"));
+            Assert.Empty(ResetCommand.GetNoConfigPositions("1noconfig1"));
+
+            Assert.Equal(new[] { 0 }, ResetCommand.GetNoConfigPositions("noconfig"));
+            Assert.Equal(new[] { 0 }, ResetCommand.GetNoConfigPositions("noconfig "));
+            Assert.Equal(new[] { 1 }, ResetCommand.GetNoConfigPositions(" noconfig"));
+            Assert.Equal(new[] { 1 }, ResetCommand.GetNoConfigPositions(" noconfig "));
+            Assert.Equal(new[] { 2 }, ResetCommand.GetNoConfigPositions("\r\nnoconfig"));
+            Assert.Equal(new[] { 0 }, ResetCommand.GetNoConfigPositions("noconfig\r\n"));
+            Assert.Equal(new[] { 2 }, ResetCommand.GetNoConfigPositions("\r\nnoconfig\r\n"));
+            Assert.Equal(new[] { 6 }, ResetCommand.GetNoConfigPositions("error noconfig"));
+
+            Assert.Equal(new[] { 0, 9 }, ResetCommand.GetNoConfigPositions("noconfig noconfig"));
+            Assert.Equal(new[] { 0, 15 }, ResetCommand.GetNoConfigPositions("noconfig error noconfig"));
+        }
     }
 }


### PR DESCRIPTION
 1. Unflip the noconfig argument (fixes #4396).
 2. Classify ```noconfig``` anywhere in the argument list.