### PR TITLE
Enable horizontal scrolling in Interactive Window

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -88,11 +88,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             _textView.Caret.PositionChanged += CaretPositionChanged;
 
-            _textView.Options.SetOptionValue(DefaultTextViewHostOptions.HorizontalScrollBarId, false);
+            _textView.Options.SetOptionValue(DefaultTextViewHostOptions.HorizontalScrollBarId, true);
             _textView.Options.SetOptionValue(DefaultTextViewHostOptions.LineNumberMarginId, false);
             _textView.Options.SetOptionValue(DefaultTextViewHostOptions.OutliningMarginId, false);
             _textView.Options.SetOptionValue(DefaultTextViewHostOptions.GlyphMarginId, false);
-            _textView.Options.SetOptionValue(DefaultTextViewOptions.WordWrapStyleId, WordWrapStyles.WordWrap);
+            _textView.Options.SetOptionValue(DefaultTextViewOptions.WordWrapStyleId, WordWrapStyles.None);
 
             _lineBreakString = _textView.Options.GetNewLineCharacter();
             _dangerous_uiOnly.EditorOperations = editorOperationsFactory.GetEditorOperations(_textView); // Constructor runs on UI thread.


### PR DESCRIPTION
It still doesn't reflect the word wrap settings, but at least the default
behavior matches the editor.