### PR TITLE
Fix Native View tests on x64

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
@@ -47,9 +48,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     var children = GetChildren(evalResult, inspectionContext);
                     if (enableNativeDebugging)
                     {
+                        string pointerString = $"(IUnknown*){PointerToString(new IntPtr(0xfe))}";
                         DkmLanguage language = new DkmLanguage(new DkmCompilerId(DkmVendorId.Microsoft, DkmLanguageId.Cpp));
                         Verify(children,
-                            EvalIntermediateResult("Native View", "{C++}(IUnknown*)0x000000FE", "(IUnknown*)0x000000FE", language));
+                            EvalIntermediateResult("Native View", "{C++}" + pointerString, pointerString, language));
                     }
                     else
                     {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/NativeViewExpansion.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return new EvalResultDataItem(Resources.NativeView, Resources.NativeViewNotNativeDebugging);
             }
 
-            var name = "(IUnknown*)0x" + string.Format(IntPtr.Size == 4 ? "{0:X8}" : "{0:X16}", comObject.NativeComPointer);
+            var name = "(IUnknown*)0x" + string.Format(IntPtr.Size == 4 ? "{0:x8}" : "{0:x16}", comObject.NativeComPointer);
             var fullName = "{C++}" + name;
 
             return new EvalResultDataItem(

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -331,7 +331,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private static string ToString(DkmEvaluationResult result)
         {
             var success = result as DkmSuccessEvaluationResult;
-            return (success != null) ? ToString(success) : ToString((DkmFailedEvaluationResult)result);
+            if (success != null) return ToString(success);
+
+            var intermediate = result as DkmIntermediateEvaluationResult;
+            if (intermediate != null) return ToString(intermediate);
+
+            return ToString((DkmFailedEvaluationResult)result);
         }
 
         private static string ToString(DkmSuccessEvaluationResult result)
@@ -365,6 +370,33 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 builder.Append(", ");
                 builder.Append(Quote(result.EditableValue));
+            }
+            builder.Append(")");
+            return pooledBuilder.ToStringAndFree();
+        }
+
+        private static string ToString(DkmIntermediateEvaluationResult result)
+        {
+            var pooledBuilder = PooledStringBuilder.GetInstance();
+            var builder = pooledBuilder.Builder;
+            builder.Append("IntermediateEvalResult(");
+            builder.Append(Quote(result.Name));
+            builder.Append(", ");
+            builder.Append(Quote(result.Expression));
+            if (result.Type != null)
+            {
+                builder.Append(", ");
+                builder.Append(Quote(result.Type));
+            }
+            if (result.FullName != null)
+            {
+                builder.Append(", ");
+                builder.Append(Quote(Escape(result.FullName)));
+            }
+            if (result.Flags != DkmEvaluationResultFlags.None)
+            {
+                builder.Append(", ");
+                builder.Append(FormatEnumValue(result.Flags));
             }
             builder.Append(")");
             return pooledBuilder.ToStringAndFree();


### PR DESCRIPTION
Pointer width was hardcoded - switched to using ```PointerToString```.

Bonus: Fix cast exception in attempt to report the failure.
Bonus: Make Native View hex lowercase to match the rest of the
ResultProvider.