### PR TITLE
Better handle missing tokens when formatting so that we can respect options like "use tabs".

### DIFF
--- a/src/Features/VisualBasic/ExtractMethod/VisualBasicMethodExtractor.vb
+++ b/src/Features/VisualBasic/ExtractMethod/VisualBasicMethodExtractor.vb
@@ -140,9 +140,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return nextOperation.Invoke()
             End Function
 
-            Private Function IsLessThanInAttribute(commonToken As SyntaxToken) As Boolean
+            Private Function IsLessThanInAttribute(token As SyntaxToken) As Boolean
                 ' < in attribute
-                Dim token = CType(commonToken, SyntaxToken)
                 If token.Kind = SyntaxKind.LessThanToken AndAlso
                    token.Parent.Kind = SyntaxKind.AttributeList AndAlso
                    DirectCast(token.Parent, AttributeListSyntax).LessThanToken.Equals(token) Then

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.DocumentationCommentExteriorCommentRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.DocumentationCommentExteriorCommentRewriter.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    internal partial class CSharpTriviaFormatter : AbstractTriviaFormatter<SyntaxTrivia>
+    internal partial class CSharpTriviaFormatter
     {
         private class DocumentationCommentExteriorCommentRewriter : CSharpSyntaxRewriter
         {

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -210,11 +210,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override LineColumnDelta Format(
-            LineColumn lineColumn, SyntaxTrivia commonTrivia, List<SyntaxTrivia> changes,
+            LineColumn lineColumn, SyntaxTrivia trivia, List<SyntaxTrivia> changes,
             CancellationToken cancellationToken)
         {
-            var trivia = (SyntaxTrivia)commonTrivia;
-
             if (trivia.HasStructure)
             {
                 return FormatStructuredTrivia(lineColumn, trivia, changes, cancellationToken);
@@ -232,10 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override LineColumnDelta Format(
-            LineColumn lineColumn, SyntaxTrivia commonTrivia, List<TextChange> changes, CancellationToken cancellationToken)
+            LineColumn lineColumn, SyntaxTrivia trivia, List<TextChange> changes, CancellationToken cancellationToken)
         {
-            var trivia = (SyntaxTrivia)commonTrivia;
-
             if (trivia.HasStructure)
             {
                 return FormatStructuredTrivia(lineColumn, trivia, changes, cancellationToken);
@@ -248,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return GetLineColumnDelta(lineColumn, newComment);
             }
 
-            return GetLineColumnDelta(lineColumn, commonTrivia);
+            return GetLineColumnDelta(lineColumn, trivia);
         }
 
         private SyntaxTrivia FormatDocumentComment(LineColumn lineColumn, SyntaxTrivia trivia)

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -11,7 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    internal partial class CSharpTriviaFormatter : AbstractTriviaFormatter<SyntaxTrivia>
+    internal partial class CSharpTriviaFormatter : AbstractTriviaFormatter
     {
         private bool _succeeded = true;
 
@@ -68,11 +68,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             return _newLine;
-        }
-
-        protected override SyntaxTrivia Convert(SyntaxTrivia trivia)
-        {
-            return (SyntaxTrivia)trivia;
         }
 
         protected override LineColumnRule GetLineColumnRuleBetween(SyntaxTrivia trivia1, LineColumnDelta existingWhitespaceBetween, bool implicitLineBreak, SyntaxTrivia trivia2)

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.cs
@@ -40,7 +40,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                 var result = default(AnalysisResult);
 
-                Analyze(token1.TrailingTrivia, ref result);
+                if (token1.IsMissing && token1.FullWidth() == 0)
+                {
+                    // Consider the following case:
+                    //
+                    //          return // <- note the missing semicolon
+                    //      }
+                    //
+                    // in this case, the compiler will insert a missing semicolon token at the 
+                    // start of the line containing the close curly.  This is problematic as it
+                    // means that if we're looking at the token-pair for the semicolon and close-
+                    // curly, then we'll think there is no newline here.  Because we think there
+                    // is no newline, we won't attempt to indent in a manner that preserves tabs
+                    // (if the user has 'use tabs for indent' enabled).
+                    //
+                    // Here we detect if our previous token is an empty missing token.  If so,
+                    // we look back to the previous non-missing token to see if it ends with a
+                    // newline.  If so, we keep track of that so we'll appropriately indent later
+                    // on. 
+
+                    var previousNonMissingToken = token1.GetPreviousToken(includeZeroWidth: false, includeSkipped: true);
+                    if (previousNonMissingToken.TrailingTrivia.Count > 0 &&
+                        previousNonMissingToken.TrailingTrivia.Last().Kind() == SyntaxKind.EndOfLineTrivia)
+                    {
+                        result.LineBreaks = 1;
+                    }
+                }
+                else
+                {
+                    Analyze(token1.TrailingTrivia, ref result);
+                }
+
                 Analyze(token2.LeadingTrivia, ref result);
 
                 return result;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -31,10 +31,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             public static bool ShouldFormatSingleLine(TriviaList list)
             {
-                foreach (var commonTrivia in list)
+                foreach (var trivia in list)
                 {
-                    var trivia = (SyntaxTrivia)commonTrivia;
-
                     Contract.ThrowIfTrue(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
                     Contract.ThrowIfTrue(trivia.Kind() == SyntaxKind.SkippedTokensTrivia);
                     Contract.ThrowIfTrue(trivia.Kind() == SyntaxKind.PreprocessingMessageTrivia);
@@ -75,10 +73,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             public static bool ContainsSkippedTokensOrText(TriviaList list)
             {
-                foreach (var commonTrivia in list)
+                foreach (var trivia in list)
                 {
-                    var trivia = (SyntaxTrivia)commonTrivia;
-
                     if (trivia.Kind() == SyntaxKind.SkippedTokensTrivia ||
                         trivia.Kind() == SyntaxKind.PreprocessingMessageTrivia)
                     {
@@ -273,10 +269,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             private bool ShouldFormat()
             {
                 var index = -1;
-                foreach (var commonTrivia in _triviaList)
+                foreach (var trivia in _triviaList)
                 {
                     index++;
-                    var trivia = (SyntaxTrivia)commonTrivia;
 
                     // order in which these methods run has a side effect. don't change the order
                     // each method run

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         /// represents a general trivia between two tokens. slightly more expensive than others since it
         /// needs to calculate stuff unlike other cases
         /// </summary>
-        private class ComplexTrivia : AbstractComplexTrivia<SyntaxToken, SyntaxTrivia>
+        private class ComplexTrivia : AbstractComplexTrivia
         {
             public ComplexTrivia(OptionSet optionSet, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2) :
                 base(optionSet, treeInfo, token1, token2)
@@ -31,16 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             protected override void ExtractLineAndSpace(string text, out int lines, out int spaces)
             {
                 text.ProcessTextBetweenTokens(this.TreeInfo, this.Token1, this.OptionSet.GetOption(FormattingOptions.TabSize, LanguageNames.CSharp), out lines, out spaces);
-            }
-
-            protected override SyntaxToken ConvertToken(SyntaxToken token)
-            {
-                return token;
-            }
-
-            protected override SyntaxTrivia ConvertTrivia(SyntaxTrivia trivia)
-            {
-                return trivia;
             }
 
             protected override TriviaData CreateComplexTrivia(int line, int space)
@@ -58,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return new ModifiedComplexTrivia(this.OptionSet, this, line, space);
             }
 
-            protected override TriviaDataWithList<SyntaxTrivia> Format(
+            protected override TriviaDataWithList Format(
                 FormattingContext context, ChainedFormattingRules formattingRules, int lines, int spaces, CancellationToken cancellationToken)
             {
                 return new FormattedComplexTrivia(context, formattingRules, this.Token1, this.Token2, lines, spaces, this.OriginalString, cancellationToken);

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
     internal partial class TriviaDataFactory
     {
-        private class FormattedComplexTrivia : TriviaDataWithList<SyntaxTrivia>
+        private class FormattedComplexTrivia : TriviaDataWithList
         {
             private readonly CSharpTriviaFormatter _formatter;
             private readonly IList<TextChange> _textChanges;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
     internal partial class TriviaDataFactory
     {
-        private class ModifiedComplexTrivia : TriviaDataWithList<SyntaxTrivia>
+        private class ModifiedComplexTrivia : TriviaDataWithList
         {
             private readonly ComplexTrivia _original;
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return ValueTuple.Create(default(SyntaxTriviaList), GetLeadingTriviaAtBeginningOfTree(pair.Key, pair.Value, cancellationToken));
             }
 
-            var csharpTriviaData = pair.Value as TriviaDataWithList<SyntaxTrivia>;
+            var csharpTriviaData = pair.Value as TriviaDataWithList;
             if (csharpTriviaData != null)
             {
                 var triviaList = csharpTriviaData.GetTriviaList(cancellationToken);
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             TriviaData triviaData,
             CancellationToken cancellationToken)
         {
-            var csharpTriviaData = triviaData as TriviaDataWithList<SyntaxTrivia>;
+            var csharpTriviaData = triviaData as TriviaDataWithList;
             if (csharpTriviaData != null)
             {
                 return SyntaxFactory.TriviaList(csharpTriviaData.GetTriviaList(cancellationToken));

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6399,5 +6399,25 @@ class Program
 }";
             AssertFormat(expected, code, changedOptionSet: changingOptions);
         }
+        
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormattingCodeWithMissingTokensShouldRespectFormatTabsOption1()
+        {
+            var optionSet = new Dictionary<OptionKey, object> { { new OptionKey(FormattingOptions.UseTabs, LanguageNames.CSharp), true } };
+
+            AssertFormat(@"class Program
+{
+	static void Main()
+	{
+		return // Note the missing semicolon
+	} // The tab here should stay a tab
+}", @"class Program
+{
+	static void Main()
+	{
+		return // Note the missing semicolon
+	} // The tab here should stay a tab
+}", changedOptionSet: optionSet);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal abstract partial class AbstractTriviaDataFactory
     {
-        protected abstract class AbstractComplexTrivia<TToken, TTrivia> : TriviaDataWithList<TTrivia>
+        protected abstract class AbstractComplexTrivia : TriviaDataWithList
         {
             private readonly SyntaxToken _token1;
             private readonly SyntaxToken _token2;
@@ -41,54 +41,21 @@ namespace Microsoft.CodeAnalysis.Formatting
                 this.Spaces = spaces;
             }
 
-            protected abstract TToken ConvertToken(SyntaxToken token);
-            protected abstract SyntaxTrivia ConvertTrivia(TTrivia trivia);
-
             protected abstract void ExtractLineAndSpace(string text, out int lines, out int spaces);
             protected abstract TriviaData CreateComplexTrivia(int line, int space);
             protected abstract TriviaData CreateComplexTrivia(int line, int space, int indentation);
-            protected abstract TriviaDataWithList<TTrivia> Format(FormattingContext context, ChainedFormattingRules formattingRules, int lines, int spaces, CancellationToken cancellationToken);
+            protected abstract TriviaDataWithList Format(FormattingContext context, ChainedFormattingRules formattingRules, int lines, int spaces, CancellationToken cancellationToken);
             protected abstract bool ContainsSkippedTokensOrText(TriviaList list);
 
-            public TToken Token1
-            {
-                get
-                {
-                    return ConvertToken(_token1);
-                }
-            }
+            public SyntaxToken Token1 => _token1;
 
-            public TToken Token2
-            {
-                get
-                {
-                    return ConvertToken(_token2);
-                }
-            }
+            public SyntaxToken Token2 => _token2;
 
-            public override bool TreatAsElastic
-            {
-                get
-                {
-                    return _treatAsElastic;
-                }
-            }
+            public override bool TreatAsElastic => _treatAsElastic;
 
-            public override bool IsWhitespaceOnlyTrivia
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            public override bool IsWhitespaceOnlyTrivia => false;
 
-            public override bool ContainsChanges
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            public override bool ContainsChanges => false;
 
             public override TriviaData WithSpace(int space, FormattingContext context, ChainedFormattingRules formattingRules)
             {
@@ -188,15 +155,14 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return CreateComplexTrivia(lineBreaks, spaces, indentation);
             }
 
-            private string CreateString(TriviaDataWithList<TTrivia> triviaData, CancellationToken cancellationToken)
+            private string CreateString(TriviaDataWithList triviaData, CancellationToken cancellationToken)
             {
                 // create string from given trivia data
                 var sb = StringBuilderPool.Allocate();
 
                 foreach (var trivia in triviaData.GetTriviaList(cancellationToken))
                 {
-                    var commonTrivia = ConvertTrivia(trivia);
-                    sb.Append(commonTrivia.ToFullString());
+                    sb.Append(trivia.ToFullString());
                 }
 
                 return StringBuilderPool.ReturnAndFree(sb);

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TriviaDataWithList.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TriviaDataWithList.cs
@@ -3,18 +3,16 @@
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal abstract class TriviaDataWithList<T> : TriviaData
+    internal abstract class TriviaDataWithList : TriviaData
     {
         public TriviaDataWithList(OptionSet optionSet, string language)
             : base(optionSet, language)
         {
         }
 
-        public abstract List<T> GetTriviaList(CancellationToken cancellationToken);
+        public abstract List<SyntaxTrivia> GetTriviaList(CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -14,7 +14,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal abstract class AbstractTriviaFormatter<TTrivia> where TTrivia : struct
+    internal abstract class AbstractTriviaFormatter
     {
         #region Caches
         private static readonly string[] s_spaceCache;
@@ -160,11 +160,6 @@ namespace Microsoft.CodeAnalysis.Formatting
         protected abstract bool IsNewLine(char ch);
 
         /// <summary>
-        /// convert common syntax trivia to SyntaxTrivia
-        /// </summary>
-        protected abstract TTrivia Convert(SyntaxTrivia trivia);
-
-        /// <summary>
         /// create whitespace trivia
         /// </summary>
         protected abstract SyntaxTrivia CreateWhitespace(string text);
@@ -240,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             get { return this.Context.TokenStream; }
         }
 
-        public List<TTrivia> FormatToSyntaxTrivia(CancellationToken cancellationToken)
+        public List<SyntaxTrivia> FormatToSyntaxTrivia(CancellationToken cancellationToken)
         {
             var changes = ListPool<SyntaxTrivia>.Allocate();
 
@@ -252,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             if (Succeeded())
             {
-                var temp = new List<TTrivia>(changes.Select(Convert));
+                var temp = new List<SyntaxTrivia>(changes);
                 ListPool<SyntaxTrivia>.Free(changes);
 
                 return temp;
@@ -261,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             ListPool<SyntaxTrivia>.Free(changes);
 
             var triviaList = new TriviaList(this.Token1.TrailingTrivia, this.Token2.LeadingTrivia);
-            return new List<TTrivia>(triviaList.Select(Convert));
+            return new List<SyntaxTrivia>(triviaList);
         }
 
         public List<TextChange> FormatToTextChanges(CancellationToken cancellationToken)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         ''' needs to calculate stuff unlike other cases
         ''' </summary>
         Private Class ComplexTrivia
-            Inherits AbstractComplexTrivia(Of SyntaxToken, SyntaxTrivia)
+            Inherits AbstractComplexTrivia
 
             Public Sub New(optionSet As OptionSet, treeInfo As TreeData, token1 As SyntaxToken, token2 As SyntaxToken)
                 MyBase.New(optionSet, treeInfo, token1, token2)
@@ -30,14 +30,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Protected Overrides Sub ExtractLineAndSpace(text As String, ByRef lines As Integer, ByRef spaces As Integer)
                 text.ProcessTextBetweenTokens(Me.TreeInfo, Me.Token1, Me.OptionSet.GetOption(FormattingOptions.TabSize, LanguageNames.VisualBasic), lines, spaces)
             End Sub
-
-            Protected Overrides Function ConvertToken(token As SyntaxToken) As SyntaxToken
-                Return token
-            End Function
-
-            Protected Overrides Function ConvertTrivia(trivia As SyntaxTrivia) As SyntaxTrivia
-                Return trivia
-            End Function
 
             Protected Overrides Function CreateComplexTrivia(line As Integer, space As Integer) As TriviaData
                 Return New ModifiedComplexTrivia(Me.OptionSet, Me, line, space)
@@ -61,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                                                 formattingRules As ChainedFormattingRules,
                                                 lines As Integer,
                                                 spaces As Integer,
-                                                cancellationToken As CancellationToken) As TriviaDataWithList(Of SyntaxTrivia)
+                                                cancellationToken As CancellationToken) As TriviaDataWithList
                 Return New FormattedComplexTrivia(context, formattingRules, Me.Token1, Me.Token2, lines, spaces, Me.OriginalString, cancellationToken)
             End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.Text
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class TriviaDataFactory
         Private Class FormattedComplexTrivia
-            Inherits TriviaDataWithList(Of SyntaxTrivia)
+            Inherits TriviaDataWithList
 
             Private ReadOnly _formatter As VisualBasicTriviaFormatter
             Private ReadOnly _textChanges As IList(Of TextChange)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
@@ -14,7 +14,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class TriviaDataFactory
         Private Class ModifiedComplexTrivia
-            Inherits TriviaDataWithList(Of SyntaxTrivia)
+            Inherits TriviaDataWithList
 
             Private ReadOnly _original As ComplexTrivia
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.TriviaRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.TriviaRewriter.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                                                                                     GetSyntaxTriviaList(GetTextSpan(pair.Key), pair.Value, _cancellationToken))
                 End If
 
-                Dim vbTriviaData = TryCast(pair.Value, TriviaDataWithList(Of SyntaxTrivia))
+                Dim vbTriviaData = TryCast(pair.Value, TriviaDataWithList)
                 If vbTriviaData IsNot Nothing Then
                     Dim triviaList = vbTriviaData.GetTriviaList(_cancellationToken)
                     Dim index = GetIndexForEndOfLeadingTrivia(triviaList)
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             End Function
 
             Private Function GetSyntaxTriviaList(textSpan As TextSpan, triviaData As TriviaData, cancellationToken As CancellationToken) As SyntaxTriviaList
-                Dim vbTriviaData = TryCast(triviaData, TriviaDataWithList(Of SyntaxTrivia))
+                Dim vbTriviaData = TryCast(triviaData, TriviaDataWithList)
                 If vbTriviaData IsNot Nothing Then
                     Return SyntaxFactory.TriviaList(vbTriviaData.GetTriviaList(cancellationToken))
                 End If

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -15,7 +15,7 @@ Imports Microsoft.VisualBasic
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class VisualBasicTriviaFormatter
-        Inherits AbstractTriviaFormatter(Of SyntaxTrivia)
+        Inherits AbstractTriviaFormatter
 
         Private _lineContinuationTrivia As SyntaxTrivia = SyntaxFactory.LineContinuationTrivia("_")
         Private _newLine As SyntaxTrivia
@@ -50,10 +50,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         Protected Overrides Function IsNewLine(ch As Char) As Boolean
             Return SyntaxFacts.IsNewLine(ch)
-        End Function
-
-        Protected Overrides Function Convert(trivia As SyntaxTrivia) As SyntaxTrivia
-            Return trivia
         End Function
 
         Protected Overrides Function CreateWhitespace(text As String) As SyntaxTrivia


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/4014