### PR TITLE
Adjust implementation of OverloadResolution.GetParameterCounts to account for a situation when params parameter is used through a named argument.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1551,8 +1551,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (arguments.Count < declaredParameterCount)
                 {
-                    // params parameter isn't used (see ExpressionBinder::TryGetExpandedParams in the native compiler)
-                    parametersUsedIncludingExpansionAndOptional = declaredParameterCount - 1;
+                    ImmutableArray<int> argsToParamsOpt = m.Result.ArgsToParamsOpt;
+
+                    if (argsToParamsOpt.IsDefaultOrEmpty || !argsToParamsOpt.Contains(declaredParameterCount - 1))
+                    {
+                        // params parameter isn't used (see ExpressionBinder::TryGetExpandedParams in the native compiler)
+                        parametersUsedIncludingExpansionAndOptional = declaredParameterCount - 1;
+                    }
+                    else
+                    {
+                        // params parameter is used by a named argument
+                        parametersUsedIncludingExpansionAndOptional = declaredParameterCount;
+                    }
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -7894,6 +7894,32 @@ public class Test
                 );
         }
 
+        [Fact, WorkItem(4424, "https://github.com/dotnet/roslyn/issues/4424")]
+        public void TieBreakOnNumberOfDeclaredParameters_06()
+        {
+            string source1 = @"
+class Test
+{
+    static void Fn(string x = """", string y = """", params object[] p) 
+    { 
+        System.Console.WriteLine(1); 
+    }
+
+    static void Fn(string x, params object[] p)
+    { 
+        System.Console.WriteLine(2); 
+    }
+
+    static void Main()
+    { Fn(""Hello"", p: ""World""); }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugExe);
+
+            CompileAndVerify(compilation, expectedOutput: @"2");
+        }
+
         [Fact, WorkItem(1099752, "DevDiv"), WorkItem(2291, "https://github.com/dotnet/roslyn/issues/2291")]
         public void BetterErrorMessage_01()
         {


### PR DESCRIPTION
Fixes #4424.

@gafter, @VSadov, @jaredpar, @agocke Please review.  