### PR TITLE
Add encoding detection for CoreCLR

### DIFF
--- a/src/Compilers/CSharp/CscCore/project.json
+++ b/src/Compilers/CSharp/CscCore/project.json
@@ -29,6 +29,7 @@
     "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23109",
     "System.Security.Principal": "4.0.0-beta-23109",
     "System.Text.Encoding": "4.0.10-beta-23109",
+    "System.Text.Encoding.CodePages": "4.0.0-beta-23019",
     "System.Text.Encoding.Extensions": "4.0.10-beta-23109",
     "System.Threading": "4.0.10-beta-23109",
     "System.Threading.Overlapped": "4.0.0-beta-23109",

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -43,6 +43,9 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\Helpers\CoreClrShim.cs">
+      <Link>CoreClrShim.cs</Link>
+    </Compile>
     <Compile Include="AdditionalTextFile.cs" />
     <Compile Include="AssemblyReferenceResolver.cs" />
     <Compile Include="AssemblyUtilities.cs" />

--- a/src/Compilers/Helpers/CoreClrShim.cs
+++ b/src/Compilers/Helpers/CoreClrShim.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+
+namespace Roslyn.Utilities
+{
+
+    /// <summary>
+    /// This is a bridge for APIs that are only available on CoreCLR or .NET 4.6
+    /// and NOT on .NET 4.5. The compiler currently targets .NET 4.5 and CoreCLR
+    /// so this shim is necessary for switching on the dependent behavior.
+    /// </summary>
+    internal static class CoreClrShim
+    {
+        internal static bool IsCoreClr { get; } =
+            Type.GetType("System.Runtime.Loader.AssemblyLoadContext, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                         throwOnError: false) != null;
+
+        internal static void Initialize()
+        {
+            // This method provides a way to force the static initializers of each type below
+            // to run. This ensures that the static field values will be computed eagerly
+            // rather than lazily on demand. If you add a new nested class below to access API
+            // surface area, be sure to "touch" the Type field here.
+
+            Touch(CodePagesEncodingProvider.Type);
+        }
+
+        private static void Touch(Type type)
+        {
+            // Do nothing.
+        }
+
+        internal static class CodePagesEncodingProvider
+        {
+            internal static readonly Type Type =
+                Type.GetType("System.Text.CodePagesEncodingProvider, System.Text.Encoding.CodePages, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                             throwOnError: false);
+
+            private static PropertyInfo s_instance = Type
+                .GetTypeInfo()
+                .GetDeclaredProperty("Instance");
+
+            internal static object Instance => s_instance.GetValue(null);
+        }
+
+        internal static class Encoding
+        {
+            private static readonly MethodInfo s_registerProvider = PortableShim.Encoding.Type
+                .GetTypeInfo()
+                .GetDeclaredMethod("RegisterProvider");
+
+            internal static void RegisterProvider(object provider)
+            {
+                try
+                {
+                    s_registerProvider.Invoke(null, new[] { provider });
+                }
+                catch (TargetInvocationException e)
+                {
+                    ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/VbcCore/project.json
+++ b/src/Compilers/VisualBasic/VbcCore/project.json
@@ -29,6 +29,7 @@
     "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23109",
     "System.Security.Principal": "4.0.0-beta-23109",
     "System.Text.Encoding": "4.0.10-beta-23109",
+    "System.Text.Encoding.CodePages": "4.0.0-beta-23019",
     "System.Text.Encoding.Extensions": "4.0.10-beta-23109",
     "System.Threading": "4.0.10-beta-23109",
     "System.Threading.Overlapped": "4.0.0-beta-23109",

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\EncodedStringText.cs">
       <Link>InternalUtilities\EncodedStringText.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Helpers\CoreClrShim.cs">
+      <Link>InternalUtilities\CoreClrShim.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\FileKey.cs">
       <Link>InternalUtilities\FileKey.cs</Link>
     </Compile>


### PR DESCRIPTION
On CoreCLR we will always be unable to fetch the default encoding and
the 1252 encoding will be unavailable unless we reference
System.Text.Encoding.CodePages. However, we don't want to take a
dependency on this assembly on desktop 4.5 so we now use
AssemblyLoadContext to try to detect whether or not we are running on
CoreCLR and, if so, reflection load the necessary assemblies to get hold
of the necessary types.