### PR TITLE
Object Creation Preselection special cases

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -248,7 +248,7 @@ class Program
 
         [WorkItem(2836, "https://github.com/dotnet/roslyn/issues/2836")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public void AfterNewFollowedByAssignment_GrandParentIsEqualsValueClause()
+        public void AfterNewFollowedBySimpleAssignment_GrandParentIsEqualsValueClause()
         {
             var markup = @"
 class Program
@@ -258,6 +258,40 @@ class Program
         bool b;
         Program p = new $$
         b = false;
+    }
+}";
+            VerifyItemExists(markup, "Program");
+        }
+
+        [WorkItem(2836, "https://github.com/dotnet/roslyn/issues/2836")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void AfterNewFollowedByCompoundAssignment_GrandParentIsEqualsValueClause()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int i;
+        Program p = new $$
+        i += 5;
+    }
+}";
+            VerifyItemExists(markup, "Program");
+        }
+
+        [WorkItem(2836, "https://github.com/dotnet/roslyn/issues/2836")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void AfterNewFollowedByCompoundAssignment_GrandParentIsEqualsValueClause2()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int i = 1000;
+        Program p = new $$
+        i <<= 4;
     }
 }";
             VerifyItemExists(markup, "Program");

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // appears to be a part of a subsequent assignment.
                 if (token.Kind() == SyntaxKind.NewKeyword &&
                     token.Parent.IsKind(SyntaxKind.ObjectCreationExpression) &&
-                    token.Parent.Parent.IsKind(SyntaxKind.SimpleAssignmentExpression))
+                    token.Parent.Parent is AssignmentExpressionSyntax)
                 {
                     var parentAssignment = token.Parent.Parent as AssignmentExpressionSyntax;
                     if (token.Parent == parentAssignment.Left)


### PR DESCRIPTION
There are cases in broken code scenarios where the new keyword in
objectcreationexpression appears to be a part of a subsequent
assignment. These have been addressed in #2537 and #3441. However the
compound assignment cases were missed. This PR addresses that by
relaxing the special case for object creation preselection from
SimpleAssignmentExpression to AssignmentExpression which includes
Compound assignments.

Fixes #2836