### PR TITLE
Adds a Mono compatible logic for GAC.

### DIFF
--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -42,6 +42,7 @@ namespace Roslyn.Utilities
             // surface area, be sure to "touch" the Type field here.
 
             Touch(Assembly.Type);
+            Touch(AssemblyName.Type);
             Touch(Directory.Type);
             Touch(Encoding.Type);
             Touch(Environment.Type);
@@ -485,6 +486,25 @@ namespace Roslyn.Utilities
                 .GetTypeInfo()
                 .GetDeclaredMethod("GetType", typeof(string), typeof(bool), typeof(bool))
                 .CreateDelegate<Func<System.Reflection.Assembly, string, bool, bool, Type>>();
+
+            internal static readonly Func<Type, System.Reflection.Assembly> GetAssembly = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod("GetAssembly", typeof(Type))
+                .CreateDelegate<Func<Type, System.Reflection.Assembly>>();
+        }
+
+        internal static class AssemblyName
+        {
+            private const string TypeName = "System.Reflection.AssemblyName";
+
+            internal static readonly Type Type = ReflectionUtilities.GetTypeFromEither(
+                contractName: $"{TypeName}, {CoreNames.System_Reflection}",
+                desktopName: TypeName);
+
+            internal static readonly Func<string, System.Reflection.AssemblyName> GetAssemblyName = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod("GetAssemblyName", typeof(string))
+                .CreateDelegate<Func<string, System.Reflection.AssemblyName>>();
         }
 
         internal static class HashAlgorithm

--- a/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
+++ b/src/Compilers/Helpers/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
@@ -490,6 +490,7 @@ namespace Microsoft.CodeAnalysis
             return FusionAssemblyIdentity.ToAssemblyIdentity(bestMatch);
         }
 
+        // Internal for testing
         internal static unsafe string GetAssemblyLocation(FusionAssemblyIdentity.IAssemblyName nameObject)
         {
             // NAME | VERSION | CULTURE | PUBLIC_KEY_TOKEN | RETARGET | PROCESSORARCHITECTURE

--- a/src/Scripting/Test/GlobalAssemblyCacheTests.cs
+++ b/src/Scripting/Test/GlobalAssemblyCacheTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 using System.Collections.Immutable;
 
@@ -79,7 +80,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(0, names.Length);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void AssemblyAndGacLocation()
         {
             var names = GlobalAssemblyCache.GetAssemblyObjects(partialNameFilter: null, architectureFilter: default(ImmutableArray<ProcessorArchitecture>)).ToArray();


### PR DESCRIPTION
Implements on each public method of GlobalAssemblyCache logic that does not require Fusion to resolve assemblies and that can be used on Mono.

This changes allow all tests using GAC to pass on Mono except one that is testing an internal method.