### PR TITLE
Clean up Interactive Exports/ContentTypes...

### DIFF
--- a/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
+++ b/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.InteractiveWindow.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [Export]
     [ExportCommandHandler(PredefinedCommandHandlerNames.Completion, PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
     [Order(After = PredefinedCommandHandlerNames.SignatureHelp)]
     internal sealed class InteractiveCompletionCommandHandler : AbstractCompletionCommandHandler

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
@@ -16,8 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
     /// buffers that have been reset but which we still want to look good.
     /// </summary>
     [Export(typeof(IClassifierProvider))]
-    [ContentType(ContentTypeNames.RoslynContentType)]
-    [TextViewRole(PredefinedTextViewRoles.Document)]
+    [TextViewRole(PredefinedInteractiveTextViewRoles.InteractiveTextViewRole)]
     internal partial class InertClassifierProvider : IClassifierProvider
     {
         private static readonly object s_classificationsKey = new object();

--- a/src/VisualStudio/CSharp/Repl/CSharpInteractiveCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpInteractiveCommandHandler.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
 {
-    [ExportCommandHandler("Interactive Command Handler", ContentTypeNames.CSharpContentType)]
+    [ExportCommandHandler("Interactive Command Handler")]
     internal sealed class CSharpInteractiveCommandHandler : InteractiveCommandHandler
     {
         private readonly CSharpVsInteractiveWindowProvider _interactiveWindowProvider;

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
@@ -10,7 +10,7 @@ Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Interactive
 
-    <ExportCommandHandler("Interactive Command Handler", ContentTypeNames.VisualBasicContentType)>
+    <ExportCommandHandler("Interactive Command Handler")>
     Friend NotInheritable Class VisualBasicInteractiveCommandHandler
         Inherits InteractiveCommandHandler
 


### PR DESCRIPTION
These changes should prevent us from prematurely loading the Interactive
dlls when opening a C# project (before the Interactive Window is open).