### PR TITLE
Remove ReadLine from AsyncWithShortCircuiting003

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -923,7 +923,6 @@ namespace AsyncConditionalBug
         static void Main(string[] args)
         {
             new Program().AsyncMethod().Wait();
-            Console.ReadLine();
         }
     }
 }";


### PR DESCRIPTION
...so that it doesn't wait indefinitely.