### PR TITLE
Do not insert newlines into what is probably a single-line construct.

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
@@ -233,9 +233,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                 }
             }
 
-            public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+            public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
             {
-                base.AddSuppressOperations(list, node, optionSet, nextOperation);
+                base.AddSuppressOperations(list, node, lastToken, optionSet, nextOperation);
 
                 // remove suppression rules for array and collection initializer
                 if (node.IsInitializerForArrayOrCollectionCreationExpression())

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
         private class SmartTokenFormattingRule : NoLineChangeFormattingRule
         {
-            public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+            public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
             {
                 // don't suppress anything
             }

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1117,7 +1117,7 @@ class C : Attribute
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public void DoNotFormatIncompleteBlockOnSingleLine1()
+        public void DoNotFormatIncompleteBlockOnSingleLineIfNotTypingCloseCurly()
         {
             var code = @"namespace ConsoleApplication1
 {
@@ -1136,6 +1136,54 @@ class C : Attribute
         {
             get { return true;
     }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatCompleteBlockOnSingleLineIfTypingCloseCurly()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true; }$$
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true; }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatIncompleteBlockOnMultipleLinesIfTypingCloseCurly()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true;
+    }$$
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get
+            {
+                return true;
+            }
 }";
             AssertFormatAfterTypeChar(code, expected);
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1117,7 +1117,7 @@ class C : Attribute
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public void DoNotFormatIncompleteBlockOnSingleLineIfNotTypingCloseCurly()
+        public void DoNotFormatIncompleteBlockOnSingleLineIfNotTypingCloseCurly1()
         {
             var code = @"namespace ConsoleApplication1
 {
@@ -1141,7 +1141,27 @@ class C : Attribute
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public void DoNotFormatCompleteBlockOnSingleLineIfTypingCloseCurly()
+        public void DoNotFormatIncompleteBlockOnSingleLineIfNotTypingCloseCurly2()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get { return true;$$
+    }
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get { return true;
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatCompleteBlockOnSingleLineIfTypingCloseCurly1()
         {
             var code = @"namespace ConsoleApplication1
 {
@@ -1163,7 +1183,25 @@ class C : Attribute
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public void FormatIncompleteBlockOnMultipleLinesIfTypingCloseCurly()
+        public void DoNotFormatCompleteBlockOnSingleLineIfTypingCloseCurly2()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get { return true; }$$
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get { return true; }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatIncompleteBlockOnMultipleLinesIfTypingCloseCurly1()
         {
             var code = @"namespace ConsoleApplication1
 {
@@ -1185,6 +1223,32 @@ class C : Attribute
                 return true;
             }
 }";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatIncompleteBlockOnMultipleLinesIfTypingCloseCurly2()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true;
+    }
+}$$";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get
+            {
+                return true;
+            }
+        }";
             AssertFormatAfterTypeChar(code, expected);
         }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1116,6 +1116,30 @@ class C : Attribute
             AssertFormatAfterTypeChar(code, expected, optionSet);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatIncompleteBlockOnSingleLine1()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true;$$
+    }
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property
+        {
+            get { return true;
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
         private static void AssertFormatAfterTypeChar(string code, string expected, Dictionary<OptionKey, object> changedOptionSet = null)
         {
             using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(code))

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1161,6 +1161,26 @@ class C : Attribute
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoNotFormatIncompleteBlockOnSingleLineIfNotTypingCloseCurly3()
+        {
+            var code = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get;$$
+    }
+}";
+            var expected = @"namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool Property { get;
+    }
+}";
+            AssertFormatAfterTypeChar(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public void DoNotFormatCompleteBlockOnSingleLineIfTypingCloseCurly1()
         {
             var code = @"namespace ConsoleApplication1

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                          new ChainedFormattingRules(this.Rules, OptionSet),
                          this.TabSize,
                          this.OptionSet.GetOption(FormattingOptions.IndentationSize, this.Document.Root.Language),
-                         tokenStream: null);
+                         tokenStream: null,
+                         lastToken: default(SyntaxToken));
             }
 
             public abstract IndentationResult? GetDesiredIndentation();

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/SpecialFormattingOperation.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/SpecialFormattingOperation.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
         Public Sub New()
         End Sub
 
