### PR TITLE
PDB path padding

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6232,7 +6232,7 @@ class Program3
 
             using (var peFile = File.OpenRead(exe.Path))
             {
-                PdbValidation.ValidateDebugDirectory(peFile, pdb.Path, isPortable: false);
+                PdbValidation.ValidateDebugDirectory(peFile, pdb.Path, isPortable: false, isDeterministic: false);
             }
 
             Assert.True(new FileInfo(exe.Path).Length < oldSize);
@@ -6243,7 +6243,7 @@ class Program3
 
             using (var peFile = File.OpenRead(exe.Path))
             {
-                PdbValidation.ValidateDebugDirectory(peFile, pdb.Path, isPortable: false);
+                PdbValidation.ValidateDebugDirectory(peFile, pdb.Path, isPortable: false, isDeterministic: false);
             }
         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1805,6 +1805,8 @@ namespace Microsoft.CodeAnalysis
             return new EmitResult(success, diagnostics.ToReadOnlyAndFree());
         }
 
+        internal bool IsEmitDeterministic => this.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
         internal bool SerializeToPeStream(
             CommonPEModuleBuilder moduleBeingBuilt,
             EmitStreamProvider peStreamProvider,
@@ -1825,7 +1827,7 @@ namespace Microsoft.CodeAnalysis
             Stream portablePdbTempStream = null;
             Stream peTempStream = null;
 
-            bool deterministic = this.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+            bool deterministic = IsEmitDeterministic;
             bool emitPortablePdb = moduleBeingBuilt.EmitOptions.DebugInformationFormat == DebugInformationFormat.PortablePdb;
             string pdbPath = (pdbStreamProvider != null) ? (moduleBeingBuilt.EmitOptions.PdbFilePath ?? FileNameUtilities.ChangeExtension(SourceModule.Name, "pdb")) : null;
 

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -28,6 +28,13 @@ namespace Microsoft.Cci
         private const string RelocationSectionName = ".reloc";
 
         /// <summary>
+        /// Minimal size of PDB path in Debug Directory. We pad the path to this minimal size to
+        /// allow some tools to patch the path without the need to rewrite the entire image.
+        /// This is a workaround put in place until these tools are retired.
+        /// </summary>
+        private readonly int _minPdbPath;
+
+        /// <summary>
         /// True if we should attempt to generate a deterministic output (no timestamps or random data).
         /// </summary>
         private readonly bool _deterministic;
@@ -53,6 +60,8 @@ namespace Microsoft.Cci
             _pdbPathOpt = pdbPathOpt;
             _deterministic = deterministic;
 
+            // The PDB padding workaround is only needed for legacy tools that don't use deterministic build.
+            _minPdbPath = deterministic ? 0 : 260;
             _nativeResourcesOpt = nativeResourcesOpt;
             _nativeResourceSectionOpt = nativeResourceSectionOpt;
             _is32bit = !_properties.Requires64bits;
@@ -457,8 +466,7 @@ namespace Microsoft.Cci
                 4 +              // 4B signature "RSDS"
                 16 +             // GUID
                 sizeof(uint) +   // Age
-                Encoding.UTF8.GetByteCount(_pdbPathOpt) +
-                1;               // Null terminator
+                Math.Max(BlobUtilities.GetUTF8ByteCount(_pdbPathOpt) + 1, _minPdbPath);
         }
 
         private int ComputeSizeOfDebugDirectory()
@@ -1380,8 +1388,12 @@ namespace Microsoft.Cci
             writer.WriteUInt32(PdbWriter.Age);
 
             // UTF-8 encoded zero-terminated path to PDB
+            int pathStart = writer.Position;
             writer.WriteUTF8(_pdbPathOpt, allowUnpairedSurrogates: true);
             writer.WriteByte(0);
+
+            // padding:
+            writer.WriteBytes(0, Math.Max(0, _minPdbPath - (writer.Position - pathStart)));
 
             writer.WriteContentTo(peStream);
             writer.Free();


### PR DESCRIPTION
Pad the path to PDB stored in PE Debug Directory to MAX_PATH to avoid breaking legacy tools that rewrite the value. This workaround will be removed once these tools are retired. The padding is not inserted when compiling in deterministic mode.