### PR TITLE
Remove serialization from Features layer

### DIFF
--- a/src/Features/Core/EditAndContinue/Deltas.cs
+++ b/src/Features/Core/EditAndContinue/Deltas.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {

--- a/src/Features/Core/EditAndContinue/ILDelta.cs
+++ b/src/Features/Core/EditAndContinue/ILDelta.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    [Serializable]
     internal struct ILDelta
     {
         public readonly byte[] Value;

--- a/src/Features/Core/EditAndContinue/MetadataDelta.cs
+++ b/src/Features/Core/EditAndContinue/MetadataDelta.cs
@@ -1,30 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.Serialization;
-
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    [Serializable]
-    internal struct MetadataDelta : ISerializable
+    internal struct MetadataDelta
     {
         public readonly byte[] Bytes;
 
         public MetadataDelta(byte[] bytes)
         {
             this.Bytes = bytes;
-        }
-
-        private MetadataDelta(SerializationInfo info, StreamingContext context)
-        {
-            this.Bytes = (byte[])info.GetValue("bytes", typeof(byte[]));
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("bytes", Bytes, typeof(byte[]));
         }
     }
 }

--- a/src/Features/Core/EditAndContinue/PdbDelta.cs
+++ b/src/Features/Core/EditAndContinue/PdbDelta.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    [Serializable]
-    internal struct PdbDelta : ISerializable
+    internal struct PdbDelta
     {
         // Tokens of updated methods. The debugger enumerates this list 
         // updated methods containing active statements.
@@ -19,18 +16,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             this.Stream = stream;
             this.UpdatedMethods = updatedMethods;
-        }
-
-        private PdbDelta(SerializationInfo info, StreamingContext context)
-        {
-            this.Stream = new MemoryStream((byte[])info.GetValue("bytes", typeof(byte[])));
-            this.UpdatedMethods = (int[])info.GetValue("methods", typeof(int[]));
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("bytes", Stream.GetBuffer(), typeof(byte[]));
-            info.AddValue("methods", UpdatedMethods, typeof(int[]));
         }
     }
 }

--- a/src/Tools/Source/DebuggerVisualizers/IL/ILDeltaDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/IL/ILDeltaDebuggerVisualizer.cs
@@ -1,25 +1,29 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
+using System.IO;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.VisualStudio.DebuggerVisualizers;
 using Roslyn.DebuggerVisualizers;
 using Roslyn.DebuggerVisualizers.UI;
-using Roslyn.Test.MetadataUtilities;
 
