### PR TITLE
Add <VisibilityItem> for Interactive tool window commands...

### DIFF
--- a/src/VisualStudio/CSharp/Repl/Commands.vsct
+++ b/src/VisualStudio/CSharp/Repl/Commands.vsct
@@ -38,6 +38,7 @@
   </Commands>
   
   <VisibilityConstraints>
+    <VisibilityItem context="guidCSProjectContext" guid="guidCSharpInteractiveCommandSet" id="cmdidCSharpInteractiveToolWindow" />
     <VisibilityItem context="guidCSProjectContext" guid="guidCSharpInteractiveCommandSet" id="cmdidResetInteractiveFromProject" />
   </VisibilityConstraints>
   

--- a/src/VisualStudio/VisualBasic/Repl/Commands.vsct
+++ b/src/VisualStudio/VisualBasic/Repl/Commands.vsct
@@ -38,6 +38,7 @@
   </Commands>
 
   <VisibilityConstraints>
+    <VisibilityItem context="guidVBProjectContext" guid="guidVisualBasicInteractiveCommandSet" id="cmdidVisualBasicInteractiveToolWindow" />
     <VisibilityItem context="guidVBProjectContext" guid="guidVisualBasicInteractiveCommandSet" id="cmdidResetInteractiveFromProject" />
   </VisibilityConstraints>
   


### PR DESCRIPTION
We're still loading the Interactive packages when the language service imports ICommandHandlers.  Adding a <VisibilityItem> should prevent that.