### PR TITLE
Fix C#/VB Inline Temporary Variable for interpolated strings that are target-typed to FormattableString

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3819,7 +3819,9 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineFormattableStringIntoCallSiteRequiringFormattableString()
         {
-            const string initial = CodeSnippets.FormattableStringType + @"
+            const string initial = @"
+using System;
+" + CodeSnippets.FormattableStringType + @"
 class C
 {
     static void M(FormattableString s)
@@ -3833,7 +3835,9 @@ class C
     }
 }";
 
-            const string expected = CodeSnippets.FormattableStringType + @"
+            const string expected = @"
+using System;
+" + CodeSnippets.FormattableStringType + @"
 class C
 {
     static void M(FormattableString s)
@@ -3842,7 +3846,7 @@ class C
 
     static void N(int x, int y)
     {
-        C.M($""{x}, {y}"");
+        M($""{x}, {y}"");
     }
 }";
 
@@ -3850,10 +3854,12 @@ class C
         }
 
         [WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/4624"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
         {
-            const string initial = CodeSnippets.FormattableStringType + @"
+            const string initial = @"
+using System;
+" + CodeSnippets.FormattableStringType + @"
 class C
 {
     static void M(string s) { }
@@ -3866,7 +3872,9 @@ class C
     }
 }";
 
-            const string expected = CodeSnippets.FormattableStringType + @"
+            const string expected = @"
+using System;
+" + CodeSnippets.FormattableStringType + @"
 class C
 {
     static void M(string s) { }
@@ -3874,10 +3882,9 @@ class C
 
     static void N(int x, int y)
     {
-        C.M((FormattableString)$""{x}, {y}"");
+        M((FormattableString)$""{x}, {y}"");
     }
 }";
-
             Test(initial, expected, compareTokens: false);
         }
     }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4111,7 +4111,9 @@ Dim s2 = AscW($"hello {x}")
         <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineFormattableStringIntoCallSiteRequiringFormattableString()
-            Dim code = FormattableStringType & "
+            Dim code = "
+Imports System
+" & FormattableStringType & "
 Class C
     Sub M(s As FormattableString)
     End Sub
@@ -4123,7 +4125,9 @@ Class C
 End Class
 "
 
-            Dim expected = FormattableStringType & "
+            Dim expected = "
+Imports System
+" & FormattableStringType & "
 Class C
     Sub M(s As FormattableString)
     End Sub
@@ -4138,9 +4142,11 @@ End Class
         End Sub
 
         <WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/4624"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
-            Dim code = FormattableStringType & "
+            Dim code = "
+Imports System
+" & FormattableStringType & "
 Class C
     Sub M(s As String)
     End Sub
@@ -4155,7 +4161,9 @@ Class C
 End Class
 "
 
-            Dim expected = FormattableStringType & "
+            Dim expected = "
+Imports System
+" & FormattableStringType & "
 Class C
     Sub M(s As String)
     End Sub

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -82,6 +82,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             // Cases:
+            //   ($"{x}") -> $"{x}"
+            if (expression.IsKind(SyntaxKind.InterpolatedStringExpression))
+            {
+                return true;
+            }
+
+            // Cases:
             //   {(x)} -> {x}
             if (node.Parent is InitializerExpressionSyntax)
             {

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -220,15 +220,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             targetType As ITypeSymbol,
             <Out> ByRef isResultPredefinedCast As Boolean) As ExpressionSyntax
 
-            ' Parenthesize the expression, except for collection initializer where parenthesizing changes the semantics.
-            Dim parenthesized = If(expression.Kind = SyntaxKind.CollectionInitializer,
-                expression,
-                expression.Parenthesize())
+            ' Parenthesize the expression, except for collection initializers and interpolated strings,
+            ' where parenthesizing changes semantics.
+            Dim newExpression = expression
 
-            Dim leadingTrivia = parenthesized.GetLeadingTrivia()
-            Dim trailingTrivia = parenthesized.GetTrailingTrivia()
+            If Not expression.IsKind(SyntaxKind.CollectionInitializer, SyntaxKind.InterpolatedStringExpression) Then
+                newExpression = expression.Parenthesize()
+            End If
 
-            Dim stripped = parenthesized.WithoutLeadingTrivia().WithoutTrailingTrivia()
+            Dim leadingTrivia = newExpression.GetLeadingTrivia()
+            Dim trailingTrivia = newExpression.GetTrailingTrivia()
+
+            Dim stripped = newExpression.WithoutLeadingTrivia().WithoutTrailingTrivia()
 
             Dim castKeyword = targetType.SpecialType.GetPredefinedCastKeyword()
             If castKeyword = SyntaxKind.None Then


### PR DESCRIPTION
Fixes issues https://github.com/dotnet/roslyn/issues/4624 and https://github.com/dotnet/roslyn/issues/4625.

There are a few of problems here:

1. The unit tests were set up incorrectly. Each unit test that was testing FormattableString within a using directive or Imports statement for System. So, the overload resolution was failing. These are now corrected.
2. C# parenthesis simplification did not remove parentheses around an interpolated string if it was te target of a cast expression. This is now addressed.
3. The VB expander should not add parentheses around interpolated strings. If an interpolated string is target-typed to FormattableString, parenthesizing it will force evaluation and it can no longer be converted to FormattableString. This breaks overload resolution and further reduction steps in the simplifier.