### PR TITLE
Suppress code for empty try-catch with /optimize (Release) mode

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var optimizing = this._compilation.Options.OptimizationLevel == OptimizationLevel.Release;
             ImmutableArray<BoundCatchBlock> catchBlocks =
-`                // When optimizing and we have a try block without side-effects, we can discard the catch blocks.
+                // When optimizing and we have a try block without side-effects, we can discard the catch blocks.
                 (optimizing && !HasSideEffects(tryBlock)) ? ImmutableArray<BoundCatchBlock>.Empty
                 : this.VisitList(node.CatchBlocks);
             BoundBlock finallyBlockOpt = (BoundBlock)this.Visit(node.FinallyBlockOpt);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -959,88 +959,81 @@ public class D
   // Code size      222 (0xde)
   .maxstack  2
   .locals init (D.Boo V_0, //v3
-  D.Boo V_1, //v3a
-  D.Boo V_2, //v4
-  D.Boo V_3) //v4
+                D.Boo V_1, //v3a
+                D.Boo V_2, //v4
+                D.Boo V_3) //v4
   .try
-{
-  .try
-{
-  IL_0000:  ldc.i4.s   42
-  IL_0002:  newobj     ""D.Boo..ctor(int)""
-  IL_0007:  stsfld     ""D.Boo D.v1""
-  IL_000c:  ldsfld     ""D.Boo D.v1""
-  IL_0011:  call       ""void D.DummyUse(D.Boo)""
-  IL_0016:  ldc.i4.s   43
-  IL_0018:  newobj     ""D.Boo..ctor(int)""
-  IL_001d:  call       ""void D.DummyUse(D.Boo)""
-  IL_0022:  ldc.i4.s   44
-  IL_0024:  newobj     ""D.Boo..ctor(int)""
-  IL_0029:  stloc.0
-  IL_002a:  ldloca.s   V_0
-  IL_002c:  constrained. ""D.Boo""
-  IL_0032:  callvirt   ""string object.ToString()""
-  IL_0037:  pop
-  IL_0038:  ldloca.s   V_2
-  IL_003a:  ldc.i4.s   45
-  IL_003c:  call       ""D.Boo..ctor(int)""
-  IL_0041:  ldloca.s   V_2
-  IL_0043:  constrained. ""D.Boo""
-  IL_0049:  callvirt   ""string object.ToString()""
-  IL_004e:  pop
-  IL_004f:  ldarg.0
-  IL_0050:  ldc.i4.s   46
-  IL_0052:  newobj     ""D.Boo..ctor(int)""
-  IL_0057:  stobj      ""D.Boo""
-  IL_005c:  ldarg.0
-  IL_005d:  ldobj      ""D.Boo""
-  IL_0062:  call       ""void D.DummyUse(D.Boo)""
-  IL_0067:  ldc.i4.s   47
-  IL_0069:  newobj     ""D.Boo..ctor(int)""
-  IL_006e:  starg.s    V_1
-  IL_0070:  ldarg.0
-  IL_0071:  ldobj      ""D.Boo""
-  IL_0076:  call       ""void D.DummyUse(D.Boo)""
-  IL_007b:  leave.s    IL_00dd
-}
+  {
+    IL_0000:  ldc.i4.s   42
+    IL_0002:  newobj     ""D.Boo..ctor(int)""
+    IL_0007:  stsfld     ""D.Boo D.v1""
+    IL_000c:  ldsfld     ""D.Boo D.v1""
+    IL_0011:  call       ""void D.DummyUse(D.Boo)""
+    IL_0016:  ldc.i4.s   43
+    IL_0018:  newobj     ""D.Boo..ctor(int)""
+    IL_001d:  call       ""void D.DummyUse(D.Boo)""
+    IL_0022:  ldc.i4.s   44
+    IL_0024:  newobj     ""D.Boo..ctor(int)""
+    IL_0029:  stloc.0
+    IL_002a:  ldloca.s   V_0
+    IL_002c:  constrained. ""D.Boo""
+    IL_0032:  callvirt   ""string object.ToString()""
+    IL_0037:  pop
+    IL_0038:  ldloca.s   V_2
+    IL_003a:  ldc.i4.s   45
+    IL_003c:  call       ""D.Boo..ctor(int)""
+    IL_0041:  ldloca.s   V_2
+    IL_0043:  constrained. ""D.Boo""
+    IL_0049:  callvirt   ""string object.ToString()""
+    IL_004e:  pop
+    IL_004f:  ldarg.0
+    IL_0050:  ldc.i4.s   46
+    IL_0052:  newobj     ""D.Boo..ctor(int)""
+    IL_0057:  stobj      ""D.Boo""
+    IL_005c:  ldarg.0
+    IL_005d:  ldobj      ""D.Boo""
+    IL_0062:  call       ""void D.DummyUse(D.Boo)""
+    IL_0067:  ldc.i4.s   47
+    IL_0069:  newobj     ""D.Boo..ctor(int)""
+    IL_006e:  starg.s    V_1
+    IL_0070:  ldarg.0
+    IL_0071:  ldobj      ""D.Boo""
+    IL_0076:  call       ""void D.DummyUse(D.Boo)""
+    IL_007b:  leave.s    IL_00dd
+  }
   catch System.Exception
-{
-  IL_007d:  pop
-  IL_007e:  ldc.i4.s   44
-  IL_0080:  newobj     ""D.Boo..ctor(int)""
-  IL_0085:  stloc.0
-  IL_0086:  ldloca.s   V_0
-  IL_0088:  constrained. ""D.Boo""
-  IL_008e:  callvirt   ""string object.ToString()""
-  IL_0093:  pop
-  IL_0094:  ldloca.s   V_1
-  IL_0096:  ldc.i4.s   44
-  IL_0098:  call       ""D.Boo..ctor(int)""
-  IL_009d:  ldloca.s   V_1
-  IL_009f:  constrained. ""D.Boo""
-  IL_00a5:  callvirt   ""string object.ToString()""
-  IL_00aa:  pop
-  IL_00ab:  ldloca.s   V_3
-  IL_00ad:  ldc.i4.s   45
-  IL_00af:  call       ""D.Boo..ctor(int)""
-  IL_00b4:  ldloca.s   V_3
-  IL_00b6:  constrained. ""D.Boo""
-  IL_00bc:  callvirt   ""string object.ToString()""
-  IL_00c1:  pop
-  IL_00c2:  ldarg.0
-  IL_00c3:  ldc.i4.s   48
-  IL_00c5:  newobj     ""D.Boo..ctor(int)""
-  IL_00ca:  stobj      ""D.Boo""
-  IL_00cf:  ldarg.0
-  IL_00d0:  ldobj      ""D.Boo""
-  IL_00d5:  call       ""void D.DummyUse(D.Boo)""
-  IL_00da:  leave.s    IL_00dd
-}
-}
-  finally
-{
-  IL_00dc:  endfinally
-}
+  {
+    IL_007d:  pop
+    IL_007e:  ldloca.s   V_0
+    IL_0080:  ldc.i4.s   44
+    IL_0082:  call       ""D.Boo..ctor(int)""
+    IL_0087:  ldloca.s   V_0
+    IL_0089:  constrained. ""D.Boo""
+    IL_008f:  callvirt   ""string object.ToString()""
+    IL_0094:  pop
+    IL_0095:  ldloca.s   V_1
+    IL_0097:  ldc.i4.s   44
+    IL_0099:  call       ""D.Boo..ctor(int)""
+    IL_009e:  ldloca.s   V_1
+    IL_00a0:  constrained. ""D.Boo""
+    IL_00a6:  callvirt   ""string object.ToString()""
+    IL_00ab:  pop
+    IL_00ac:  ldloca.s   V_3
+    IL_00ae:  ldc.i4.s   45
+    IL_00b0:  call       ""D.Boo..ctor(int)""
+    IL_00b5:  ldloca.s   V_3
+    IL_00b7:  constrained. ""D.Boo""
+    IL_00bd:  callvirt   ""string object.ToString()""
+    IL_00c2:  pop
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldc.i4.s   48
+    IL_00c6:  newobj     ""D.Boo..ctor(int)""
+    IL_00cb:  stobj      ""D.Boo""
+    IL_00d0:  ldarg.0
+    IL_00d1:  ldobj      ""D.Boo""
+    IL_00d6:  call       ""void D.DummyUse(D.Boo)""
+    IL_00db:  leave.s    IL_00dd
+  }
   IL_00dd:  ret
 }
 ");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -810,6 +810,7 @@ using System.Security;
 
 class C
 {
+    static void nop() {}
     static void Main()
     {
             try
@@ -821,7 +822,7 @@ class C
             }
             finally
             {
-                try { }
+                try { nop(); }
                 catch { }
             }
 
@@ -833,36 +834,37 @@ class C
             compilation.VerifyIL("C.Main",
 @"
 {
-  // Code size       13 (0xd)
+  // Code size       18 (0x12)
   .maxstack  1
   .try
-{
-  .try
-{
-  IL_0000:  ldnull
-  IL_0001:  throw
-}
-  catch System.Exception
-{
-  IL_0002:  pop
-  IL_0003:  leave.s    IL_000c
-}
-}
+  {
+    .try
+    {
+      IL_0000:  ldnull
+      IL_0001:  throw
+    }
+    catch System.Exception
+    {
+      IL_0002:  pop
+      IL_0003:  leave.s    IL_0011
+    }
+  }
   finally
-{
-  IL_0005:  nop
-  .try
-{
-  IL_0006:  leave.s    IL_000b
-}
-  catch object
-{
-  IL_0008:  pop
-  IL_0009:  leave.s    IL_000b
-}
-  IL_000b:  endfinally
-}
-  IL_000c:  ret
+  {
+    IL_0005:  nop
+    .try
+    {
+      IL_0006:  call       ""void C.nop()""
+      IL_000b:  leave.s    IL_0010
+    }
+    catch object
+    {
+      IL_000d:  pop
+      IL_000e:  leave.s    IL_0010
+    }
+    IL_0010:  endfinally
+  }
+  IL_0011:  ret
 }
 ");
         }
@@ -1399,6 +1401,7 @@ using System.Threading;
 
 class Program
 {
+    static void nop() { }
     static ManualResetEventSlim s = new ManualResetEventSlim(false);
 
     static void Main(string[] args)
@@ -1425,6 +1428,7 @@ class Program
             {
                 try
                 {
+                    nop();
                 }
                 catch
                 {
@@ -1455,9 +1459,8 @@ try2
 catch3
 ");
             compilation.VerifyIL("Program.Test",
-@"
-{
-  // Code size       82 (0x52)
+@"{
+  // Code size       87 (0x57)
   .maxstack  1
   .try
   {
@@ -1469,56 +1472,56 @@ catch3
         IL_0005:  callvirt   ""void System.Threading.ManualResetEventSlim.Set()""
         IL_000a:  ldsfld     ""System.Threading.ManualResetEventSlim Program.s""
         IL_000f:  brtrue.s   IL_000a
-        IL_0011:  leave.s    IL_0025
+        IL_0011:  leave.s    IL_002a
       }
       catch object
       {
         IL_0013:  pop
         .try
         {
-          IL_0014:  leave.s    IL_0023
+          IL_0014:  call       ""void Program.nop()""
+          IL_0019:  leave.s    IL_0028
         }
         catch object
         {
-          IL_0016:  pop
-          IL_0017:  ldstr      ""catch1""
-          IL_001c:  call       ""void System.Console.WriteLine(string)""
-          IL_0021:  leave.s    IL_0023
+          IL_001b:  pop
+          IL_001c:  ldstr      ""catch1""
+          IL_0021:  call       ""void System.Console.WriteLine(string)""
+          IL_0026:  leave.s    IL_0028
         }
-        IL_0023:  leave.s    IL_0025
+        IL_0028:  leave.s    IL_002a
       }
-      IL_0025:  leave.s    IL_0042
+      IL_002a:  leave.s    IL_0047
     }
     finally
     {
-      IL_0027:  nop
+      IL_002c:  nop
       .try
       {
-        IL_0028:  ldstr      ""try2""
-        IL_002d:  call       ""void System.Console.WriteLine(string)""
-        IL_0032:  leave.s    IL_0041
+        IL_002d:  ldstr      ""try2""
+        IL_0032:  call       ""void System.Console.WriteLine(string)""
+        IL_0037:  leave.s    IL_0046
       }
       catch object
       {
-        IL_0034:  pop
-        IL_0035:  ldstr      ""catch2""
-        IL_003a:  call       ""void System.Console.WriteLine(string)""
-        IL_003f:  leave.s    IL_0041
+        IL_0039:  pop
+        IL_003a:  ldstr      ""catch2""
+        IL_003f:  call       ""void System.Console.WriteLine(string)""
+        IL_0044:  leave.s    IL_0046
       }
-      IL_0041:  endfinally
+      IL_0046:  endfinally
     }
-    IL_0042:  leave.s    IL_0051
+    IL_0047:  leave.s    IL_0056
   }
   catch object
   {
-    IL_0044:  pop
-    IL_0045:  ldstr      ""catch3""
-    IL_004a:  call       ""void System.Console.WriteLine(string)""
-    IL_004f:  leave.s    IL_0051
+    IL_0049:  pop
+    IL_004a:  ldstr      ""catch3""
+    IL_004f:  call       ""void System.Console.WriteLine(string)""
+    IL_0054:  leave.s    IL_0056
   }
-  IL_0051:  ret
-}
-");
+  IL_0056:  ret
+}");
         }
 
         [Fact]
@@ -1788,6 +1791,7 @@ catch2
 @"using System;
 class C
 {
+    static void nop() { }
     static void ThrowInTry()
     {
         try { throw new Exception(); }
@@ -1804,7 +1808,7 @@ class C
     }
     static void ThrowInTryInFinally()
     {
-        try { }
+        try { nop(); }
         finally
         {
             try { throw new Exception(); }
@@ -1814,6 +1818,7 @@ class C
 }
 class D
 {
+    static void nop() { }
     static void ThrowInTry()
     {
         try { throw new Exception(); }
@@ -1833,7 +1838,7 @@ class D
 
     static void ThrowInTryInFinally()
     {
-        try { }
+        try { nop(); }
         catch { }
         finally
         {
@@ -1882,26 +1887,27 @@ class D
 ");
             compilation.VerifyIL("C.ThrowInTryInFinally",
 @"{
-  // Code size       12 (0xc)
+  // Code size       17 (0x11)
   .maxstack  1
   .try
-{
-  IL_0000:  leave.s    IL_000a
-}
+  {
+    IL_0000:  call       ""void C.nop()""
+    IL_0005:  leave.s    IL_000f
+  }
   finally
-{
-  IL_0002:  nop
-  .try
-{
-  IL_0003:  newobj     ""System.Exception..ctor()""
-  IL_0008:  throw
-}
-  finally
-{
-  IL_0009:  endfinally
-}
-}
-  IL_000a:  br.s       IL_000a
+  {
+    IL_0007:  nop
+    .try
+    {
+      IL_0008:  newobj     ""System.Exception..ctor()""
+      IL_000d:  throw
+    }
+    finally
+    {
+      IL_000e:  endfinally
+    }
+  }
+  IL_000f:  br.s       IL_000f
 }");
             compilation.VerifyIL("D.ThrowInTry",
 @"{
@@ -1958,45 +1964,45 @@ class D
 }");
             compilation.VerifyIL("D.ThrowInTryInFinally",
 @"{
-  // Code size       18 (0x12)
+  // Code size       23 (0x17)
   .maxstack  1
   .try
-{
-  .try
-{
-  IL_0000:  leave.s    IL_0011
-}
-  catch object
-{
-  IL_0002:  pop
-  IL_0003:  leave.s    IL_0011
-}
-}
+  {
+    .try
+    {
+      IL_0000:  call       ""void D.nop()""
+      IL_0005:  leave.s    IL_0016
+    }
+    catch object
+    {
+      IL_0007:  pop
+      IL_0008:  leave.s    IL_0016
+    }
+  }
   finally
-{
-  IL_0005:  nop
-  .try
-{
-  .try
-{
-  IL_0006:  newobj     ""System.Exception..ctor()""
-  IL_000b:  throw
-}
-  catch object
-{
-  IL_000c:  pop
-  IL_000d:  leave.s    IL_0010
-}
-}
-  finally
-{
-  IL_000f:  endfinally
-}
-  IL_0010:  endfinally
-}
-  IL_0011:  ret
-}
-");
+  {
+    IL_000a:  nop
+    .try
+    {
+      .try
+      {
+        IL_000b:  newobj     ""System.Exception..ctor()""
+        IL_0010:  throw
+      }
+      catch object
+      {
+        IL_0011:  pop
+        IL_0012:  leave.s    IL_0015
+      }
+    }
+    finally
+    {
+      IL_0014:  endfinally
+    }
+    IL_0015:  endfinally
+  }
+  IL_0016:  ret
+}");
         }
 
         [WorkItem(540716, "DevDiv")]
@@ -2007,26 +2013,27 @@ class D
 @"using System;
 class C
 {
+    static void nop() { }
     static void ThrowInFinally()
     {
-        try { }
+        try { nop(); }
         finally { throw new Exception(); }
     }
     static void ThrowInFinallyInTry()
     {
         try
         {
-            try { }
+            try { nop(); }
             finally { throw new Exception(); }
         }
         finally { }
     }
     static int ThrowInFinallyInFinally()
     {
-        try { }
+        try { nop(); }
         finally
         {
-            try { }
+            try { nop(); }
             finally { throw new Exception(); }
         }
 
@@ -2036,9 +2043,10 @@ class C
 }
 class D
 {
+    static void nop() { }
     static void ThrowInFinally()
     {
-        try { }
+        try { nop(); }
         catch { }
         finally { throw new Exception(); }
     }
@@ -2046,7 +2054,7 @@ class D
     {
         try
         {
-            try { }
+            try { nop(); }
             catch { }
             finally { throw new Exception(); }
         }
@@ -2055,11 +2063,11 @@ class D
     }
     static void ThrowInFinallyInFinally()
     {
-        try { }
+        try { nop(); }
         catch { }
         finally
         {
-            try { }
+            try { nop(); }
             catch { }
             finally { throw new Exception(); }
         }
@@ -2068,93 +2076,98 @@ class D
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("C.ThrowInFinally",
 @"{
-  // Code size       10 (0xa)
+  // Code size       15 (0xf)
   .maxstack  1
   .try
   {
-    IL_0000:  leave.s    IL_0008
+    IL_0000:  call       ""void C.nop()""
+    IL_0005:  leave.s    IL_000d
   }
   finally
   {
-    IL_0002:  newobj     ""System.Exception..ctor()""
-    IL_0007:  throw     
+    IL_0007:  newobj     ""System.Exception..ctor()""
+    IL_000c:  throw
   }
-  IL_0008:  br.s       IL_0008
+  IL_000d:  br.s       IL_000d
 }");
             compilation.VerifyIL("C.ThrowInFinallyInTry",
 @"{
-  // Code size       11 (0xb)
+  // Code size       16 (0x10)
   .maxstack  1
   .try
   {
     .try
     {
-      IL_0000:  leave.s    IL_0008
+      IL_0000:  call       ""void C.nop()""
+      IL_0005:  leave.s    IL_000d
     }
     finally
     {
-      IL_0002:  newobj     ""System.Exception..ctor()""
-      IL_0007:  throw     
+      IL_0007:  newobj     ""System.Exception..ctor()""
+      IL_000c:  throw
     }
-    IL_0008:  br.s       IL_0008
+    IL_000d:  br.s       IL_000d
   }
   finally
   {
-    IL_000a:  endfinally
+    IL_000f:  endfinally
   }
 }");
             // The nop below is to work around a verifier bug.
             // See DevDiv 563799.
             compilation.VerifyIL("C.ThrowInFinallyInFinally",
 @"{
-  // Code size       15 (0xf)
+  // Code size       25 (0x19)
   .maxstack  1
   .try
   {
-    IL_0000:  leave.s    IL_000d
+    IL_0000:  call       ""void C.nop()""
+    IL_0005:  leave.s    IL_0017
   }
   finally
   {
-    IL_0002:  nop
+    IL_0007:  nop
     .try
     {
-      IL_0003:  leave.s    IL_000b
+      IL_0008:  call       ""void C.nop()""
+      IL_000d:  leave.s    IL_0015
     }
     finally
     {
-      IL_0005:  newobj     ""System.Exception..ctor()""
-      IL_000a:  throw
+      IL_000f:  newobj     ""System.Exception..ctor()""
+      IL_0014:  throw
     }
-    IL_000b:  br.s       IL_000b
+    IL_0015:  br.s       IL_0015
   }
-  IL_000d:  br.s       IL_000d
+  IL_0017:  br.s       IL_0017
 }");
             compilation.VerifyIL("D.ThrowInFinally",
 @"{
-  // Code size       13 (0xd)
+  // Code size       18 (0x12)
   .maxstack  1
   .try
   {
     .try
     {
-      IL_0000:  leave.s    IL_000b
+      IL_0000:  call       ""void D.nop()""
+      IL_0005:  leave.s    IL_0010
     }
     catch object
     {
-      IL_0002:  pop       
-      IL_0003:  leave.s    IL_000b
+      IL_0007:  pop
+      IL_0008:  leave.s    IL_0010
     }
   }
   finally
   {
-    IL_0005:  newobj     ""System.Exception..ctor()""
-    IL_000a:  throw     
+    IL_000a:  newobj     ""System.Exception..ctor()""
+    IL_000f:  throw
   }
-  IL_000b:  br.s       IL_000b
+  IL_0010:  br.s       IL_0010
 }");
             compilation.VerifyIL("D.ThrowInFinallyInTry",
 @"{
-  // Code size       20 (0x14)
+  // Code size       25 (0x19)
   .maxstack  1
   .try
   {
@@ -2164,73 +2177,76 @@ class D
       {
         .try
         {
-          IL_0000:  leave.s    IL_0005
+          IL_0000:  call       ""void D.nop()""
+          IL_0005:  leave.s    IL_000a
         }
         catch object
         {
-          IL_0002:  pop
-          IL_0003:  leave.s    IL_0005
+          IL_0007:  pop
+          IL_0008:  leave.s    IL_000a
         }
-        IL_0005:  leave.s    IL_000d
+        IL_000a:  leave.s    IL_0012
       }
       finally
       {
-        IL_0007:  newobj     ""System.Exception..ctor()""
-        IL_000c:  throw
+        IL_000c:  newobj     ""System.Exception..ctor()""
+        IL_0011:  throw
       }
-      IL_000d:  br.s       IL_000d
+      IL_0012:  br.s       IL_0012
     }
     catch object
     {
-      IL_000f:  pop
-      IL_0010:  leave.s    IL_0013
+      IL_0014:  pop
+      IL_0015:  leave.s    IL_0018
     }
   }
   finally
   {
-    IL_0012:  endfinally
+    IL_0017:  endfinally
   }
-  IL_0013:  ret
+  IL_0018:  ret
 }");
             compilation.VerifyIL("D.ThrowInFinallyInFinally",
 @"{
-  // Code size       21 (0x15)
+  // Code size       31 (0x1f)
   .maxstack  1
   .try
   {
     .try
     {
-      IL_0000:  leave.s    IL_0013
+      IL_0000:  call       ""void D.nop()""
+      IL_0005:  leave.s    IL_001d
     }
     catch object
     {
-      IL_0002:  pop
-      IL_0003:  leave.s    IL_0013
+      IL_0007:  pop
+      IL_0008:  leave.s    IL_001d
     }
   }
   finally
   {
-    IL_0005:  nop
+    IL_000a:  nop
     .try
     {
       .try
       {
-        IL_0006:  leave.s    IL_0011
+        IL_000b:  call       ""void D.nop()""
+        IL_0010:  leave.s    IL_001b
       }
       catch object
       {
-        IL_0008:  pop
-        IL_0009:  leave.s    IL_0011
+        IL_0012:  pop
+        IL_0013:  leave.s    IL_001b
       }
     }
     finally
     {
-      IL_000b:  newobj     ""System.Exception..ctor()""
-      IL_0010:  throw
+      IL_0015:  newobj     ""System.Exception..ctor()""
+      IL_001a:  throw
     }
-    IL_0011:  br.s       IL_0011
+    IL_001b:  br.s       IL_001b
   }
-  IL_0013:  br.s       IL_0013
+  IL_001d:  br.s       IL_001d
 }");
         }
 
@@ -2637,11 +2653,13 @@ class C
 @"using System.IO;
 class C
 {
+    static void nop() { }
     static int F = 0;
     static void M()
     {
         try
         {
+            nop();
         }
         catch (FileNotFoundException e)
         {
@@ -2667,34 +2685,35 @@ class C
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("C.M",
 @"{
-  // Code size       22 (0x16)
+  // Code size       27 (0x1b)
   .maxstack  2
   .locals init (System.IO.FileNotFoundException V_0) //e
   .try
   {
-    IL_0000:  leave.s    IL_0015
+    IL_0000:  call       ""void C.nop()""
+    IL_0005:  leave.s    IL_001a
   }
   catch System.IO.FileNotFoundException
   {
-    IL_0002:  stloc.0   
-    IL_0003:  ldsfld     ""int C.F""
-    IL_0008:  ldc.i4.0  
-    IL_0009:  ble.s      IL_000d
-    IL_000b:  rethrow   
-    IL_000d:  ldloc.0   
-    IL_000e:  throw     
+    IL_0007:  stloc.0
+    IL_0008:  ldsfld     ""int C.F""
+    IL_000d:  ldc.i4.0
+    IL_000e:  ble.s      IL_0012
+    IL_0010:  rethrow
+    IL_0012:  ldloc.0
+    IL_0013:  throw
   }
   catch System.IO.IOException
   {
-    IL_000f:  pop       
-    IL_0010:  rethrow   
+    IL_0014:  pop
+    IL_0015:  rethrow
   }
   catch object
   {
-    IL_0012:  pop       
-    IL_0013:  rethrow   
+    IL_0017:  pop
+    IL_0018:  rethrow
   }
-  IL_0015:  ret       
+  IL_001a:  ret
 }");
         }
 
@@ -2946,6 +2965,7 @@ class Program
 
     class Program
     {
+        static void nop() { }
         static void F()
         {
             Console.WriteLine(""hello"");
@@ -2955,7 +2975,7 @@ class Program
         {
             try
             {
-                
+                nop();
             }
             catch 
             {
@@ -2975,21 +2995,21 @@ class Program
             var compilation = CompileAndVerify(source, expectedOutput: "hello");
             compilation.VerifyIL("Program.T1",
 @"{
-  // Code size       11 (0xb)
+  // Code size       16 (0x10)
   .maxstack  1
   .try
-{
-  IL_0000:  leave.s    IL_0005
-}
+  {
+    IL_0000:  call       ""void Program.nop()""
+    IL_0005:  leave.s    IL_000a
+  }
   catch object
-{
-  IL_0002:  pop
-  IL_0003:  br.s       IL_0003
-}
-  IL_0005:  call       ""void Program.F()""
-  IL_000a:  ret
-}
-");
+  {
+    IL_0007:  pop
+    IL_0008:  br.s       IL_0008
+  }
+  IL_000a:  call       ""void Program.F()""
+  IL_000f:  ret
+}");
         }
 
         [Fact(), WorkItem(544911, "DevDiv")]
@@ -3294,7 +3314,6 @@ Out");
 ");
         }
 
-
         [Fact(), WorkItem(713418, "DevDiv")]
         public void ConditionalUnconditionalBranches001()
         {
@@ -3366,6 +3385,37 @@ Out");
   IL_0029:  ldstr      ""Out""
   IL_002e:  call       ""void System.Console.WriteLine(string)""
   IL_0033:  ret
+}
+");
+        }
+
+        [Fact(), WorkItem(2443, "https://github.com/dotnet/roslyn/issues/2443")]
+        public void OptimizeEmptyTryBlock()
+        {
+            var source = @"
+using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        try
+        {
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+    }
+}
+";
+            var compilation = CompileAndVerify(source, expectedOutput: @"");
+            compilation.VerifyIL("Program.Main",
+@"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -1808,7 +1808,7 @@ class C
     }
     static void ThrowInTryInFinally()
     {
-        try { nop(); }
+        try { }
         finally
         {
             try { throw new Exception(); }
@@ -1887,27 +1887,26 @@ class D
 ");
             compilation.VerifyIL("C.ThrowInTryInFinally",
 @"{
-  // Code size       17 (0x11)
+  // Code size       12 (0xc)
   .maxstack  1
   .try
   {
-    IL_0000:  call       ""void C.nop()""
-    IL_0005:  leave.s    IL_000f
+    IL_0000:  leave.s    IL_000a
   }
   finally
   {
-    IL_0007:  nop
+    IL_0002:  nop
     .try
     {
-      IL_0008:  newobj     ""System.Exception..ctor()""
-      IL_000d:  throw
+      IL_0003:  newobj     ""System.Exception..ctor()""
+      IL_0008:  throw
     }
     finally
     {
-      IL_000e:  endfinally
+      IL_0009:  endfinally
     }
   }
-  IL_000f:  br.s       IL_000f
+  IL_000a:  br.s       IL_000a
 }");
             compilation.VerifyIL("D.ThrowInTry",
 @"{
@@ -2016,24 +2015,24 @@ class C
     static void nop() { }
     static void ThrowInFinally()
     {
-        try { nop(); }
+        try { }
         finally { throw new Exception(); }
     }
     static void ThrowInFinallyInTry()
     {
         try
         {
-            try { nop(); }
+            try { }
             finally { throw new Exception(); }
         }
         finally { }
     }
     static int ThrowInFinallyInFinally()
     {
-        try { nop(); }
+        try { }
         finally
         {
-            try { nop(); }
+            try { }
             finally { throw new Exception(); }
         }
 
@@ -2076,70 +2075,66 @@ class D
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("C.ThrowInFinally",
 @"{
-  // Code size       15 (0xf)
+  // Code size       10 (0xa)
   .maxstack  1
   .try
   {
-    IL_0000:  call       ""void C.nop()""
-    IL_0005:  leave.s    IL_000d
+    IL_0000:  leave.s    IL_0008
   }
   finally
   {
-    IL_0007:  newobj     ""System.Exception..ctor()""
-    IL_000c:  throw
+    IL_0002:  newobj     ""System.Exception..ctor()""
+    IL_0007:  throw
   }
-  IL_000d:  br.s       IL_000d
+  IL_0008:  br.s       IL_0008
 }");
             compilation.VerifyIL("C.ThrowInFinallyInTry",
 @"{
-  // Code size       16 (0x10)
+  // Code size       11 (0xb)
   .maxstack  1
   .try
   {
     .try
     {
-      IL_0000:  call       ""void C.nop()""
-      IL_0005:  leave.s    IL_000d
+      IL_0000:  leave.s    IL_0008
     }
     finally
     {
-      IL_0007:  newobj     ""System.Exception..ctor()""
-      IL_000c:  throw
+      IL_0002:  newobj     ""System.Exception..ctor()""
+      IL_0007:  throw
     }
-    IL_000d:  br.s       IL_000d
+    IL_0008:  br.s       IL_0008
   }
   finally
   {
-    IL_000f:  endfinally
+    IL_000a:  endfinally
   }
 }");
             // The nop below is to work around a verifier bug.
             // See DevDiv 563799.
             compilation.VerifyIL("C.ThrowInFinallyInFinally",
 @"{
-  // Code size       25 (0x19)
+  // Code size       15 (0xf)
   .maxstack  1
   .try
   {
-    IL_0000:  call       ""void C.nop()""
-    IL_0005:  leave.s    IL_0017
+    IL_0000:  leave.s    IL_000d
   }
   finally
   {
-    IL_0007:  nop
+    IL_0002:  nop
     .try
     {
-      IL_0008:  call       ""void C.nop()""
-      IL_000d:  leave.s    IL_0015
+      IL_0003:  leave.s    IL_000b
     }
     finally
     {
-      IL_000f:  newobj     ""System.Exception..ctor()""
-      IL_0014:  throw
+      IL_0005:  newobj     ""System.Exception..ctor()""
+      IL_000a:  throw
     }
-    IL_0015:  br.s       IL_0015
+    IL_000b:  br.s       IL_000b
   }
-  IL_0017:  br.s       IL_0017
+  IL_000d:  br.s       IL_000d
 }");
             compilation.VerifyIL("D.ThrowInFinally",
 @"{

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -41,63 +41,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("C.EmptyTryFinally",
 @"{
-  // Code size        4 (0x4)
+  // Code size        1 (0x1)
   .maxstack  0
-  .try
-  {
-    IL_0000:  leave.s    IL_0003
-  }
-  finally
-  {
-    IL_0002:  endfinally
-  }
-  IL_0003:  ret       
+  IL_0000:  ret
 }");
             compilation.VerifyIL("C.EmptyTryFinallyInTry",
 @"{
-  // Code size        5 (0x5)
+  // Code size        1 (0x1)
   .maxstack  0
-  .try
-  {
-    .try
-    {
-      IL_0000:  leave.s    IL_0004
-    }
-    finally
-    {
-      IL_0002:  endfinally
-    }
-  }
-  finally
-  {
-    IL_0003:  endfinally
-  }
-  IL_0004:  ret       
+  IL_0000:  ret
 }");
             // the nop below is to work around a verifier bug.
             // See DevDiv 563799.
             compilation.VerifyIL("C.EmptyTryFinallyInFinally",
 @"{
-  // Code size        8 (0x8)
+  // Code size        1 (0x1)
   .maxstack  0
-  .try
-  {
-    IL_0000:  leave.s    IL_0007
-  }
-  finally
-  {
-    IL_0002:  nop
-    .try
-    {
-      IL_0003:  leave.s    IL_0006
-    }
-    finally
-    {
-      IL_0005:  endfinally
-    }
-    IL_0006:  endfinally
-  }
-  IL_0007:  ret
+  IL_0000:  ret
 }");
         }
 
@@ -1851,131 +1811,80 @@ class D
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("C.ThrowInTry",
 @"{
-  // Code size        7 (0x7)
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""System.Exception..ctor()""
+  IL_0005:  throw
+}");
+            compilation.VerifyIL("C.ThrowInTryInTry",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""System.Exception..ctor()""
+  IL_0005:  throw
+}");
+            compilation.VerifyIL("C.ThrowInTryInFinally",
+@"{
+  // Code size       10 (0xa)
+  .maxstack  1
+  .try
+  {
+    IL_0000:  leave.s    IL_0008
+  }
+  finally
+  {
+    IL_0002:  newobj     ""System.Exception..ctor()""
+    IL_0007:  throw
+  }
+  IL_0008:  br.s       IL_0008
+}");
+            compilation.VerifyIL("D.ThrowInTry",
+@"{
+  // Code size       10 (0xa)
   .maxstack  1
   .try
   {
     IL_0000:  newobj     ""System.Exception..ctor()""
-    IL_0005:  throw     
+    IL_0005:  throw
   }
-  finally
+  catch object
   {
-    IL_0006:  endfinally
+    IL_0006:  pop
+    IL_0007:  leave.s    IL_0009
   }
-}");
-            compilation.VerifyIL("C.ThrowInTryInTry",
-@"{
-  // Code size        8 (0x8)
-  .maxstack  1
-  .try
-{
-  .try
-{
-  IL_0000:  newobj     ""System.Exception..ctor()""
-  IL_0005:  throw
-}
-  finally
-{
-  IL_0006:  endfinally
-}
-}
-  finally
-{
-  IL_0007:  endfinally
-}
-}
-");
-            compilation.VerifyIL("C.ThrowInTryInFinally",
-@"{
-  // Code size       12 (0xc)
-  .maxstack  1
-  .try
-  {
-    IL_0000:  leave.s    IL_000a
-  }
-  finally
-  {
-    IL_0002:  nop
-    .try
-    {
-      IL_0003:  newobj     ""System.Exception..ctor()""
-      IL_0008:  throw
-    }
-    finally
-    {
-      IL_0009:  endfinally
-    }
-  }
-  IL_000a:  br.s       IL_000a
-}");
-            compilation.VerifyIL("D.ThrowInTry",
-@"{
-  // Code size       11 (0xb)
-  .maxstack  1
-  .try
-  {
-    .try
-    {
-      IL_0000:  newobj     ""System.Exception..ctor()""
-      IL_0005:  throw     
-    }
-    catch object
-    {
-      IL_0006:  pop       
-      IL_0007:  leave.s    IL_000a
-    }
-  }
-  finally
-  {
-    IL_0009:  endfinally
-  }
-  IL_000a:  ret       
+  IL_0009:  ret
 }");
             compilation.VerifyIL("D.ThrowInTryInTry",
 @"{
-  // Code size       12 (0xc)
+  // Code size       10 (0xa)
   .maxstack  1
   .try
   {
-    .try
-    {
-      .try
-      {
-        IL_0000:  newobj     ""System.Exception..ctor()""
-        IL_0005:  throw     
-      }
-      catch object
-      {
-        IL_0006:  pop       
-        IL_0007:  leave.s    IL_000b
-      }
-    }
-    finally
-    {
-      IL_0009:  endfinally
-    }
+    IL_0000:  newobj     ""System.Exception..ctor()""
+    IL_0005:  throw
   }
-  finally
+  catch object
   {
-    IL_000a:  endfinally
+    IL_0006:  pop
+    IL_0007:  leave.s    IL_0009
   }
-  IL_000b:  ret       
+  IL_0009:  ret
 }");
             compilation.VerifyIL("D.ThrowInTryInFinally",
 @"{
-  // Code size       23 (0x17)
+  // Code size       22 (0x16)
   .maxstack  1
   .try
   {
     .try
     {
       IL_0000:  call       ""void D.nop()""
-      IL_0005:  leave.s    IL_0016
+      IL_0005:  leave.s    IL_0015
     }
     catch object
     {
       IL_0007:  pop
-      IL_0008:  leave.s    IL_0016
+      IL_0008:  leave.s    IL_0015
     }
   }
   finally
@@ -1983,24 +1892,17 @@ class D
     IL_000a:  nop
     .try
     {
-      .try
-      {
-        IL_000b:  newobj     ""System.Exception..ctor()""
-        IL_0010:  throw
-      }
-      catch object
-      {
-        IL_0011:  pop
-        IL_0012:  leave.s    IL_0015
-      }
+      IL_000b:  newobj     ""System.Exception..ctor()""
+      IL_0010:  throw
     }
-    finally
+    catch object
     {
-      IL_0014:  endfinally
+      IL_0011:  pop
+      IL_0012:  leave.s    IL_0014
     }
-    IL_0015:  endfinally
+    IL_0014:  endfinally
   }
-  IL_0016:  ret
+  IL_0015:  ret
 }");
         }
 
@@ -2025,7 +1927,7 @@ class C
             try { }
             finally { throw new Exception(); }
         }
-        finally { }
+        finally { nop(); }
     }
     static int ThrowInFinallyInFinally()
     {
@@ -2058,7 +1960,7 @@ class D
             finally { throw new Exception(); }
         }
         catch { }
-        finally { }
+        finally { nop(); }
     }
     static void ThrowInFinallyInFinally()
     {
@@ -2090,7 +1992,7 @@ class D
 }");
             compilation.VerifyIL("C.ThrowInFinallyInTry",
 @"{
-  // Code size       11 (0xb)
+  // Code size       16 (0x10)
   .maxstack  1
   .try
   {
@@ -2107,7 +2009,8 @@ class D
   }
   finally
   {
-    IL_000a:  endfinally
+    IL_000a:  call       ""void C.nop()""
+    IL_000f:  endfinally
   }
 }");
             // The nop below is to work around a verifier bug.
@@ -2162,7 +2065,7 @@ class D
 }");
             compilation.VerifyIL("D.ThrowInFinallyInTry",
 @"{
-  // Code size       25 (0x19)
+  // Code size       30 (0x1e)
   .maxstack  1
   .try
   {
@@ -2192,14 +2095,15 @@ class D
     catch object
     {
       IL_0014:  pop
-      IL_0015:  leave.s    IL_0018
+      IL_0015:  leave.s    IL_001d
     }
   }
   finally
   {
-    IL_0017:  endfinally
+    IL_0017:  call       ""void D.nop()""
+    IL_001c:  endfinally
   }
-  IL_0018:  ret
+  IL_001d:  ret
 }");
             compilation.VerifyIL("D.ThrowInFinallyInFinally",
 @"{

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -1214,11 +1214,14 @@ class Class1
                 {
                     i = 1;
                 }
-                finally {}
+                finally
+                {
+                    j = 2;
+                }
                 break;
 
             default:
-                i = 2;                
+                i = 2;
                 break;
         }
 
@@ -1229,45 +1232,46 @@ class Class1
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Class1.Main", @"
 {
-  // Code size       28 (0x1c)
+  // Code size       30 (0x1e)
   .maxstack  1
   .locals init (int V_0, //j
-  int V_1) //i
+                int V_1) //i
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.3
   IL_0003:  stloc.1
   IL_0004:  ldloc.0
-  IL_0005:  brtrue.s   IL_0012
+  IL_0005:  brtrue.s   IL_0014
   IL_0007:  nop
   .try
-{
-  .try
-{
-  IL_0008:  ldc.i4.0
-  IL_0009:  stloc.1
-  IL_000a:  leave.s    IL_0014
-}
-  catch object
-{
-  IL_000c:  pop
-  IL_000d:  ldc.i4.1
-  IL_000e:  stloc.1
-  IL_000f:  leave.s    IL_0014
-}
-}
+  {
+    .try
+    {
+      IL_0008:  ldc.i4.0
+      IL_0009:  stloc.1
+      IL_000a:  leave.s    IL_0016
+    }
+    catch object
+    {
+      IL_000c:  pop
+      IL_000d:  ldc.i4.1
+      IL_000e:  stloc.1
+      IL_000f:  leave.s    IL_0016
+    }
+  }
   finally
-{
-  IL_0011:  endfinally
-}
-  IL_0012:  ldc.i4.2
-  IL_0013:  stloc.1
-  IL_0014:  ldloc.1
-  IL_0015:  call       ""void System.Console.Write(int)""
-  IL_001a:  ldloc.1
-  IL_001b:  ret
-}
-"
+  {
+    IL_0011:  ldc.i4.2
+    IL_0012:  stloc.0
+    IL_0013:  endfinally
+  }
+  IL_0014:  ldc.i4.2
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""void System.Console.Write(int)""
+  IL_001c:  ldloc.1
+  IL_001d:  ret
+}"
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -2154,10 +2154,12 @@ unsafe class C
             var text = @"
 unsafe class C
 {
+    void nop() { }
     void Test()
     {
         try
         {
+            nop();
         }
         catch
         {
@@ -2170,37 +2172,38 @@ unsafe class C
 ";
             // Cleanup not in finally.
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
-                VerifyIL("C.Test", @"
-{
-  // Code size       28 (0x1c)
+                VerifyIL("C.Test",
+@"{
+  // Code size       34 (0x22)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
   .try
   {
-    IL_0000:  leave.s    IL_001b
+    IL_0000:  ldarg.0
+    IL_0001:  call       ""void C.nop()""
+    IL_0006:  leave.s    IL_0021
   }
   catch object
   {
-    IL_0002:  pop
-    IL_0003:  ldstr      ""hello""
-    IL_0008:  stloc.1
-    IL_0009:  ldloc.1
-    IL_000a:  conv.i
-    IL_000b:  stloc.0
-    IL_000c:  ldloc.0
-    IL_000d:  brfalse.s  IL_0017
-    IL_000f:  ldloc.0
-    IL_0010:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-    IL_0015:  add
-    IL_0016:  stloc.0
-    IL_0017:  ldnull
-    IL_0018:  stloc.1
-    IL_0019:  leave.s    IL_001b
+    IL_0008:  pop
+    IL_0009:  ldstr      ""hello""
+    IL_000e:  stloc.1
+    IL_000f:  ldloc.1
+    IL_0010:  conv.i
+    IL_0011:  stloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  brfalse.s  IL_001d
+    IL_0015:  ldloc.0
+    IL_0016:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+    IL_001b:  add
+    IL_001c:  stloc.0
+    IL_001d:  ldnull
+    IL_001e:  stloc.1
+    IL_001f:  leave.s    IL_0021
   }
-  IL_001b:  ret
-}
-");
+  IL_0021:  ret
+}");
         }
 
         [Fact]
@@ -2209,10 +2212,12 @@ unsafe class C
             var text = @"
 unsafe class C
 {
+    static void nop() { }
     void Test()
     {
         try
         {
+            nop();
         }
         catch
         {
@@ -2230,7 +2235,7 @@ unsafe class C
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
                 VerifyIL("C.Test", @"
 {
-  // Code size       32 (0x20)
+  // Code size       37 (0x25)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
@@ -2238,42 +2243,42 @@ unsafe class C
   {
     .try
     {
-      IL_0000:  leave.s    IL_001f
+      IL_0000:  call       ""void C.nop()""
+      IL_0005:  leave.s    IL_0024
     }
     catch object
     {
-      IL_0002:  pop
+      IL_0007:  pop
       .try
       {
-        IL_0003:  ldstr      ""hello""
-        IL_0008:  stloc.1
-        IL_0009:  ldloc.1
-        IL_000a:  conv.i
-        IL_000b:  stloc.0
-        IL_000c:  ldloc.0
-        IL_000d:  brfalse.s  IL_0017
-        IL_000f:  ldloc.0
-        IL_0010:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-        IL_0015:  add
-        IL_0016:  stloc.0
-        IL_0017:  leave.s    IL_001c
+        IL_0008:  ldstr      ""hello""
+        IL_000d:  stloc.1
+        IL_000e:  ldloc.1
+        IL_000f:  conv.i
+        IL_0010:  stloc.0
+        IL_0011:  ldloc.0
+        IL_0012:  brfalse.s  IL_001c
+        IL_0014:  ldloc.0
+        IL_0015:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+        IL_001a:  add
+        IL_001b:  stloc.0
+        IL_001c:  leave.s    IL_0021
       }
       finally
       {
-        IL_0019:  ldnull
-        IL_001a:  stloc.1
-        IL_001b:  endfinally
+        IL_001e:  ldnull
+        IL_001f:  stloc.1
+        IL_0020:  endfinally
       }
-      IL_001c:  leave.s    IL_001f
+      IL_0021:  leave.s    IL_0024
     }
   }
   finally
   {
-    IL_001e:  endfinally
+    IL_0023:  endfinally
   }
-  IL_001f:  ret
-}
-");
+  IL_0024:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -2929,41 +2929,33 @@ unsafe class C
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
                 VerifyIL("C.<>c.<Test>b__0_0()", @"
 {
-  // Code size       27 (0x1b)
+  // Code size       26 (0x1a)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
   .try
   {
-    .try
-    {
-      IL_0000:  ldstr      ""hello""
-      IL_0005:  stloc.1
-      IL_0006:  ldloc.1
-      IL_0007:  conv.i
-      IL_0008:  stloc.0
-      IL_0009:  ldloc.0
-      IL_000a:  brfalse.s  IL_0014
-      IL_000c:  ldloc.0
-      IL_000d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-      IL_0012:  add
-      IL_0013:  stloc.0
-      IL_0014:  leave.s    IL_001a
-    }
-    finally
-    {
-      IL_0016:  ldnull
-      IL_0017:  stloc.1
-      IL_0018:  endfinally
-    }
+    IL_0000:  ldstr      ""hello""
+    IL_0005:  stloc.1
+    IL_0006:  ldloc.1
+    IL_0007:  conv.i
+    IL_0008:  stloc.0
+    IL_0009:  ldloc.0
+    IL_000a:  brfalse.s  IL_0014
+    IL_000c:  ldloc.0
+    IL_000d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+    IL_0012:  add
+    IL_0013:  stloc.0
+    IL_0014:  leave.s    IL_0019
   }
   finally
   {
-    IL_0019:  endfinally
+    IL_0016:  ldnull
+    IL_0017:  stloc.1
+    IL_0018:  endfinally
   }
-  IL_001a:  ret
-}
-");
+  IL_0019:  ret
+}");
         }
 
         [Fact]
@@ -3092,41 +3084,33 @@ unsafe class C
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
                 VerifyIL("C.<>c.<.ctor>b__1_0()", @"
 {
-  // Code size       27 (0x1b)
+  // Code size       26 (0x1a)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
   .try
   {
-    .try
-    {
-      IL_0000:  ldstr      ""hello""
-      IL_0005:  stloc.1
-      IL_0006:  ldloc.1
-      IL_0007:  conv.i
-      IL_0008:  stloc.0
-      IL_0009:  ldloc.0
-      IL_000a:  brfalse.s  IL_0014
-      IL_000c:  ldloc.0
-      IL_000d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-      IL_0012:  add
-      IL_0013:  stloc.0
-      IL_0014:  leave.s    IL_001a
-    }
-    finally
-    {
-      IL_0016:  ldnull
-      IL_0017:  stloc.1
-      IL_0018:  endfinally
-    }
+    IL_0000:  ldstr      ""hello""
+    IL_0005:  stloc.1
+    IL_0006:  ldloc.1
+    IL_0007:  conv.i
+    IL_0008:  stloc.0
+    IL_0009:  ldloc.0
+    IL_000a:  brfalse.s  IL_0014
+    IL_000c:  ldloc.0
+    IL_000d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+    IL_0012:  add
+    IL_0013:  stloc.0
+    IL_0014:  leave.s    IL_0019
   }
   finally
   {
-    IL_0019:  endfinally
+    IL_0016:  ldnull
+    IL_0017:  stloc.1
+    IL_0018:  endfinally
   }
-  IL_001a:  ret
-}
-");
+  IL_0019:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -1976,6 +1976,7 @@ unsafe class C
             var text = @"
 unsafe class C
 {
+    static void nop() { }
     void Test()
     {
         try
@@ -1986,6 +1987,7 @@ unsafe class C
         }
         finally
         {
+            nop();
         }
     }
 }
@@ -1994,7 +1996,7 @@ unsafe class C
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
                 VerifyIL("C.Test", @"
 {
-  // Code size       27 (0x1b)
+  // Code size       32 (0x20)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
@@ -2013,7 +2015,7 @@ unsafe class C
       IL_000d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
       IL_0012:  add
       IL_0013:  stloc.0
-      IL_0014:  leave.s    IL_001a
+      IL_0014:  leave.s    IL_001f
     }
     finally
     {
@@ -2024,9 +2026,10 @@ unsafe class C
   }
   finally
   {
-    IL_0019:  endfinally
+    IL_0019:  call       ""void C.nop()""
+    IL_001e:  endfinally
   }
-  IL_001a:  ret
+  IL_001f:  ret
 }
 ");
         }
@@ -2235,50 +2238,44 @@ unsafe class C
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).
                 VerifyIL("C.Test", @"
 {
-  // Code size       37 (0x25)
+  // Code size       36 (0x24)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1)
   .try
   {
+    IL_0000:  call       ""void C.nop()""
+    IL_0005:  leave.s    IL_0023
+  }
+  catch object
+  {
+    IL_0007:  pop
     .try
     {
-      IL_0000:  call       ""void C.nop()""
-      IL_0005:  leave.s    IL_0024
+      IL_0008:  ldstr      ""hello""
+      IL_000d:  stloc.1
+      IL_000e:  ldloc.1
+      IL_000f:  conv.i
+      IL_0010:  stloc.0
+      IL_0011:  ldloc.0
+      IL_0012:  brfalse.s  IL_001c
+      IL_0014:  ldloc.0
+      IL_0015:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+      IL_001a:  add
+      IL_001b:  stloc.0
+      IL_001c:  leave.s    IL_0021
     }
-    catch object
+    finally
     {
-      IL_0007:  pop
-      .try
-      {
-        IL_0008:  ldstr      ""hello""
-        IL_000d:  stloc.1
-        IL_000e:  ldloc.1
-        IL_000f:  conv.i
-        IL_0010:  stloc.0
-        IL_0011:  ldloc.0
-        IL_0012:  brfalse.s  IL_001c
-        IL_0014:  ldloc.0
-        IL_0015:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-        IL_001a:  add
-        IL_001b:  stloc.0
-        IL_001c:  leave.s    IL_0021
-      }
-      finally
-      {
-        IL_001e:  ldnull
-        IL_001f:  stloc.1
-        IL_0020:  endfinally
-      }
-      IL_0021:  leave.s    IL_0024
+      IL_001e:  ldnull
+      IL_001f:  stloc.1
+      IL_0020:  endfinally
     }
+    IL_0021:  leave.s    IL_0023
   }
-  finally
-  {
-    IL_0023:  endfinally
-  }
-  IL_0024:  ret
-}");
+  IL_0023:  ret
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSyncLock.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSyncLock.vb
@@ -874,6 +874,7 @@ End Module
 Module M1
     Sub Main()
         Try
+            Dim o = Nothing
         Catch
         Finally
 lab1:
@@ -888,37 +889,46 @@ End Module
 
             CompileAndVerify(source).VerifyIL("M1.Main", <![CDATA[
 {
-  // Code size       32 (0x20)
+  // Code size       44 (0x2c)
   .maxstack  2
   .locals init (Object V_0,
                 Boolean V_1)
   .try
   {
-    IL_0000:  leave.s    IL_001e
+    .try
+    {
+      IL_0000:  leave.s    IL_002a
+    }
+    catch System.Exception
+    {
+      IL_0002:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_0007:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_000c:  leave.s    IL_002a
+    }
   }
   finally
   {
-    IL_0002:  ldsfld     "String.Empty As String"
-    IL_0007:  stloc.0
-    IL_0008:  ldc.i4.0
-    IL_0009:  stloc.1
+    IL_000e:  ldsfld     "String.Empty As String"
+    IL_0013:  stloc.0
+    IL_0014:  ldc.i4.0
+    IL_0015:  stloc.1
     .try
     {
-      IL_000a:  ldloc.0
-      IL_000b:  ldloca.s   V_1
-      IL_000d:  call       "Sub System.Threading.Monitor.Enter(Object, ByRef Boolean)"
-      IL_0012:  leave.s    IL_0002
+      IL_0016:  ldloc.0
+      IL_0017:  ldloca.s   V_1
+      IL_0019:  call       "Sub System.Threading.Monitor.Enter(Object, ByRef Boolean)"
+      IL_001e:  leave.s    IL_000e
     }
     finally
     {
-      IL_0014:  ldloc.1
-      IL_0015:  brfalse.s  IL_001d
-      IL_0017:  ldloc.0
-      IL_0018:  call       "Sub System.Threading.Monitor.Exit(Object)"
-      IL_001d:  endfinally
+      IL_0020:  ldloc.1
+      IL_0021:  brfalse.s  IL_0029
+      IL_0023:  ldloc.0
+      IL_0024:  call       "Sub System.Threading.Monitor.Exit(Object)"
+      IL_0029:  endfinally
     }
   }
-  IL_001e:  br.s       IL_001e
+  IL_002a:  br.s       IL_002a
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSyncLock.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSyncLock.vb
@@ -888,46 +888,37 @@ End Module
 
             CompileAndVerify(source).VerifyIL("M1.Main", <![CDATA[
 {
-  // Code size       44 (0x2c)
+  // Code size       32 (0x20)
   .maxstack  2
   .locals init (Object V_0,
-  Boolean V_1)
+                Boolean V_1)
   .try
-{
-  .try
-{
-  IL_0000:  leave.s    IL_002a
-}
-  catch System.Exception
-{
-  IL_0002:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0007:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_000c:  leave.s    IL_002a
-}
-}
+  {
+    IL_0000:  leave.s    IL_001e
+  }
   finally
-{
-  IL_000e:  ldsfld     "String.Empty As String"
-  IL_0013:  stloc.0
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.1
-  .try
-{
-  IL_0016:  ldloc.0
-  IL_0017:  ldloca.s   V_1
-  IL_0019:  call       "Sub System.Threading.Monitor.Enter(Object, ByRef Boolean)"
-  IL_001e:  leave.s    IL_000e
-}
-  finally
-{
-  IL_0020:  ldloc.1
-  IL_0021:  brfalse.s  IL_0029
-  IL_0023:  ldloc.0
-  IL_0024:  call       "Sub System.Threading.Monitor.Exit(Object)"
-  IL_0029:  endfinally
-}
-}
-  IL_002a:  br.s       IL_002a
+  {
+    IL_0002:  ldsfld     "String.Empty As String"
+    IL_0007:  stloc.0
+    IL_0008:  ldc.i4.0
+    IL_0009:  stloc.1
+    .try
+    {
+      IL_000a:  ldloc.0
+      IL_000b:  ldloca.s   V_1
+      IL_000d:  call       "Sub System.Threading.Monitor.Enter(Object, ByRef Boolean)"
+      IL_0012:  leave.s    IL_0002
+    }
+    finally
+    {
+      IL_0014:  ldloc.1
+      IL_0015:  brfalse.s  IL_001d
+      IL_0017:  ldloc.0
+      IL_0018:  call       "Sub System.Threading.Monitor.Exit(Object)"
+      IL_001d:  endfinally
+    }
+  }
+  IL_001e:  br.s       IL_001e
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -12692,6 +12692,7 @@ End Namespace
 Class C
     Shared Sub M()
         Try
+            Dim o = Nothing
         Catch e As Exception
         End Try
     End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTryCatchThrow.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTryCatchThrow.vb
@@ -880,6 +880,81 @@ End Module
             </compilation>)
         End Sub
 
+        <Fact()>
+        Public Sub EmptyTryOrEmptyFinally()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System        
+Module EmitTest
+    Sub Main()
+        Try
+        Catch
+            Console.Write("Catch 0 ")
+        Finally
+        End Try
+
+        Try
+        Catch
+            Console.Write("Catch 1 ")
+        Finally
+            Console.Write("Finally 1 ")
+        End Try
+
+        Try
+            Console.Write("Try 2 ")
+        Catch
+            Console.Write("Catch 2 ")
+        Finally
+        End Try
+
+        Try
+            Console.Write("Try 3")
+        Finally
+        End Try
+    End Sub
+
+End Module
+    </file>
+</compilation>,
+expectedOutput:="Finally 1 Try 2 Try 3").
+            VerifyIL("EmitTest.Main",
+            <![CDATA[
+{
+  // Code size       59 (0x3b)
+  .maxstack  1
+  .try
+  {
+    IL_0000:  leave.s    IL_000d
+  }
+  finally
+  {
+    IL_0002:  ldstr      "Finally 1 "
+    IL_0007:  call       "Sub System.Console.Write(String)"
+    IL_000c:  endfinally
+  }
+  IL_000d:  nop
+  .try
+  {
+    IL_000e:  ldstr      "Try 2 "
+    IL_0013:  call       "Sub System.Console.Write(String)"
+    IL_0018:  leave.s    IL_0030
+  }
+  catch System.Exception
+  {
+    IL_001a:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_001f:  ldstr      "Catch 2 "
+    IL_0024:  call       "Sub System.Console.Write(String)"
+    IL_0029:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_002e:  leave.s    IL_0030
+  }
+  IL_0030:  ldstr      "Try 3"
+  IL_0035:  call       "Sub System.Console.Write(String)"
+  IL_003a:  ret
+}
+]]>)
+        End Sub
+
     End Class
 End Namespace
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2054,6 +2054,7 @@ class C<T>
     E<T> e1 = null;
     try
     {
+        string.Empty.ToString();
     }
     catch (E<T> e2)
     {
@@ -2074,7 +2075,7 @@ class C<T>
             // Return type E<T> with type argument T from <>c<T>.
             Assert.Equal(returnType.TypeArguments[0].ContainingSymbol, containingType.ContainingType);
             var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
-            Assert.Equal(locals.Length, 1);
+            Assert.Equal(1, locals.Length);
             // All locals of type E<T> with type argument T from <>c<T>.
             foreach (var local in locals)
             {
@@ -2085,27 +2086,30 @@ class C<T>
 
             methodData.VerifyIL(
 @"{
-  // Code size       12 (0xc)
+  // Code size       23 (0x17)
   .maxstack  1
   .locals init (E<T> V_0) //e1
   IL_0000:  ldnull
   IL_0001:  stloc.0
   .try
-{
-  IL_0002:  leave.s    IL_000a
-}
+  {
+    IL_0002:  ldsfld     ""string string.Empty""
+    IL_0007:  callvirt   ""string object.ToString()""
+    IL_000c:  pop
+    IL_000d:  leave.s    IL_0015
+  }
   catch E<T>
-{
-  IL_0004:  stloc.0
-  IL_0005:  leave.s    IL_000a
-}
+  {
+    IL_000f:  stloc.0
+    IL_0010:  leave.s    IL_0015
+  }
   catch object
-{
-  IL_0007:  pop
-  IL_0008:  leave.s    IL_000a
-}
-  IL_000a:  ldloc.0
-  IL_000b:  ret
+  {
+    IL_0012:  pop
+    IL_0013:  leave.s    IL_0015
+  }
+  IL_0015:  ldloc.0
+  IL_0016:  ret
 }");
         }
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -1959,6 +1959,7 @@ End Class"
 "DirectCast(Function()
     Dim e1 As E(Of T) = Nothing
     Try
+        e1 = Nothing
     Catch e2 As E(Of T)
         e1 = e2
     End Try
@@ -1980,28 +1981,30 @@ End Function, Func(Of E(Of T)))()")
             Next
             methodData.VerifyIL(
 "{
-  // Code size       22 (0x16)
+  // Code size       24 (0x18)
   .maxstack  2
   .locals init (E(Of T) V_0, //e1
-  E(Of T) V_1) //e2
+                E(Of T) V_1) //e2
   IL_0000:  ldnull
   IL_0001:  stloc.0
   .try
-{
-  IL_0002:  leave.s    IL_0014
-}
+  {
+    IL_0002:  ldnull
+    IL_0003:  stloc.0
+    IL_0004:  leave.s    IL_0016
+  }
   catch E(Of T)
-{
-  IL_0004:  dup
-  IL_0005:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
-  IL_000a:  stloc.1
-  IL_000b:  ldloc.1
-  IL_000c:  stloc.0
-  IL_000d:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
-  IL_0012:  leave.s    IL_0014
-}
-  IL_0014:  ldloc.0
-  IL_0015:  ret
+  {
+    IL_0006:  dup
+    IL_0007:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_000c:  stloc.1
+    IL_000d:  ldloc.1
+    IL_000e:  stloc.0
+    IL_000f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_0014:  leave.s    IL_0016
+  }
+  IL_0016:  ldloc.0
+  IL_0017:  ret
 }")
         End Sub
 


### PR DESCRIPTION
Fixes #2443 

@AlekseyTs @VSadov @jaredpar @agocke Please review.
@tmat This affects an expression evaluator test. Please review.