### PR TITLE
A nameof() expression is always legal in an expression tree, as it is a constant

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -529,6 +529,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitMethodGroup(node);
         }
 
+        public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
+        {
+            // The nameof(...) operator collapses to a constant in an expression tree,
+            // so it does not matter what is recursively within it.
+            return node;
+        }
+
         public override BoundNode VisitNullCoalescingOperator(BoundNullCoalescingOperator node)
         {
             if (_inExpressionLambda && node.LeftOperand.ConstantValue != null && node.LeftOperand.ConstantValue.IsNull)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5041,6 +5041,31 @@ class C
             }
         }
 
+
+        [WorkItem(3923, "https://github.com/dotnet/roslyn/issues/3923")]
+        [Fact]
+        public void NameofInExpressionTree()
+        {
+            string program = @"
+using System;
+using System.Linq.Expressions;
+
+public class Program
+{
+    public static void Main()
+    {
+        Expression<Func<string>> func = () => nameof(Main);
+        Console.WriteLine(func.Compile().Invoke());
+    }
+}
+";
+            CompileAndVerify(
+                sources: new string[] { program },
+                additionalRefs: new[] { SystemCoreRef },
+                expectedOutput: @"Main")
+                .VerifyDiagnostics();
+        }
+
         #endregion Regression Tests
 
         #region helpers


### PR DESCRIPTION
Fixes #3923

(The analogous situation isn't a bug in VB)

@AlekseyTs @VSadov @jaredpar @agocke Please review