-        Public Overrides Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation))
+        Public Overrides Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, lastToken As SyntaxToken, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation))
             ' don't suppress anything
         End Sub
 

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -90,7 +90,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 
             Dim currentNode = startNode
             Do While currentNode IsNot Nothing
-                Dim operations = FormattingOperations.GetAlignTokensOperations(formattingRules, currentNode, optionSet)
+                Dim operations = FormattingOperations.GetAlignTokensOperations(
+                    formattingRules, currentNode, lastToken:=Nothing, optionSet:=optionSet)
 
                 If Not operations.Any() Then
                     currentNode = currentNode.Parent

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -217,7 +217,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' collect all indent operation
             Dim operations = New List(Of IndentBlockOperation)()
             While node IsNot Nothing
-                operations.AddRange(FormattingOperations.GetIndentBlockOperations(Formatter.GetDefaultFormattingRules(document), node, optionSet))
+                operations.AddRange(FormattingOperations.GetIndentBlockOperations(
+                                    Formatter.GetDefaultFormattingRules(document), node, lastToken:=Nothing, optionSet:=optionSet))
                 node = node.Parent
             End While
 

--- a/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
+++ b/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
     Friend Class LineAdjustmentFormattingRule
         Implements IFormattingRule
 
-        Public Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
+        Public Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, lastToken As SyntaxToken, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
             nextOperation.Invoke(list)
         End Sub
 

