### PR TITLE
Don't include `public` accessiblity modifier in completion inside an interface

### DIFF
--- a/src/EditorFeatures/CSharpTest/Recommendations/PublicKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/PublicKeywordRecommenderTests.cs
@@ -183,7 +183,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public void InsideInterface()
         {
-            VerifyKeyword(
+            VerifyAbsence(
 @"interface I {
    $$");
         }

--- a/src/Features/CSharp/Completion/KeywordRecommenders/PublicKeywordRecommender.cs
+++ b/src/Features/CSharp/Completion/KeywordRecommenders/PublicKeywordRecommender.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             if (context.SyntaxTree.IsGlobalMemberDeclarationContext(context.Position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
                 context.IsMemberDeclarationContext(
                     validModifiers: SyntaxKindSet.AllMemberModifiers,
-                    validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations,
+                    validTypeDeclarations: SyntaxKindSet.ClassStructTypeDeclarations,
                     canBePartial: false,
                     cancellationToken: cancellationToken))
             {


### PR DESCRIPTION
Fixes #732.

C# completion list must not suggest `public` as a potential accessibility modifier to use inside an `interface { }` block; otherwise, it produces code that does not compile.

Note that there was an incorrect test here, which expected that `public` **would** be included in an `interface`. Reading the description of #732, this simply seems to be based on a confusion of resolved accessibility vs. legal modifiers.
