### PR TITLE
Properly ref count diagnostic taggers.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -94,14 +94,20 @@ class Program
 
             using (var workspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml))
             {
-                var analyzerMap = ImmutableDictionary.CreateBuilder<string, ImmutableArray<DiagnosticAnalyzer>>();
-                analyzerMap.Add(LanguageNames.CSharp,
-                    ImmutableArray.Create<DiagnosticAnalyzer>(
-                        new CSharpSimplifyTypeNamesDiagnosticAnalyzer(),
-                        new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer()));
+                var analyzerMap = new Dictionary<string, DiagnosticAnalyzer[]>
+                {
+                    {
+                        LanguageNames.CSharp,
+                        new DiagnosticAnalyzer[]
+                        {
+                            new CSharpSimplifyTypeNamesDiagnosticAnalyzer(),
+                            new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer()
+                        }
+                    }
+                };
 
                 var spans =
-                    GetErrorSpans(workspace, analyzerMap.ToImmutable())
+                    GetErrorSpans(workspace, analyzerMap)
                         .OrderBy(s => s.Span.Span.Start).ToImmutableArray();
 
                 Assert.Equal(3, spans.Length);

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 _notificationService.RegisterNotification(() =>
                     {
                         _workQueue.AssertIsForeground();
-                        ReportChangedSpan(new SnapshotSpan(snapshot, 0, snapshot.Length));
+                        ReportChangedSpan(snapshot.GetFullSpan());
                     },
                     ReportChangeDelayInMilliseconds,
                     _listener.BeginAsyncOperation("ReportEntireFileChanged"),

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         {
             var tagger = buffer.Properties.GetOrCreateSingletonProperty(
                 _uniqueKey, () => new AggregatingTagger(this, buffer));
+            tagger.OnTaggerCreated();
             return tagger as IAccurateTagger<T>;
         }
 

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTagger.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             {
                 // TODO: call the handler only if the spans affect this buffer
                 var snapshot = _buffer.CurrentSnapshot;
-                handler(this, new SnapshotSpanEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length)));
+                handler(this, new SnapshotSpanEventArgs(snapshot.GetFullSpan()));
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     {
                         // We will compute the new read only regions to be all spans that are not currently in an editable span
                         var editableSpans = GetEditableSpansForSnapshot(_subjectBuffer.CurrentSnapshot);
-                        var entireBufferSpan = new NormalizedSnapshotSpanCollection(new SnapshotSpan(_subjectBuffer.CurrentSnapshot, 0, _subjectBuffer.CurrentSnapshot.Length));
+                        var entireBufferSpan = _subjectBuffer.CurrentSnapshot.GetSnapshotSpanCollection();
                         var newReadOnlySpans = NormalizedSnapshotSpanCollection.Difference(entireBufferSpan, new NormalizedSnapshotSpanCollection(editableSpans));
 
                         foreach (var newReadOnlySpan in newReadOnlySpans)

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Taggers/AbstractRenameTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Taggers/AbstractRenameTagger.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             var tagsChanged = TagsChanged;
             if (tagsChanged != null)
             {
-                tagsChanged(this, new SnapshotSpanEventArgs(new SnapshotSpan(_buffer.CurrentSnapshot, 0, _buffer.CurrentSnapshot.Length)));
+                tagsChanged(this, new SnapshotSpanEventArgs(_buffer.CurrentSnapshot.GetFullSpan()));
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
@@ -103,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
                 // The elision buffer is too long.  We've already trimmed it, but now we want to add
                 // a "..." to it.  We do that by creating a projection of both the elision buffer and
                 // a new text buffer wrapping the ellipsis.
-                var elisionSpan = new SnapshotSpan(elisionBuffer.CurrentSnapshot, 0, elisionBuffer.CurrentSnapshot.Length);
+                var elisionSpan = elisionBuffer.CurrentSnapshot.GetFullSpan();
 
                 var sourceSpans = new List<object>()
                 {

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/NagivateToHighlightReferenceCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/NagivateToHighlightReferenceCommandHandler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Outlining;
@@ -63,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
                     return;
                 }
 
-                var spans = GetTags(tagAggregator, new SnapshotSpan(args.TextView.TextSnapshot, 0, args.TextView.TextSnapshot.Length)).ToList();
+                var spans = GetTags(tagAggregator, args.TextView.TextSnapshot.GetFullSpan()).ToList();
 
                 Contract.ThrowIfFalse(spans.Any(), "We should have at least found the tag under the cursor!");
 

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
@@ -47,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             SnapshotPoint? caretPosition = null,
             TextChangeRange? textChangeRange = null,
             CancellationToken cancellationToken = default(CancellationToken))
-            : this(null, new[] { new DocumentSnapshotSpan(document, new SnapshotSpan(snapshot, 0, snapshot.Length)) }, 
+            : this(null, new[] { new DocumentSnapshotSpan(document, snapshot.GetFullSpan()) }, 
                   caretPosition, textChangeRange, null, cancellationToken)
         {
         }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 {
-    public class DiagnosticTagSourceTests
+    public class DiagnosticsSquiggleTaggerProviderTests
     {
         private class TaggerWrapper : IDisposable
         {

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.Utilities;
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                     wrapper.WaitForTags();
 
                     var snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
-                    var spans = tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(snapshot, 0, snapshot.Length))).ToList();
+                    var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
                     Assert.True(spans.First().Span.Contains(new Span(0, 1)));
 
                     // test second update
@@ -131,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                     wrapper.WaitForTags();
 
                     snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
-                    spans = tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(snapshot, 0, snapshot.Length))).ToList();
+                    spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
                     Assert.True(spans.First().Span.Contains(new Span(0, 1)));
                 }
             }
