### PR TITLE
Allow collection of C#/VB command line without actually compiling

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -72,6 +72,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return _store.GetOrDefault(nameof(CodePage), 0); }
         }
 
+        [Output]
+        public string CommandLineInvocation
+        {
+            set { _store[nameof(CommandLineInvocation)] = value; }
+            get { return _store.GetOrDefault(nameof(CommandLineInvocation), string.Empty); }
+        }
+
         public string DebugType
         {
             set { _store[nameof(DebugType)] = value; }
@@ -187,6 +194,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return _store.GetOrDefault(nameof(Prefer32Bit), false); }
         }
 
+        public bool ProvideCommandLineInvocation
+        {
+            set { _store[nameof(ProvideCommandLineInvocation)] = value; }
+            get { return _store.GetOrDefault(nameof(ProvideCommandLineInvocation), false); }
+        }
+
         public ITaskItem[] References
         {
             set { _store[nameof(References)] = value; }
@@ -209,6 +222,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             set { _store[nameof(ResponseFiles)] = value; }
             get { return (ITaskItem[])_store[nameof(ResponseFiles)]; }
+        }
+
+        public bool SkipCompilerExecution
+        {
+            set { _store[nameof(SkipCompilerExecution)] = value; }
+            get { return _store.GetOrDefault(nameof(SkipCompilerExecution), false); }
         }
 
         public ITaskItem[] Sources
