### PR TITLE
Add padding around the lightbulb diff preview

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml
@@ -102,7 +102,8 @@
         </StackPanel>
         <DockPanel Name="PreviewDockPanel" DockPanel.Dock="Top" Visibility="Collapsed">
             <ScrollViewer Name="PreviewScrollViewer" IsTabStop="True"
-                          HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"/>
+                          HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                          Padding="3 1 3 1"/>
         </DockPanel>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Fixes internal bug 1175249

This makes it easier to distinguish the left/right sides of the
highlighted red/green indicators for changes from the outer border of
the larger preview pane, especially in High Contrast.