### PR TITLE
Introduce Variable in AutoProperty Initializer

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2578,5 +2578,47 @@ namespace N
 
             Test(code, expected, index: 0, compareTokens: false);
         }
+
+        [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void InAutoPropertyInitializer()
+        {
+            var code =
+@"using System;
+class C
+{
+    int Prop1 { get; } = [|1 + 2|];
+}";
+            var expected =
+@"using System;
+class C
+{
+    private const int {|Rename:V|} = 1 + 2;
+
+    int Prop1 { get; } = V;
+}";
+            Test(code, expected, index: 0, compareTokens: false);
+        }
+
+        [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void InAutoPropertyInitializer2()
+        {
+            var code =
+@"using System;
+class C
+{
+    public DateTime TimeStamp { get; } = [|DateTime.UtcNow|];
+}";
+            var expected =
+@"using System;
+class C
+{
+    private static readonly DateTime {|Rename:utcNow|} = DateTime.UtcNow;
+
+    public DateTime TimeStamp { get; } = utcNow;
+}";
+            Test(code, expected, index: 0, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2620,5 +2620,24 @@ class C
 }";
             Test(code, expected, index: 0, compareTokens: false);
         }
+
+        [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public void BlockContextPreferredOverAutoPropertyInitializerContext()
+        {
+            var code =
+@"using System;
+class C
+{
+    Func<int, int> X { get; } = a => { return [|7|]; };
+}";
+            var expected =
+@"using System;
+class C
+{
+    Func<int, int> X { get; } = a => { const int {|Rename:V|} = 7; return V; };
+}";
+            Test(code, expected, index: 2, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1657,5 +1657,90 @@ End Namespace"
 
             Test(code, expected, index:=0, compareTokens:=False)
         End Sub
+
+        <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub InAutoPropertyInitializerEqualsClause()
+            Dim code =
+<File>
+Imports System
+Class C
+    Property Name As String = [|"Roslyn"|]
+End Class
+</File>
+            Dim expected =
+<File>
+Imports System
+Class C
+    Private Const {|Rename:V|} As String = "Roslyn"
+    Property Name As String = V
+End Class
+</File>
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub InAutoPropertyWithCollectionInitializerAfterEqualsClause()
+            Dim code =
+<File>
+Imports System
+Class C
+    Property Grades As Integer() = [|{90, 73}|]
+End Class
+</File>
+            Dim expected =
+<File>
+Imports System
+Class C
+    Private Shared ReadOnly {|Rename:p|} As Integer() = {90, 73}
+    Property Grades As Integer() = p
+End Class
+</File>
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub InAutoPropertyInitializerAsClause()
+            Dim code =
+<File>
+Imports System
+Class C
+        Public Property Items As New List(Of String) From {[|"M"|], "T", "W"}
+End Class
+</File>
+            Dim expected =
+<File>
+Imports System
+Class C
+    Private Const {|Rename:V|} As String = "M"
+    Public Property Items As New List(Of String) From {V, "T", "W"}
+End Class
+</File>
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Sub InAutoPropertyObjectCreationExpressionWithinAsClause()
+            Dim code =
+<File>
+Imports System
+Class C
+        Property Orders As New List(Of Object)([|500|])
+End Class
+</File>
+            Dim expected =
+<File>
+Imports System
+Class C
+    Private Const {|Rename:V|} As Integer = 500
+    Property Orders As New List(Of Object)(V)
+End Class
+</File>
+            Test(code, expected, index:=0, compareTokens:=False)
+        End Sub
+
     End Class
 End Namespace

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -49,6 +50,11 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
         protected override bool IsInConstructorInitializer(ExpressionSyntax expression)
         {
             return expression.GetAncestorOrThis<ConstructorInitializerSyntax>() != null;
+        }
+
+        protected override bool IsInAutoPropertyInitializer(ExpressionSyntax expression)
+        {
+            return expression.GetAncestorOrThis<EqualsValueClauseSyntax>().IsParentKind(SyntaxKind.PropertyDeclaration);
         }
 
         protected override bool IsInExpressionBodiedMember(ExpressionSyntax expression)

--- a/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -9,7 +8,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.IntroduceVariable;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -130,11 +130,10 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     return false;
                 }
 
-                // The ordering of checks is important here. If we are inside a block within an Expression 
-                // bodied member, we should treat it as if we are in block context.
-                // For example, in such a scenario we should generate inside the block, instead of rewriting
-                // a concise expression bodied member to its equivalent that has a body with a block.
-                // For this reason, block should precede expression bodied member check.
+                /* NOTE: All checks from this point forward are intentionally ordered to be AFTER the check for Block Context. */
+
+                // If we are inside a block within an Expression bodied member we should generate inside the block, 
+                // instead of rewriting a concise expression bodied member to its equivalent that has a body with a block.
                 if (_service.IsInExpressionBodiedMember(this.Expression))
                 {
                     if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             public bool InParameterContext { get; private set; }
             public bool InQueryContext { get; private set; }
             public bool InExpressionBodiedMemberContext { get; private set; }
+            public bool InAutoPropertyInitializerContext { get; private set; }
 
             public bool IsConstant { get; private set; }
 
@@ -139,6 +140,17 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))
                     {
                         this.InExpressionBodiedMemberContext = true;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                if (_service.IsInAutoPropertyInitializer(this.Expression))
+                {
+                    if (CanGenerateInto<TTypeDeclarationSyntax>(cancellationToken))
+                    {
+                        this.InAutoPropertyInitializerContext = true;
                         return true;
                     }
 

--- a/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
         protected abstract bool IsInParameterInitializer(TExpressionSyntax expression);
         protected abstract bool IsInConstructorInitializer(TExpressionSyntax expression);
         protected abstract bool IsInAttributeArgumentInitializer(TExpressionSyntax expression);
+        protected abstract bool IsInAutoPropertyInitializer(TExpressionSyntax expression);
         protected abstract bool IsInExpressionBodiedMember(TExpressionSyntax expression);
 
         protected abstract IEnumerable<SyntaxNode> GetContainingExecutableBlocks(TExpressionSyntax expression);
@@ -91,6 +92,11 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 actions.Add(CreateAction(state, allOccurrences: true, isConstant: state.IsConstant, isLocal: false, isQueryLocal: false));
             }
             else if (state.InConstructorInitializerContext)
+            {
+                actions.Add(CreateAction(state, allOccurrences: false, isConstant: state.IsConstant, isLocal: false, isQueryLocal: false));
+                actions.Add(CreateAction(state, allOccurrences: true, isConstant: state.IsConstant, isLocal: false, isQueryLocal: false));
+            }
+            else if (state.InAutoPropertyInitializerContext)
             {
                 actions.Add(CreateAction(state, allOccurrences: false, isConstant: state.IsConstant, isLocal: false, isQueryLocal: false));
                 actions.Add(CreateAction(state, allOccurrences: true, isConstant: state.IsConstant, isLocal: false, isQueryLocal: false));

--- a/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
+++ b/src/Features/VisualBasic/IntroduceVariable/VisualBasicIntroduceVariableService.vb
@@ -90,11 +90,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                 Return True
             End If
 
-            Dim propertyStatement = expression.GetAncestorOrThis(Of PropertyStatementSyntax)()
-            If propertyStatement IsNot Nothing Then
-                Return expression.GetAncestorsOrThis(Of AsClauseSyntax).Contains(propertyStatement.AsClause)
-            End If
-
             Return False
         End Function
 
@@ -115,6 +110,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
 
         Protected Overrides Function IsInParameterInitializer(expression As ExpressionSyntax) As Boolean
             Return expression.GetAncestorOrThis(Of EqualsValueSyntax)().IsParentKind(SyntaxKind.Parameter)
+        End Function
+
+        Protected Overrides Function IsInAutoPropertyInitializer(expression As ExpressionSyntax) As Boolean
+            Dim propertyStatement = expression.GetAncestorOrThis(Of PropertyStatementSyntax)()
+            If propertyStatement IsNot Nothing Then
+                Return expression.GetAncestorsOrThis(Of AsClauseSyntax).Contains(propertyStatement.AsClause) OrElse
+                    expression.GetAncestorOrThis(Of EqualsValueSyntax).Contains(propertyStatement.Initializer)
+            End If
+
+            Return False
         End Function
 
         Protected Overrides Function IsInExpressionBodiedMember(expression As ExpressionSyntax) As Boolean


### PR DESCRIPTION
Fixes #936. This allows introduce variable codefix to function in autoproperty initializers for both VB and C#.