### PR TITLE
Remove dependency on particular evaluator implementation

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -206,6 +206,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
                 _window._buffer.Flush();
 
+                if (State == State.WaitingForInput)
+                {
+                    Debug.Assert(_window._projectionSpans.Last().Kind == ReplSpanKind.Language);
+                    StoreUncommittedInput();
+                    RemoveProjectionSpans(_window._projectionSpans.Count - 2, 2);
+                    _window._currentLanguageBuffer = null;
+                }
+
                 // replace the task being interrupted by a "reset" task:
                 State = State.Resetting;
                 _currentTask = _window._evaluator.ResetAsync(initialize);


### PR DESCRIPTION
```InteractiveWindow``` tacitly assumed that
```IInteractiveEvaluator.ResetAsync``` would a newline-terminated string
to the current language buffer, making it safe to insert a new prompt at
the cursor position.  Obviously, this behavior is implementation-specific
and cannot be relied upon.

Instead, store the uncommitted input and remove the current language
buffer.  If the evaluator adds input, then a new one will be created for
it.  Otherwise, things will be tidy when the window creates a new prompt
and restores the uncommitted input.

Fixes #4518