### PR TITLE
Lifted IntPtr Conversions

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -4999,6 +4999,31 @@ class C : TestBase
                 expectedOutput: expectedOutput);
         }
 
+        [Fact]
+        public void LiftedIntPtrConversion()
+        {
+            string source = @"
+using System;
+using System.Linq.Expressions;
+
+class C : TestBase
+{
+    static void Main()
+    {
+        Check(() => (IntPtr?)M(), ""Convert(Call(null.[System.Nullable`1[System.Int32] M()]() Type:System.Nullable`1[System.Int32]) Lifted LiftedToNull Method:[IntPtr op_Explicit(Int32)] Type:System.Nullable`1[System.IntPtr])"");
+        Console.WriteLine(""DONE"");
+    }
+
+    static int? M() { return 0; }
+}
+";
+
+            CompileAndVerify(
+                new[] { source, ExpressionTestLibrary },
+                new[] { ExpressionAssemblyRef },
+                expectedOutput: "DONE");
+        }
+
         /// <summary>
         /// Ignore inaccessible members of System.Linq.Expressions.Expression.
         /// </summary>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
@@ -4719,5 +4719,30 @@ VerifyIL("NullableTest.EqualEqual",
 
         End Sub
 
+        <Fact>
+        Public Sub LiftedToIntPtrConversion()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Imports System
+
+Module M
+    Sub Main()
+        Console.WriteLine(CType(M(Nothing), IntPtr?))
+        Console.WriteLine(CType(M(42), IntPtr?))
+    End Sub
+
+    Function M(p as Integer?) As Integer?
+        Return p
+    End Function
+End Module
+
+    </file>
+</compilation>
+
+            Dim expectedOutput = "" + vbCrLf + "42"
+            CompileAndVerify(source, expectedOutput)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
The compiler wasn't properly handling the case of a conversion between
`Nullable<int>` and `Nullable<IntPtr>`.  The compiler specially handles
IntPtr conversions but wasn't properly lowering them in the
LocalRewriter.

I verified the output IL and expression trees are identical to the
native compiler for these cases.

This closes DevDiv 1210529