@@ -155,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                     wrapper.WaitForTags();
 
                     var snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
-                    var spans = tagger2.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(snapshot, 0, snapshot.Length))).ToList();
+                    var spans = tagger2.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
                     Assert.False(spans.IsEmpty());
                 }
             }

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -253,7 +253,7 @@
     <Compile Include="Diagnostics\DiagnosticProviderTestUtilities.cs" />
     <Compile Include="Diagnostics\DiagnosticServiceTests.cs" />
     <Compile Include="Diagnostics\DiagnosticStateTests.cs" />
-    <Compile Include="Diagnostics\DiagnosticTagSourceTests.cs" />
+    <Compile Include="Diagnostics\DiagnosticsSquiggleTaggerProviderTests.cs" />
     <Compile Include="Diagnostics\GenerateType\GenerateTypeTestState.cs" />
     <Compile Include="Diagnostics\GenerateType\TestGenerateTypeOptionsService.cs" />
     <Compile Include="Diagnostics\GenerateType\TestProjectManagementService.cs" />

--- a/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
             var elisionBuffer = IProjectionBufferFactoryServiceExtensions.CreateElisionBufferWithoutIndentation(
                 exportProvider.GetExportedValue<IProjectionBufferFactoryService>(),
                 exportProvider.GetExportedValue<IEditorOptionsFactoryService>().GlobalOptions,
-                new SnapshotSpan(textBuffer.CurrentSnapshot, new Span(0, textBuffer.CurrentSnapshot.Length)));
+                textBuffer.CurrentSnapshot.GetFullSpan());
 
             var elisionSnapshot = elisionBuffer.CurrentSnapshot;
             Assert.Equal(elisionSnapshot.LineCount, 3);

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Differencing;
@@ -258,12 +259,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 
                         // check left buffer
                         var leftSnapshot = leftBuffer.CurrentSnapshot;
-                        var leftSpans = leftTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(leftSnapshot, 0, leftSnapshot.Length))).ToList();
+                        var leftSpans = leftTagger.GetTags(leftSnapshot.GetSnapshotSpanCollection()).ToList();
                         Assert.Equal(1, leftSpans.Count);
 
                         // check right buffer
                         var rightSnapshot = rightBuffer.CurrentSnapshot;
-                        var rightSpans = rightTagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(rightSnapshot, 0, rightSnapshot.Length))).ToList();
+                        var rightSpans = rightTagger.GetTags(rightSnapshot.GetSnapshotSpanCollection()).ToList();
                         Assert.Equal(0, rightSpans.Count);
                     }
                 }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor.VisualBasic.RenameTracking;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.UnitTests.Diagnostics;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
@@ -142,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
         {
             WaitForAsyncOperations();
 
-            var tags = _tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(_view.TextBuffer.CurrentSnapshot, new Span(0, _view.TextBuffer.CurrentSnapshot.Length))));
+            var tags = _tagger.GetTags(_view.TextBuffer.CurrentSnapshot.GetSnapshotSpanCollection());
 
             Assert.Equal(0, tags.Count());
         }
