### PR TITLE
Target the facade assembly for the CoreClrShim

### DIFF
--- a/src/Compilers/CSharp/CscCore/project.json
+++ b/src/Compilers/CSharp/CscCore/project.json
@@ -25,6 +25,7 @@
     "System.Runtime.Extensions": "4.0.10-beta-23109",
     "System.Runtime.Handles": "4.0.0-beta-23109",
     "System.Runtime.InteropServices": "4.0.20-beta-23109",
+    "System.Runtime.Loader": "4.0.0-beta-23109",
     "System.Runtime.Serialization.Json": "4.0.0-beta-23109",
     "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23109",
     "System.Security.Principal": "4.0.0-beta-23109",

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -30,19 +30,19 @@ namespace Microsoft.CodeAnalysis.Text
         {
             try
             {
-                // If we're running on CoreCLR there is no "default" codepage
-                // but we should be able to grab 1252 from System.Text.Encoding.CodePages
                 if (CoreClrShim.IsCoreClr)
                 {
+                    // If we're running on CoreCLR there is no "default" codepage but
+                    // we should be able to grab 1252 from System.Text.Encoding.CodePages
                     CoreClrShim.Encoding.RegisterProvider(CoreClrShim.CodePagesEncodingProvider.Instance);
                     // We should now have 1252 from the CodePagesEncodingProvider
                     return PortableShim.Encoding.GetEncoding(1252);
                 }
-                // If we're running on the desktop framework we should be able
-                // to get the default ANSI code page in the operating system's
-                // regional and language settings,
                 else
                 {
+                    // If we're running on the desktop framework we should be able
+                    // to get the default ANSI code page in the operating system's
+                    // regional and language settings,
                     return PortableShim.Encoding.GetEncoding(0)
                         ?? PortableShim.Encoding.GetEncoding(1252);
                 }

--- a/src/Compilers/Helpers/CoreClrShim.cs
+++ b/src/Compilers/Helpers/CoreClrShim.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
     internal static class CoreClrShim
     {
         internal static bool IsCoreClr { get; } =
-            Type.GetType("System.Runtime.Loader.AssemblyLoadContext, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            Type.GetType("System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
                          throwOnError: false) != null;
 
         internal static void Initialize()

--- a/src/Compilers/VisualBasic/VbcCore/project.json
+++ b/src/Compilers/VisualBasic/VbcCore/project.json
@@ -25,6 +25,7 @@
     "System.Runtime.Extensions": "4.0.10-beta-23109",
     "System.Runtime.Handles": "4.0.0-beta-23109",
     "System.Runtime.InteropServices": "4.0.20-beta-23109",
+    "System.Runtime.Loader": "4.0.0-beta-23109",
     "System.Runtime.Serialization.Json": "4.0.0-beta-23109",
     "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23109",
     "System.Security.Principal": "4.0.0-beta-23109",


### PR DESCRIPTION
Once System.Runtime.Loader is referenced in the project.json files
a facade is correctly copied to the output directory, so
AssemblyLoadContext can be loaded even if the assembly it's located in
changes.

@jaredpar Please review