### PR TITLE
Stop throwing unreachable exceptions in AddImport codefix provider.

### DIFF
--- a/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -422,10 +422,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                 return $"using static {staticNamespaceString};";
             }
 
-            // If we get here then neither a namespace or an extern alias can be added.
-            // There is no valid string to show to the user and there is 
-            // likely a bug that we should know about.
-            throw ExceptionUtilities.Unreachable;
+            // We can't find a string to show to the user, we should not show this codefix.
+            return null;
         }
 
         protected override async Task<Document> AddImportAsync(

--- a/src/Features/Core/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -108,10 +108,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
                                 foreach (var import in proposedImports)
                                 {
-                                    var action = new MyCodeAction(this.GetDescription(import, semanticModel, node), (c) =>
-                                        this.AddImportAsync(node, import, document, placeSystemNamespaceFirst, cancellationToken));
-
-                                    context.RegisterCodeFix(action, diagnostic);
+                                    var description = this.GetDescription(import, semanticModel, node);
+                                    if (description != null)
+                                    {
+                                        var action = new MyCodeAction(description, (c) =>
+                                            this.AddImportAsync(node, import, document, placeSystemNamespaceFirst, cancellationToken));
+                                        context.RegisterCodeFix(action, diagnostic);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Instead, do not show the codefix if we are unable to find the correct string to display.

Fixes #4395 and internal bug 1188340

Note: this exception is never thrown for VB.