### PR TITLE
Stop reporting unused usings in submissions

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/ScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/ScriptTests.cs
@@ -582,9 +582,6 @@ class CLS
                     // (1,7): error CS0246: The type or namespace name 'Unknown' could not be found (are you missing a using directive or an assembly reference?)
                     // using Unknown;
                     Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unknown").WithArguments("Unknown").WithLocation(1, 7),
-                    // (1,1): hidden CS8019: Unnecessary using directive.
-                    // using Unknown;
-                    Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Unknown;").WithLocation(1, 1),
             };
 
             // Emit produces the same diagnostics as GetDiagnostics (below).

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -1383,7 +1383,7 @@ class A
                 Diagnostic(ErrorCode.WRN_MainIgnored, "Main").WithArguments("A.Main()").WithLocation(4, 17));
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Unknown)]
+        [ClrOnlyFact(ClrOnlyReason.Submission)]
         public void GetEntryPoint_Submission()
         {
             var source = @"1 + 1";
@@ -1402,7 +1402,7 @@ class A
             entryPoint.Diagnostics.Verify();
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Unknown)]
+        [ClrOnlyFact(ClrOnlyReason.Submission)]
         public void GetEntryPoint_Submission_MainIgnored()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -358,5 +358,26 @@ using System;
                 // using System;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithWarningAsError(false));
         }
+
+        [Fact]
+        public void UnusedUsingInteractive()
+        {
+            var tree = Parse("using System;", options: TestOptions.Interactive);
+            var comp = CSharpCompilation.CreateSubmission("sub1", tree, new[] { MscorlibRef_v4_0_30316_17626 });
+
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UnusedUsingScript()
+        {
+            var tree = Parse("using System;", options: TestOptions.Script);
+            var comp = CreateCompilationWithMscorlib(tree);
+
+            comp.VerifyDiagnostics(
+                // (2,1): info CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;"));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -359,7 +359,7 @@ using System;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithWarningAsError(false));
         }
 
-        [Fact]
+        [ClrOnlyFact(ClrOnlyReason.Submission)]
         public void UnusedUsingInteractive()
         {
             var tree = Parse("using System;", options: TestOptions.Interactive);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -3685,7 +3685,7 @@ o.F();";
             compilation.VerifyDiagnostics();
         }
 
-        [ClrOnlyFact]
+        [ClrOnlyFact(ClrOnlyReason.Submission)]
         public void InteractiveExtensionMethods()
         {
             var parseOptions = TestOptions.Interactive;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
@@ -111,10 +111,7 @@ Bar::NS.Foo d = new Bar::NS.Foo();
             comp.VerifyDiagnostics(
                 // (1,1): error CS7015: 'extern alias' is not valid in this context
                 // extern alias Bar;
-                Diagnostic(ErrorCode.ERR_ExternAliasNotAllowed, "extern alias Bar;"),
-                // (1,1): info CS8020: Unused extern alias.
-                // extern alias Bar;
-                Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias Bar;"));
+                Diagnostic(ErrorCode.ERR_ExternAliasNotAllowed, "extern alias Bar;"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
@@ -98,7 +98,7 @@ Bar::NS.Foo d = new Bar::NS.Foo();
             comp.VerifyDiagnostics();
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Unknown)]
+        [ClrOnlyFact(ClrOnlyReason.Submission)]
         public void ExternAliasInInteractive_Error()
         {
             var src = "extern alias Bar;";

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -300,5 +300,24 @@ Imports System
             ' With doc comments.
             CreateCompilationWithMscorlib(source, parseOptions:=New VisualBasicParseOptions(documentationMode:=DocumentationMode.Diagnose)).AssertTheseDiagnostics(<errors></errors>, suppressInfos:=False)
         End Sub
+
+        <Fact()>
+        Public Sub UnusedImportInteractive()
+            Dim tree = Parse("Imports System", options:=TestOptions.Interactive)
+            Dim compilation = VisualBasicCompilation.CreateSubmission("sub1", tree, {MscorlibRef_v4_0_30316_17626})
+            compilation.AssertNoDiagnostics(suppressInfos:=False)
+        End Sub
+
+        <Fact()>
+        Public Sub UnusedImportScript()
+            Dim tree = Parse("Imports System", options:=TestOptions.Script)
+            Dim compilation = CreateCompilationWithMscorlib(tree)
+            compilation.AssertTheseDiagnostics(
+                <errors>
+BC50001: Unused import statement.
+Imports System
+~~~~~~~~~~~~~~
+                </errors>, suppressInfos:=False)
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -301,7 +301,7 @@ Imports System
             CreateCompilationWithMscorlib(source, parseOptions:=New VisualBasicParseOptions(documentationMode:=DocumentationMode.Diagnose)).AssertTheseDiagnostics(<errors></errors>, suppressInfos:=False)
         End Sub
 
-        <Fact()>
+        <ClrOnlyFact(ClrOnlyReason.Submission)>
         Public Sub UnusedImportInteractive()
             Dim tree = Parse("Imports System", options:=TestOptions.Interactive)
             Dim compilation = VisualBasicCompilation.CreateSubmission("sub1", tree, {MscorlibRef_v4_0_30316_17626})

--- a/src/Test/Utilities/Desktop/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Desktop/ConditionalFactAttribute.cs
@@ -35,6 +35,9 @@ namespace Roslyn.Test.Utilities
 
         // Can't sign. 
         Signing,
+
+        // Can't find System.Object when compiling a submission (not understood).
+        Submission,
     }
 
     public class ClrOnlyFact : FactAttribute


### PR DESCRIPTION
Since they can be used in subsequent submissions, they are always
considered to be used.

Fixes #4392