### PR TITLE
Use object.Equals when comparing diag arguments

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2042,6 +2042,25 @@ public class Test
             Assert.Equal(1, compilation.GetDiagnostics().Length);
         }
 
+        [Fact]
+        public void TestArgumentEquality()
+        {
+            var text = @"
+using System;
+
+public class Test
+{
+    public static void Main()
+    {
+        (Console).WriteLine();
+    }
+}";
+            var tree = Parse(text);
+
+            // (8,10): error CS0119: 'Console' is a type, which is not valid in the given context
+            AssertEx.Equal(CreateCompilationWithMscorlib(tree).GetDiagnostics(), CreateCompilationWithMscorlib(tree).GetDiagnostics());
+        }
+
         #region Mocks
         internal class CustomErrorInfo : DiagnosticInfo
         {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis
                     result = true;
                     for (int i = 0; i < _arguments.Length; i++)
                     {
-                        if (_arguments[i] != other._arguments[i])
+                        if (!object.Equals(_arguments[i], other._arguments[i]))
                         {
                             result = false;
                             break;


### PR DESCRIPTION
```LocalizableErrorArgument```, in particular, will not be ReferenceEquals
across 	```DiagnosticInfo``` instantiations.