### PR TITLE
Fixes for scripting tests in Mono

### DIFF
--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1946,7 +1946,7 @@ fruit.Skip(1).Where(s => s.Length > 4).Count()
         }
 
         [WorkItem(541166)]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void DefineExtensionMethods()
         {
             var engine = new CSharpScriptEngine();

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2275,7 +2275,7 @@ new Metadata.ICSPropImpl()
             Assert.NotNull(result);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void MissingDependency()
         {
             var engine = new CSharpScriptEngine();

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2140,17 +2140,23 @@ new System.Data.DataSet()
         [Fact]
         public void SearchPaths_BaseDirectory()
         {
+            var dir1 = Path.Combine(System.Environment.CurrentDirectory, "nodir1");
+            var dir2 = Path.Combine(System.Environment.CurrentDirectory, "nodir2");
+
+            var dllPath = Path.Combine(dir1, "x.dll");
+            var csxPath = Path.Combine(dir1, "a.csx");
+
             var engine = new CSharpScriptEngine(new MetadataReferenceProvider(new Dictionary<string, PortableExecutableReference>
             {
-                { @"C:\dir\x.dll", (PortableExecutableReference)SystemCoreRef }
+                { dllPath, (PortableExecutableReference)SystemCoreRef }
             }));
 
             engine.MetadataReferenceResolver = new VirtualizedFileReferenceResolver(
                 existingFullPaths: new[]
                 {
-                    @"C:\dir\x.dll"
+                   dllPath
                 },
-                baseDirectory: @"C:\foo\bar"
+                baseDirectory: dir2
             );
 
             var session = engine.CreateSession();
@@ -2163,7 +2169,7 @@ var x = from a in new[] { 1,2,3 }
         select a + 1;
 ";
 
-            var submission = session.CompileSubmission<object>(source, @"C:\dir\a.csx", isInteractive: false);
+            var submission = session.CompileSubmission<object>(source, csxPath, isInteractive: false);
             submission.Execute();
         }
 

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -348,7 +348,8 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp.UnitTests
 
             options = new ObjectFormattingOptions(maxLineLength: 20, memberFormat: MemberDisplayFormat.List);
             var str = CSharpObjectFormatter.Instance.FormatObject(obj, options);
-            Assert.Equal("LongMembers {\r\n  LongName012345 ...\r\n  LongValue: \"01 ...\r\n}\r\n", str);
+            Assert.Equal("LongMembers {" + Environment.NewLine + "  LongName012345 ..." + Environment.NewLine +
+                    "  LongValue: \"01 ..." + Environment.NewLine + "}" + Environment.NewLine, str);
         }
 
         [Fact]

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp.UnitTests
             Assert.Equal("object[0, 0] { }", str);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void DebuggerProxy_FrameworkTypes_IEnumerable()
         {
             string str;

--- a/src/Scripting/Test/MetadataShadowCopyProviderTests.cs
+++ b/src/Scripting/Test/MetadataShadowCopyProviderTests.cs
@@ -40,6 +40,9 @@ namespace Roslyn.Services.UnitTests
         [Fact]
         public void Errors()
         {
+            var root = Path.GetPathRoot(System.Environment.CurrentDirectory);
+            var dllInRoot = Path.Combine(root, "foo.dll");
+
             Assert.Throws<ArgumentNullException>(() => _provider.NeedsShadowCopy(null));
             Assert.Throws<ArgumentException>(() => _provider.NeedsShadowCopy("c:foo.dll"));
             Assert.Throws<ArgumentException>(() => _provider.NeedsShadowCopy("bar.dll"));
@@ -58,14 +61,14 @@ namespace Roslyn.Services.UnitTests
             Assert.Throws<ArgumentException>(() => _provider.GetReference(@"\bar.dll"));
             Assert.Throws<ArgumentException>(() => _provider.GetReference(@"../bar.dll"));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _provider.GetMetadataShadowCopy(@"c:\foo.dll", (MetadataImageKind)Byte.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _provider.GetMetadataShadowCopy(dllInRoot, (MetadataImageKind)Byte.MaxValue));
             Assert.Throws<ArgumentNullException>(() => _provider.GetMetadataShadowCopy(null, MetadataImageKind.Assembly));
             Assert.Throws<ArgumentException>(() => _provider.GetMetadataShadowCopy("c:foo.dll", MetadataImageKind.Assembly));
             Assert.Throws<ArgumentException>(() => _provider.GetMetadataShadowCopy("bar.dll", MetadataImageKind.Assembly));
             Assert.Throws<ArgumentException>(() => _provider.GetMetadataShadowCopy(@"\bar.dll", MetadataImageKind.Assembly));
             Assert.Throws<ArgumentException>(() => _provider.GetMetadataShadowCopy(@"../bar.dll", MetadataImageKind.Assembly));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _provider.GetMetadata(@"c:\foo.dll", (MetadataImageKind)Byte.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _provider.GetMetadata(dllInRoot, (MetadataImageKind)Byte.MaxValue));
             Assert.Throws<ArgumentNullException>(() => _provider.GetMetadata(null, MetadataImageKind.Assembly));
             Assert.Throws<ArgumentException>(() => _provider.GetMetadata("c:foo.dll", MetadataImageKind.Assembly));
         }

--- a/src/Scripting/Test/MetadataShadowCopyProviderTests.cs
+++ b/src/Scripting/Test/MetadataShadowCopyProviderTests.cs
@@ -19,11 +19,21 @@ namespace Roslyn.Services.UnitTests
     {
         private readonly MetadataShadowCopyProvider _provider;
 
-        private static readonly ImmutableArray<string> s_systemNoShadowCopyDirectories = ImmutableArray.Create(
-                FileUtilities.NormalizeDirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.Windows)),
-                FileUtilities.NormalizeDirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)),
-                FileUtilities.NormalizeDirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)),
-                FileUtilities.NormalizeDirectoryPath(RuntimeEnvironment.GetRuntimeDirectory()));
+        private static readonly ImmutableArray<string> s_systemNoShadowCopyDirectories;
+
+        static MetadataShadowCopyProviderTests()
+        {
+            IEnumerable<string> list = new List<string>() {
+                Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                RuntimeEnvironment.GetRuntimeDirectory()};
+
+            // On Mono special folders can be empty strings.
+            list = list.Where(e => e != string.Empty).Select(e => FileUtilities.NormalizeDirectoryPath(e));
+
+            s_systemNoShadowCopyDirectories = ImmutableArray.Create(list.ToArray());
+        }
 
         public MetadataShadowCopyProviderTests()
         {

--- a/src/Scripting/Test/ObjectFormatterTestBase.cs
+++ b/src/Scripting/Test/ObjectFormatterTestBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Scripting.UnitTests
         public void AssertMembers(string str, params string[] expected)
         {
             int i = 0;
-            foreach (var line in str.Split(new[] { "\r\n  " }, StringSplitOptions.None))
+            foreach (var line in str.Split(new[] { Environment.NewLine + "  " }, StringSplitOptions.None))
             {
                 if (i == 0)
                 {
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Scripting.UnitTests
                 }
                 else if (i == expected.Length - 1)
                 {
-                    Assert.Equal(expected[i] + "\r\n}\r\n", line);
+                    Assert.Equal(expected[i] + Environment.NewLine + "}" + Environment.NewLine, line);
                 }
                 else
                 {


### PR DESCRIPTION
This fixes tests that do not pass in Mono except those that require GAC and

Roslyn.Services.UnitTests.MetadataShadowCopyProviderTests.Modules [#33007](https://bugzilla.xamarin.com/show_bug.cgi?id=33007)
Microsoft.CodeAnalysis.Scripting.CSharp.UnitTests.InteractiveSessionTests.AssemblyResolution [#32966](https://bugzilla.xamarin.com/show_bug.cgi?id=32966)
