### PR TITLE
Clean up Interactive Exports/ContentTypes...

### DIFF
--- a/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
+++ b/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [Export]
     [ExportCommandHandler(PredefinedCommandHandlerNames.Completion, PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
     [Order(After = PredefinedCommandHandlerNames.SignatureHelp)]
     internal sealed class InteractiveCompletionCommandHandler : AbstractCompletionCommandHandler

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
     /// buffers that have been reset but which we still want to look good.
     /// </summary>
     [Export(typeof(IClassifierProvider))]
-    [ContentType(ContentTypeNames.RoslynContentType)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     internal partial class InertClassifierProvider : IClassifierProvider
     {

--- a/src/VisualStudio/CSharp/Repl/CSharpInteractiveCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpInteractiveCommandHandler.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
 {
-    [ExportCommandHandler("Interactive Command Handler", ContentTypeNames.CSharpContentType)]
+    [ExportCommandHandler("Interactive Command Handler")]
     internal sealed class CSharpInteractiveCommandHandler : InteractiveCommandHandler
     {
         private readonly CSharpVsInteractiveWindowProvider _interactiveWindowProvider;

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
@@ -10,7 +10,7 @@ Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Interactive
 
-    <ExportCommandHandler("Interactive Command Handler", ContentTypeNames.VisualBasicContentType)>
+    <ExportCommandHandler("Interactive Command Handler")>
     Friend NotInheritable Class VisualBasicInteractiveCommandHandler
         Inherits InteractiveCommandHandler
 


### PR DESCRIPTION
These changes should prevent us from prematurely loading the Interactive
dlls when opening a C# project (before the Interactive Window is open).