### PR TITLE
Fix VB parenthesis simplification bug around interpolated strings

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3814,5 +3814,71 @@ class C
     }
 }");
         }
+
+        [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void InlineFormattableStringIntoCallSiteRequiringFormattableString()
+        {
+            const string initial = CodeSnippets.FormattableStringType + @"
+class C
+{
+    static void M(FormattableString s)
+    {
+    }
+
+    static void N(int x, int y)
+    {
+        FormattableString [||]s = $""{x}, {y}"";
+        M(s);
+    }
+}";
+
+            const string expected = CodeSnippets.FormattableStringType + @"
+class C
+{
+    static void M(FormattableString s)
+    {
+    }
+
+    static void N(int x, int y)
+    {
+        C.M($""{x}, {y}"");
+    }
+}";
+
+            Test(initial, expected, compareTokens: false);
+        }
+
+        [WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/4624"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
+        {
+            const string initial = CodeSnippets.FormattableStringType + @"
+class C
+{
+    static void M(string s) { }
+    static void M(FormattableString s) { }
+
+    static void N(int x, int y)
+    {
+        FormattableString [||]s = $""{x}, {y}"";
+        M(s);
+    }
+}";
+
+            const string expected = CodeSnippets.FormattableStringType + @"
+class C
+{
+    static void M(string s) { }
+    static void M(FormattableString s) { }
+
+    static void N(int x, int y)
+    {
+        C.M((FormattableString)$""{x}, {y}"");
+    }
+}";
+
+            Test(initial, expected, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3769,7 +3769,7 @@ class A
 
         [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
-        public void DontParenthesizeInterpolatedString()
+        public void DontParenthesizeInterpolatedStringWithNoInterpolation()
         {
             Test(
             @"
@@ -3787,6 +3787,30 @@ class C
     public void M()
     {
         var s2 = string.Replace($""hello"", ""world"");
+    }
+}");
+        }
+
+        [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void DontParenthesizeInterpolatedStringWithInterpolation()
+        {
+            Test(
+            @"
+class C
+{
+    public void M(int x)
+    {
+        var [|s1|] = $""hello {x}"";
+        var s2 = string.Replace(s1, ""world"");
+    }
+}
+", @"
+class C
+{
+    public void M(int x)
+    {
+        var s2 = string.Replace($""hello {x}"", ""world"");
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3766,5 +3766,29 @@ class A
     }
 }");
         }
+
+        [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public void DontParenthesizeInterpolatedString()
+        {
+            Test(
+            @"
+class C
+{
+    public void M()
+    {
+        var [|s1|] = $""hello"";
+        var s2 = string.Replace(s1, ""world"");
+    }
+}
+", @"
+class C
+{
+    public void M()
+    {
+        var s2 = string.Replace($""hello"", ""world"");
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -461,7 +461,7 @@ Console.WriteLine(i + 1 * k)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <Fact(skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(Skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         <WorkItem(551797)>
         Public Sub InlineIntoExpression3()
             Dim code =
@@ -4104,6 +4104,70 @@ Dim s2 = AscW(s1)
 Dim x = 42
 Dim s2 = AscW($"hello {x}")
 </MethodBody>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub InlineFormattableStringIntoCallSiteRequiringFormattableString()
+            Dim code = FormattableStringType & "
+Class C
+    Sub M(s As FormattableString)
+    End Sub
+
+    Sub N(x As Integer, y As Integer)
+        Dim [||]s As FormattableString = $""{x}, {y}""
+        M(s)
+    End Sub
+End Class
+"
+
+            Dim expected = FormattableStringType & "
+Class C
+    Sub M(s As FormattableString)
+    End Sub
+
+    Sub N(x As Integer, y As Integer)
+        M($""{x}, {y}"")
+    End Sub
+End Class
+"
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/4624"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
+            Dim code = FormattableStringType & "
+Class C
+    Sub M(s As String)
+    End Sub
+
+    Sub M(s As FormattableString)
+    End Sub
+
+    Sub N(x As Integer, y As Integer)
+        Dim [||]s As FormattableString = $""{x}, {y}""
+        M(s)
+    End Sub
+End Class
+"
+
+            Dim expected = FormattableStringType & "
+Class C
+    Sub M(s As String)
+    End Sub
+
+    Sub M(s As FormattableString)
+    End Sub
+
+    Sub N(x As Integer, y As Integer)
+        M(CType($""{x}, {y}"", FormattableString))
+    End Sub
+End Class
+"
 
             Test(code, expected, compareTokens:=False)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4072,5 +4072,22 @@ End With
             Test(code, expected, compareTokens:=False)
         End Sub
 
+        <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub DontParenthesizeInterpolatedString()
+            Dim code =
+<MethodBody>
+Dim [||]s1 = $"hello"
+Dim s2 = AscW(s1)
+</MethodBody>
+
+            Dim expected =
+<MethodBody>
+Dim s2 = AscW($"hello")
+</MethodBody>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4074,7 +4074,7 @@ End With
 
         <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
-        Public Sub DontParenthesizeInterpolatedString()
+        Public Sub DontParenthesizeInterpolatedStringWithNoInterpolation()
             Dim code =
 <MethodBody>
 Dim [||]s1 = $"hello"
@@ -4084,6 +4084,25 @@ Dim s2 = AscW(s1)
             Dim expected =
 <MethodBody>
 Dim s2 = AscW($"hello")
+</MethodBody>
+
+            Test(code, expected, compareTokens:=False)
+        End Sub
+
+        <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Sub DontParenthesizeInterpolatedStringWithInterpolation()
+            Dim code =
+<MethodBody>
+Dim x = 42
+Dim [||]s1 = $"hello {x}"
+Dim s2 = AscW(s1)
+</MethodBody>
+
+            Dim expected =
+<MethodBody>
+Dim x = 42
+Dim s2 = AscW($"hello {x}")
 </MethodBody>
 
             Test(code, expected, compareTokens:=False)

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.vb
@@ -68,6 +68,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return True
             End If
 
+            ' Case:
+            '   ($"")
+            If expression.IsKind(SyntaxKind.InterpolatedStringExpression) Then
+                Return True
+            End If
+
             ' Cases:
             '   (Me)
             '   (MyBase)


### PR DESCRIPTION
Fixes issue #4583.

I checked C# and it doesn't exhibit the same problem. I added a regression unit test for C# anyway since there wasn't one in place.

Reviewers: @balajikris, @brettfo, @CyrusNajmabadi, @davkean, @dpoeschl, @jasonmalinowski, @jmarolf, @Pilchie, @rchande