### PR TITLE
Escape System.Delegate when it is committed without qualification

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6627,5 +6627,21 @@ End Class]]>
             Dim expectedDescription = $"Property C.x As Integer"
             VerifyItemInLinkedFiles(markup, "x", expectedDescription)
         End Sub
+
+        <WorkItem(4405, "https://github.com/dotnet/roslyn/issues/4405")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub VerifyDelegateEscapedWhenCommitted()
+            Dim text =
+<code><![CDATA[
+Imports System
+Module Module1
+    Sub Main()
+        Dim x As {0}
+    End Sub
+End Module
+
+]]></code>.Value
+            VerifyProviderCommit(String.Format(text, "$$"), "Delegate", String.Format(text, "[Delegate]"), Nothing, "")
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6641,7 +6641,11 @@ Module Module1
 End Module
 
 ]]></code>.Value
-            VerifyProviderCommit(String.Format(text, "$$"), "Delegate", String.Format(text, "[Delegate]"), Nothing, "")
+            VerifyProviderCommit(markupBeforeCommit:=String.Format(text, "$$"),
+                                 itemToCommit:="Delegate",
+                                 expectedCodeAfterCommit:=String.Format(text, "[Delegate]"),
+                                 commitChar:=Nothing,
+                                 textTypedSoFar:="")
         End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Extensions/StringExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/StringExtensions.vb
@@ -108,8 +108,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                      SpecialType.System_Char,
                      SpecialType.System_String,
                      SpecialType.System_Enum,
-                     SpecialType.System_Object,
-                     SpecialType.System_Delegate
+                     SpecialType.System_Object
                     Return True
                 Case Else
                     Return False


### PR DESCRIPTION
The helper used to determine if completion should escape a type erroneously returned true for System.Delegate.
Fixes #4405.

Reviewers: @balajikris @brettfo @CyrusNajmabadi  @daveaglick  @dpoeschl @DustinCampbell @jasonmalinowski @Pilchie 