@@ -312,6 +331,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
+            if (ProvideCommandLineInvocation)
+            {
+                CommandLineInvocation = GenerateResponseFileContents();
+            }
+
+            if (SkipCompilerExecution)
+            {
+                return 0;
+            }
+
             if (!UseSharedCompilation || !String.IsNullOrEmpty(this.ToolPath))
             {
                 return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             if (ProvideCommandLineArgs)
             {
-                CommandLineArgs = GetArguments(commandLineCommands, responseFileCommands, false)
+                CommandLineArgs = GetArguments(commandLineCommands, responseFileCommands)
                     .Select(arg => new TaskItem(arg)).ToArray();
             }
 
@@ -351,11 +351,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 try
                 {
+                    CompilerServerLogger.Log($"CommandLine = '{commandLineCommands}'");
+                    CompilerServerLogger.Log($"BuildResponseFile = '{responseFileCommands}'");
+
                     var responseTask = BuildClient.TryRunServerCompilation(
                         Language,
                         TryGetClientDir() ?? Path.GetDirectoryName(pathToTool),
                         CurrentDirectoryToUse(),
-                        GetArguments(commandLineCommands, responseFileCommands, true),
+                        GetArguments(commandLineCommands, responseFileCommands),
                         _sharedCompileCts.Token,
                         libEnvVariable: LibDirectoryToUse());
 
@@ -524,14 +527,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Get the command line arguments to pass to the compiler.
         /// </summary>
-        private string[] GetArguments(string commandLineCommands, string responseFileCommands, bool emitServerLog)
+        private string[] GetArguments(string commandLineCommands, string responseFileCommands)
         {
-            if (emitServerLog)
-            {
-                CompilerServerLogger.Log($"CommandLine = '{commandLineCommands}'");
-                CompilerServerLogger.Log($"BuildResponseFile = '{responseFileCommands}'");
-            }
-
             var commandLineArguments =
                 CommandLineParser.SplitCommandLineIntoArguments(commandLineCommands, removeHashComments: true);
             var responseFileArguments =

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -19,7 +19,7 @@
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
-          Returns=""
+          Returns="$(CscCommandLineInvocation)"
           DependsOnTargets="$(CoreCompileDependsOn)"
     >
     <!-- These two compiler warnings are raised when a reference is bound to a different version
@@ -105,10 +105,12 @@
           Platform="$(PlatformTarget)"
           Prefer32Bit="$(Prefer32Bit)"
           PreferredUILang="$(PreferredUILang)"
+          ProvideCommandLineInvocation="$(ProvideCommandLineInvocation)"
           References="@(ReferencePath)"
           ReportAnalyzer="$(ReportAnalyzer)"
           Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
           ResponseFiles="$(CompilerResponseFile)"
+          SkipCompilerExecution="$(SkipCompilerExecution)"
           Sources="@(Compile)"
           SubsystemVersion="$(SubsystemVersion)"
           TargetType="$(OutputType)"
@@ -125,7 +127,9 @@
           Win32Icon="$(ApplicationIcon)"
           Win32Manifest="$(Win32Manifest)"
           Win32Resource="$(Win32Resource)"
-              />
+          >
+      <Output TaskParameter="CommandLineInvocation" PropertyName="CscCommandLineInvocation" />
+    </Csc>
 
     <ItemGroup>
       <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -19,7 +19,7 @@
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
-          Returns="$(CscCommandLineInvocation)"
+          Returns="@(CscCommandLineArgs)"
           DependsOnTargets="$(CoreCompileDependsOn)"
     >
     <!-- These two compiler warnings are raised when a reference is bound to a different version
@@ -105,7 +105,7 @@
           Platform="$(PlatformTarget)"
           Prefer32Bit="$(Prefer32Bit)"
           PreferredUILang="$(PreferredUILang)"
-          ProvideCommandLineInvocation="$(ProvideCommandLineInvocation)"
+          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
           References="@(ReferencePath)"
           ReportAnalyzer="$(ReportAnalyzer)"
           Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
@@ -128,7 +128,7 @@
           Win32Manifest="$(Win32Manifest)"
           Win32Resource="$(Win32Resource)"
           >
-      <Output TaskParameter="CommandLineInvocation" PropertyName="CscCommandLineInvocation" />
+      <Output TaskParameter="CommandLineArgs" ItemName="CscCommandLineArgs" />
     </Csc>
 
     <ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -19,7 +19,7 @@
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
-          Returns="$(VbcCommandLineInvocation)"
+          Returns="@(VbcCommandLineArgs)"
           DependsOnTargets="$(CoreCompileDependsOn)"
     >
     <PropertyGroup>
@@ -97,7 +97,7 @@
           Platform="$(PlatformTarget)"
           Prefer32Bit="$(Prefer32Bit)"
           PreferredUILang="$(PreferredUILang)"
-          ProvideCommandLineInvocation="$(ProvideCommandLineInvocation)"
+          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
           References="@(ReferencePath)"
           RemoveIntegerChecks="$(RemoveIntegerChecks)"
           ReportAnalyzer="$(ReportAnalyzer)"
@@ -126,7 +126,7 @@
           Win32Resource="$(Win32Resource)"
           VBRuntime="$(VBRuntime)"
           >
-      <Output TaskParameter="CommandLineInvocation" PropertyName="CscCommandLineInvocation" />
+      <Output TaskParameter="CommandLineArgs" ItemName="VbcCommandLineArgs" />
     </Vbc>
     <ItemGroup>
       <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -19,7 +19,7 @@
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
-          Returns=""
+          Returns="$(VbcCommandLineInvocation)"
           DependsOnTargets="$(CoreCompileDependsOn)"
     >
     <PropertyGroup>
@@ -97,6 +97,7 @@
           Platform="$(PlatformTarget)"
           Prefer32Bit="$(Prefer32Bit)"
           PreferredUILang="$(PreferredUILang)"
+          ProvideCommandLineInvocation="$(ProvideCommandLineInvocation)"
           References="@(ReferencePath)"
           RemoveIntegerChecks="$(RemoveIntegerChecks)"
           ReportAnalyzer="$(ReportAnalyzer)"
@@ -104,6 +105,7 @@
           ResponseFiles="$(CompilerResponseFile)"
           RootNamespace="$(RootNamespace)"
           SdkPath="$(FrameworkPathOverride)"
+          SkipCompilerExecution="$(SkipCompilerExecution)"
           Sources="@(Compile)"
           SubsystemVersion="$(SubsystemVersion)"
           TargetCompactFramework="$(TargetCompactFramework)"
@@ -123,8 +125,9 @@
           Win32Manifest="$(Win32Manifest)"
           Win32Resource="$(Win32Resource)"
           VBRuntime="$(VBRuntime)"
-          />
-
+          >
+      <Output TaskParameter="CommandLineInvocation" PropertyName="CscCommandLineInvocation" />
+    </Vbc>
     <ItemGroup>
       <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />
     </ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -273,6 +273,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return false;
             }
 
+            if (SkipCompilerExecution)
+            {
+                return !Log.HasLoggedErrors;
+            }
+
             MovePdbFileIfNecessary(OutputAssembly.ItemSpec);
 
             return !Log.HasLoggedErrors;

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -273,12 +273,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return false;
             }
 
-            if (SkipCompilerExecution)
+            if (!SkipCompilerExecution)
             {
-                return !Log.HasLoggedErrors;
+                MovePdbFileIfNecessary(OutputAssembly.ItemSpec);
             }
-
-            MovePdbFileIfNecessary(OutputAssembly.ItemSpec);
 
             return !Log.HasLoggedErrors;
         }


### PR DESCRIPTION
For design-time builds that seek to initialize the language service the command line is all we need. 
This change makes the command line arguments available to other MSBuild targets or (more importantly) a host that sets these global properties as part of the build:

    ProvideCommandLineInvocation=true
    SkipCompilerExecution=true

In this way, the CoreCompile target's `Returns` produces the command line that has all the information necessary to initialize the language service elsewhere. 