### PR TITLE
Place taggers in using blocks in tests.

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ReferenceCounting.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ReferenceCounting.cs
@@ -19,9 +19,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 {
 #if DEBUG
                     Contract.Fail($@"Should have been disposed!
+DataSource-StackTrace:
+{_dataSource.StackTrace}
 
-{_stackTrace}
-");
+StackTrace:
+{_stackTrace}");
 #else
                     Contract.Fail($@"Should have been disposed! Try running in Debug to get the allocation callstack");
 #endif

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
+#if DEBUG
+using System.Diagnostics;
+#endif
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
@@ -67,12 +69,20 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected virtual IEnumerable<Option<bool>> Options => SpecializedCollections.EmptyEnumerable<Option<bool>>();
         protected virtual IEnumerable<PerLanguageOption<bool>> PerLanguageOptions => SpecializedCollections.EmptyEnumerable<PerLanguageOption<bool>>();
 
+#if DEBUG
+        public readonly string StackTrace;
+#endif
+
         protected AbstractAsynchronousTaggerProvider(
             IAsynchronousOperationListener asyncListener,
             IForegroundNotificationService notificationService)
         {
-            this._asyncListener = asyncListener;
-            this._notificationService = notificationService;
+            _asyncListener = asyncListener;
+            _notificationService = notificationService;
+
+#if DEBUG
+            StackTrace = new StackTrace().ToString();
+#endif
         }
 
         private TagSource CreateTagSource(ITextView textViewOpt, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -238,34 +238,35 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
                 var leftBuffer = diffView.LeftView.BufferGraph.GetTextBuffers(t => t.ContentType.IsOfType(ContentTypeNames.CSharpContentType)).First();
                 var leftProvider = new DiagnosticsSquiggleTaggerProvider(optionsService, diagnosticService, foregroundService, listeners);
                 var leftTagger = leftProvider.CreateTagger<IErrorTag>(leftBuffer);
-
-                var rightBuffer = diffView.RightView.BufferGraph.GetTextBuffers(t => t.ContentType.IsOfType(ContentTypeNames.CSharpContentType)).First();
-                var rightProvider = new DiagnosticsSquiggleTaggerProvider(optionsService, diagnosticService, foregroundService, listeners);
-                var rightTagger = rightProvider.CreateTagger<IErrorTag>(rightBuffer);
-
-                // wait up to 20 seconds for diagnostics
-                taskSource.Task.Wait(20000);
-                if (!taskSource.Task.IsCompleted)
+                using (var leftDisposable = leftTagger as IDisposable)
                 {
-                    // something is wrong
-                    FatalError.Report(new System.Exception("not finished after 20 seconds"));
+                    var rightBuffer = diffView.RightView.BufferGraph.GetTextBuffers(t => t.ContentType.IsOfType(ContentTypeNames.CSharpContentType)).First();
+                    var rightProvider = new DiagnosticsSquiggleTaggerProvider(optionsService, diagnosticService, foregroundService, listeners);
+                    var rightTagger = rightProvider.CreateTagger<IErrorTag>(rightBuffer);
+                    using (var rightDisposable = rightTagger as IDisposable)
+                    {
+                        // wait up to 20 seconds for diagnostics
+                        taskSource.Task.Wait(20000);
+                        if (!taskSource.Task.IsCompleted)
+                        {
+                            // something is wrong
+                            FatalError.Report(new System.Exception("not finished after 20 seconds"));
+                        }
+
+                        // wait taggers
+                        waiter.CreateWaitTask().PumpingWait();
+
+                        // check left buffer
+                        var leftSnapshot = leftBuffer.CurrentSnapshot;
+                        var leftSpans = leftTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(leftSnapshot, 0, leftSnapshot.Length))).ToList();
+                        Assert.Equal(1, leftSpans.Count);
+
+                        // check right buffer
+                        var rightSnapshot = rightBuffer.CurrentSnapshot;
+                        var rightSpans = rightTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(rightSnapshot, 0, rightSnapshot.Length))).ToList();
+                        Assert.Equal(0, rightSpans.Count);
+                    }
                 }
-
-                // wait taggers
-                waiter.CreateWaitTask().PumpingWait();
-
-                // check left buffer
-                var leftSnapshot = leftBuffer.CurrentSnapshot;
-                var leftSpans = leftTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(leftSnapshot, 0, leftSnapshot.Length))).ToList();
-                Assert.Equal(1, leftSpans.Count);
-
-                // check right buffer
-                var rightSnapshot = rightBuffer.CurrentSnapshot;
-                var rightSpans = rightTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(rightSnapshot, 0, rightSnapshot.Length))).ToList();
-                Assert.Equal(0, rightSpans.Count);
-
-                ((IDisposable)leftTagger).Dispose();
-                ((IDisposable)rightTagger).Dispose();
             }
         }
 

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -586,6 +586,6 @@ namespace Roslyn.Test.Utilities
             return inputString;
         }
 
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Also capture a stacktrace in DEBUG of the tagger provider that created the tagger.