### PR TITLE
Fix attributes on ReplCommandCompletionProvider...

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Completion/CompletionProviders/ReplCommandCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Completion/CompletionProviders/ReplCommandCompletionProvider.cs
@@ -13,15 +13,19 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.CompletionProviders
 {
-    [Order(Before = PredefinedCompletionProviderNames.Keyword)]
     [ExportCompletionProvider("ReplCommandCompletionProvider", LanguageNames.CSharp)]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    [TextViewRole(PredefinedInteractiveTextViewRoles.InteractiveTextViewRole)]
+    [Order(Before = PredefinedCompletionProviderNames.Keyword)]
     internal class ReplCommandCompletionProvider : AbstractCompletionProvider
     {
         private async Task<TextSpan> GetTextChangeSpanAsync(Document document, int position, CancellationToken cancellationToken)


### PR DESCRIPTION
Third time's a charm...

I don't know why this wasn't repro'ing on my machine, but the completion provider triggers loading of the REPL dlls on the RPS machines.  We shouldn't need to import these unless we're in the Interactive Window.