### PR TITLE
Fix VB formatting to stop introducing a space before the ? in a conditional access expression

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
@@ -197,59 +197,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 Return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 
-
             ' ? . [conditional access operator]
             If previousToken.Kind = SyntaxKind.QuestionToken AndAlso currentToken.Kind = SyntaxKind.DotToken AndAlso
-                previousToken.Parent.IsKind(SyntaxKind.ConditionalAccessExpression) Then
+               previousToken.Parent.IsKind(SyntaxKind.ConditionalAccessExpression) Then
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 
-            ' identifier ? [conditional access operator]
-            If previousToken.Kind = SyntaxKind.IdentifierToken AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' Me ? [conditional access operator]
-            If previousToken.Kind = SyntaxKind.MeKeyword AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' MyBase ? [conditional access operator]
-            If previousToken.Kind = SyntaxKind.MyBaseKeyword AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' MyClass ? [conditional access operator]
-            If previousToken.Kind = SyntaxKind.MyClassExpression AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' } ? [conditional access operator after initializer]
-            If previousToken.Kind = SyntaxKind.CloseBraceToken AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' " ? [conditional access operator after string literal]
-            If previousToken.Kind = SyntaxKind.StringLiteralToken AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' ) ? [conditional access off invocation]
-            If previousToken.Kind = SyntaxKind.CloseParenToken AndAlso currentToken.Kind = SyntaxKind.QuestionToken AndAlso
-                    currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
-
+            ' * ?
+            If currentToken.Kind = SyntaxKind.QuestionToken AndAlso
+               currentToken.Parent.Kind = SyntaxKind.ConditionalAccessExpression Then
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4080,6 +4080,53 @@ End Module
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
+        Public Sub ChainedConditionalAccessFormatting()
+            Const code = "
+Module Module1
+    Class G
+        Public t As String
+    End Class
+
+    Sub Main()
+        Dim x = New G()
+        Dim q = x ? . t ? . ToString() ? . ToString ( 0 )
+        Dim me = Me ? . ToString() ? . Length
+        Dim mb = MyBase ? . ToString() ? . Length
+        Dim mc = MyClass ? . ToString() ? . Length
+        Dim i = New With {.a = 3} ? . ToString() ? . Length
+        Dim s = ""Test"" ? . ToString() ? . Length
+        Dim s2 = $""Test"" ? . ToString() ? . Length
+        Dim x1 = <a></a> ? . <b> ? . <c>
+        Dim x2 = <a/> ? . <b> ? . <c>
+    End Sub
+End Module
+"
+
+            Const expected = "
+Module Module1
+    Class G
+        Public t As String
+    End Class
+
+    Sub Main()
+        Dim x = New G()
+        Dim q = x?.t?.ToString()?.ToString(0)
+        Dim me = Me?.ToString()?.Length
+        Dim mb = MyBase?.ToString()?.Length
+        Dim mc = MyClass?.ToString()?.Length
+        Dim i = New With {.a = 3}?.ToString()?.Length
+        Dim s = ""Test""?.ToString()?.Length
+        Dim s2 = $""Test""?.ToString()?.Length
+        Dim x1 = <a></a>?.<b>?.<c>
+        Dim x2 = <a/>?.<b>?.<c>
+    End Sub
+End Module
+"
+
+            AssertFormat(code, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
         Public Sub NameOfFormatting()
             Dim text = <Code>
 Module M

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4034,7 +4034,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
         Public Sub ConditionalAccessFormatting()
-            Dim text = <Code>
+            Const code = "
 Module Module1
     Class G
         Public t As String
@@ -4045,15 +4045,17 @@ Module Module1
         Dim q = x ? . t ? ( 0 )
         Dim me = Me ? . ToString()
         Dim mb = MyBase ? . ToString()
-        Dim mc = MyClas ? . ToString()
+        Dim mc = MyClass ? . ToString()
         Dim i = New With {.a = 3} ? . ToString()
-        Dim s = "Test" ? . ToString()
+        Dim s = ""Test"" ? . ToString()
+        Dim s2 = $""Test"" ? . ToString()
+        Dim x1 = <a></a> ? . <b>
+        Dim x2 = <a/> ? . <b>
     End Sub
 End Module
+"
 
-</Code>
-
-            Dim expected = <Code>
+            Const expected = "
 Module Module1
     Class G
         Public t As String
@@ -4064,15 +4066,17 @@ Module Module1
         Dim q = x?.t?(0)
         Dim me = Me?.ToString()
         Dim mb = MyBase?.ToString()
-        Dim mc = MyClas?.ToString()
+        Dim mc = MyClass?.ToString()
         Dim i = New With {.a = 3}?.ToString()
-        Dim s = "Test"?.ToString()
+        Dim s = ""Test""?.ToString()
+        Dim s2 = $""Test""?.ToString()
+        Dim x1 = <a></a>?.<b>
+        Dim x2 = <a/>?.<b>
     End Sub
 End Module
+"
 
-</Code>
-
-            AssertFormat(text.Value, expected.Value, experimental:=True)
+            AssertFormat(code, expected)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>


### PR DESCRIPTION
Fixes #4619.

The code to handle spaces before the ? in a conditional access expression was very specific, only removing the space if the previous token was of a specific kind. However, there were several cases missed (and one bug after MyClass). Now we take a more general approach that is similar to how we treat member-access expressions: If we see a conditional access expression, we assume that there should never be a space before the ?. Any cases where a space is desired would be exceptional.