@@ -158,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
         {
             WaitForAsyncOperations();
 
-            var tags = _tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(_view.TextBuffer.CurrentSnapshot, new Span(0, _view.TextBuffer.CurrentSnapshot.Length))));
+            var tags = _tagger.GetTags(_view.TextBuffer.CurrentSnapshot.GetSnapshotSpanCollection());
 
             // There should only ever be one tag
             Assert.Equal(1, tags.Count());

--- a/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
+++ b/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.Utilities;
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
                     wrapper.WaitForTags();
 
                     var snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
-                    var spans = tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(snapshot, 0, snapshot.Length))).ToList();
+                    var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
 
                     return spans;
                 }
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
                     wrapper.WaitForTags();
 
                     var snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
-                    var spans = tagger.GetTags(new NormalizedSnapshotSpanCollection(new SnapshotSpan(snapshot, 0, snapshot.Length))).ToImmutableArray();
+                    var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToImmutableArray();
 
                     return spans;
                 }

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -1690,8 +1690,7 @@ static class E
 
         Private Shared Function GetTagsOfType(expectedTagType As ITextMarkerTag, renameService As InlineRenameService, textBuffer As ITextBuffer) As IEnumerable(Of Span)
             Dim tagger = New RenameTagger(textBuffer, renameService)
-            Dim snapshotSpan = New SnapshotSpan(textBuffer.CurrentSnapshot, 0, textBuffer.CurrentSnapshot.Length)
-            Dim tags = tagger.GetTags(New NormalizedSnapshotSpanCollection(snapshotSpan))
+            Dim tags = tagger.GetTags(textBuffer.CurrentSnapshot.GetSnapshotSpanCollection())
 
             Return (From tag In tags
                     Where tag.Tag Is expectedTagType

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
         Public Function GetRenameTrackingTags(tagger As ITagger(Of RenameTrackingTag), workspace As TestWorkspace, document As TestHostDocument) As IEnumerable(Of ITagSpan(Of RenameTrackingTag))
             WaitForRename(workspace)
             Dim view = document.GetTextView()
-            Return tagger.GetTags(New NormalizedSnapshotSpanCollection(New SnapshotSpan(view.TextBuffer.CurrentSnapshot, New Span(0, view.TextBuffer.CurrentSnapshot.Length))))
+            Return tagger.GetTags(view.TextBuffer.CurrentSnapshot.GetSnapshotSpanCollection())
         End Function
     End Module
 End Namespace

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -86,11 +86,6 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
             return new SnapshotSpan(snapshot, span);
         }
 
-        public static SnapshotSpan GetFullSpan(this ITextSnapshot snapshot)
-        {
-            return snapshot.GetSpan(0, snapshot.Length);
-        }
-
         public static ITagSpan<TTag> GetTagSpan<TTag>(this ITextSnapshot snapshot, Span span, TTag tag)
             where TTag : ITag
         {
@@ -114,11 +109,18 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
             return new SnapshotSpan(snapshot, Span.FromBounds(startPosition.Value, endPosition.Value));
         }
 
-        public static SnapshotSpan GetSpan(this ITextSnapshot snapshot)
+        public static SnapshotSpan GetFullSpan(this ITextSnapshot snapshot)
         {
             Contract.ThrowIfNull(snapshot);
 
             return new SnapshotSpan(snapshot, new Span(0, snapshot.Length));
+        }
+
+        public static NormalizedSnapshotSpanCollection GetSnapshotSpanCollection(this ITextSnapshot snapshot)
+        {
+            Contract.ThrowIfNull(snapshot);
+
+            return new NormalizedSnapshotSpanCollection(snapshot.GetFullSpan());
         }
 
         public static void GetLineAndColumn(this ITextSnapshot snapshot, int position, out int lineNumber, out int columnIndex)

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Text.Operations
@@ -66,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     Dim buffer = args.SubjectBuffer
                     Dim snapshot = buffer.CurrentSnapshot
 
-                    Dim wholeFile = New SnapshotSpan(snapshot, 0, snapshot.Length)
+                    Dim wholeFile = snapshot.GetFullSpan()
                     Dim commitBufferManager = _bufferManagerFactory.CreateForBuffer(buffer)
                     commitBufferManager.ExpandDirtyRegion(wholeFile)
                     commitBufferManager.CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)

