### PR TITLE
Restrict DiaSymReader.Native search paths

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -747,9 +747,11 @@ namespace Microsoft.Cci
 
         private static bool s_MicrosoftDiaSymReaderNativeLoadFailed;
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
         [DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymWriter")]
         private extern static void CreateSymWriter32(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
         [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymWriter")]
         private extern static void CreateSymWriter64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
 

--- a/src/Compilers/Core/Portable/SqmServiceProvider.cs
+++ b/src/Compilers/Core/Portable/SqmServiceProvider.cs
@@ -52,6 +52,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         {
             try
             {
+                // These DLLs are only distributed with VS, they are installed to "Program Files (x86)\MSBuild\14.0\Bin".
                 IntPtr vssqmdll = IntPtr.Zero;
                 string vssqmpath;
                 if (IntPtr.Size == 8)

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -12,9 +12,11 @@ namespace Roslyn.Test.PdbUtilities
 {
     public static class SymReaderFactory
     {
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
         [DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymReader")]
         private extern static void CreateSymReader32(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
         [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymReader")]
         private extern static void CreateSymReader64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
 


### PR DESCRIPTION
Restrict search for DiaSymReader.Native native library to the directory that contains the assembly that declares the P/Invoke (Microsoft.CodeAnalysis). This prevents csc/compiler server to pick unwanted versions accidentally located in the current directory or on %PATH%. 