-[assembly: DebuggerVisualizer(typeof(ILDebuggerVisualizer), Target = typeof(ILDelta), Description = "IL Visualizer")]
+[assembly: DebuggerVisualizer(
+    typeof(ILDeltaDebuggerVisualizer),
+    typeof(ILDeltaVisualizerObjectSource),
+    Target = typeof(ILDelta),
+    Description = "IL Visualizer")]
 
 namespace Roslyn.DebuggerVisualizers
 {
-    public sealed class ILDebuggerVisualizer : DialogDebuggerVisualizer
+    public sealed class ILDeltaDebuggerVisualizer : DialogDebuggerVisualizer
     {
         protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
         {
-            StringBuilder sb = new StringBuilder();
-            var ilBytes = ((ILDelta)objectProvider.GetObject()).Value;
-            var viewer = new TextViewer(ImmutableArray.Create(ilBytes).GetMethodIL(), "IL");
+            var stream = objectProvider.GetData();
+            var reader = new StreamReader(stream);
+            var text = reader.ReadToEnd();
+
+            var viewer = new TextViewer(text, "IL");
             viewer.ShowDialog();
         }
     }

--- a/src/Tools/Source/DebuggerVisualizers/IL/ILDeltaVisualizerObjectSource.cs
+++ b/src/Tools/Source/DebuggerVisualizers/IL/ILDeltaVisualizerObjectSource.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.VisualStudio.DebuggerVisualizers;
+using Roslyn.Test.MetadataUtilities;
+
+namespace Roslyn.DebuggerVisualizers
+{
+    public sealed class ILDeltaVisualizerObjectSource : VisualizerObjectSource
+    {
+        public override void GetData(object target, Stream outgoingData)
+        {
+            var ilDelta = (ILDelta)target;
+            var text = ImmutableArray.Create(ilDelta.Value).GetMethodIL();
+
+            var writer = new StreamWriter(outgoingData);
+            writer.Write(text);
+            writer.Flush();
+        }
+    }
+}

--- a/src/Tools/Source/DebuggerVisualizers/Install.cmd
+++ b/src/Tools/Source/DebuggerVisualizers/Install.cmd
@@ -1,6 +1,6 @@
 @echo off
 set VISUALIZERS=%USERPROFILE%\Documents\Visual Studio 2015\Visualizers
-set BIN=%~dp0..\..\..\Binaries\Debug
+set BIN=%~dp0..\..\..\..\Binaries\Debug
 
 copy /y "%BIN%\Roslyn.DebuggerVisualizers.dll" "%VISUALIZERS%"
 copy /y "%BIN%\Roslyn.Test.PdbUtilities.dll" "%VISUALIZERS%"

--- a/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaDebuggerVisualizer.cs
@@ -1,35 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.VisualStudio.DebuggerVisualizers;
 using Roslyn.DebuggerVisualizers;
 using Roslyn.DebuggerVisualizers.UI;
-using Roslyn.Test.MetadataUtilities;
 
 [assembly: DebuggerVisualizer(
     typeof(MetadataDeltaDebuggerVisualizer),
+    typeof(MetadataDeltaVisualizerObjectSource),
     Target = typeof(MetadataDelta),
-    Description = "PDB Visualizer")]
+    Description = "Metadata Visualizer")]
 
 namespace Roslyn.DebuggerVisualizers
 {
     public sealed class MetadataDeltaDebuggerVisualizer : DialogDebuggerVisualizer
     {
-        unsafe protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
+        protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
         {
-            var md = (MetadataDelta)objectProvider.GetObject();
-            var writer = new StringWriter();
-            fixed (byte* ptr = md.Bytes)
-            {
-                var reader = new MetadataReader(ptr, md.Bytes.Length, MetadataReaderOptions.ApplyWindowsRuntimeProjections);
-                var visualizer = new MetadataVisualizer(reader, writer);
-                visualizer.Visualize();
-            }
-            var viewer = new TextViewer(writer.ToString(), "Metadata");
+            var stream = objectProvider.GetData();
+            var reader = new StreamReader(stream);
+            var text = reader.ReadToEnd();
+
+            var viewer = new TextViewer(text, "Metadata");
             viewer.ShowDialog();
         }
     }

--- a/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaVisualizerObjectSource.cs
+++ b/src/Tools/Source/DebuggerVisualizers/Metadata/MetadataDeltaVisualizerObjectSource.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.VisualStudio.DebuggerVisualizers;
+using Roslyn.Test.MetadataUtilities;
+
+namespace Roslyn.DebuggerVisualizers
+{
+    public sealed class MetadataDeltaVisualizerObjectSource : VisualizerObjectSource
+    {
+        public override void GetData(object target, Stream outgoingData)
+        {
+            var metadataDelta = (MetadataDelta)target;
+            var text = GetMetadataText(metadataDelta);
+
+            var writer = new StreamWriter(outgoingData);
+            writer.Write(text);
+            writer.Flush();
+        }
+
+        private static unsafe string GetMetadataText(MetadataDelta metadataDelta)
+        {
+            var writer = new StringWriter();
+
+            fixed (byte* ptr = metadataDelta.Bytes)
+            {
+                var reader = new MetadataReader(ptr, metadataDelta.Bytes.Length, MetadataReaderOptions.ApplyWindowsRuntimeProjections);
+                var visualizer = new MetadataVisualizer(reader, writer);
+                visualizer.Visualize();
+            }
+
+            return writer.ToString();
+        }
+    }
+}

--- a/src/Tools/Source/DebuggerVisualizers/PDB/PdbDeltaDebuggerVisualizer.cs
+++ b/src/Tools/Source/DebuggerVisualizers/PDB/PdbDeltaDebuggerVisualizer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.EditAndContinue;
@@ -10,21 +11,22 @@ using Roslyn.DebuggerVisualizers.UI;
 using Roslyn.Test.PdbUtilities;
 
 [assembly: DebuggerVisualizer(
-    typeof(PdbDebuggerVisualizer),
+    typeof(PdbDeltaDebuggerVisualizer),
+    typeof(PdbDeltaVisualizerObjectSource),
     Target = typeof(PdbDelta),
     Description = "PDB Visualizer")]
 
 namespace Roslyn.DebuggerVisualizers
 {
-    public sealed class PdbDebuggerVisualizer : DialogDebuggerVisualizer
+    public sealed class PdbDeltaDebuggerVisualizer : DialogDebuggerVisualizer
     {
         protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
         {
-            StringBuilder sb = new StringBuilder();
-            var pdb = (PdbDelta)objectProvider.GetObject();
-            string xml = PdbToXmlConverter.DeltaPdbToXml(pdb.Stream, Enumerable.Range(0x06000001, 0xff));
+            var stream = objectProvider.GetData();
+            var reader = new StreamReader(stream);
+            var text = reader.ReadToEnd();
 
-            var viewer = new TextViewer(xml, "PDB");
+            var viewer = new TextViewer(text, "PDB");
             viewer.ShowDialog();
         }
     }

--- a/src/Tools/Source/DebuggerVisualizers/PDB/PdbDeltaVisualizerObjectSource.cs
+++ b/src/Tools/Source/DebuggerVisualizers/PDB/PdbDeltaVisualizerObjectSource.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.VisualStudio.DebuggerVisualizers;
+using Roslyn.Test.PdbUtilities;
+
+namespace Roslyn.DebuggerVisualizers
+{
+    public sealed class PdbDeltaVisualizerObjectSource : VisualizerObjectSource
+    {
+        public override void GetData(object target, Stream outgoingData)
+        {
+            var pdbDelta = (PdbDelta)target;
+            var text = PdbToXmlConverter.DeltaPdbToXml(pdbDelta.Stream, Enumerable.Range(0x06000001, 0xff));
+
+            var writer = new StreamWriter(outgoingData);
+            writer.Write(text);
+            writer.Flush();
+        }
+    }
+}

--- a/src/Tools/Source/DebuggerVisualizers/Roslyn.DebuggerVisualizers.csproj
+++ b/src/Tools/Source/DebuggerVisualizers/Roslyn.DebuggerVisualizers.csproj
@@ -43,7 +43,9 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=$(SystemCollectionsImmutableAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -59,9 +61,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="IL\ILDebuggerVisualizer.cs" />
+    <Compile Include="IL\ILDeltaDebuggerVisualizer.cs" />
+    <Compile Include="IL\ILDeltaVisualizerObjectSource.cs" />
     <Compile Include="Metadata\MetadataDeltaDebuggerVisualizer.cs" />
-    <Compile Include="PDB\PdbDebuggerVisualizer.cs" />
+    <Compile Include="Metadata\MetadataDeltaVisualizerObjectSource.cs" />
+    <Compile Include="PDB\PdbDeltaDebuggerVisualizer.cs" />
+    <Compile Include="PDB\PdbDeltaVisualizerObjectSource.cs" />
     <Compile Include="UI\TextViewer.cs">
       <SubType>form</SubType>
     </Compile>


### PR DESCRIPTION
Addresses #4354 and needed for #3998.

A few of the ENC types were marked as [Serializable] so that they worked within custom debugger visualizers. This change adds custom serialization to the debugger visualizers so that the types no longer need to be marked as [Serializable].

Reviewers: @tmat, @jaredpar, @Pilchie 