### PR TITLE
Fix 4121and4125

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -335,6 +335,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             public void AddInput(string command)
             {
                 // If the language buffer is readonly then input can not be added. Return immediately.
+                // The language buffer gets marked as readonly in SubmitAsync method when input on the prompt 
+                // gets submitted. So it would be readonly when the user types #reset on the prompt. In that 
+                // case it is the right thing to bail out of this method.
                 if (_window._currentLanguageBuffer != null && _window._currentLanguageBuffer.IsReadOnly(0))
                 {
                     return;

--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -334,6 +334,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             public void AddInput(string command)
             {
+                // If the language buffer is readonly then input can not be added. Return immediately.
+                if (_window._currentLanguageBuffer != null && _window._currentLanguageBuffer.IsReadOnly(0))
+                {
+                    return;
+                }
+
                 if (State == State.ExecutingInput || _window._currentLanguageBuffer == null)
                 {
                     AddLanguageBuffer();

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -55,12 +55,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             return snapshotMock.Object;
         }
 
-        public string GetTextFromCurrentLanguageBuffer
+        public string GetTextFromCurrentLanguageBuffer()
         {
-            get
-            {
-                return Window.CurrentLanguageBuffer.CurrentSnapshot.GetText();
-            }
+            return Window.CurrentLanguageBuffer.CurrentSnapshot.GetText();
         }
 
         #endregion
@@ -621,23 +618,23 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
 		[Fact]
         public void CheckHistoryPrevious()
         {
-            const string V = "1 ";
-            Window.InsertCode(V);
-            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            const string inputString = "1 ";
+            Window.InsertCode(inputString);
+            Assert.Equal(inputString, GetTextFromCurrentLanguageBuffer());
             Task.Run(() => Window.Operations.ExecuteInput()).PumpingWait();
             Window.Operations.HistoryPrevious();
-            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            Assert.Equal(inputString, GetTextFromCurrentLanguageBuffer());
         }
 
         [Fact]
         public void CheckHistoryPreviousAfterReset()
         {
-            const string V = "#reset";
-            Window.InsertCode(V);
-            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            const string resetCommand = "#reset";
+            Window.InsertCode(resetCommand);
+            Assert.Equal(resetCommand, GetTextFromCurrentLanguageBuffer());
             Task.Run(() => Window.Operations.ExecuteInput()).PumpingWait();
             Window.Operations.HistoryPrevious();
-            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            Assert.Equal(resetCommand, GetTextFromCurrentLanguageBuffer());
         }
     }
 }

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -629,12 +629,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/4121")]
-        public void CheckHistoryAfterResetButtonClick()
+        [Fact]
+        public void CheckHistoryPreviousAfterReset()
         {
-            Task.Run(() => Window.Operations.ResetAsync(initialize: true)).PumpingWait();
-            Task.Run(() => Window.Operations.HistoryPrevious()).PumpingWait();
-            Assert.Equal("#reset", GetTextFromCurrentLanguageBuffer);
+            const string V = "#reset";
+            Window.InsertCode(V);
+            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
+            Task.Run(() => Window.Operations.ExecuteInput()).PumpingWait();
+            Window.Operations.HistoryPrevious();
+            Assert.Equal(V, GetTextFromCurrentLanguageBuffer);
         }
     }
 }


### PR DESCRIPTION
The root issue here was the call to AddInput method ( which echoes the command on the language buffer) which was being made even when the reset command was typed at the prompt instead of just when reset button was clicked. The language buffer actually gets marked as readonly when input on the prompt gets submitted. We now check to see if the language buffer is readonly and bail out of AddInput if it is.  Previously AddInput was trying to echo the reset command which did nothing as the buffer was readonly but the subsequent processing in AddInput was causing all these issues. 

Fixes #4121, #4125 and #4277