### PR TITLE
Rename Roslyn.Test.Utilities projects.

### DIFF
--- a/build/Toolset.sln
+++ b/build/Toolset.sln
@@ -35,7 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VisualBasic", "VisualBasic"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompilerTestResources", "..\src\Compilers\Test\Resources\Core\CompilerTestResources.csproj", "{7FE6B002-89D8-4298-9B1B-0B5C247DD1FD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompilerTestUtilities2", "..\src\Compilers\Test\Utilities\Core2\CompilerTestUtilities2.csproj", "{F7712928-1175-47B3-8819-EE086753DEE2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.FX45", "..\src\Test\Utilities\Portable\TestUtilities.FX45.csproj", "{F7712928-1175-47B3-8819-EE086753DEE2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpCompilerTestUtilities", "..\src\Compilers\Test\Utilities\CSharp\CSharpCompilerTestUtilities.csproj", "{4371944A-D3BA-4B5B-8285-82E5FFC6D1F9}"
 EndProject
@@ -55,7 +55,7 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "BasicCompilerSyntaxTest", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdbUtilities", "..\src\Test\PdbUtilities\PdbUtilities.csproj", "{AFDE6BEA-5038-4A4A-A88E-DBD2E4088EED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\src\Test\Utilities\TestUtilities.csproj", "{76C6F005-C89D-4348-BB4A-391898DBEB52}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.Desktop", "..\src\Test\Utilities\Desktop\TestUtilities.Desktop.csproj", "{76C6F005-C89D-4348-BB4A-391898DBEB52}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workspaces", "Workspaces", "{55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}"
 EndProject


### PR DESCRIPTION
Applies renaming done by d38a8d5f24fe86b9ecb505b3bf99b5a9726d933d.