### PR TITLE
Don't execute a progression search query on projects without a FilePath.

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
@@ -30,6 +30,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public partial class TestWorkspaceFactory
     {
+        /// <summary>
+        /// This place-holder value is used to set a project's file path to be null.  It was explicitly chosen to be
+        /// convoluted to avoid any accidental usage (e.g., what if I really wanted FilePath to be the string "null"?),
+        /// obvious to anybody debugging that it is a special value, and invalid as an actual file path.
+        /// </summary>
+        public const string NullFilePath = "NullFilePath::{AFA13775-BB7D-4020-9E58-C68CF43D8A68}";
+
         private class TestDocumentationProvider : DocumentationProvider
         {
             protected override string GetDocumentationForSymbol(string documentationMemberID, CultureInfo preferredCulture, CancellationToken cancellationToken = default(CancellationToken))
@@ -225,7 +232,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             if (projectElement.Attribute(FilePathAttributeName) != null)
             {
                 filePath = projectElement.Attribute(FilePathAttributeName).Value;
-                if (string.Compare(filePath, "null", StringComparison.Ordinal) == 0 || string.Compare(filePath, "Nothing", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(filePath, NullFilePath, StringComparison.Ordinal) == 0)
                 {
                     // allow explicit null file path
                     filePath = null;

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
@@ -225,6 +225,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             if (projectElement.Attribute(FilePathAttributeName) != null)
             {
                 filePath = projectElement.Attribute(FilePathAttributeName).Value;
+                if (string.Compare(filePath, "null", StringComparison.Ordinal) == 0 || string.Compare(filePath, "Nothing", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    // allow explicit null file path
+                    filePath = null;
+                }
             }
             else
             {

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -27,7 +26,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
         {
             var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 
-            var searchTasks = solution.Projects.Select(p => ProcessProjectAsync(p, graphBuilder, cancellationToken)).ToArray();
+            var searchTasks = solution.Projects
+                .Where(p => p.FilePath != null)
+                .Select(p => ProcessProjectAsync(p, graphBuilder, cancellationToken))
+                .ToArray();
             await Task.WhenAll(searchTasks).ConfigureAwait(false);
 
             return graphBuilder;

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.VisualStudio.GraphModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 Imports Roslyn.Test.Utilities
@@ -381,7 +382,7 @@ End Namespace
         Public Sub SearchWithNullFilePathsOnProject()
             Using testState = New ProgressionTestState(
                     <Workspace>
-                        <Project Language="C#" CommonReferences="true" FilePath="null">
+                        <Project Language="C#" CommonReferences="true" FilePath=<%= TestWorkspaceFactory.NullFilePath %>>
                             <Document FilePath="Z:\SomeVenusDocument.aspx.cs">
                                 namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
                             </Document>

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
@@ -376,5 +376,37 @@ End Namespace
                     </DirectedGraph>)
             End Using
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Sub SearchWithNullFilePathsOnProject()
+            Using testState = New ProgressionTestState(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" FilePath="null">
+                            <Document FilePath="Z:\SomeVenusDocument.aspx.cs">
+                                namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim outputContext = testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="A.D.B"), GraphContextDirection.Custom)
+
+                ' When searching, don't descend into projects with a null FilePath because they are artifacts and not
+                ' representable in the Solution Explorer, e.g., Venus projects create sub-projects with a null file
+                ' path for each .aspx file.  Documents, on the other hand, are never allowed to have a null file path
+                ' and as such are not tested here.  The project/document structure for these scenarios would look
+                ' similar to this:
+                '
+                '    Project: SomeVenusProject, FilePath=C:\path\to\project.csproj
+                '      + Document: SomeVenusDocument.aspx, FilePath=C:\path\to\SomeVenusDocument.aspx
+                '        + Project: 1_SomeNamespace_SomeVenusDocument.aspx, FilePath=null        <- the problem is here
+                '          + Document: SomeVenusDocument.aspx.cs
+                AssertSimplifiedGraphIs(
+                    outputContext.Graph,
+                    <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+                        <Nodes/>
+                        <Links/>
+                    </DirectedGraph>)
+            End Using
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
This can happen in Venus projects which create temporary projects for each contained `.aspx` file.  E.g., if a Venus project contains `SomeVenusDocument.aspx`, then a hidden project with a name like `1_SomeNamespace_SomeVenusDocument.aspx` is created that has a null `FilePath` and only contains one document, `SomeVenusDocument.aspx.cs`.  This is a project system artifact to enable proper binding to the backing `.aspx.cs` file so that various IDE features (IntelliSense, completion, etc.) are enabled in the pseudo-HTML `.aspx` file.

This is in response to an internal bug where searching the Solution Explorer when Venus projects are loaded can cause VS to crash.  I was unable to repro this manually, but confirmed the cause of the crash by examining a private dump and confirming the existence of a project like I mentioned above: a specially-crafted name, null `FilePath`, and only one document pointing to the appropriate `.aspx.cs` file.

The crash was ultimately coming from [here](http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/Progression/GraphNodeIdCreation.cs,29) because the property `document.Project.FilePath` was null.

I didn't guard against `document.FilePath` being null because that scenario is explicitly not allowed and would already be caught by contract checks [here](http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Workspace/Solution/DocumentInfo.cs,70).

The code path for C#/VB is shared, hence no VB-specific test.

Tagging @Pilchie @dpoeschl @jasonmalinowski @rchande @balajikris @basoundr @jmarolf @davkean for review.