### PR TITLE
Un-redirect Console.Out at the end of each test

### DIFF
--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2527,26 +2527,5 @@ System.TypedReference c;
         }
 
         #endregion
-
-        private struct OutputRedirect : IDisposable
-        {
-            private readonly TextWriter _oldOut;
-            private readonly StringWriter _newOut;
-
-            public OutputRedirect(IFormatProvider formatProvider)
-            {
-                _oldOut = Console.Out;
-                _newOut = new StringWriter(formatProvider);
-                Console.SetOut(_newOut);
-            }
-
-            public string Output => _newOut.ToString();
-
-            void IDisposable.Dispose()
-            {
-                Console.SetOut(_oldOut);
-                _newOut.Dispose();
-            }
-        }
     }
 }

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -67,11 +67,10 @@ InnerClass iC = new InnerClass();
 iC.Goo();
 ");
 
-            using (var output = new StringWriter(CultureInfo.InvariantCulture))
+            using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                Console.SetOut(output);
                 session.Execute(@"System.Console.WriteLine(iC.innerStr);");
-                Assert.Equal("test", output.ToString().Trim());
+                Assert.Equal("test", redirect.Output.Trim());
             }
         }
 
@@ -96,11 +95,10 @@ InnerStruct iS = new InnerStruct();
 iS.Goo();
 ");
 
-            using (var output = new StringWriter(CultureInfo.InvariantCulture))
+            using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                Console.SetOut(output);
                 session.Execute(@"System.Console.WriteLine(iS.innerStr);");
-                Assert.Equal("test", output.ToString().Trim());
+                Assert.Equal("test", redirect.Output.Trim());
             }
         }
 
@@ -692,11 +690,10 @@ using System;");
             {
                 session.Execute(@"public int i =  1;");
             }
-            using (var output = new StringWriter(CultureInfo.InvariantCulture))
+            using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                Console.SetOut(output);
                 session.Execute(@"System.Console.WriteLine(i);");
-                Assert.Equal(1, int.Parse(output.ToString()));
+                Assert.Equal(1, int.Parse(redirect.Output));
             }
         }
 
@@ -737,16 +734,14 @@ public class E
 int z; z = x + y;
 ");
 
-            using (var output = new StringWriter(CultureInfo.InvariantCulture))
+            using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                Console.SetOut(output);
-
                 // Ref.Emit
                 session.Execute(@"
 System.Console.Write(new E());
 System.Console.Write(x + y);
 ");
-                Assert.True(output.ToString().Trim().EndsWith("+E2", StringComparison.Ordinal), output.ToString());
+                Assert.True(redirect.Output.Trim().EndsWith("+E2", StringComparison.Ordinal), redirect.Output);
             }
         }
 
@@ -1526,11 +1521,10 @@ delegate void TestDelegate(string s);
 TestDelegate testDelB = delegate (string s) { Console.WriteLine(s); };
 ");
 
-            using (var output = new StringWriter(CultureInfo.InvariantCulture))
+            using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                Console.SetOut(output);
                 session.Execute(@"testDelB(""hello"");");
-                Assert.Equal("hello", output.ToString().Trim());
+                Assert.Equal("hello", redirect.Output.Trim());
             }
         }
 
@@ -2533,5 +2527,26 @@ System.TypedReference c;
         }
 
         #endregion
+
+        private struct OutputRedirect : IDisposable
+        {
+            private readonly TextWriter _oldOut;
+            private readonly StringWriter _newOut;
+
+            public OutputRedirect(IFormatProvider formatProvider)
+            {
+                _oldOut = Console.Out;
+                _newOut = new StringWriter(formatProvider);
+                Console.SetOut(_newOut);
+            }
+
+            public string Output => _newOut.ToString();
+
+            void IDisposable.Dispose()
+            {
+                Console.SetOut(_oldOut);
+                _newOut.Dispose();
+            }
+        }
     }
 }

--- a/src/Scripting/CoreTest/RedirectedOutput.cs
+++ b/src/Scripting/CoreTest/RedirectedOutput.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Scripting
+{
+    public struct OutputRedirect : IDisposable  
+    {  
+        private readonly TextWriter _oldOut;  
+        private readonly StringWriter _newOut;  
+    
+        public OutputRedirect(IFormatProvider formatProvider)  
+        {  
+            _oldOut = Console.Out;  
+            _newOut = new StringWriter(formatProvider);  
+            Console.SetOut(_newOut);  
+        }  
+    
+        public string Output => _newOut.ToString();  
+    
+        void IDisposable.Dispose()  
+        {  
+            Console.SetOut(_oldOut);  
+            _newOut.Dispose();  
+        }
+    }
+}

--- a/src/Scripting/CoreTest/ScriptingTest.csproj
+++ b/src/Scripting/CoreTest/ScriptingTest.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="ObjectFormatterTestBase.cs" />
     <Compile Include="ObjectFormatterTests.Fixtures.cs" />
+    <Compile Include="RedirectedOutput.cs" />
     <Compile Include="ScriptEngine.cs" />
     <Compile Include="ScriptingTestHelpers.cs" />
     <Compile Include="Session.cs" />


### PR DESCRIPTION
The InteractiveSessionTests were redirecting ```Console.Out``` to a
```StringWriter``` and then disposing of the ```StringWriter``` breaking
downstream tests that attempted to write to ```Console.Out```
(specifically, ```ScriptTests.TestRunVoidScript```).