--- a/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             End Using
         End Function
 
-        Private Function ProduceSquiggles(analyzerMap As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer)), ParamArray lines As String()) As IEnumerable(Of ITagSpan(Of IErrorTag))
+        Private Function ProduceSquiggles(analyzerMap As Dictionary(Of String, DiagnosticAnalyzer()), ParamArray lines As String()) As IEnumerable(Of ITagSpan(Of IErrorTag))
             Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromLines(lines)
                 Return GetErrorSpans(workspace, analyzerMap)
             End Using
@@ -71,13 +71,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
         <Fact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Sub SuggestionTagsForUnnecessaryCode()
 
-            Dim analyzerMap = ImmutableDictionary.CreateBuilder(Of String, ImmutableArray(Of DiagnosticAnalyzer))
+            Dim analyzerMap = New Dictionary(Of String, DiagnosticAnalyzer())
             analyzerMap.Add(LanguageNames.VisualBasic,
-                    ImmutableArray.Create(Of DiagnosticAnalyzer)(
+                    {
                         New VisualBasicSimplifyTypeNamesDiagnosticAnalyzer(),
-                        New VisualBasicRemoveUnnecessaryImportsDiagnosticAnalyzer()))
+                        New VisualBasicRemoveUnnecessaryImportsDiagnosticAnalyzer()
+                    })
 
-            Dim spans = ProduceSquiggles(analyzerMap.ToImmutable(),
+            Dim spans = ProduceSquiggles(analyzerMap,
 "
 ' System.Diagnostics is used - rest are unused.
 Imports System.Diagnostics

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InertClassifierProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             var classifier = classifierAggregator.GetClassifier(textView);
             try
             {
-                var classifications = classifier.GetClassificationSpans(textBuffer.CurrentSnapshot.GetSpan());
+                var classifications = classifier.GetClassificationSpans(textBuffer.CurrentSnapshot.GetFullSpan());
                 textBuffer.Properties.AddProperty(s_classificationsKey, classifications);
             }
             finally

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Debugging;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -143,7 +144,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     {
                         var subjectBuffer = wpfTextView.TextBuffer;
                         var snapshot = subjectBuffer.CurrentSnapshot;
-                        var fullSpan = new SnapshotSpan(snapshot, start: 0, length: snapshot.Length);
+                        var fullSpan = snapshot.GetFullSpan();
                         var tagger = outliningTaggerProvider.CreateTagger<IOutliningRegionTag>(subjectBuffer);
                         using (var disposable = tagger as IDisposable)
                         {

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.Tagger.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.Tagger.cs
@@ -33,8 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                 {
                     if (TagsChanged != null)
                     {
-                        var span = new SnapshotSpan(_textBuffer.CurrentSnapshot, new Span(0, _textBuffer.CurrentSnapshot.Length));
-                        TagsChanged(this, new SnapshotSpanEventArgs(new SnapshotSpan(_textBuffer.CurrentSnapshot, span)));
+                        var span = _textBuffer.CurrentSnapshot.GetFullSpan();
+                        TagsChanged(this, new SnapshotSpanEventArgs(span));
                     }
                 }
             }

--- a/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Tagging
@@ -49,7 +50,7 @@ class 123 { }
                     listener.CreateWaitTask().PumpingWait()
 
                     Dim snapshot = buffer.CurrentSnapshot
-                    Dim spans = tagger.GetTags(New NormalizedSnapshotSpanCollection(New SnapshotSpan(snapshot, 0, snapshot.Length))).ToImmutableArray()
+                    Dim spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToImmutableArray()
 
                     Assert.True(spans.Count() > 0)
                     Assert.True(spans.All(Function(s) s.Span.Length > 0))


### PR DESCRIPTION
I noticed a case where diagnostic tags weren't appearing.  I worked a bit and found a repro where we had multiple active taggers handed out, but one was disposed.  Because the taggers were sharing state, this meant that all active taggers were effectively 'disposed'.

I've added a proper refcounting scheme so that we don't actually release the tagger resources if there are outstanding taggers needing them.  

--

I recommend reading this review one commit at a time.

Fixes https://github.com/dotnet/roslyn/issues/4724