--- a/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
 {
     internal class EndRegionFormattingRule : IFormattingRule
     {
-        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
         }

--- a/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
 {
     internal class BlankLineInGeneratedMethodFormattingRule : IFormattingRule
     {
-        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
         }

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/EndRegionFormattingRule.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/EndRegionFormattingRule.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
     Friend Class EndRegionFormattingRule
         Implements IFormattingRule
 
-        Public Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
+        Public Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, lastToken As SyntaxToken, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
             nextOperation.Invoke(list)
         End Sub
 

--- a/src/Workspaces/CSharp/Portable/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/DefaultOperationProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     // to reduce number of unnecessary heap allocations, most of them just return null.
     internal class DefaultOperationProvider : IFormattingRule
     {
-        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
@@ -166,5 +166,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
             return FormattingOperations.CreateAdjustSpacesOperation(space, option);
         }
+
+        protected void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+        {
+            var bracePair = node.GetBracePair();
+            if (!bracePair.IsValidBracePair())
+            {
+                return;
+            }
+
+            var firstTokenOfNode = node.GetFirstToken(includeZeroWidth: true);
+
+            if (node.IsLambdaBodyBlock())
+            {
+                // include lambda itself.
+                firstTokenOfNode = node.Parent.GetFirstToken(includeZeroWidth: true);
+            }
+
+            // suppress wrapping on whole construct that owns braces and also brace pair itself if it is on same line
+            AddSuppressWrappingIfOnSingleLineOperation(list, firstTokenOfNode, bracePair.Item2);
+            AddSuppressWrappingIfOnSingleLineOperation(list, bracePair.Item1, bracePair.Item2);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             var endBrace = bracePair.Item2;
             if (lastToken.Kind() != SyntaxKind.CloseBraceToken && 
-                lastToken.Kind () != SyntaxKind.EndOfFileToken &&
+                lastToken.Kind() != SyntaxKind.EndOfFileToken &&
                 !endBrace.IsMissing)
             {
                 // The user didn't just type the close brace.  So any close brace we have may 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -167,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return FormattingOperations.CreateAdjustSpacesOperation(space, option);
         }
 
-        protected void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+        protected void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken)
         {
             var bracePair = node.GetBracePair();
             if (!bracePair.IsValidBracePair())
@@ -183,9 +184,65 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 firstTokenOfNode = node.Parent.GetFirstToken(includeZeroWidth: true);
             }
 
-            // suppress wrapping on whole construct that owns braces and also brace pair itself if it is on same line
-            AddSuppressWrappingIfOnSingleLineOperation(list, firstTokenOfNode, bracePair.Item2);
-            AddSuppressWrappingIfOnSingleLineOperation(list, bracePair.Item1, bracePair.Item2);
+            // We may think we have a complete set of braces, but that may not actually be the case
+            // due incomplete code.  i.e. we have something like:
+            //
+            // class C
+            // {
+            //      int Blah {
+            //          get { return blah
+            // }
+            //
+            // In this case the parse will think that the get-accessor is actually on two lines 
+            // (because it will consume the close curly that more accurately belongs to the class.
+            //
+            // Now there are different behaviors we want depending on what the user is doing 
+            // and what we are formatting.  For example, if the user hits semicolon at the end of
+            // "blah", then we want to keep the accessor on a single line.  In this scenario we
+            // effectively want to ignore the following close curly as it may not be important to
+            // this construct in the mind of the user. 
+            //
+            // However, say the user hits semicolon, then hits enter, then types a close curly.
+            // In this scenario we woudl actually want the get-accessor to be formatted over multiple 
+            // lines.  The difference here is that because the user just hit close-curly here we can 
+            // consider it as being part of the closest construct and we can consider its placement
+            // when deciding if the construct is on a single line.
+
+            var endBrace = bracePair.Item2;
+            if (lastToken.Kind() != SyntaxKind.CloseBraceToken && 
+                lastToken.Kind () != SyntaxKind.EndOfFileToken &&
+                !endBrace.IsMissing)
+            {
+                // The user didn't just type the close brace.  So any close brace we have may 
+                // actually belong to a containing construct.  See if any containers are missing
+                // a close brace, and if so, act as if our own close brace is missing.
+
+                if (SomeParentHasMissingCloseBrace(node.Parent))
+                {
+                    endBrace = endBrace.GetPreviousToken();
+                }
+            }
+
+            // suppress wrapping on whole construct that owns braces and also brace pair itself if 
+            // it is on same line
+            AddSuppressWrappingIfOnSingleLineOperation(list, firstTokenOfNode, endBrace);
+            AddSuppressWrappingIfOnSingleLineOperation(list, bracePair.Item1, endBrace);
+        }
+
+        private bool SomeParentHasMissingCloseBrace(SyntaxNode node)
+        {
+            while (node.Kind() != SyntaxKind.CompilationUnit)
+            {
+                var bracePair = node.GetBracePair();
+                if (bracePair.Item2.IsMissing)
+                {
+                    return true;
+                }
+
+                node = node.Parent;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp Elastic trivia Formatting Rule";
 
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/QueryExpressionFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/QueryExpressionFormattingRule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp Query Expressions Formatting Rule";
 
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return nextOperation.Invoke();
         }
 
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -160,27 +160,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             AddSuppressWrappingIfOnSingleLineOperation(list, firstToken, lastToken);
         }
 
-        private void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
-        {
-            var bracePair = node.GetBracePair();
-            if (!bracePair.IsValidBracePair())
-            {
-                return;
-            }
-
-            var firstTokenOfNode = node.GetFirstToken(includeZeroWidth: true);
-
-            if (node.IsLambdaBodyBlock())
-            {
-                // include lambda itself.
-                firstTokenOfNode = node.Parent.GetFirstToken(includeZeroWidth: true);
-            }
-
-            // suppress wrapping on whole construct that owns braces and also brace pair itself if it is on same line
-            AddSuppressWrappingIfOnSingleLineOperation(list, firstTokenOfNode, bracePair.Item2);
-            AddSuppressWrappingIfOnSingleLineOperation(list, bracePair.Item1, bracePair.Item2);
-        }
-
         private void AddInitializerSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
         {
             // array or collection initializer case

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -14,13 +14,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp Suppress Formatting Rule";
 
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
 
             AddInitializerSuppressOperations(list, node);
 
-            AddBraceSuppressOperations(list, node);
+            AddBraceSuppressOperations(list, node, lastToken);
 
             AddStatementExceptBlockSuppressOperations(list, node);
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -101,27 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             AddSuppressWrappingIfOnSingleLineOperation(list, firstToken, lastToken);
         }
 
-        private void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
-        {
-            var bracePair = node.GetBracePair();
-            if (!bracePair.IsValidBracePair())
-            {
-                return;
-            }
-
-            var firstTokenOfNode = node.GetFirstToken(includeZeroWidth: true);
-
-            if (node.IsLambdaBodyBlock())
-            {
-                // include lambda itself.
-                firstTokenOfNode = node.Parent.GetFirstToken(includeZeroWidth: true);
-            }
-
-            // suppress wrapping on whole construct that owns braces and also brace pair itself if it is on same line
-            AddSuppressWrappingIfOnSingleLineOperation(list, firstTokenOfNode, bracePair.Item2);
-            AddSuppressWrappingIfOnSingleLineOperation(list, bracePair.Item1, bracePair.Item2);
-        }
-
         private void RemoveSuppressOperationForStatementMethodDeclaration(List<SuppressOperation> list, SyntaxNode node)
         {
             var statementNode = node as StatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -14,11 +14,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
     internal class WrappingFormattingRule : BaseFormattingRule
     {
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
 
-            AddBraceSuppressOperations(list, node);
+            AddBraceSuppressOperations(list, node, lastToken);
 
             AddStatementExceptBlockSuppressOperations(list, node);
 

--- a/src/Workspaces/Core/Portable/Formatting/BottomUpBaseIndentationFinder.cs
+++ b/src/Workspaces/Core/Portable/Formatting/BottomUpBaseIndentationFinder.cs
@@ -19,12 +19,14 @@ namespace Microsoft.CodeAnalysis.Formatting
         private readonly ChainedFormattingRules _formattingRules;
         private readonly int _tabSize;
         private readonly int _indentationSize;
+        private readonly SyntaxToken _lastToken;
 
         public BottomUpBaseIndentationFinder(
             ChainedFormattingRules formattingRules,
             int tabSize,
             int indentationSize,
-            TokenStream tokenStream)
+            TokenStream tokenStream,
+            SyntaxToken lastToken)
         {
             Contract.ThrowIfNull(formattingRules);
 
@@ -32,6 +34,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             _tabSize = tabSize;
             _indentationSize = indentationSize;
             _tokenStream = tokenStream;
+            _lastToken = lastToken;
         }
 
         public int? FromIndentBlockOperations(
@@ -209,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             // gather all indent operations 
             var list = new List<IndentBlockOperation>();
-            allNodes.Do(n => _formattingRules.AddIndentBlockOperations(list, n));
+            allNodes.Do(n => _formattingRules.AddIndentBlockOperations(list, n, _lastToken));
 
             // sort them in right order
             list.RemoveAll(CommonFormattingHelpers.IsNull);
@@ -247,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             while (currentNode != null)
             {
                 list.Clear();
-                _formattingRules.AddAlignTokensOperations(list, currentNode);
+                _formattingRules.AddAlignTokensOperations(list, currentNode, _lastToken);
 
                 if (list.Count == 0)
                 {
@@ -278,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             var currentNode = startNode;
             while (currentNode != null)
             {
-                _formattingRules.AddIndentBlockOperations(list, currentNode);
+                _formattingRules.AddIndentBlockOperations(list, currentNode, _lastToken);
 
                 if (list.Any(o => o != null && o.TextSpan.Contains(position)))
                 {

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.InitialContextFinder.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.InitialContextFinder.cs
@@ -22,11 +22,13 @@ namespace Microsoft.CodeAnalysis.Formatting
             private readonly TokenStream _tokenStream;
             private readonly ChainedFormattingRules _formattingRules;
             private readonly SyntaxNode _rootNode;
+            private readonly SyntaxToken _lastToken;
 
             public InitialContextFinder(
                 TokenStream tokenStream,
                 ChainedFormattingRules formattingRules,
-                SyntaxNode rootNode)
+                SyntaxNode rootNode,
+                SyntaxToken lastToken)
             {
                 Contract.ThrowIfNull(tokenStream);
                 Contract.ThrowIfNull(formattingRules);
@@ -35,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 _tokenStream = tokenStream;
                 _formattingRules = formattingRules;
                 _rootNode = rootNode;
+                _lastToken = lastToken;
             }
 
             public ValueTuple<List<IndentBlockOperation>, List<SuppressOperation>> Do(SyntaxToken startToken, SyntaxToken endToken)
@@ -76,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     node.DescendantNodesAndSelf(n => n != previous && n.Span.IntersectsWith(span) && !span.Contains(n.Span))
                         .Do(n =>
                             {
-                                _formattingRules.AddIndentBlockOperations(list, n);
+                                _formattingRules.AddIndentBlockOperations(list, n, _lastToken);
                                 foreach (var element in list)
                                 {
                                     if (element != null)
@@ -179,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 var currentIndentationNode = startNode;
                 while (currentIndentationNode != null)
                 {
-                    _formattingRules.AddSuppressOperations(list, currentIndentationNode);
+                    _formattingRules.AddSuppressOperations(list, currentIndentationNode, _lastToken);
 
                     list.RemoveAll(predicate);
                     if (list.Count > 0)

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return;
             }
 
-            var initialContextFinder = new InitialContextFinder(_tokenStream, formattingRules, rootNode);
+            var initialContextFinder = new InitialContextFinder(_tokenStream, formattingRules, rootNode, endToken);
             var results = initialContextFinder.Do(startToken, endToken);
 
             if (results.Item1 != null)
@@ -106,7 +106,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                                                 formattingRules,
                                                 this.OptionSet.GetOption(FormattingOptions.TabSize, _language),
                                                 this.OptionSet.GetOption(FormattingOptions.IndentationSize, _language),
-                                                _tokenStream);
+                                                _tokenStream,
+                                                endToken);
                 var initialIndentation = baseIndentationFinder.GetIndentationOfCurrentPosition(
                     rootNode,
                     initialOperation,

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 using (Logger.LogBlock(FunctionId.Formatting_CollectIndentBlock, cancellationToken))
                 {
-                    return AddOperations<IndentBlockOperation>(task.Result, (l, n) => _formattingRules.AddIndentBlockOperations(l, n), cancellationToken);
+                    return AddOperations<IndentBlockOperation>(task.Result, (l, n) => _formattingRules.AddIndentBlockOperations(l, n, _token2), cancellationToken);
                 }
             },
             cancellationToken);
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 using (Logger.LogBlock(FunctionId.Formatting_CollectSuppressOperation, cancellationToken))
                 {
-                    return AddOperations<SuppressOperation>(task.Result, (l, n) => _formattingRules.AddSuppressOperations(l, n), cancellationToken);
+                    return AddOperations<SuppressOperation>(task.Result, (l, n) => _formattingRules.AddSuppressOperations(l, n, _token2), cancellationToken);
                 }
             },
             cancellationToken);
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 using (Logger.LogBlock(FunctionId.Formatting_CollectAlignOperation, cancellationToken))
                 {
-                    var operations = AddOperations<AlignTokensOperation>(task.Result, (l, n) => _formattingRules.AddAlignTokensOperations(l, n), cancellationToken);
+                    var operations = AddOperations<AlignTokensOperation>(task.Result, (l, n) => _formattingRules.AddAlignTokensOperations(l, n, _token2), cancellationToken);
 
                     // make sure we order align operation from left to right
                     operations.Sort((o1, o2) => o1.BaseToken.Span.CompareTo(o2.BaseToken.Span));
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 using (Logger.LogBlock(FunctionId.Formatting_CollectAnchorOperation, cancellationToken))
                 {
-                    return AddOperations<AnchorIndentationOperation>(task.Result, (l, n) => _formattingRules.AddAnchorIndentationOperations(l, n), cancellationToken);
+                    return AddOperations<AnchorIndentationOperation>(task.Result, (l, n) => _formattingRules.AddAnchorIndentationOperations(l, n, _token2), cancellationToken);
                 }
             },
             cancellationToken);

--- a/src/Workspaces/Core/Portable/Formatting/Engine/ActionCache`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/ActionCache`1.cs
@@ -9,12 +9,12 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal class ActionCache<TArgument> : IActionHolder<TArgument>
     {
-        public Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> NextOperation { get; }
-        public Action<int, List<TArgument>, SyntaxNode, IActionHolder<TArgument>> Continuation { get; }
+        public Action<int, List<TArgument>, SyntaxNode, SyntaxToken, NextAction<TArgument>> NextOperation { get; }
+        public Action<int, List<TArgument>, SyntaxNode, SyntaxToken, IActionHolder<TArgument>> Continuation { get; }
 
         public ActionCache(
-            Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> nextOperation,
-            Action<int, List<TArgument>, SyntaxNode, IActionHolder<TArgument>> continuation)
+            Action<int, List<TArgument>, SyntaxNode, SyntaxToken, NextAction<TArgument>> nextOperation,
+            Action<int, List<TArgument>, SyntaxNode, SyntaxToken, IActionHolder<TArgument>> continuation)
         {
             this.NextOperation = nextOperation;
             this.Continuation = continuation;

--- a/src/Workspaces/Core/Portable/Formatting/Rules/AbstractFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/AbstractFormattingRule.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     /// </summary>
     internal abstract class AbstractFormattingRule : IFormattingRule
     {
-        public virtual void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public virtual void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
         }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/IActionHolder`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/IActionHolder`1.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 {
     internal interface IActionHolder<TArgument>
     {
-        Action<int, List<TArgument>, SyntaxNode, NextAction<TArgument>> NextOperation { get; }
-        Action<int, List<TArgument>, SyntaxNode, IActionHolder<TArgument>> Continuation { get; }
+        Action<int, List<TArgument>, SyntaxNode, SyntaxToken, NextAction<TArgument>> NextOperation { get; }
+        Action<int, List<TArgument>, SyntaxNode, SyntaxToken, IActionHolder<TArgument>> Continuation { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/IFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/IFormattingRule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// Returns SuppressWrappingIfOnSingleLineOperations under a node either by itself or by
         /// filtering/replacing operations returned by NextOperation
         /// </summary>
-        void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation);
+        void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation);
 
         /// <summary>
         /// returns AnchorIndentationOperations under a node either by itself or by filtering/replacing operations returned by NextOperation

--- a/src/Workspaces/Core/Portable/Formatting/Rules/NextAction`1.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/NextAction`1.cs
@@ -12,18 +12,20 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     {
         private readonly int _index;
         private readonly SyntaxNode _node;
+        private readonly SyntaxToken _lastToken;
         private readonly IActionHolder<TArgument> _actionCache;
 
-        public NextAction(int index, SyntaxNode node, IActionHolder<TArgument> actionCache)
+        public NextAction(int index, SyntaxNode node, SyntaxToken lastToken, IActionHolder<TArgument> actionCache)
         {
             _index = index;
             _node = node;
+            _lastToken = lastToken;
             _actionCache = actionCache;
         }
 
         public void Invoke(List<TArgument> arguments)
         {
-            _actionCache.Continuation(_index, arguments, _node, _actionCache);
+            _actionCache.Continuation(_index, arguments, _node, _lastToken, _actionCache);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/NoOpFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/NoOpFormattingRule.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 {
     internal class NoOpFormattingRule : IFormattingRule
     {
-        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+        public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
         {
             nextOperation.Invoke(list);
         }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/FormattingOperations.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/FormattingOperations.cs
@@ -161,48 +161,48 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// return SuppressOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static IEnumerable<SuppressOperation> GetSuppressOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, OptionSet optionSet)
+        internal static IEnumerable<SuppressOperation> GetSuppressOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, optionSet);
 
             var list = new List<SuppressOperation>();
-            chainedFormattingRules.AddSuppressOperations(list, node);
+            chainedFormattingRules.AddSuppressOperations(list, node, lastToken);
             return list;
         }
 
         /// <summary>
         /// return AnchorIndentationOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static IEnumerable<AnchorIndentationOperation> GetAnchorIndentationOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, OptionSet optionSet)
+        internal static IEnumerable<AnchorIndentationOperation> GetAnchorIndentationOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, optionSet);
 
             var list = new List<AnchorIndentationOperation>();
-            chainedFormattingRules.AddAnchorIndentationOperations(list, node);
+            chainedFormattingRules.AddAnchorIndentationOperations(list, node, lastToken);
             return list;
         }
 
         /// <summary>
         /// return IndentBlockOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static IEnumerable<IndentBlockOperation> GetIndentBlockOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, OptionSet optionSet)
+        internal static IEnumerable<IndentBlockOperation> GetIndentBlockOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, optionSet);
 
             var list = new List<IndentBlockOperation>();
-            chainedFormattingRules.AddIndentBlockOperations(list, node);
+            chainedFormattingRules.AddIndentBlockOperations(list, node, lastToken);
             return list;
         }
 
         /// <summary>
         /// return AlignTokensOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static IEnumerable<AlignTokensOperation> GetAlignTokensOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, OptionSet optionSet)
+        internal static IEnumerable<AlignTokensOperation> GetAlignTokensOperations(IEnumerable<IFormattingRule> formattingRules, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, optionSet);
 
             var list = new List<AlignTokensOperation>();
-            chainedFormattingRules.AddAlignTokensOperations(list, node);
+            chainedFormattingRules.AddAlignTokensOperations(list, node, lastToken);
             return list;
         }
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Sub AddSuppressOperations(operations As List(Of SuppressOperation), node As SyntaxNode, optionSet As OptionSet, nextAction As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
+        Public Sub AddSuppressOperations(operations As List(Of SuppressOperation), node As SyntaxNode, lastToken As SyntaxToken, optionSet As OptionSet, nextAction As NextAction(Of SuppressOperation)) Implements IFormattingRule.AddSuppressOperations
         End Sub
 
         Public Sub AddAnchorIndentationOperations(operations As List(Of AnchorIndentationOperation), node As SyntaxNode, optionSet As OptionSet, nextAction As NextAction(Of AnchorIndentationOperation)) Implements IFormattingRule.AddAnchorIndentationOperations

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation))
+        Public Overrides Sub AddSuppressOperations(list As List(Of SuppressOperation), node As SyntaxNode, lastToken As SyntaxToken, optionSet As OptionSet, nextOperation As NextAction(Of SuppressOperation))
             nextOperation.Invoke(list)
         End Sub
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/2837

Be more conservative about formatting braces across multiple lines wh… 

…en the tree has missing curlies.

This is to ensure that if you have

```cs
class C
{
    int Foo { get { return
}
```

And you type ```;``` after ```return``` that we don't place the get-accessor on multiple lines.
In this case the parser thinks the last curly brace belongs to the get-accessor (and thus we
used to naively think the get-accessor was on multiple lines).

Note: we customize our behavior here depending on which token you're typing.  If you're actually
typeing the close curly, then we assume the curly belongs to the nearest construct (and thus in
the above example the 'get-accessor' *would* be on multiple lines).  This is because it's unlikely
that you would have left the accessor in this unfinished state to go work on some other construct.

However, if you're not actually typing the close curly (and there are misisng close curlies), then
we'll conservatively assume that the close curly might not belong to us when determining if we
were written on a single line.

Note: most of the change here is simply due to having to pass along the information about what
token was being edited.
